### PR TITLE
Develop (#35)

### DIFF
--- a/model/aux/bash/ww3_ounf_inp2nml.sh
+++ b/model/aux/bash/ww3_ounf_inp2nml.sh
@@ -182,7 +182,7 @@ cat >> $nmlfile << EOF
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/model/bin/make_makefile.sh
+++ b/model/bin/make_makefile.sh
@@ -97,7 +97,7 @@
               shared mpp mpiexp thread GSE prop \
               stress s_ln source stab s_nl snls s_bot s_db miche s_tr s_bs \
               dstress s_ice s_is reflection s_xx \
-              wind windx rwind curr currx mgwind mgprop mggse \
+              wind windx wcor rwind curr currx mgwind mgprop mggse \
               subsec tdyn dss0 pdif tide refrx ig rotag arctic nnt mprf \
               cou oasis agcm ogcm igcm trknc setup pdlib memck uost
   do
@@ -247,6 +247,11 @@
       windx  ) TY='one'
                ID='wind interpolation in space'
                OK='WNX0 WNX1 WNX2' ;;
+#sort:wcor:
+      wcor   ) TY='upto1'
+               ID='wind speed correction'
+               TS='WCOR'
+               OK='WCOR' ;;
 #sort:rwind:
       rwind  ) TY='upto1'
                ID='wind vs. current definition'

--- a/model/ftn/w3initmd.ftn
+++ b/model/ftn/w3initmd.ftn
@@ -109,7 +109,7 @@
       PUBLIC
 !/
       REAL, PARAMETER                :: CRITOS = 15.
-      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.00  '
+      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.01  '
       CHARACTER(LEN=512), PARAMETER  :: SWITCHES  = &
                     'PUT_SW1' // &
                     'PUT_SW2' // &

--- a/model/ftn/w3triamd.ftn
+++ b/model/ftn/w3triamd.ftn
@@ -666,7 +666,10 @@ CONTAINS
         DO IBC = 1, N_OUTSIDE_BOUNDARY
            IX = OUTSIDE_BOUNDARY(IBC)
            !write(*,*) 'TEST1', IX, TMPSTA(1,IX), CCON(IX), COUNTCON(IX), ZBIN(1,IX), ZLIM
-           IF (IX.NE.0) THEN  ! There was a bug in the mesh conversion, OUTSIDE_BOUNDARY(IBC) should not be zero 
+
+           ! OUTSIDE_BOUNDARY(IBC) is defined over the full nodes NODES indexes
+           ! whereas TMPSTA and ZBIN are defined over the clean up list of nodes NX
+           IF ((IX.NE.0).AND.(IX.LE.NX)) THEN
              IF ((TMPSTA(1,IX).EQ.1).AND.(STATUS(IX).EQ.0)  &
                .AND.(ZBIN(1,IX).LT.ZLIM))  TMPSTA(1,IX)=2  
             END IF       

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -32,6 +32,7 @@
 !/    12-Sep-2018 : Added extra partitioned fields      ( version 6.06 )
 !/    25-Sep-2018 : Add WBT parameter                   ( version 6.06 )
 !/    28-Mar-2019 : Bugfix to NBIPART check.            ( version 6.07 )
+!/    21-May-2019 : Feature fixed filename              ( version 7.01 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -157,10 +158,9 @@
                                  IOUT, S3, IRET, HASNC4,               &
                                  NBIPART, CNTIPART, NCVARTYPE, IPART,  &
                                  RTDNX, RTDNY
-      INTEGER                 :: TOUT(2), TDUM(2),                     &
-                                 NCIDS(NOGRP,NGRPP,6), STOPDATE(8)
+      INTEGER                 :: TOUT(2), TDUM(2), STOPDATE(8)
 !
-      INTEGER, ALLOCATABLE    :: TABIPART(:)
+      INTEGER, ALLOCATABLE    :: TABIPART(:), NCIDS(:,:,:)
 !
 !/S      INTEGER, SAVE           :: IENT = 0
 !
@@ -383,6 +383,7 @@
       ! Alternative processing of TABIPART to capture requests 
       ! greater than NOSWLL (C.Bunney):
       ALLOCATE(TABIPART(NOSWLL + 1))
+      ALLOCATE(NCIDS(NOGRP,NGRPP,NOSWLL + 1))
       NBIPART=0
       DO I=1,30
         IF(STRINGIPART(I:I) .EQ. ' ') CYCLE
@@ -874,17 +875,21 @@
 
 ! 1.2 Sets the date as ISO8601 convention 
       ! S3 defines the number of characters in the date for the filename
-      ! S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
+      ! S3=0 -> field, S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
       ! Setups min and max date format
-      IF (S3.LT.4) S3=4 
+      IF (S3.GT.0 .AND. S3.LT.4) S3=4 
       IF (S3.GT.10) S3=10 
 !
       ! Defines the format of FILETIME
       S5=S3-8
       S4=S3
       OLDTIMEID=TIMEID
+      ! if S3=>nodate then filetime='field'
+      IF (S3.EQ.0) THEN
+        S4=5
+        TIMEID="field"
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHZ'
-      IF (S3.EQ.10) THEN 
+      ELSE IF (S3.EQ.10) THEN 
         S4=S4+2 ! add chars for ISO8601 : day T hours Z
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (TIMEID,FORMAT1) TIME(1), 'T', &
@@ -3397,9 +3402,6 @@
             ! Defines the netcdf extension
             FNAMENC(S1+S2+1:S1+S2+3) = '.nc'
             FNAMENC(S1+S2+4:S1+S2+6) = '   '
-
-!/NCO ! For NCEP application, requires fixed netcdf file name
-!/NCO            FNAMENC='ww3.gridded.nc'
 
             ! If the flag frequency is .TRUE., defines the fourth dimension
             IF (FLFRQ) THEN 

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1297,7 +1297,6 @@
             ELSE IF ( J .EQ. 6 ) THEN
 !             IPRT: IX0, IXN, IXS, IY0, IYN, IYS
               CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-              READ (NDSI,*,END=2001,ERR=2002) IPRT, PRTFRM
 !/DEBUGINIT              write(740+IAPROC,*), 'Before reading IPRT'
 !/DEBUGINIT              write(740+IAPROC,*), 'Before read 2002, case 10'
               READ (NDSI,*) IPRT, PRTFRM

--- a/model/inp/ww3_ounf.inp
+++ b/model/inp/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/model/nml/ww3_ounf.nml
+++ b/model/nml/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTART            = '19000101 000000'  ! Stop date for the output field
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file

--- a/regtests/mww3_test_01/input/ww3_ounf.nml
+++ b/regtests/mww3_test_01/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_02/input/ww3_ounf.nml
+++ b/regtests/mww3_test_02/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_03/input/ww3_ounf.nml
+++ b/regtests/mww3_test_03/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_04/input/ww3_ounf.inp
+++ b/regtests/mww3_test_04/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_04/input/ww3_ounf.nml
+++ b/regtests/mww3_test_04/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_05/input/ww3_ounf.inp
+++ b/regtests/mww3_test_05/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_05/input/ww3_ounf.nml
+++ b/regtests/mww3_test_05/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_06/input/ww3_ounf.inp
+++ b/regtests/mww3_test_06/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_06/input/ww3_ounf.nml
+++ b/regtests/mww3_test_06/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf_rect1.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf_rect1.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf_zcmpl.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf_zcmpl.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_multi/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_multi/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_multi/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_shel/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_shel/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_shel/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/input/ww3_ounf.inp
+++ b/regtests/mww3_test_08/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/input/ww3_ounf.nml
+++ b/regtests/mww3_test_08/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD0F_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD0F_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD0F_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD0F_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_U_cap/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_U_cap/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_U_cap/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_U_cap/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tbt1.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tbt1.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tbt1.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tbt1.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tbt2.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tbt2.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tbt2.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tbt2.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC1/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC1/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC3/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC3/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M1/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M2/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M4/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M4/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M5/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M5/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M6/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M6/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M7/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M7/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC5/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC5/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC5/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC5/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IS2/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IS2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IS2/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IS2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tic1.4/input/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tic1.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.1/input_IC1/ww3_ounf.inp
+++ b/regtests/ww3_tic2.1/input_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.1/input_IC1/ww3_ounf.nml
+++ b/regtests/ww3_tic2.1/input_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.inp
+++ b/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.nml
+++ b/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tic2.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tic2.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.2/input_IC2/ww3_ounf.inp
+++ b/regtests/ww3_tic2.2/input_IC2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.2/input_IC2/ww3_ounf.nml
+++ b/regtests/ww3_tic2.2/input_IC2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tic2.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tic2.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.1/input2/ww3_ounf.nml
+++ b/regtests/ww3_tp1.1/input2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.10/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.10/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.10/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.10/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]
@@ -33,6 +33,7 @@
   FIELD%TIMESTART        =  '19680606 000000'
   FIELD%TIMESTRIDE       =  '3600.'
   FIELD%TIMECOUNT        =  '1000'
+  FIELD%TIMESPLIT        =  0
   FIELD%LIST             =  'DPT HS FC CFX'
   FIELD%PARTITION        =  '0 1 2'
   FIELD%TYPE             =  4

--- a/regtests/ww3_tp1.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.4/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.5/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.5/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.5/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.5/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.6/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.6/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.6/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.6/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.7/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.7/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.7/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.7/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.7/input_OBST/ww3_ounf.nml
+++ b/regtests/ww3_tp1.7/input_OBST/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.8/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.8/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.8/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.8/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.8/input_BJ/ww3_ounf.nml
+++ b/regtests/ww3_tp1.8/input_BJ/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.9/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.9/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.9/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.9/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.inp
+++ b/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.nml
+++ b/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.10/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.10/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.11/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.11/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.13/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.13/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.14/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.14/input/ww3_ounf.inp
@@ -25,7 +25,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY DX DY, unstructured:IP NP DP DP]
 $
 ww3.

--- a/regtests/ww3_tp2.14/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.14/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.15/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.15/input/ww3_ounf.inp
@@ -12,7 +12,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.15/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.15/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.16/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.16/input/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.16/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.16/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.17/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.17/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.4/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.5/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.5/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.5/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.5/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.5/input_REF/ww3_ounf.nml
+++ b/regtests/ww3_tp2.5/input_REF/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.6/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.6/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.7/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.7/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.7/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.7/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.8/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.8/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.8/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.8/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.9/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.9/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.9/input/ww3_ounf_flds_hrly.nml
+++ b/regtests/ww3_tp2.9/input/ww3_ounf_flds_hrly.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts1/input/ww3_ounf.nml
+++ b/regtests/ww3_ts1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts1/input_fld/ww3_ounf.nml
+++ b/regtests/ww3_ts1/input_fld/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts3/input/ww3_ounf.inp
+++ b/regtests/ww3_ts3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_ts3/input/ww3_ounf.nml
+++ b/regtests/ww3_ts3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_rg_multi/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_rg_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_rg_shel/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_rg_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_ug/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_ug/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]


### PR DESCRIPTION
Pull request being merged into new branch ifremer_pull_20190521 for further testing of following changes:
* add feature for fixed filename with ndates=0 for ww3_ounf
* bugfix for netcdf file id allocation
* remove extra line due to copy/paste error
* change vers from 7.00 to 7.01
add comment
* add WCOR to switch list
* add check on array index

output of matrix.comp between ifremer_pull_20190521 and develop branch. no differences except version number 7.01 and mww3_test05 due to the number of time steps. all files are the same bit to bit

[NOAA_ifremer_pull_20190521_matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/3334643/NOAA_ifremer_pull_20190521_matrixDiff.txt)
