### PR TITLE
Revert "Merging feature/sharedobject to develop"

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -117,7 +117,7 @@ if [ "$cmplr" == "intel" ] || [ "$cmplr" == "intel_debug" ] || \
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -fPIC -ip -p -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias'
+  optc='-c -module $path_m -no-fma -ip -p -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias'
   optl='-o $prog -p -g'
 
   # list options
@@ -179,7 +179,7 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || \
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -J$path_m -p -fPIC -g -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+  optc='-c -J$path_m -p -g -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
   optl='-o $prog -p -g'
 
   # omp options

--- a/model/bin/comp.Intel
+++ b/model/bin/comp.Intel
@@ -77,9 +77,8 @@
 #
 # Intel compiler on Linux ----------------------------------------------------
 # 2.b.1 Build options and determine compiler name
-  
-  opt="-c $list -O3 -assume byterecl -fPIC -module $path_m"
-#  opt="-c $list -O3 -assume byterecl -ip -module $path_m"
+
+  opt="-c $list -O3 -assume byterecl -ip -module $path_m"
 # opt="-c $list -O3 -assume byterecl -xSSE4.2 -ip  -module $path_m"
 # opt="-c $list -O3 -assume byterecl -prec-div -prec-sqrt -xHost -align array128byte -ip  -module $path_m"
 # opt="-c $list -O0 -assume byterecl -g -traceback -check all -fpe0 -ftrapuv -module $path_m"

--- a/model/bin/make_makefile.sh
+++ b/model/bin/make_makefile.sh
@@ -851,7 +851,6 @@
          ww3_ounp ww3_gspl ww3_gint ww3_bound ww3_bounc ww3_systrk $tideprog"
   progs="$progs ww3_multi_esmf  ww3_uprstr"
   progs="$progs libww3"
-  progs="$progs libww3.so"
 
   for prog in $progs
   do
@@ -1060,13 +1059,6 @@
              source="w3triamd w3srcemd $dsx $flx $ln $st $nl $bt $ic $is $db $tr $bs $xx $refcode $igcode $uostmd"
                  IO='w3iogrmd w3iogomd w3iopomd w3iotrmd w3iorsmd w3iobcmd w3iosfmd w3partmd'
                 aux="constants w3servmd w3timemd $tidecode w3arrymd w3dispmd w3cspcmd w3gsrumd" ;;
-     libww3.so) IDstring='Object file archive'
-               core='w3fldsmd w3initmd w3wavemd w3wdasmd w3updtmd'
-               data='wmmdatmd w3gdatmd w3wdatmd w3adatmd w3idatmd w3odatmd'
-               prop="$pr"
-             source="w3triamd w3srcemd $dsx $flx $ln $st $nl $bt $ic $is $db $tr $bs $xx $refcode $igcode $uostmd"
-                 IO='w3iogrmd w3iogomd w3iopomd w3iotrmd w3iorsmd w3iobcmd w3iosfmd w3partmd'
-                aux="constants w3servmd w3timemd $tidecode w3arrymd w3dispmd w3cspcmd w3gsrumd" ;;  
      ww3_uprstr) IDstring='Update Restart File' 
               core= 
 	          data='wmmdatmd w3triamd w3gdatmd w3wdatmd w3adatmd w3idatmd w3odatmd' 
@@ -1086,7 +1078,7 @@
       filesl="$data $core $prop $source $IO $aux"
     # if program name is libww3, then
     # the target is compile and create archive
-    elif [ "$prog" = "libww3" ] ||  [ "$prog" = "libww3.so" ]
+    elif [ "$prog" = "libww3" ]
     then
       d_string="$prog"' : $(aPo)/'
       files="$aux $core $data $prop $source $IO"
@@ -1131,19 +1123,6 @@
       done
       echo "	@cd \$(aPo); $ar_cmd $lib $objs" >> makefile
       echo ' '                                   >> makefile
-    # if program name is libww3.so, then
-    # the target is compile and create archive
-    elif [ "$prog" = "libww3.so" ]
-    then
-      lib=$prog
-      objs=""
-      for file in $filesl
-      do
-        objs="$objs $file.o"
-      done
-      echo "	@cd \$(aPo); ld -o $lib -shared $objs" >> makefile
-      echo ' '                                   >> makefile
-      
     else
       echo '	@$(aPb)/link '"$filesl"          >> makefile
       echo ' '                                   >> makefile

--- a/model/bin/w3_automake
+++ b/model/bin/w3_automake
@@ -132,7 +132,6 @@
   reg_programs="$reg_programs gx_outp"
   reg_programs="$reg_programs ww3_uprstr"
   reg_programs="$reg_programs libww3"
-  reg_programs="$reg_programs libww3.so"
 
 # PRNC OUNF OUNP BOUNC TRNC
   cdf_programs="ww3_prnc"

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -174,7 +174,6 @@
     cdf_programs="$cdf_programs ww3_multi"
     cdf_programs="$cdf_programs ww3_sbs1"
     cdf_programs="$cdf_programs libww3"
-    cdf_programs="$cdf_programs libww3.so"
     if [ $ESMFMKFILE ]
     then
       cdf_programs="$cdf_programs ww3_multi_esmf"
@@ -183,7 +182,6 @@
     reg_programs="$reg_programs ww3_multi"
     reg_programs="$reg_programs ww3_sbs1"
     reg_programs="$reg_programs libww3"
-    reg_programs="$reg_programs libww3.so"    
     if [ $ESMFMKFILE ]
     then
       reg_programs="$reg_programs ww3_multi_esmf"
@@ -664,9 +662,6 @@ EOF
       # if program name is libww3, then
       # the target is compile and create archive
       elif [ "$prog" = "libww3" ]
-      then
-        target="$prog"
-      elif [ "$prog" = "libww3.so" ]
       then
         target="$prog"
       else

--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -23,7 +23,7 @@ wget ftp://polar.ncep.noaa.gov/tempor/ww3ftp/ww3_from_ftp.v6.07.tar.gz
 tar -xvzf ww3_from_ftp.v6.07.tar.gz
 
 #Move regtest info from data_regtests to regtests:
-echo -e "Moving data from data_regtests to regtests"  
+echo -e "Moving data from data_regtests to regtets"  
 cp -r data_regtests/ww3_tp2.15/input/*.nc  regtests/ww3_tp2.15/input/
 cp -r data_regtests/ww3_tp2.13/*.png       regtests/ww3_tp2.13/
 cp -r data_regtests/ww3_tic1.4/input/*.nc  regtests/ww3_tic1.4/input/
@@ -53,7 +53,7 @@ else
   echo -e ' Not deleting tar file.' 
 fi
 
-echo -e "\n\n Files were copied from the data_regtests to the regstets folder."
+echo -e "\n\n Files were copied from the data_regtests to the regtets folder."
 echo -e "Do you want to delete the data_regtests folder? [y|n]: "
 read wnew2
 if [ "${wnew2}" = "Y" ] || [ "${wnew2}" = "y" ]


### PR DESCRIPTION
Reverts NOAA-EMC/WW3#29

Building shared libraries has doubled the compilation time for some of the programs (eg, using the -fPIC option instead of -ip). This changeset is being reverted and will be reintegrated when the developer provides a solution for reducing compile time.