### PR TITLE
Bug fix to ad3 when running parallel make

### DIFF
--- a/model/bin/ad3
+++ b/model/bin/ad3
@@ -303,7 +303,19 @@
   fi
 
   rm -f $path_o/$name.o
-  rm -f *.mod
+  ## Chris B: Dont delete *.mod - could clobber files in parallel make
+  ## Need to delete specific mod file that could be upper/lower/mixed case!
+#  rm -f *.mod ## too indiscriminate
+
+  ## Using find -iname most succinct, but maybe not all version of find have
+  ## the -iname option? 
+#  find . -iname "${name}.mod" -delete  # not all versions of find have -iname?
+
+  # Fall back on grep -i 
+  mods=`ls *.mod | grep -i "${name}.mod 2> /dev/null"`
+  if [ -n ${mods} ]; then
+    rm -f ${mods}
+  fi 
 
 # --------------------------------------------------------------------------- #
 # 3. Compile source code f / f90                                              #
@@ -380,7 +392,17 @@ then
       rm -f $name.o
     else
       mv $name.o $path_o/.
-      mods=`ls *.mod 2> /dev/null`
+      ## ChrisB: Don't move all module files...could break parallel make.
+      ## Just target specific module file (could be mixed case filename
+      ## depending on compiler - use case insensitive find):
+#      mods=`ls *.mod 2> /dev/null` 
+
+      ## Using find -iname most succinct, but maybe not all version of find have
+      ## the -iname option? 
+#      mods=`find . -iname "${name}.mod"` # not all versions of find have -iname?
+
+      # Fall back on grep -i 
+      mods=`ls *.mod | grep -i "${name}.mod 2> /dev/null"`
       if [ -n "$mods" ]
       then
         for mod in $mods


### PR DESCRIPTION
When running parallel make, it is possible under certain circumstancs for `ad3` to delete/move compiled MOD files too soon.

This is only an issue if the compiler does not provide a switch to allow a different directory to specified to output MOD files. In this case, the `ad3` program moves the MOD files from the scratch directory to the `mod` directory manually. Howerer, this uses a `*.mod` file glob which can erronously move/delete files from other compilation processes when running a parallel make.

As the compiler may output MOD files with a filename that may be upper/lower/mixed case, it is necessary to use a case insensitive grep to locate the correct MOD file. A `find -iname` works better, but the `-iname` switch to `find` may not be available on all systems.