### PR TITLE
added conditional on line 404, so NDSEN > 0, alleviates mpi error

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -401,7 +401,7 @@
              IF ( OUT_NAMES(IFJ) .EQ. 'T' )                            &
                                FLG2D(IFI,IFJ)=.TRUE.
           ENDDO
-          IF (IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI
+          IF (NDSEN .GT. 0 .AND. IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI
          ENDIF
         END DO
 !


### PR DESCRIPTION
I was receiving the following error using OpenMPI: 
```
At line 394 of file w3iogomd.F90
Fortran runtime error: Unit number is negative and unit was not already opened with OPEN(NEWUNIT=...)
```
Making the fix to w3iogomd.ftn on line 404 alleviated this error: 
FROM: 
`IF (IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI`
TO:
`IF (NDSEN .GE. 0  .AND. IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI`

