### PR TITLE
Hf ad3

### DIFF
--- a/model/bin/ad3
+++ b/model/bin/ad3
@@ -303,7 +303,19 @@
   fi
 
   rm -f $path_o/$name.o
-  rm -f *.mod
+  ## Chris B: Dont delete *.mod - could clobber files in parallel make
+  ## Need to delete specific mod file that could be upper/lower/mixed case!
+#  rm -f *.mod ## too indiscriminate
+
+  ## Using find -iname most succinct, but maybe not all version of find have
+  ## the -iname option? 
+#  find . -iname "${name}.mod" -delete  # not all versions of find have -iname?
+
+  # Fall back on grep -i 
+  mods=`ls *.mod | grep -i "${name}.mod 2> /dev/null"`
+  if [ -n ${mods} ]; then
+    rm -f ${mods}
+  fi 
 
 # --------------------------------------------------------------------------- #
 # 3. Compile source code f / f90                                              #
@@ -380,7 +392,17 @@ then
       rm -f $name.o
     else
       mv $name.o $path_o/.
-      mods=`ls *.mod 2> /dev/null`
+      ## ChrisB: Don't move all module files...could break parallel make.
+      ## Just target specific module file (could be mixed case filename
+      ## depending on compiler - use case insensitive find):
+#      mods=`ls *.mod 2> /dev/null` 
+
+      ## Using find -iname most succinct, but maybe not all version of find have
+      ## the -iname option? 
+#      mods=`find . -iname "${name}.mod"` # not all versions of find have -iname?
+
+      # Fall back on grep -i 
+      mods=`ls *.mod | grep -i "${name}.mod 2> /dev/null"`
       if [ -n "$mods" ]
       then
         for mod in $mods


### PR DESCRIPTION
When running parallel make, it is possible under certain circumstancs for ad3 to delete/move compiled MOD files too soon. This is only an issue if the compiler does not provide a switch to allow a different directory to specified to output MOD files. IWhen running parallel make, it is possible under certain circumstancs for ad3 to delete/move compiled MOD files too soon. This is only an issue if the compiler does not provide a switch to allow a different directory to specified to output MOD files. In this case, the ad3 program moves the MOD files from the scratch directory to the mod directory manually. Howerer, this uses a *.mod file glob which can erronously move/delete files from other compilation processes when running a parallel make.

In running the full regtests matrix prior to this pull request, there were the expected differences in mww3_test_03 case dN with load balancing options, and in mod_defs for one variation of 3 tests (mww3_test_07, ww3_tp2.7, and ww3_ts4). In my view these results are robust, they identify something that needs to be fine-combed in the generation of mod_defs for these latter tests, but that indicate that all branches are ready for merge.

regtests matrix output run on Theia
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (5 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (3 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (3 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (7 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (4 files differ)
mww3_test_07/./work_PR3_UQ                     (3 files differ)
ww3_tic1.2/./work_IC3_CHENG                     (2 files differ)
ww3_tp1.6/./work_PR2_UNO                     (2 files differ)
ww3_tp1.6/./work_PR2_UQ                     (2 files differ)
ww3_tp1.6/./work_PR3_UNO                     (2 files differ)
ww3_tp1.6/./work_PR3_UQ                     (2 files differ)
ww3_tp2.7/./work_ST0                     (1 files differ)
ww3_ts4/./work_ug_MPI                     (1 files differ)
**********************************************************************
******************** summary of comparison ***************************
********** only results of non-identical cases are listed ************
****** if less than 10 files differ for a case, they are listed ******
**********************************************************************

* test case: mww3_test_03; test run: ./work_PR3_UQ_MPI_d2
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  124 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  8 files differ
out_pnt.low2 (binary) out_grd.low2 (binary) out_grd.low3 (binary) out_grd.low1 (binary) out_grd.hgh3 (binary) out_grd.hgh1 (binary) out_pnt.hgh2 (binary) out_grd.hgh2 (binary)

* test case: mww3_test_03; test run: ./work_PR3_UQ_MPI_d2_c
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  124 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  8 files differ
out_pnt.low2 (binary) out_grd.low3 (binary) out_grd.low2 (binary) out_grd.low1 (binary) out_grd.hgh3 (binary) out_pnt.hgh2 (binary) out_grd.hgh2 (binary) out_grd.hgh1 (binary)

* test case: mww3_test_03; test run: ./work_PR2_UQ_MPI_d2
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  127 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  5 files differ
out_pnt.low2 (binary) out_grd.low1 (binary) out_grd.low2 (binary) out_grd.hgh1 (binary) out_grd.hgh2 (binary)

* test case: mww3_test_03; test run: ./work_PR3_UNO_MPI_d2
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  129 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  3 files differ
out_grd.low2 (binary) out_grd.hgh2 (binary) out_grd.hgh1 (binary)

* test case: mww3_test_03; test run: ./work_PR3_UNO_MPI_d2_c
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  129 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  3 files differ
out_grd.low2 (binary) out_grd.hgh2 (binary) out_grd.hgh1 (binary)

* test case: mww3_test_03; test run: ./work_PR1_MPI_d2
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  125 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  7 files differ
out_grd.low2 (binary) out_grd.low3 (binary) out_grd.low1 (binary) out_pnt.hgh2 (binary) out_grd.hgh2 (binary) out_grd.hgh3 (binary) out_grd.hgh1 (binary)

* test case: mww3_test_03; test run: ./work_PR2_UNO_MPI_d2
*********************************************************
  found 135 files in base directory
  found 135 files in compare directory
  128 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  4 files differ
out_grd.low2 (binary) out_grd.low1 (binary) out_grd.hgh2 (binary) out_grd.hgh1 (binary)

* test case: mww3_test_07; test run: ./work_PR3_UQ
*********************************************************
  found 25 files in base directory
  found 25 files in compare directory
  19 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  3 files differ
mod_def.rect1 (binary) mod_def.points (binary) mod_def.zcmpl (binary)

* test case: ww3_tic1.2; test run: ./work_IC3_CHENG
*********************************************************
  found 60 files in base directory
  found 60 files in compare directory
  55 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  2 files differ
out_grd.ww3 (binary) out_pnt.ww3 (binary)

* test case: ww3_tp1.6; test run: ./work_PR2_UNO
*********************************************************
  found 25 files in base directory
  found 25 files in compare directory
  20 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  2 files differ
out_grd.ww3 (binary) out_pnt.ww3 (binary)

* test case: ww3_tp1.6; test run: ./work_PR2_UQ
*********************************************************
  found 25 files in base directory
  found 25 files in compare directory
  20 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  2 files differ
out_grd.ww3 (binary) out_pnt.ww3 (binary)

* test case: ww3_tp1.6; test run: ./work_PR3_UNO
*********************************************************
  found 25 files in base directory
  found 25 files in compare directory
  20 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  2 files differ
out_grd.ww3 (binary) out_pnt.ww3 (binary)

* test case: ww3_tp1.6; test run: ./work_PR3_UQ
*********************************************************
  found 25 files in base directory
  found 25 files in compare directory
  20 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  2 files differ
out_grd.ww3 (binary) out_pnt.ww3 (binary)

* test case: ww3_tp2.7; test run: ./work_ST0
*********************************************************
  found 78 files in base directory
  found 78 files in compare directory
  74 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  1 files differ
mod_def.ww3 (binary)

* test case: ww3_ts4; test run: ./work_ug_MPI
*********************************************************
  found 13 files in base directory
  found 13 files in compare directory
  9 files are identical
  3 files skipped
  0 files in base directory only
  0 files in comp directory only
  1 files differ
mod_def.ww3 (binary)