### PR TITLE
hf_nml_outbnd: Minor bug in ww3_grid.ftn: Info about outbound files

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -401,7 +401,7 @@
              IF ( OUT_NAMES(IFJ) .EQ. 'T' )                            &
                                FLG2D(IFI,IFJ)=.TRUE.
           ENDDO
-          IF (IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI
+          IF (NDSEN .GE. 0 .AND. IFJ .LT. NOGE(IFI)) WRITE(NDSEN,1007) IFI
          ENDIF
         END DO
 !
@@ -590,7 +590,7 @@
              IF (US3DF(1).GE.1) THEN
                FLG2D(6,8)=.TRUE.
              ELSE
-               WRITE(NDSEN,1008) 'USF','US3D'
+               IF (NDSEN .GE. 0) WRITE(NDSEN,1008) 'USF','US3D'
                END IF
            CASE('P2L')
              FLG2D(6,9)=.TRUE.
@@ -602,7 +602,7 @@
              IF (USSPF(1).GE.1) THEN
                FLG2D(6,12)=.TRUE.
              ELSE
-               WRITE(NDSEN,1008) 'USP','USSP'
+               IF (NDSEN .GE. 0) WRITE(NDSEN,1008) 'USP','USSP'
                END IF
 !
 ! Group 7
@@ -652,7 +652,7 @@
              FLG2D(10,2)=.TRUE.
 !/COU           CASE('DRY')
            CASE DEFAULT
-             IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN,1004) TRIM(TESTSTR)
+             IF (NDSEN .GE. 0) WRITE (NDSEN,1004) TRIM(TESTSTR)
            END SELECT
 !
           IF(ANY(FLG2D(IFI,:))) FLG1D(IFI)=.TRUE. !Update FLG1D
@@ -683,20 +683,20 @@
       RETURN
 !
  2001 CONTINUE
-      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN,1001)
+      IF (NDSEN .GE. 0) WRITE (NDSEN,1001)
       RETURN
  2002 CONTINUE
-      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN, 1002) IFI, IERR
+      IF (NDSEN .GE. 0) WRITE (NDSEN, 1002) IFI, IERR
       RETURN
  2003 CONTINUE
-      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN, 1003) IERR
+      IF (NDSEN .GE. 0) WRITE (NDSEN, 1003) IERR
       RETURN
 !2004 CONTINUE ! replaced by warning in code ....
  2005 CONTINUE
-      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN, 1005) AFLG
+      IF (NDSEN .GE. 0) WRITE (NDSEN, 1005) AFLG
       RETURN
  2006 CONTINUE
-      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN, 1006) IFI,IERR
+      IF (NDSEN .GE. 0) WRITE (NDSEN, 1006) IFI,IERR
       RETURN
 !
  1945 FORMAT ( '            Fields   : ',A)
@@ -1010,7 +1010,7 @@
            IF (US3DF(1).GE.1) THEN
              FLG2D(6,8)=.TRUE.
            ELSE
-             WRITE(NDSEN,1008) 'USF','US3D'
+             IF (NDSEN .GE. 0) WRITE(NDSEN,1008) 'USF','US3D'
              END IF
          CASE('P2L')
            FLG2D(6,9)=.TRUE.
@@ -1022,7 +1022,7 @@
            IF (USSPF(1).GE.1) THEN
              FLG2D(6,12)=.TRUE.
            ELSE
-             WRITE(NDSEN,1008) 'USP','USSP'
+             IF (NDSEN .GE. 0) WRITE(NDSEN,1008) 'USP','USSP'
              END IF
 
 !
@@ -1073,7 +1073,7 @@
            FLG2D(10,1)=.TRUE.
 !/COU           CASE('DRY')
          CASE DEFAULT
-           IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSEN,1004) TRIM(TESTSTR)
+           IF (NDSEN .GE. 0) WRITE (NDSEN,1004) TRIM(TESTSTR)
          END SELECT
 !
         IOUT=IOUT+1

--- a/model/ftn/ww3_grid.ftn
+++ b/model/ftn/ww3_grid.ftn
@@ -4876,7 +4876,9 @@
 !     ILOOP = 2 to fill data arrays
 !
       WRITE (NDSO,990)
-      OPEN (NDSS,FILE=TRIM(FNMPRE)//'ww3_grid.scratch',FORM='FORMATTED')
+! ww3_grid.scratch is not used with namelist input (C.Hansen 20190701)
+      IF ( .NOT. FLGNML ) &
+        OPEN (NDSS,FILE=TRIM(FNMPRE)//'ww3_grid.scratch',FORM='FORMATTED')
 !
       DO ILOOP = 1, 2
 !
@@ -4888,11 +4890,13 @@
         NBO(0) = 0
         NBO2(0)= 0
         FIRST  = .TRUE.
-        REWIND (NDSS)
-        IF ( ILOOP .EQ. 1 ) THEN
-          NDSI2 = NDSI
-        ELSE
-          NDSI2 = NDSS
+        IF ( .NOT. FLGNML ) THEN
+          REWIND (NDSS)
+          IF ( ILOOP .EQ. 1 ) THEN
+            NDSI2 = NDSI
+          ELSE
+            NDSI2 = NDSS
+          END IF
         END IF
 !
         DO
@@ -4906,21 +4910,29 @@
               NPO = NML_OUTBND_LINE(I)%NP
               I=I+1
             ELSE
-              EXIT
+!              EXIT
+! Bug (minor): If we exit here, a code block below will not be reached that
+! writes info about the last boundary file:'File nestI.ww3  Number of points ..'
+! ( The block does WRITE(NDSO,991), WRITE (NDSO,992), etc.)
+! Instead, let NPO=0 mark that we have got the info for the last file, and the
+! do-loop over outbound lines will exit immediately after the block. This is a
+! minor bug because it only affects output messages (C. Hansen 20190701)
+               NPO = 0
             END IF
           ELSE
             CALL NEXTLN ( COMSTR , NDSI2 , NDSE )
             READ (NDSI2,*,END=2001,ERR=2002) XO0, YO0, DXO, DYO, NPO
           END IF
 !
-          IF ( ILOOP .EQ. 1 ) THEN
-            IF (FLGNML) THEN
-              WRITE(NDSS,'(A)') NML_OUTBND_LINE(I-1)
-            ELSE
+          IF ( .NOT. FLGNML .AND. ILOOP .EQ. 1 ) THEN
+!            IF (FLGNML) THEN
+! NML_OUTBND_LINE are not strings (C. Hansen 20190701), but NDSS isn't used
+!              WRITE(NDSS,'(A)') NML_OUTBND_LINE(I-1)
+!            ELSE
               BACKSPACE (NDSI)
               READ (NDSI,'(A)') LINE
               WRITE (NDSS,'(A)') LINE
-            END IF
+!            END IF
           END IF
 !
 ! ... Check if new file to be used
@@ -5109,7 +5121,7 @@
 !
         END DO
 !
-      CLOSE ( NDSS, STATUS='DELETE' )
+      IF ( .NOT. FLGNML ) CLOSE ( NDSS, STATUS='DELETE' )
 !
       FLBPO  = NBOTOT .GT. 0
       IF ( .NOT. FLBPO ) THEN

--- a/model/ftn/ww3_grid.ftn
+++ b/model/ftn/ww3_grid.ftn
@@ -4876,7 +4876,6 @@
 !     ILOOP = 2 to fill data arrays
 !
       WRITE (NDSO,990)
-! ww3_grid.scratch is not used with namelist input (C.Hansen 20190701)
       IF ( .NOT. FLGNML ) &
         OPEN (NDSS,FILE=TRIM(FNMPRE)//'ww3_grid.scratch',FORM='FORMATTED')
 !
@@ -4910,13 +4909,6 @@
               NPO = NML_OUTBND_LINE(I)%NP
               I=I+1
             ELSE
-!              EXIT
-! Bug (minor): If we exit here, a code block below will not be reached that
-! writes info about the last boundary file:'File nestI.ww3  Number of points ..'
-! ( The block does WRITE(NDSO,991), WRITE (NDSO,992), etc.)
-! Instead, let NPO=0 mark that we have got the info for the last file, and the
-! do-loop over outbound lines will exit immediately after the block. This is a
-! minor bug because it only affects output messages (C. Hansen 20190701)
                NPO = 0
             END IF
           ELSE
@@ -4925,14 +4917,9 @@
           END IF
 !
           IF ( .NOT. FLGNML .AND. ILOOP .EQ. 1 ) THEN
-!            IF (FLGNML) THEN
-! NML_OUTBND_LINE are not strings (C. Hansen 20190701), but NDSS isn't used
-!              WRITE(NDSS,'(A)') NML_OUTBND_LINE(I-1)
-!            ELSE
               BACKSPACE (NDSI)
               READ (NDSI,'(A)') LINE
               WRITE (NDSS,'(A)') LINE
-!            END IF
           END IF
 !
 ! ... Check if new file to be used


### PR DESCRIPTION
In the output from ww3_grid, some info text is missing about the last outbound boundary file for one-way nesting: "File nestI.ww3 Number of points .."  when namelists input files are used.

Solution: Let NPO=0 mark that we have got the info for the last output b.c. file. Then the do-loop over outbound lines will exit immediately after the block that writes the info.

Additional correction: The file ww3_grid.scratch isn't used when namelists input files are used. Therefore, also prepend a condition "IF ( .NOT. FLGNML )" to other statements handling the file NDSS.
