### PR TITLE
Removing trailing whitespace in files in ftn folder

### DIFF
--- a/model/ftn/PDLIB/yowdatapool.ftn
+++ b/model/ftn/PDLIB/yowdatapool.ftn
@@ -44,7 +44,7 @@ module yowDatapool
 !  integer,parameter :: rkind = 4
 !#else
   !> double precision. Default real datatype
-  integer,parameter :: rkind = 4 
+  integer,parameter :: rkind = 4
 !#endif
   logical, parameter :: debugPrePartition = .false.
   logical, parameter :: debugPostPartition = .false.
@@ -75,7 +75,7 @@ module yowDatapool
 !#ifdef USE_SINGLE
   integer, save :: rtype = MPI_REAL4
 !#else
-!  integer, save :: rtype = MPI_REAL8  
+!  integer, save :: rtype = MPI_REAL8
 !#endif
 
 end module yowDatapool

--- a/model/ftn/PDLIB/yowerr.ftn
+++ b/model/ftn/PDLIB/yowerr.ftn
@@ -81,8 +81,8 @@ module yowerr
       if(ierr/=MPI_SUCCESS) write(*,*) "parallel_abort: ierr=", ierr
     endif
   end subroutine parallel_abort
-  
-  
+
+
   !> print various error strings and exit.
   !> Call this to print an error string and optional line number, file and MPI error string
   !> \param[in] string Errorstring
@@ -90,7 +90,7 @@ module yowerr
   !> \param[in] file Filename
   !> \param[in] errno The MPI error number which is translated into an error string
   subroutine abort(string, line, file, errno)
-    use yowDatapool, only: comm     
+    use yowDatapool, only: comm
     use MPI
     implicit none
     ! Errorstring to print
@@ -124,40 +124,40 @@ module yowerr
     if(.not. present(errno)) then
       write(*,'(a)', advance='no' ) " ERROR "
     endif
-    
+
     ! print file and linenumber
     if(present(file)) then
       write(*,'(a)',advance='no' ) file
-      
+
       if(present(line)) then
         Write(lineNumber, '(i10)') line
         write(*, '(2a)', advance='no') ":", trim(adjustl(lineNumber))
       endif
-      
+
       write(*, '(a)', advance='no') " "
     endif
-    
+
     ! if only linenumber is present, add an "Line:" string
     if(.not. present(file) .and. present(line)) then
         Write(lineNumber, '(i10)') line
         write(*, '(2a)', advance='no') "Line:", trim(adjustl(lineNumber))
         write(*, '(a)', advance='no') " "
     endif
-    
+
     ! print the errror string
     if(present(string)) then
       write(*,'(a)', advance='no') string
     endif
-    
+
     ! translate and print the MPI error string
     if(present(errno) .and. errno /= MPI_SUCCESS) then
       call mpi_error_string(errno, errorstring, stringLengh, ierr)
       write(*,'(2a)', advance='no') 'MPI ERROR: ', errorstring(1:stringLengh)
     endif
-    
+
     write(*,*)
     stop
-  
+
   end subroutine
 
   !> print warning

--- a/model/ftn/PDLIB/yowexchangeModule.ftn
+++ b/model/ftn/PDLIB/yowexchangeModule.ftn
@@ -47,7 +47,7 @@ module yowExchangeModule
 
   !> Holds some data belong to a neighbor Domain
   type, public :: t_neighborDomain
-    
+
     !> the domain ID
     !> The domain ID of the neighbor domain. Starts by 1
     integer :: domainID = 0
@@ -152,7 +152,7 @@ module yowExchangeModule
     integer :: dsplSend(this%numNodesToSend)
     integer :: dsplRecv(this%numNodesToReceive)
 
-    
+
     dsplSend = ipgl(this%nodesToSend)-1
     dsplRecv = ghostgl(this%nodesToReceive) + np -1
 
@@ -161,7 +161,7 @@ module yowExchangeModule
     if(ierr /= MPI_SUCCESS) CALL PARALLEL_ABORT("createMPIType", ierr)
     call mpi_type_commit(this%p1DRsendType,ierr)
     if(ierr /= MPI_SUCCESS) CALL PARALLEL_ABORT("createMPIType", ierr)
-    
+
     call mpi_type_create_indexed_block(this%numNodesToReceive, 1, dsplRecv, rtype, this%p1DRrecvType,ierr)
     if(ierr /= MPI_SUCCESS) CALL PARALLEL_ABORT("createMPIType", ierr)
     call mpi_type_commit(this%p1DRrecvType,ierr)
@@ -232,7 +232,7 @@ module yowExchangeModule
     if(stat/=0)  CALL ABORT('neighborDomains allocation failure')
   end subroutine
 
-  subroutine createMPITypes()    
+  subroutine createMPITypes()
     implicit none
     integer :: i
 
@@ -343,7 +343,7 @@ module yowExchangeModule
   end subroutine
 
   !> \overload PDLIB_exchange1Dreal
-  !> 
+  !>
   !> \note MPI recv tag: 30000 + MPI rank
   !> \note MPI send tag: 30000 + neighbor MPI rank
   subroutine PDLIB_exchange2Dreal(U)

--- a/model/ftn/PDLIB/yowfunction.ftn
+++ b/model/ftn/PDLIB/yowfunction.ftn
@@ -169,7 +169,7 @@ module yowfunction
 !/DEBUGINIT     WRITE(740+IAPROC,*) 'Before ComputeListNP_ListNPA_Kernel'
 !/DEBUGINIT     FLUSH(740+IAPROC)
     IF (IAPROC .le. NAPROC) THEN
-      CALL ComputeListNP_ListNPA_ListIPLG_Kernel    
+      CALL ComputeListNP_ListNPA_ListIPLG_Kernel
     END IF
 !/DEBUGINIT     WRITE(740+IAPROC,*) ' After ComputeListNP_ListNPA_Kernel'
 !/DEBUGINIT     FLUSH(740+IAPROC)

--- a/model/ftn/PDLIB/yowpdlibmain.ftn
+++ b/model/ftn/PDLIB/yowpdlibmain.ftn
@@ -47,7 +47,7 @@ module yowpdlibMain
   public :: initFromGridDim, finalizePD
 
   contains
-  
+
   !> @param[in] MNP number of nodes global
   !> @param[in] XP node X value
   !> @param[in] XY node Y value
@@ -504,7 +504,7 @@ module yowpdlibMain
       xyz(2*(i-1)+1) = REAL(node%x)
       xyz(2*(i-1)+2) = REAL(node%y)
       if(debugParmetis) then
-        write(710+myrank,*) i, np, xyz(2*(i-1)+1), xyz(2*(i-1)+2)  
+        write(710+myrank,*) i, np, xyz(2*(i-1)+1), xyz(2*(i-1)+2)
         call flush(710+myrank)
       endif
     end do
@@ -1080,7 +1080,7 @@ module yowpdlibMain
         do j=1, 3
           assigned = .false.
           node => nodes_global(elements(i)%node(j))
-          
+
           if(node%domainID == myrank+1) then
             INE(j, ne) = node%id
             assigned = .true.
@@ -1092,7 +1092,7 @@ module yowpdlibMain
               if(node%id_global == ghostlg(k)) then
                 ! conversion: the ghost nodes are stored behind the local nodes.
                 if(INE(j,ne) /= 0) then
-                  write(*,*) "will write to INE(j, ne) but there is allready a value", j, ne, INE(j, ne) 
+                  write(*,*) "will write to INE(j, ne) but there is allready a value", j, ne, INE(j, ne)
                 endif
                 INE(j, ne) = np + k
                 node%id = np+k
@@ -1109,7 +1109,7 @@ module yowpdlibMain
       endif
     end do
 
-    ! check if INE contains 0. 
+    ! check if INE contains 0.
     do i=1, ne
       if(MINVAL(ABS(INE(:,i))) == 0) then
         write(*,*) "0 in INE ne=", ne
@@ -1180,7 +1180,7 @@ module yowpdlibMain
     implicit none
     integer I1, I2, I3, stat, IE, NI(3)
     real(rkind) :: DXP1, DXP2, DXP3, DYP1, DYP2, DYP3, DBLTMP, TRIA03
-    
+
 
     allocate(PDLIB_SI(npa), PDLIB_CCON(npa), PDLIB_IEN(6,ne), PDLIB_TRIA(ne), stat=stat)
     if(stat/=0) call parallel_abort('SI allocation failure')
@@ -1190,7 +1190,7 @@ module yowpdlibMain
     DO IE = 1 , ne
       I1 = INE(1,IE)
       I2 = INE(2,IE)
-      I3 = INE(3,IE) 
+      I3 = INE(3,IE)
       NI = INE(:,IE)
 
       DXP1=x(I2) - x(I1)
@@ -1424,7 +1424,7 @@ module yowpdlibMain
     implicit none
 
     call finalizeRankModule()
-    call finalizeExchangeModule()   
+    call finalizeExchangeModule()
     call finalizeElementpool()
     call finalizeNodepool()
   end subroutine
@@ -1460,7 +1460,7 @@ module yowpdlibMain
     integer :: i
     type(t_Node), pointer :: node
     type(t_element), pointer :: ele
-    
+
     write(1113+myrank,*) 0
     write(1113+myrank,*) np_global
 
@@ -1474,7 +1474,7 @@ module yowpdlibMain
       ele => elements(i)
       write(1113+myrank,*) ele%node(:)-1 ,0, i
     end do
-    
-    
+
+
   end subroutine
 end module yowpdlibMain

--- a/model/ftn/PDLIB/yowrankModule.ftn
+++ b/model/ftn/PDLIB/yowrankModule.ftn
@@ -248,7 +248,7 @@ module yowRankModule
   subroutine finalizeRankModule()
     implicit none
     integer :: i
-  
+
     if(allocated(rank)) then
       do i=1, size(rank)
         if(allocated(rank(i)%iplg)) deallocate(rank(i)%iplg)

--- a/model/ftn/SCRIP/SCRIP.mk
+++ b/model/ftn/SCRIP/SCRIP.mk
@@ -26,7 +26,7 @@ $(aPo)/scrip_remap_vars.o: SCRIP/scrip_remap_vars.f \
 	$(aPo)/scrip_constants.o \
 	$(aPo)/scrip_grids.o \
 	$(aPo)/scrip_errormod.o \
-	$(aPo)/scrip_iounitsmod.o 
+	$(aPo)/scrip_iounitsmod.o
 	@$(aPb)/ad3 scrip_remap_vars
 
 $(aPo)/scrip_remap_conservative.o: SCRIP/scrip_remap_conservative.f \
@@ -36,7 +36,7 @@ $(aPo)/scrip_remap_conservative.o: SCRIP/scrip_remap_conservative.f \
 	$(aPo)/scrip_remap_vars.o \
 	$(aPo)/scrip_grids.o \
 	$(aPo)/scrip_errormod.o \
-	$(aPo)/scrip_iounitsmod.o 
+	$(aPo)/scrip_iounitsmod.o
 	@$(aPb)/ad3 scrip_remap_conservative
 
 $(aPo)/scrip_timers.o: SCRIP/scrip_timers.f \
@@ -51,6 +51,6 @@ $(aPo)/scrip_interface.o: SCRIP/scrip_interface.ftn \
 	$(aPo)/scrip_grids.o \
 	$(aPo)/scrip_remap_conservative.o \
 	$(aPo)/scrip_iounitsmod.o \
-	$(aPo)/scrip_errormod.o 
+	$(aPo)/scrip_errormod.o
 	@$(aPb)/ad3 scrip_interface
 

--- a/model/ftn/SCRIP/SCRIP_NC.mk
+++ b/model/ftn/SCRIP/SCRIP_NC.mk
@@ -33,7 +33,7 @@ $(aPo)/scrip_remap_vars.o: SCRIP/scrip_remap_vars.f \
 	$(aPo)/scrip_grids.o \
 	$(aPo)/scrip_errormod.o \
 	$(aPo)/scrip_netcdfmod.o \
-	$(aPo)/scrip_iounitsmod.o 
+	$(aPo)/scrip_iounitsmod.o
 	@$(aPb)/ad3 scrip_remap_vars
 
 $(aPo)/scrip_remap_conservative.o: SCRIP/scrip_remap_conservative.f \
@@ -44,7 +44,7 @@ $(aPo)/scrip_remap_conservative.o: SCRIP/scrip_remap_conservative.f \
 	$(aPo)/scrip_grids.o \
 	$(aPo)/scrip_errormod.o \
 	$(aPo)/scrip_netcdfmod.o \
-	$(aPo)/scrip_iounitsmod.o 
+	$(aPo)/scrip_iounitsmod.o
 	@$(aPb)/ad3 scrip_remap_conservative
 
 $(aPo)/scrip_timers.o: SCRIP/scrip_timers.f \
@@ -82,6 +82,6 @@ $(aPo)/scrip_interface.o: SCRIP/scrip_interface.ftn \
 	$(aPo)/scrip_remap_write.o \
 	$(aPo)/scrip_remap_read.o \
 	$(aPo)/scrip_iounitsmod.o \
-	$(aPo)/scrip_errormod.o 
+	$(aPo)/scrip_errormod.o
 	@$(aPb)/ad3 scrip_interface
 

--- a/model/ftn/SCRIP/scrip_constants.f
+++ b/model/ftn/SCRIP/scrip_constants.f
@@ -6,12 +6,12 @@
 !
 !     CVS:$Id: constants.f,v 1.2 2000/04/19 21:56:25 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -26,10 +26,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3.
 !
@@ -47,7 +47,7 @@
 
 !-----------------------------------------------------------------------
 
-      real (kind = SCRIP_r8), parameter :: 
+      real (kind = SCRIP_r8), parameter ::
      &                        zero   = 0.0_SCRIP_r8,
      &                        one    = 1.0_SCRIP_r8,
      &                        two    = 2.0_SCRIP_r8,

--- a/model/ftn/SCRIP/scrip_grids.f
+++ b/model/ftn/SCRIP/scrip_grids.f
@@ -9,12 +9,12 @@
 !
 !     CVS:$Id: grids.f,v 1.6 2001/08/21 21:06:41 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -29,10 +29,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     this grids.f has been modified from the version available from 
+!     this grids.f has been modified from the version available from
 !     Los Alamos National Laboratory.
 !     modifications are marked with "NRL"
 !     list of modifications:
@@ -40,8 +40,8 @@
 !           (major change)
 !     - print statements added
 !     - allocations removed (moved to scrip_wrapper subroutine)
-!     - imask removed (this was an intermediate step from ncdf to 
-!           the logicals grid1_mask grid2_mask; creation of these 
+!     - imask removed (this was an intermediate step from ncdf to
+!           the logicals grid1_mask grid2_mask; creation of these
 !           logicals is now handled by scrip_wrapper)
 !
 !***********************************************************************
@@ -74,10 +74,10 @@
       integer (SCRIP_i4), dimension(:), allocatable, save ::
      &             grid1_dims, grid2_dims  ! size of each grid dimension
 
-      character(SCRIP_charLength), save :: 
+      character(SCRIP_charLength), save ::
      &             grid1_name, grid2_name  ! name for each grid
 
-      character (SCRIP_charLength), save :: 
+      character (SCRIP_charLength), save ::
      &             grid1_units, ! units for grid coords (degs/radians)
      &             grid2_units  ! units for grid coords
 
@@ -99,7 +99,7 @@
       real (SCRIP_r8), dimension(:), allocatable, target, save ::
      &             grid1_center_lat,  ! lat/lon coordinates for
      &             grid1_center_lon,  ! each grid center in radians
-     &             grid2_center_lat, 
+     &             grid2_center_lat,
      &             grid2_center_lon,
      &             grid1_area,        ! tot area of each grid1 cell
      &             grid2_area,        ! tot area of each grid2 cell
@@ -116,7 +116,7 @@
       real (SCRIP_r8), dimension(:,:), allocatable, target, save ::
      &             grid1_corner_lat,  ! lat/lon coordinates for
      &             grid1_corner_lon,  ! each grid corner in radians
-     &             grid2_corner_lat, 
+     &             grid2_corner_lat,
      &             grid2_corner_lon
 
       logical (SCRIP_logical), save ::
@@ -128,13 +128,13 @@
      &             grid1_bound_box,  ! lat/lon bounding box for use
      &             grid2_bound_box   ! in restricting grid searches
 
-      integer (SCRIP_i4), save ::    ! Cells overlapping the poles 
+      integer (SCRIP_i4), save ::    ! Cells overlapping the poles
                                      ! (may be 0)
-     &     grid1_npole_cell,        
-     &     grid1_spole_cell,         
+     &     grid1_npole_cell,
+     &     grid1_spole_cell,
      &     grid2_npole_cell,
      &     grid2_spole_cell
-      
+
 
 !-----------------------------------------------------------------------
 !
@@ -162,7 +162,7 @@
 !
 !-----------------------------------------------------------------------
 
-      real (SCRIP_r8), save :: 
+      real (SCRIP_r8), save ::
      &     north_thresh,  ! threshold for coord transf.
      &     south_thresh   ! threshold for coord transf.
 
@@ -172,7 +172,7 @@
       !*** degeneracies in intersection
 
       integer (SCRIP_i4), save ::
-     &     npseg                    
+     &     npseg
 
 !***********************************************************************
 
@@ -215,7 +215,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4) :: 
+      integer (SCRIP_i4) ::
      &  n,      ! loop counter
      &  nele,   ! element loop counter
      &  i,j,
@@ -227,17 +227,17 @@
      &     zero_crossing, pi_crossing,
      &     grid1_add, grid2_add,
      &     corner, next_corn
-     
+
       real (SCRIP_r8) ::
      &     beglon, beglat, endlon, endlat
 
       logical (SCRIP_logical) ::
      &     found
 
-!NRL      integer (SCRIP_i4), dimension(:), allocatable :: 
+!NRL      integer (SCRIP_i4), dimension(:), allocatable ::
 !NRL     &                            imask ! integer mask read from file
 
-      real (SCRIP_r8) :: 
+      real (SCRIP_r8) ::
      &  dlat,dlon           ! lat/lon intervals for search bins
 
       real (SCRIP_r8), dimension(4) ::
@@ -258,14 +258,14 @@
 !
 !-----------------------------------------------------------------------
 
-      allocate( 
+      allocate(
 !NRL &          grid1_mask      (grid1_size),
 !NRL &          grid2_mask      (grid2_size),
      &          special_polar_cell1(grid1_size),
      &          special_polar_cell2(grid2_size),
-!NRL &          grid1_center_lat(grid1_size), 
+!NRL &          grid1_center_lat(grid1_size),
 !NRL &          grid1_center_lon(grid1_size),
-!NRL &          grid2_center_lat(grid2_size), 
+!NRL &          grid2_center_lat(grid2_size),
 !NRL &          grid2_center_lon(grid2_size),
      &          grid1_area      (grid1_size),
      &          grid1_area_in   (grid1_size),
@@ -429,7 +429,7 @@
 !-----------------------------------------------------------------------
 !
 !     make sure input latitude range is within the machine values
-!     for +/- pi/2 
+!     for +/- pi/2
 !
 !-----------------------------------------------------------------------
 
@@ -453,7 +453,7 @@
 !     problems
 !
 !-----------------------------------------------------------------------
-      
+
       where (abs(grid1_corner_lat-pih) < 1.e-03) grid1_corner_lat =  pih
       where (abs(grid1_corner_lat+pih) < 1.e-03) grid1_corner_lat = -pih
       where (abs(grid2_corner_lat-pih) < 1.e-03) grid2_corner_lat =  pih
@@ -496,7 +496,7 @@
             ip1 = 1
             !*** but if it is not, correct
             e_add = (j - 1)*nx + ip1
-            if (abs(grid1_center_lat(e_add) - 
+            if (abs(grid1_center_lat(e_add) -
      &              grid1_center_lat(n   )) > pih) then
               ip1 = i
             endif
@@ -509,7 +509,7 @@
             jp1 = 1
             !*** but if it is not, correct
             n_add = (jp1 - 1)*nx + i
-            if (abs(grid1_center_lat(n_add) - 
+            if (abs(grid1_center_lat(n_add) -
      &              grid1_center_lat(n   )) > pih) then
               jp1 = j
             endif
@@ -554,7 +554,7 @@
             ip1 = 1
             !*** but if it is not, correct
             e_add = (j - 1)*nx + ip1
-            if (abs(grid2_center_lat(e_add) - 
+            if (abs(grid2_center_lat(e_add) -
      &              grid2_center_lat(n   )) > pih) then
               ip1 = i
             endif
@@ -567,7 +567,7 @@
             jp1 = 1
             !*** but if it is not, correct
             n_add = (jp1 - 1)*nx + i
-            if (abs(grid2_center_lat(n_add) - 
+            if (abs(grid2_center_lat(n_add) -
      &              grid2_center_lat(n   )) > pih) then
               jp1 = j
             endif
@@ -627,14 +627,14 @@
 
       grid1_npole_cell = 0
       grid1_spole_cell = 0
-         
+
       do grid1_add = 1, grid1_size
 
          found = .false.
          do corner = 1, grid1_corners
             endlat = grid1_corner_lat(corner,grid1_add)
             if (abs(abs(endlat)-pih) .lt. 1e-5) then
-               found = .true.   ! cell has polar pnt; so pole is 
+               found = .true.   ! cell has polar pnt; so pole is
                                 ! not in the interior of the cell
                exit
             endif
@@ -662,7 +662,7 @@
 
             beglon = endlon
          enddo
-         
+
          if (zero_crossing .eq. 1 .and. pi_crossing .eq. 1) then
 
             !***
@@ -695,7 +695,7 @@
          do corner = 1, grid2_corners
             endlat = grid2_corner_lat(corner,grid2_add)
             if (abs(abs(endlat)-pih) .lt. 1e-5) then
-               found = .true.   ! cell has polar pnt; so pole is 
+               found = .true.   ! cell has polar pnt; so pole is
                                 ! not in the interior of the cell
                exit
             endif
@@ -710,7 +710,7 @@
          do corner = 1, grid2_corners
             next_corn = mod(corner,grid2_corners) + 1
             endlon = grid2_corner_lon(next_corn,grid2_add)
-            
+
             if (abs(beglon-endlon) > pi) then
                zero_crossing = 1
             else
@@ -722,7 +722,7 @@
 
             beglon = endlon
          enddo
-         
+
          if (zero_crossing .eq. 1 .and. pi_crossing .eq. 1) then
 
             !***
@@ -751,13 +751,13 @@
          ncorners_at_pole = 0
          do i = 1, grid1_corners
             beglat = grid1_corner_lat(i,grid1_add)
-            if (abs(abs(beglat)-pih) .le. 1.e-5) 
+            if (abs(abs(beglat)-pih) .le. 1.e-5)
      &           ncorners_at_pole = ncorners_at_pole + 1
          enddo
 
-         if (ncorners_at_pole .eq. 1) 
+         if (ncorners_at_pole .eq. 1)
      &        special_polar_cell1(grid1_add) = .true.
-            
+
       enddo
 
       special_polar_cell2 = .false.
@@ -766,13 +766,13 @@
          ncorners_at_pole = 0
          do i = 1, grid2_corners
             beglat = grid2_corner_lat(i,grid2_add)
-            if (abs(abs(beglat)-pih) .le. 1.e-5) 
+            if (abs(abs(beglat)-pih) .le. 1.e-5)
      &              ncorners_at_pole = ncorners_at_pole + 1
          enddo
 
-         if (ncorners_at_pole .eq. 1) 
+         if (ncorners_at_pole .eq. 1)
      &        special_polar_cell2(grid2_add) = .true.
-            
+
       enddo
 
       if(l_master)print *, ' '
@@ -790,21 +790,21 @@
 !     if(l_master)print *, 'grid1_spole_cell',grid1_spole_cell
       if (grid1_spole_cell .gt. 0) then
          do i = 1, grid1_corners
-            print *, grid1_corner_lat(i,grid1_spole_cell), 
+            print *, grid1_corner_lat(i,grid1_spole_cell),
      &           grid1_corner_lon(i,grid1_spole_cell)
          enddo
       endif
 !     if(l_master)print *, 'grid2_npole_cell',grid2_npole_cell
       if (grid2_npole_cell .gt. 0) then
          do i = 1, grid2_corners
-            print *, grid2_corner_lat(i,grid2_npole_cell), 
+            print *, grid2_corner_lat(i,grid2_npole_cell),
      &           grid2_corner_lon(i,grid2_npole_cell)
          enddo
       endif
 !     if(l_master)print *, 'grid2_spole_cell',grid2_spole_cell
       if (grid2_spole_cell .gt. 0) then
          do i = 1, grid2_corners
-            print *, grid2_corner_lat(i,grid2_spole_cell), 
+            print *, grid2_corner_lat(i,grid2_spole_cell),
      &           grid2_corner_lon(i,grid2_spole_cell)
          enddo
       endif
@@ -813,7 +813,7 @@
 
 !-----------------------------------------------------------------------
 !
-!     set up and assign address ranges to search bins in order to 
+!     set up and assign address ranges to search bins in order to
 !     further restrict later searches
 !
 !-----------------------------------------------------------------------
@@ -930,7 +930,7 @@
          call SCRIP_GridComputeArea(grid1_area_in, grid1_corner_lat,
      &                              grid1_corner_lon, errorCode)
 
-         if (SCRIP_ErrorCheck(errorCode, rtnName, 
+         if (SCRIP_ErrorCheck(errorCode, rtnName,
      &                        'error computing grid1 area')) return
       endif
 
@@ -938,7 +938,7 @@
          call SCRIP_GridComputeArea(grid2_area_in, grid2_corner_lat,
      &                              grid2_corner_lon, errorCode)
 
-         if (SCRIP_ErrorCheck(errorCode, rtnName, 
+         if (SCRIP_ErrorCheck(errorCode, rtnName,
      &                        'error computing grid2 area')) return
       endif
 
@@ -993,7 +993,7 @@
 
       real (SCRIP_r8) ::
      &   dphi                ! delta(longitude) for this segment
-     
+
 !-----------------------------------------------------------------------
 !
 !  determine size of grid and initialize
@@ -1019,7 +1019,7 @@
             nextCorner = mod(nCorner,numCorners) + 1
 
             !*** trapezoid rule - delta(Lon) is -0.5*dx
-            dphi = CornerLon(   nCorner,nCell) - 
+            dphi = CornerLon(   nCorner,nCell) -
      &             CornerLon(nextCorner,nCell)
             if (dphi > pi) then
                dphi = dphi - pi2
@@ -1028,7 +1028,7 @@
             endif
             dphi = 0.5_SCRIP_r8*dphi
 
-            Area(nCell) = Area(nCell) + 
+            Area(nCell) = Area(nCell) +
      &                    dphi*(sin(CornerLat(   nCorner,nCell)) +
      &                          sin(CornerLat(nextCorner,nCell)))
          end do

--- a/model/ftn/SCRIP/scrip_interface.ftn
+++ b/model/ftn/SCRIP/scrip_interface.ftn
@@ -30,23 +30,23 @@
 !         When WW3 is working on WMGHGH, each MPI task performs identical computations
 !         and therefore creates its own copy of the an identical solution. Thus there
 !         is no MPI parallelization of WMGHGH. Presumably, this was designed with the
-!         expectation that WMGHGH computations are fairly quick. Unfortunately, SCRIP 
-!         can be slow for large grids, making WMGHGH slow. It is possible to run SCRIP 
-!         with OpenMP (with pgf90, it simply requires that we compile with the -mp flag). 
-!         Unfortunately, this doesn't change the situation whereby each MPI task calls 
-!         SCRIP and creates its own copy of an identical solution. Thus, if we want 
-!         to use OpenMP to speed up SCRIP, it means that we have to leave some cores idle 
-!         during the actual WW3 compuation. Example: using pgf90, we execute ww3_multi 
-!         with mpirun -n 4. Thus, four MPI tasks are created. And say we compiled SCRIP 
-!         using -mp and have nthreads=2 specified in scrip_interface.f. When multi gets 
-!         to SCRIP, each MPI task will create 2 OpenMP threads, which means that we'd 
-!         better have 8 threads available to do this, and also note that 4 threads will 
-!         be idle after SCRIP is finished. This isn't an ideal solution. A better 
-!         prior to the SCRIP call, is instructed to only compute using one MPI thread. 
+!         expectation that WMGHGH computations are fairly quick. Unfortunately, SCRIP
+!         can be slow for large grids, making WMGHGH slow. It is possible to run SCRIP
+!         with OpenMP (with pgf90, it simply requires that we compile with the -mp flag).
+!         Unfortunately, this doesn't change the situation whereby each MPI task calls
+!         SCRIP and creates its own copy of an identical solution. Thus, if we want
+!         to use OpenMP to speed up SCRIP, it means that we have to leave some cores idle
+!         during the actual WW3 compuation. Example: using pgf90, we execute ww3_multi
+!         with mpirun -n 4. Thus, four MPI tasks are created. And say we compiled SCRIP
+!         using -mp and have nthreads=2 specified in scrip_interface.f. When multi gets
+!         to SCRIP, each MPI task will create 2 OpenMP threads, which means that we'd
+!         better have 8 threads available to do this, and also note that 4 threads will
+!         be idle after SCRIP is finished. This isn't an ideal solution. A better
+!         prior to the SCRIP call, is instructed to only compute using one MPI thread.
 !         Then, SCRIP does its thing using OpenMPI and returns to WMGHGH. Then, WMGHGH
 !         shares all the information with all the nodes and continues.
-!      On connection to WW3: 
-!         This is handled by "scrip_wrapper" routines. These routines formerly resided 
+!      On connection to WW3:
+!         This is handled by "scrip_wrapper" routines. These routines formerly resided
 !         in this file (scrip_interface.f*) but are now in wmscrpmd.ftn
 !
 ! 10. Switches :
@@ -55,7 +55,7 @@
 
       use SCRIP_KindsMod    ! defines data types
 
-!.....notes: since the calling subroutine (wmghgh) does not know a priori the size 
+!.....notes: since the calling subroutine (wmghgh) does not know a priori the size
 !............of the weights arrays, we manage the communication via this module.
       implicit none
 
@@ -95,24 +95,24 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     "Clear" all variables declared at module level of SCRIP routines
 !     (clear "common block" equivalent)
 !
 !  6. Method :
 !
-!     rules: 
+!     rules:
 !        - if not an array (scalar), set to zero or other start value
 !        - if dimensioned array, set to zero
 !        - if allocatable array, deallocate
-!        - private variables: ignore, since we would need to 
+!        - private variables: ignore, since we would need to
 !             make them public in order to clear them, which may do more
 !             harm than good.
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine SCRIP_interface
 !
@@ -120,11 +120,11 @@
 !
 !     None
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
-!     We "clear" all variables with "save" attribute, 
+!     We "clear" all variables with "save" attribute,
 !     both "module variables" and "subroutine variables"
 !     including all variables that are initialized with a value
 !     in the type declaration, e.g. "real :: x=5.0"
@@ -151,9 +151,9 @@
       num_links_map1=0
       max_links_map2=0
       num_links_map2=0
-      num_maps=0 
-      num_wts=0   
-      map_type=0  
+      num_maps=0
+      num_wts=0
+      map_type=0
       norm_opt=0
       resize_increment=0
       if(allocated(grid1_add_map1))deallocate(grid1_add_map1)
@@ -164,7 +164,7 @@
       if(allocated(wts_map2))deallocate(wts_map2)
 
 !.....remap_conserv.f :
-!.....scalars: 
+!.....scalars:
       first_call_store_link_cnsrv = .true.
       first_call_locate_segstart= .true.
       first_call_locate_point= .true.
@@ -273,19 +273,19 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
 !     subroutine scrip:
-!     This routine is the driver for computing the addresses and weights 
+!     This routine is the driver for computing the addresses and weights
 !     for interpolating between two grids on a sphere.
 !
 !-----------------------------------------------------------------------
 !
 !     CVS:$Id: scrip.f,v 1.6 2001/08/21 21:06:44 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -300,10 +300,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3. Here is a list of modifications:
 !     - changed from standalone program to a subroutine, to be called
@@ -319,7 +319,7 @@
 !     - in context of scrip_wrapper, these initial values for the settings
 !          are never changed. Thus, these settings are basically hardwired
 !          in here.
-!     - lines associated with remap_distance_weight, remap_bilinear, 
+!     - lines associated with remap_distance_weight, remap_bilinear,
 !          remap_bicubic are removed. Motivation: we do not need these
 !          routines, so we opt to exclude them in our compile
 !          (fewer .f files, fewer compiles).
@@ -434,14 +434,14 @@
       normalize_opt = 'fracarea'
       output_opt = 'scrip'
       restrict_type = 'latitude'
-      num_srch_bins = 90 
+      num_srch_bins = 90
       luse_grid1_area = .false.
       luse_grid2_area = .false.
       npseg=11 ! or num_polar_segs
       north_thresh=1.5_SCRIP_r8 ! or npole_threshold
       south_thresh=-1.5_SCRIP_r8 ! or spole_threshold
       nthreads=2 ! or num_threads
-     
+
       select case(map_method)
       case ('conservative')
          map_type = map_type_conserv
@@ -506,7 +506,7 @@
 
 !/T38      call date_and_time (CDATE_TIME(1), CDATE_TIME(2), CDATE_TIME(3), DATE_TIME)
 !/T38      beg_time = ((date_time(5)*60 + date_time(6))*60 +date_time(7))*1000 + date_time(8)
-      
+
 !/SCRIPNC      if (l_read) then
 !/SCRIPNC         if(l_master)write(SCRIP_stdout, *) 'Reading remapping data from ', interp_file1
 !/SCRIPNC         call read_remap_ww3(map1_name, interp_file1, errorCode)
@@ -534,7 +534,7 @@
 !     reduce size of remapping arrays
 !
 !-----------------------------------------------------------------------
-      
+
 !/T38         call date_and_time (CDATE_TIME(1), CDATE_TIME(2), CDATE_TIME(3), DATE_TIME)
 !/T38         beg_time = ((date_time(5)*60 + date_time(6))*60 +date_time(7))*1000 + date_time(8)
 
@@ -585,7 +585,7 @@
    subroutine SCRIP_driverExit(errorCode,errormsg)
 
 ! !DESCRIPTION:
-!  This routine exits the SCRIP driver program. It first calls the 
+!  This routine exits the SCRIP driver program. It first calls the
 !  SCRIP error print function to print any errors encountered and then
 !  exits the message environment before stopping.
 !
@@ -629,7 +629,7 @@
 !     scrip_interface.ftn and converted to f90 format (line continuations)
 !
 !-----------------------------------------------------------------------
-     
+
      implicit none
 
 !-----------------------------------------------------------------------
@@ -637,7 +637,7 @@
 !     Input and Output arrays
 !
 !-----------------------------------------------------------------------
-     
+
      integer (SCRIP_i4), intent(inout), dimension(:) :: &
           add1,  &    ! destination address array (num_links)
           add2        ! source      address array
@@ -650,7 +650,7 @@
 !     local variables
 !
 !-----------------------------------------------------------------------
-     
+
      integer (SCRIP_i4) ::   &
           num_links,         & ! num of links for this mapping
           num_wts,           & ! num of weights for this mapping
@@ -666,17 +666,17 @@
 !     determine total number of links to sort and number of weights
 !
 !-----------------------------------------------------------------------
-     
+
      num_links = SIZE(add1)
      num_wts   = SIZE(weights, DIM=1)
 
 !-----------------------------------------------------------------------
 !
-!     start at the lowest level (N/2) of the tree and sift lower 
+!     start at the lowest level (N/2) of the tree and sift lower
 !     values to the bottom of the tree, promoting the larger numbers
 !
 !-----------------------------------------------------------------------
-     
+
      do lvl=num_links/2,1,-1
 
         final_lvl = lvl
@@ -703,7 +703,7 @@
                 ((add1(chk_lvl1) == add1(chk_lvl2)) .AND. &
                 (add2(chk_lvl1) >  add2(chk_lvl2)))) then
               max_lvl = chk_lvl1
-           else 
+           else
               max_lvl = chk_lvl2
            endif
 
@@ -727,7 +727,7 @@
               !*** store last values and exit the loop
               !***
 
-           else 
+           else
               add1(final_lvl) = add1(max_lvl)
               add2(final_lvl) = add2(max_lvl)
               weights(:,final_lvl) = weights(:,max_lvl)
@@ -749,7 +749,7 @@
 !     value and promote the values below
 !
 !-----------------------------------------------------------------------
-     
+
      do lvl=num_links,3,-1
 
         !***
@@ -766,7 +766,7 @@
         weights(:,lvl) = weights(:,1)
 
         !***
-        !*** as above this loop sifts the tmp values down until proper 
+        !*** as above this loop sifts the tmp values down until proper
         !*** level is reached
         !***
 
@@ -786,7 +786,7 @@
                 ((add1(chk_lvl1) == add1(chk_lvl2)) .AND. &
                 (add2(chk_lvl1) >  add2(chk_lvl2)))) then
               max_lvl = chk_lvl1
-           else 
+           else
               max_lvl = chk_lvl2
            endif
 
@@ -810,7 +810,7 @@
               !*** store last values and exit the loop
               !***
 
-           else 
+           else
               add1(final_lvl) = add1(max_lvl)
               add2(final_lvl) = add2(max_lvl)
               weights(:,final_lvl) = weights(:,max_lvl)

--- a/model/ftn/SCRIP/scrip_remap_read.f
+++ b/model/ftn/SCRIP/scrip_remap_read.f
@@ -8,12 +8,12 @@
 !
 !     CVS:$Id: remap_read.f,v 1.6 2000/04/19 21:56:26 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -28,16 +28,16 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3.
 !
 !***********************************************************************
 
-      module scrip_remap_read 
+      module scrip_remap_read
 
 !-----------------------------------------------------------------------
 !
@@ -63,7 +63,7 @@
 !-----------------------------------------------------------------------
 
 
-      character(SCRIP_charLength), private :: 
+      character(SCRIP_charLength), private ::
      &   map_method       ! character string for map_type
      &,  normalize_opt    ! character string for normalization option
      &,  convention       ! character string for output convention
@@ -144,10 +144,10 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4) ::  
+      integer (SCRIP_i4) ::
      &  errorCode            ! error code for SCRIP routine
 
-      character (14), parameter :: 
+      character (14), parameter ::
      &  rtnName = 'read_remap_ww3'
 
 !-----------------------------------------------------------------------
@@ -267,7 +267,7 @@
      &  grid1_name           ! grid name for source grid
      &, grid2_name           ! grid name for dest   grid
 
-      integer (SCRIP_i4) ::  
+      integer (SCRIP_i4) ::
      &  n                    ! dummy index
      &, errorCode            ! error code for SCRIP routine
 
@@ -275,7 +275,7 @@
      &  grid1_mask_int,      ! integer masks to determine
      &  grid2_mask_int       ! cells that participate in map
 
-      character (20), parameter :: 
+      character (20), parameter ::
      &  rtnName = 'read_remap_scrip_ww3'
 
 !-----------------------------------------------------------------------
@@ -293,7 +293,7 @@
       errorCode = SCRIP_Success
       ncstat = nf90_get_att (nc_file_id, NF90_GLOBAL, 'source_grid',
      &                          grid1_name)
-      if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error 
+      if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading source grid name')) return
 
       ncstat = nf90_get_att (nc_file_id, NF90_GLOBAL, 'dest_grid',
@@ -313,34 +313,34 @@
 !
 !-----------------------------------------------------------------------
 
-      ncstat = nf90_inq_dimid(nc_file_id, 'dst_grid_size', 
+      ncstat = nf90_inq_dimid(nc_file_id, 'dst_grid_size',
      &                      nc_dstgrdsize_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid id')) return
 !     ncstat = nf90_inq_dimlen(nc_file_id, nc_dstgrdsize_id, grid2_size)
-      ncstat = nf90_inquire_dimension(nc_file_id, nc_dstgrdsize_id, 
+      ncstat = nf90_inquire_dimension(nc_file_id, nc_dstgrdsize_id,
      &                                len = grid2_size)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid size')) return
 
-      ncstat = nf90_inq_dimid(nc_file_id, 'num_links', 
+      ncstat = nf90_inq_dimid(nc_file_id, 'num_links',
      &                      nc_numlinks_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading number of links id')) return
-!     ncstat = nf90_inq_dimlen(nc_file_id, nc_numlinks_id, 
+!     ncstat = nf90_inq_dimlen(nc_file_id, nc_numlinks_id,
 !    &                       num_links_map1)
-      ncstat = nf90_inquire_dimension(nc_file_id, nc_numlinks_id, 
+      ncstat = nf90_inquire_dimension(nc_file_id, nc_numlinks_id,
      &                                len = num_links_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading number of links')) return
       max_links_map1 = num_links_map1
 
-      ncstat = nf90_inq_dimid(nc_file_id, 'num_wgts', 
+      ncstat = nf90_inq_dimid(nc_file_id, 'num_wgts',
      &                      nc_numwgts_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading number of weights id')) return
 !     ncstat = nf90_inq_dimlen(nc_file_id, nc_numwgts_id, num_wts)
-      ncstat = nf90_inquire_dimension(nc_file_id, nc_numwgts_id, 
+      ncstat = nf90_inquire_dimension(nc_file_id, nc_numwgts_id,
      &                                len = num_wts)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading number of weights')) return
@@ -369,22 +369,22 @@
 !
 !-----------------------------------------------------------------------
 
-      ncstat = nf90_inq_varid(nc_file_id, 'dst_grid_frac', 
+      ncstat = nf90_inq_varid(nc_file_id, 'dst_grid_frac',
      &                                   nc_dstgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid fraction id')) return
 
-      ncstat = nf90_inq_varid(nc_file_id, 'src_address', 
+      ncstat = nf90_inq_varid(nc_file_id, 'src_address',
      &                                   nc_srcgrdadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading source grid address id')) return
 
-      ncstat = nf90_inq_varid(nc_file_id, 'dst_address', 
+      ncstat = nf90_inq_varid(nc_file_id, 'dst_address',
      &                                   nc_dstgrdadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid address id')) return
 
-      ncstat = nf90_inq_varid(nc_file_id, 'remap_matrix', 
+      ncstat = nf90_inq_varid(nc_file_id, 'remap_matrix',
      &                                   nc_rmpmatrix_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading remap matrix id')) return
@@ -395,22 +395,22 @@
 !
 !-----------------------------------------------------------------------
 
-      ncstat = nf90_get_var(nc_file_id, nc_dstgrdfrac_id, 
+      ncstat = nf90_get_var(nc_file_id, nc_dstgrdfrac_id,
      &                                       grid2_frac)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid fraction')) return
 
-      ncstat = nf90_get_var(nc_file_id, nc_srcgrdadd_id, 
+      ncstat = nf90_get_var(nc_file_id, nc_srcgrdadd_id,
      &                        grid1_add_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading source grid address')) return
 
-      ncstat = nf90_get_var(nc_file_id, nc_dstgrdadd_id, 
+      ncstat = nf90_get_var(nc_file_id, nc_dstgrdadd_id,
      &                        grid2_add_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading destination grid address')) return
 
-      ncstat = nf90_get_var(nc_file_id, nc_rmpmatrix_id, 
+      ncstat = nf90_get_var(nc_file_id, nc_rmpmatrix_id,
      &                                       wts_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName, 'error
      &   reading remap weights')) return

--- a/model/ftn/SCRIP/scrip_remap_vars.f
+++ b/model/ftn/SCRIP/scrip_remap_vars.f
@@ -8,12 +8,12 @@
 !
 !     CVS:$Id: remap_vars.f,v 1.5 2000/04/19 21:56:26 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -28,10 +28,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3.
 !
@@ -63,7 +63,7 @@
      &,     map_type_distwgt  = 4
      &,     map_type_particle = 5
 
-      integer (SCRIP_i4), save :: 
+      integer (SCRIP_i4), save ::
      &      max_links_map1  ! current size of link arrays
      &,     num_links_map1  ! actual number of links for remapping
      &,     max_links_map2  ! current size of link arrays
@@ -98,7 +98,7 @@
 !-----------------------------------------------------------------------
 !
 !     this routine initializes some variables and provides an initial
-!     allocation of arrays (fairly large so frequent resizing 
+!     allocation of arrays (fairly large so frequent resizing
 !     unnecessary).
 !
 !-----------------------------------------------------------------------
@@ -124,11 +124,11 @@
 
 !-----------------------------------------------------------------------
 !
-!     initialize num_links and set max_links to four times the largest 
+!     initialize num_links and set max_links to four times the largest
 !     of the destination grid sizes initially (can be changed later).
 !     set a default resize increment to increase the size of link
 !     arrays if the number of links exceeds the initial size
-!   
+!
 !-----------------------------------------------------------------------
 
       num_links_map1 = 0
@@ -144,7 +144,7 @@
 !-----------------------------------------------------------------------
 !
 !     allocate address and weight arrays for mapping 1
-!   
+!
 !-----------------------------------------------------------------------
 
       allocate (grid1_add_map1(max_links_map1),
@@ -153,8 +153,8 @@
 
 !-----------------------------------------------------------------------
 !
-!     allocate address and weight arrays for mapping 2 if necessary 
-!   
+!     allocate address and weight arrays for mapping 2 if necessary
+!
 !-----------------------------------------------------------------------
 
       if (num_maps > 1) then
@@ -219,13 +219,13 @@
         !***
 
         mxlinks = size(grid1_add_map1)
-        allocate (add1_tmp(mxlinks), add2_tmp(mxlinks), 
+        allocate (add1_tmp(mxlinks), add2_tmp(mxlinks),
      &            wts_tmp(num_wts,mxlinks))
 
         add1_tmp = grid1_add_map1
         add2_tmp = grid2_add_map1
         wts_tmp  = wts_map1
-        
+
         !***
         !*** deallocate originals and increment max_links then
         !*** reallocate arrays at new size
@@ -261,7 +261,7 @@
         !***
 
         mxlinks = size(grid1_add_map2)
-        allocate (add1_tmp(mxlinks), add2_tmp(mxlinks), 
+        allocate (add1_tmp(mxlinks), add2_tmp(mxlinks),
      &            wts_tmp(num_wts,mxlinks),stat=ierr)
         if (ierr .ne. 0) then
           print *,'error allocating temps in resize: ',ierr
@@ -271,7 +271,7 @@
         add1_tmp = grid1_add_map2
         add2_tmp = grid2_add_map2
         wts_tmp  = wts_map2
-        
+
         !***
         !*** deallocate originals and increment max_links then
         !*** reallocate arrays at new size

--- a/model/ftn/SCRIP/scrip_remap_write.f
+++ b/model/ftn/SCRIP/scrip_remap_write.f
@@ -1,19 +1,19 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !
-!     This module contains routines for writing the remapping data to 
-!     a file.  Before writing the data for each mapping, the links are 
+!     This module contains routines for writing the remapping data to
+!     a file.  Before writing the data for each mapping, the links are
 !     sorted by destination grid address.
 !
 !-----------------------------------------------------------------------
 !
 !     CVS:$Id: remap_write.f,v 1.7 2001/08/21 21:06:42 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -28,10 +28,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3.
 !
@@ -58,13 +58,13 @@
 !
 !-----------------------------------------------------------------------
 
-      character(SCRIP_charLength), private :: 
+      character(SCRIP_charLength), private ::
      &   map_method       ! character string for map_type
      &,  normalize_opt    ! character string for normalization option
      &,  history          ! character string for history information
      &,  convention       ! character string for output convention
 
-      character(8), private :: 
+      character(8), private ::
      &   cdate            ! character date string
 
       integer (SCRIP_i4), dimension(:), allocatable, private ::
@@ -78,7 +78,7 @@
 !-----------------------------------------------------------------------
 
       integer (SCRIP_i4), private ::
-     &   ncstat               ! error flag for netCDF calls 
+     &   ncstat               ! error flag for netCDF calls
      &,  nc_file_id           ! id for netCDF file
      &,  nc_srcgrdsize_id     ! id for source grid size
      &,  nc_dstgrdsize_id     ! id for destination grid size
@@ -117,7 +117,7 @@
 
 !***********************************************************************
 
-      subroutine write_remap(map1_name, map2_name, interp_file1, 
+      subroutine write_remap(map1_name, map2_name, interp_file1,
      &                    interp_file2, output_opt, l_master, errorCode)
 
 !-----------------------------------------------------------------------
@@ -218,7 +218,7 @@
 
       select case(output_opt)
       case ('scrip')
-         if (l_master)  
+         if (l_master)
      &   call write_remap_scrip(map1_name, interp_file1, 1, errorCode)
          if (SCRIP_ErrorCheck(errorCode, rtnName,
      &       'error in write_remap_scrip')) return
@@ -227,7 +227,7 @@
          if (SCRIP_ErrorCheck(errorCode, rtnName,
      &       'error in write_remap_csm')) return
       case default
-         call SCRIP_ErrorSet(errorCode, rtnName, 
+         call SCRIP_ErrorSet(errorCode, rtnName,
      &                       'unknown output file convention')
          return
       end select
@@ -241,7 +241,7 @@
       if (num_maps > 1) then
         select case(output_opt)
         case ('scrip')
-          if (l_master)  
+          if (l_master)
      &    call write_remap_scrip(map2_name, interp_file2, 2, errorCode)
           if (SCRIP_ErrorCheck(errorCode, rtnName,
      &        'error in write_remap_scrip')) return
@@ -278,7 +278,7 @@
 !-----------------------------------------------------------------------
 
       character(SCRIP_charLength), intent(in) ::
-     &            map_name     ! name for mapping 
+     &            map_name     ! name for mapping
      &,           interp_file  ! filename for remap data
 
       integer (SCRIP_i4), intent(in) ::
@@ -404,12 +404,12 @@
         itmp2 = grid1_size
       endif
 
-      ncstat = nf90_def_dim(nc_file_id, 'src_grid_size', itmp1, 
+      ncstat = nf90_def_dim(nc_file_id, 'src_grid_size', itmp1,
      &                      nc_srcgrdsize_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                 'error defining source grid size')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_size', itmp2, 
+      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_size', itmp2,
      &                      nc_dstgrdsize_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &            'error defining destination grid size')) return
@@ -426,12 +426,12 @@
         itmp2 = grid1_corners
       endif
 
-      ncstat = nf90_def_dim(nc_file_id, 'src_grid_corners', 
+      ncstat = nf90_def_dim(nc_file_id, 'src_grid_corners',
      &                      itmp1, nc_srcgrdcorn_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining num corners on source grid')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_corners', 
+      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_corners',
      &                      itmp2, nc_dstgrdcorn_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &     'error defining num corners on destination grid')) return
@@ -448,12 +448,12 @@
         itmp2 = grid1_rank
       endif
 
-      ncstat = nf90_def_dim(nc_file_id, 'src_grid_rank', 
+      ncstat = nf90_def_dim(nc_file_id, 'src_grid_rank',
      &                      itmp1, nc_srcgrdrank_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                    'error defining source grid rank')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_rank', 
+      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_rank',
      &                      itmp2, nc_dstgrdrank_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &               'error defining destination grid rank')) return
@@ -468,12 +468,12 @@
         itmp1 = num_links_map2
       endif
 
-      ncstat = nf90_def_dim(nc_file_id, 'num_links', 
+      ncstat = nf90_def_dim(nc_file_id, 'num_links',
      &                      itmp1, nc_numlinks_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                           'error defining remap size')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'num_wgts', 
+      ncstat = nf90_def_dim(nc_file_id, 'num_wgts',
      &                      num_wts, nc_numwgts_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                    'error defining number of weights')) return
@@ -502,14 +502,14 @@
       !*** define grid center latitude array
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_center_lat', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_center_lat',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdcntrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid center lat')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_center_lat', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_center_lat',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdcntrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid center lat')) return
@@ -518,14 +518,14 @@
       !*** define grid center longitude array
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_center_lon', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_center_lon',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdcntrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid center lon')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_center_lon', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_center_lon',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdcntrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid center lon')) return
@@ -537,14 +537,14 @@
       nc_dims2_id(1) = nc_srcgrdcorn_id
       nc_dims2_id(2) = nc_srcgrdsize_id
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_corner_lat', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_corner_lat',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_srcgrdcrnrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid corner lats')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_corner_lon', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_corner_lon',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_srcgrdcrnrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid corner lons')) return
@@ -552,14 +552,14 @@
       nc_dims2_id(1) = nc_dstgrdcorn_id
       nc_dims2_id(2) = nc_dstgrdsize_id
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_corner_lat', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_corner_lat',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_dstgrdcrnrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid corner lats')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_corner_lon', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_corner_lon',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_dstgrdcrnrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid corner lons')) return
@@ -576,42 +576,42 @@
         grid2_ctmp = grid1_units
       endif
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlat_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlat_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlon_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlon_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlat_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlon_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlat_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlon_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination grid units')) return
@@ -625,7 +625,7 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid mask')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdimask_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdimask_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid mask units')) return
@@ -635,7 +635,7 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid mask')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdimask_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdimask_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination grid mask units')) return
@@ -644,24 +644,24 @@
       !*** define grid area arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_area', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_area',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdarea_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid area')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdarea_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdarea_id,
      &                      'units', 'square radians')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source area units')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_area', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_area',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdarea_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid area')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdarea_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdarea_id,
      &                      'units', 'square radians')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination area units')) return
@@ -670,24 +670,24 @@
       !*** define grid fraction arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_grid_frac', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_grid_frac',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid fraction')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdfrac_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdfrac_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source fraction units')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_frac', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_frac',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination fraction')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination frac units')) return
@@ -696,14 +696,14 @@
       !*** define mapping arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_address', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_address',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_srcadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source addresses')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_address', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_address',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_dstadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination addresses')) return
@@ -711,8 +711,8 @@
       nc_dims2_id(1) = nc_numwgts_id
       nc_dims2_id(2) = nc_numlinks_id
 
-      ncstat = nf90_def_var(nc_file_id, 'remap_matrix', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'remap_matrix',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_rmpmatrix_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining remapping weights')) return
@@ -909,12 +909,12 @@
      &         'error writing grid2 frac')) return
 
       if (direction == 1) then
-        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id,
      &                        grid1_add_map1)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing source addresses')) return
 
-        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id,
      &                        grid2_add_map1)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing destination addresses')) return
@@ -923,12 +923,12 @@
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing weights')) return
       else
-        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id,
      &                        grid2_add_map2)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing source addresses')) return
 
-        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id,
      &                          grid1_add_map2)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing destination addresses')) return
@@ -948,7 +948,7 @@
 
 !***********************************************************************
 
-      subroutine write_remap_ww3(map1_name, interp_file1, 
+      subroutine write_remap_ww3(map1_name, interp_file1,
      &                           output_opt, l_master, errorCode)
 
 !-----------------------------------------------------------------------
@@ -1052,13 +1052,13 @@
       select case(output_opt)
       case ('scrip')
          if (l_master) then
-            call write_remap_scrip_ww3(map1_name_pass, 
+            call write_remap_scrip_ww3(map1_name_pass,
      &           interp_file1_pass, errorCode)
          endif
          if (SCRIP_ErrorCheck(errorCode, rtnName,
      &       'error in write_remap_scrip')) return
       case default
-         call SCRIP_ErrorSet(errorCode, rtnName, 
+         call SCRIP_ErrorSet(errorCode, rtnName,
      &                       'unknown output file convention')
          return
       end select
@@ -1085,7 +1085,7 @@
 !-----------------------------------------------------------------------
 
       character(SCRIP_charLength), intent(in) ::
-     &            map_name     ! name for mapping 
+     &            map_name     ! name for mapping
      &,           interp_file  ! filename for remap data
 
 !-----------------------------------------------------------------------
@@ -1106,7 +1106,7 @@
       character(SCRIP_charLength) ::
      &  grid1_ctmp        ! character temp for grid1 names
      &, grid2_ctmp        ! character temp for grid2 names
-     &, map_name_ctmp     ! character temp for name for mapping 
+     &, map_name_ctmp     ! character temp for name for mapping
      &, interp_file_ctmp  ! character temp filename for remap data
 
       integer (SCRIP_i4) ::
@@ -1203,7 +1203,7 @@
 
       itmp2 = grid2_size
 
-      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_size', itmp2, 
+      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_size', itmp2,
      &                      nc_dstgrdsize_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &            'error defining destination grid size')) return
@@ -1214,12 +1214,12 @@
 
       itmp1 = num_links_map1
 
-      ncstat = nf90_def_dim(nc_file_id, 'num_links', 
+      ncstat = nf90_def_dim(nc_file_id, 'num_links',
      &                      itmp1, nc_numlinks_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                           'error defining remap size')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'num_wgts', 
+      ncstat = nf90_def_dim(nc_file_id, 'num_wgts',
      &                      num_wts, nc_numwgts_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                    'error defining number of weights')) return
@@ -1236,13 +1236,13 @@
       !***
 
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_grid_frac', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_grid_frac',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination fraction')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination frac units')) return
@@ -1251,14 +1251,14 @@
       !*** define mapping arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'src_address', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'src_address',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_srcadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source addresses')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'dst_address', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'dst_address',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_dstadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination addresses')) return
@@ -1266,8 +1266,8 @@
       nc_dims2_id(1) = nc_numwgts_id
       nc_dims2_id(2) = nc_numlinks_id
 
-      ncstat = nf90_def_var(nc_file_id, 'remap_matrix', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'remap_matrix',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_rmpmatrix_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining remapping weights')) return
@@ -1291,12 +1291,12 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid2 frac')) return
 
-      ncstat = nf90_put_var(nc_file_id, nc_srcadd_id, 
+      ncstat = nf90_put_var(nc_file_id, nc_srcadd_id,
      &                        grid1_add_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing source addresses')) return
 
-      ncstat = nf90_put_var(nc_file_id, nc_dstadd_id, 
+      ncstat = nf90_put_var(nc_file_id, nc_dstadd_id,
      &                        grid2_add_map1)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing destination addresses')) return
@@ -1333,7 +1333,7 @@
 !-----------------------------------------------------------------------
 
       character(SCRIP_charLength), intent(in) ::
-     &            map_name     ! name for mapping 
+     &            map_name     ! name for mapping
      &,           interp_file  ! filename for remap data
 
       integer (SCRIP_i4), intent(in) ::
@@ -1511,12 +1511,12 @@
         itmp2 = grid1_rank
       endif
 
-      ncstat = nf90_def_dim(nc_file_id, 'src_grid_rank', 
+      ncstat = nf90_def_dim(nc_file_id, 'src_grid_rank',
      &                      itmp1, nc_srcgrdrank_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid rank')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_rank', 
+      ncstat = nf90_def_dim(nc_file_id, 'dst_grid_rank',
      &                      itmp2, nc_dstgrdrank_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid rank')) return
@@ -1583,13 +1583,13 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining remap size')) return
 
-      ncstat = nf90_def_dim(nc_file_id, 'num_wgts', 
+      ncstat = nf90_def_dim(nc_file_id, 'num_wgts',
      &                     num_wts, nc_numwgts_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining number of weights')) return
 
       if (num_wts > 1) then
-        ncstat = nf90_def_dim(nc_file_id, 'num_wgts1', 
+        ncstat = nf90_def_dim(nc_file_id, 'num_wgts1',
      &                       num_wts-1, nc_numwgts1_id)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error defining number of weights1')) return
@@ -1620,13 +1620,13 @@
       !***
 
       ncstat = nf90_def_var(nc_file_id, 'yc_a',
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdcntrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid center lats')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'yc_b', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'yc_b',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdcntrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid center lats')) return
@@ -1635,14 +1635,14 @@
       !*** define grid center longitude array
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'xc_a', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'xc_a',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdcntrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid center lons')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'xc_b', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'xc_b',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdcntrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid center lons')) return
@@ -1654,14 +1654,14 @@
       nc_dims2_id(1) = nc_srcgrdcorn_id
       nc_dims2_id(2) = nc_srcgrdsize_id
 
-      ncstat = nf90_def_var(nc_file_id, 'yv_a', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'yv_a',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_srcgrdcrnrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid corner lats')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'xv_a', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'xv_a',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_srcgrdcrnrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid corner lons')) return
@@ -1669,14 +1669,14 @@
       nc_dims2_id(1) = nc_dstgrdcorn_id
       nc_dims2_id(2) = nc_dstgrdsize_id
 
-      ncstat = nf90_def_var(nc_file_id, 'yv_b', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'yv_b',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_dstgrdcrnrlat_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid corner lats')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'xv_b', 
-     &                      NF90_DOUBLE, nc_dims2_id, 
+      ncstat = nf90_def_var(nc_file_id, 'xv_b',
+     &                      NF90_DOUBLE, nc_dims2_id,
      &                      nc_dstgrdcrnrlon_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid corner lons')) return
@@ -1696,42 +1696,42 @@
         grid2_ctmp = grid1_units
       endif
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlat_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlat_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcntrlon_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcntrlon_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlat_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdcrnrlon_id,
      &                      'units', grid1_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlat_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlat_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlon_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdcrnrlon_id,
      &                      'units', grid2_ctmp)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid units')) return
@@ -1745,7 +1745,7 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid mask')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdimask_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdimask_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source mask units')) return
@@ -1755,7 +1755,7 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid mask')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdimask_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdimask_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing destination mask units')) return
@@ -1764,24 +1764,24 @@
       !*** define grid area arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'area_a', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'area_a',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdarea_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid area')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdarea_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdarea_id,
      &                      'units', 'square radians')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source area units')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'area_b', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'area_b',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdarea_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid area')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdarea_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdarea_id,
      &                      'units', 'square radians')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination area units')) return
@@ -1790,24 +1790,24 @@
       !*** define grid fraction arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'frac_a', 
-     &                      NF90_DOUBLE, nc_srcgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'frac_a',
+     &                      NF90_DOUBLE, nc_srcgrdsize_id,
      &                      nc_srcgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source grid frac')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_srcgrdfrac_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_srcgrdfrac_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source frac units')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'frac_b', 
-     &                      NF90_DOUBLE, nc_dstgrdsize_id, 
+      ncstat = nf90_def_var(nc_file_id, 'frac_b',
+     &                      NF90_DOUBLE, nc_dstgrdsize_id,
      &                      nc_dstgrdfrac_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination grid frac')) return
 
-      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id, 
+      ncstat = nf90_put_att(nc_file_id, nc_dstgrdfrac_id,
      &                      'units', 'unitless')
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination frac units')) return
@@ -1816,20 +1816,20 @@
       !*** define mapping arrays
       !***
 
-      ncstat = nf90_def_var(nc_file_id, 'col', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'col',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_srcadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining source addresses')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'row', 
-     &                      NF90_INT, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'row',
+     &                      NF90_INT, nc_numlinks_id,
      &                      nc_dstadd_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error defining destination addresses')) return
 
-      ncstat = nf90_def_var(nc_file_id, 'S', 
-     &                      NF90_DOUBLE, nc_numlinks_id, 
+      ncstat = nf90_def_var(nc_file_id, 'S',
+     &                      NF90_DOUBLE, nc_numlinks_id,
      &                      nc_rmpmatrix_id)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                      'error defining weights')) return
@@ -1838,8 +1838,8 @@
         nc_dims2_id(1) = nc_numwgts1_id
         nc_dims2_id(2) = nc_numlinks_id
 
-        ncstat = nf90_def_var(nc_file_id, 'S2', 
-     &                     NF90_DOUBLE, nc_dims2_id, 
+        ncstat = nf90_def_var(nc_file_id, 'S2',
+     &                     NF90_DOUBLE, nc_dims2_id,
      &                     nc_rmpmatrix2_id)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &                     'error defining weights2')) return
@@ -1935,7 +1935,7 @@
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing grid2 dims')) return
 
-      ncstat = nf90_put_var(nc_file_id, nc_srcgrdimask_id, 
+      ncstat = nf90_put_var(nc_file_id, nc_srcgrdimask_id,
      &                      src_mask_int)
       if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &         'error writing source grid mask')) return
@@ -2040,18 +2040,18 @@
      &         'error writing grid2 frac')) return
 
       if (direction == 1) then
-        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id,
      &                        grid1_add_map1)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing source addresses')) return
 
-        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id,
      &                        grid2_add_map1)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing destination addresses')) return
 
         if (num_wts == 1) then
-          ncstat = nf90_put_var(nc_file_id, nc_rmpmatrix_id, 
+          ncstat = nf90_put_var(nc_file_id, nc_rmpmatrix_id,
      &                               wts_map1(1,:))
           if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &             'error writing weights')) return
@@ -2070,18 +2070,18 @@
           deallocate(wts1,wts2)
         endif
       else
-        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_srcadd_id,
      &                        grid2_add_map2)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing source addresses')) return
 
-        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id, 
+        ncstat = nf90_put_var(nc_file_id, nc_dstadd_id,
      &                        grid1_add_map2)
         if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &           'error writing destination addresses')) return
 
         if (num_wts == 1) then
-          ncstat = nf90_put_var(nc_file_id, nc_rmpmatrix_id, 
+          ncstat = nf90_put_var(nc_file_id, nc_rmpmatrix_id,
      &                          wts_map2(1,:))
           if (SCRIP_NetcdfErrorCheck(ncstat, errorCode, rtnName,
      &             'error writing weights')) return
@@ -2163,7 +2163,7 @@
 
 !-----------------------------------------------------------------------
 !
-!     start at the lowest level (N/2) of the tree and sift lower 
+!     start at the lowest level (N/2) of the tree and sift lower
 !     values to the bottom of the tree, promoting the larger numbers
 !
 !-----------------------------------------------------------------------
@@ -2194,7 +2194,7 @@
      &       ((add1(chk_lvl1) == add1(chk_lvl2)) .AND.
      &        (add2(chk_lvl1) >  add2(chk_lvl2)))) then
             max_lvl = chk_lvl1
-          else 
+          else
             max_lvl = chk_lvl2
           endif
 
@@ -2218,7 +2218,7 @@
           !*** store last values and exit the loop
           !***
 
-          else 
+          else
             add1(final_lvl) = add1(max_lvl)
             add2(final_lvl) = add2(max_lvl)
             weights(:,final_lvl) = weights(:,max_lvl)
@@ -2257,7 +2257,7 @@
         weights(:,lvl) = weights(:,1)
 
         !***
-        !*** as above this loop sifts the tmp values down until proper 
+        !*** as above this loop sifts the tmp values down until proper
         !*** level is reached
         !***
 
@@ -2277,7 +2277,7 @@
      &       ((add1(chk_lvl1) == add1(chk_lvl2)) .AND.
      &        (add2(chk_lvl1) >  add2(chk_lvl2)))) then
             max_lvl = chk_lvl1
-          else 
+          else
             max_lvl = chk_lvl2
           endif
 
@@ -2301,7 +2301,7 @@
           !*** store last values and exit the loop
           !***
 
-          else 
+          else
             add1(final_lvl) = add1(max_lvl)
             add2(final_lvl) = add2(max_lvl)
             weights(:,final_lvl) = weights(:,max_lvl)

--- a/model/ftn/SCRIP/scrip_timers.f
+++ b/model/ftn/SCRIP/scrip_timers.f
@@ -7,12 +7,12 @@
 !
 !     CVS:$Id: timers.f,v 1.2 2000/04/19 21:56:26 pwjones Exp $
 !
-!     Copyright (c) 1997, 1998 the Regents of the University of 
+!     Copyright (c) 1997, 1998 the Regents of the University of
 !       California.
 !
-!     This software and ancillary information (herein called software) 
-!     called SCRIP is made available under the terms described here.  
-!     The software has been approved for release with associated 
+!     This software and ancillary information (herein called software)
+!     called SCRIP is made available under the terms described here.
+!     The software has been approved for release with associated
 !     LA-CC Number 98-45.
 !
 !     Unless otherwise indicated, this software has been authored
@@ -27,10 +27,10 @@
 !     any liability or responsibility for the use of this software.
 !
 !     If software is modified to produce derivative works, such modified
-!     software should be clearly marked, so as not to confuse it with 
+!     software should be clearly marked, so as not to confuse it with
 !     the version available from Los Alamos National Laboratory.
 !
-!     This code has been modified from the version available from 
+!     This code has been modified from the version available from
 !     Los Alamos National Laboratory, for the purpose of running it
 !     within WW3.
 !
@@ -44,23 +44,23 @@
 
       implicit none
 
-      integer (SCRIP_i4), parameter ::  
+      integer (SCRIP_i4), parameter ::
      &     max_timers = 99  ! max number of timers allowed
 
-      integer (SCRIP_i4), save :: 
+      integer (SCRIP_i4), save ::
      &     cycles_max       ! max value of clock allowed by system
 
-      integer (SCRIP_i4), dimension(max_timers), save :: 
+      integer (SCRIP_i4), dimension(max_timers), save ::
      &     cycles1,         ! cycle number at start for each timer
      &     cycles2          ! cycle number at stop  for each timer
 
-      real (SCRIP_r4), save ::  
+      real (SCRIP_r4), save ::
      &     clock_rate       ! clock_rate in seconds for each cycle
 
-      real (SCRIP_r4), dimension(max_timers), save ::  
+      real (SCRIP_r4), dimension(max_timers), save ::
      &     cputime          ! accumulated cpu time in each timer
 
-      character (len=8), dimension(max_timers), save ::  
+      character (len=8), dimension(max_timers), save ::
      &     status           ! timer status string
 
 !***********************************************************************
@@ -85,7 +85,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
@@ -115,7 +115,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
@@ -133,7 +133,7 @@
 !-----------------------------------------------------------------------
 !
 !     This routine returns the result of a given timer.  This can be
-!     called instead of timer_print so that the calling routine can 
+!     called instead of timer_print so that the calling routine can
 !     print it in desired format.
 !
 !-----------------------------------------------------------------------
@@ -144,7 +144,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
@@ -153,7 +153,7 @@
 !
 !-----------------------------------------------------------------------
 
-      real (SCRIP_r4) ::  
+      real (SCRIP_r4) ::
      &     timer_get   ! accumulated cputime in given timer
 
 !-----------------------------------------------------------------------
@@ -186,22 +186,22 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
 
-      !--- 
-      !--- print the cputime accumulated for timer 
+      !---
+      !--- print the cputime accumulated for timer
       !--- make sure timer is stopped
       !---
 
       if (status(timer) .eq. 'stopped') then
-        write(*,"(' CPU time for timer',i3,':',1p,e16.8)")  
+        write(*,"(' CPU time for timer',i3,':',1p,e16.8)")
      &       timer,cputime(timer)
       else
         call timer_stop(timer)
-        write(*,"(' CPU time for timer',i3,':',1p,e16.8)")  
+        write(*,"(' CPU time for timer',i3,':',1p,e16.8)")
      &       timer,cputime(timer)
         call timer_start(timer)
       endif
@@ -226,7 +226,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
@@ -260,7 +260,7 @@
 !
 !-----------------------------------------------------------------------
 
-      integer (SCRIP_i4), intent(in) ::  
+      integer (SCRIP_i4), intent(in) ::
      &    timer            ! timer number
 
 !-----------------------------------------------------------------------
@@ -278,10 +278,10 @@
         !---
 
         if (cycles2(timer) .ge. cycles1(timer)) then
-          cputime(timer) = cputime(timer) + clock_rate*  
+          cputime(timer) = cputime(timer) + clock_rate*
      &                     (cycles2(timer) - cycles1(timer))
         else
-          cputime(timer) = cputime(timer) + clock_rate*  
+          cputime(timer) = cputime(timer) + clock_rate*
      &                (cycles2(timer) - cycles1(timer) + cycles_max)
         endif
 

--- a/model/ftn/constants.ftn
+++ b/model/ftn/constants.ftn
@@ -20,7 +20,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -55,7 +55,7 @@
 !
 !      - The flag for generating test output files is included here as
 !        it is needed in both ww3_shel and ww3_multi at the same time.
-!        Make sure that this flag is true if you want to write to the 
+!        Make sure that this flag is true if you want to write to the
 !        test output file !
 !
 !/ ------------------------------------------------------------------- /
@@ -65,10 +65,10 @@
       REAL, PARAMETER         :: GRAV   =    9.806
       REAL, PARAMETER         :: DWAT   = 1000.
       REAL, PARAMETER         :: DAIR   =    1.225
-      REAL, PARAMETER         :: nu_air  = 1.4E-5        
+      REAL, PARAMETER         :: nu_air  = 1.4E-5
 !mdo  *** Changing nu_water to be consistent with DWAT=1000 (assumes 10degC)
-      REAL, PARAMETER         :: nu_water  = 1.31E-6    !mdo   WAS: 3.E-6        
-      REAL, PARAMETER         :: sed_sg  = 2.65        
+      REAL, PARAMETER         :: nu_water  = 1.31E-6    !mdo   WAS: 3.E-6
+      REAL, PARAMETER         :: sed_sg  = 2.65
       REAL, PARAMETER         :: KAPPA = 0.40       !Von Karman's constant
 !
       REAL, PARAMETER         :: PI     = 3.141592653589793
@@ -86,19 +86,19 @@
 !
       REAL                    :: UNDEF = -999.9
 !
-! Parameters for friction factor table 
+! Parameters for friction factor table
 !
-      INTEGER, PARAMETER       :: SIZEFWTABLE=300  
+      INTEGER, PARAMETER       :: SIZEFWTABLE=300
       REAL                     :: FWTABLE(0:SIZEFWTABLE)
       REAL                     :: DELAB
-      REAL,    PARAMETER       :: ABMIN = -1. 
+      REAL,    PARAMETER       :: ABMIN = -1.
       REAL, PRIVATE, PARAMETER :: ABMAX = 8.
       INTEGER, PARAMETER       :: srce_direct = 0
       INTEGER, PARAMETER       :: srce_imp_post = 1
       INTEGER, PARAMETER       :: srce_imp_pre = 2
       INTEGER, PARAMETER       :: DEBUG_NODE = 1014
       INTEGER, PARAMETER       :: DEBUG_ELEMENT = 50
-      LOGICAL                  :: LPDLIB = .FALSE. 
+      LOGICAL                  :: LPDLIB = .FALSE.
       LOGICAL                  :: LSETUP
 !
 ! Parameters in support of running as ESMF component
@@ -201,26 +201,26 @@
             fsubw=.08/(ker**2+kei**2)
             fsubw=.5*(fsubwmemo+fsubw)
             dzeta0=.5*(dzeta0memo+dzeta0)
-            END DO   
+            END DO
 !
-! Maximum value of 0.5 for fe is based on field 
-! and lab experiment by Lowe et al. JGR 2005, 2007 
-! 
-            FWTABLE(I)  = MIN(fsubw,0.5) 
+! Maximum value of 0.5 for fe is based on field
+! and lab experiment by Lowe et al. JGR 2005, 2007
+!
+            FWTABLE(I)  = MIN(fsubw,0.5)
 !           WRITE(994,*) 'Friction factor:',I,ABR,FWTABLE(I)
          END DO
       RETURN
       END SUBROUTINE TABU_FW
 
 ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-SUBROUTINE KZEONE(X, Y, RE0, IM0, RE1, IM1)                      
+SUBROUTINE KZEONE(X, Y, RE0, IM0, RE1, IM1)
 !  June 1999 adaptation to CRESTb, all tests on range of (x,y) have been
 !  bypassed, we implicitly expect X to be positive or |x,y| non zero
-! 
+!
 ! This subroutine is copyright by ACM
 ! see http://www.acm.org/pubs/copyright_policy/softwareCRnotice.html
 ! ACM declines any responsibility of any kind
-! 
+!
 ! THE VARIABLES X AND Y ARE THE REAL AND IMAGINARY PARTS OF
 ! THE ARGUMENT OF THE FIRST TWO MODIFIED BESSEL FUNCTIONS
 ! OF THE SECOND KIND,K0 AND K1.  RE0,IM0,RE1 AND IM1 GIVE
@@ -236,7 +236,7 @@ SUBROUTINE KZEONE(X, Y, RE0, IM0, RE1, IM1)
    DOUBLE PRECISION X, Y, X2, Y2, RE0, IM0, RE1, IM1, &
       R1, R2, T1, T2, P1, P2, RTERM, ITERM, L
    DOUBLE PRECISION , PARAMETER, DIMENSION(8) :: EXSQ = &
-         (/ 0.5641003087264D0,0.4120286874989D0,0.1584889157959D0, & 
+         (/ 0.5641003087264D0,0.4120286874989D0,0.1584889157959D0, &
             0.3078003387255D-1,0.2778068842913D-2,0.1000044412325D-3, &
             0.1059115547711D-5,0.1522475804254D-8 /)
    DOUBLE PRECISION , PARAMETER, DIMENSION(8) :: TSQ = &
@@ -377,20 +377,20 @@ SUBROUTINE KZEONE(X, Y, RE0, IM0, RE1, IM1)
       IM1 = T1*R2 + T2*R1
       RETURN
       END SUBROUTINE KZEONE
-      
+
 ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 SUBROUTINE KERKEI(X,KER,KEI)
 !**********************************************************************
 ! Computes the values of the zeroth order Kelvin function Ker and Kei
-! These functions are used to determine the friction factor fw as a 
+! These functions are used to determine the friction factor fw as a
 ! function of the bottom roughness length assuming a linear profile
 ! of eddy viscosity (See Grant and Madsen, 1979)
 !**********************************************************************
    IMPLICIT NONE
-   
+
    DOUBLE PRECISION ZR,ZI,CYR,CYI,CYR1,CYI1
    REAL X,KER,KEI
-   
+
    ZR=X*.50D0*SQRT(2.0D0)
    ZI=ZR
    CALL KZEONE(ZR, ZI, CYR, CYI,CYR1,CYI1)

--- a/model/ftn/ctest.ftn
+++ b/model/ftn/ctest.ftn
@@ -11,7 +11,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/gx_outf.ftn
+++ b/model/ftn/gx_outf.ftn
@@ -32,16 +32,16 @@
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    05-Oct-2011 : Updating to the 53 output parameter ( version 4.05 ) 
-!/                  (J-H Alves) 
-!/    25-Feb-2013 : Adding double-index output fields   ( version 4.11 ) 
+!/    05-Oct-2011 : Updating to the 53 output parameter ( version 4.05 )
+!/                  (J-H Alves)
+!/    25-Feb-2013 : Adding double-index output fields   ( version 4.11 )
 !/    27-Aug-2015 : ICEH and ICEF added as output       ( version 5.10 )
 !/    25-Aug-2018 : Add WBT parameter                   ( version 6.06 )
 !/
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -80,7 +80,7 @@
 !      DSEC21    Func.   Id.    Difference between times.
 !      W3IOGR    Subr. W3IOGRMD Reading/writing model definition file.
 !      W3IOGO    Subr. W3IOGOMD Reading/writing raw gridded data file.
-!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags. 
+!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags.
 !      W3EXGO    Subr. Internal Execute grid output.
 !     ----------------------------------------------------------------
 !
@@ -261,14 +261,14 @@
 !
 ! ... Output fields
 !
-      FLREQ(:,:)=.FALSE. ! Initialize FLGRD 
+      FLREQ(:,:)=.FALSE. ! Initialize FLGRD
       CALL W3READFLGRD ( NDSI, NDSO, 9, NDSE, COMSTR, FLOG,      &
                                  FLREQ, 1, 1, IERR )
 !
 !
 ! Reset flags for variables not yet implemented in grads output interface
 !
-!    This needs to be reviewed whenever new parameters are added to the 
+!    This needs to be reviewed whenever new parameters are added to the
 !     grads ctl and data files
 !
       IFI = 3
@@ -279,7 +279,7 @@
           FLREQ(IFI,IFJ) = .FALSE.
         END IF
       END DO
-      IFI = 5 
+      IFI = 5
       DO IFJ = 7,10
         IF ( FLREQ(IFI,IFJ) ) THEN
           WRITE (NDSO,946) IDOUT(IFI,IFJ),                           &
@@ -291,7 +291,7 @@
         DO IFJ = 1,NOGE(IFI)
           IF ( FLREQ(IFI,IFJ) ) THEN
             WRITE (NDSO,946) IDOUT(IFI,IFJ),                           &
-                             '*** NOT YET CODED INTO GXOUTF ***' 
+                             '*** NOT YET CODED INTO GXOUTF ***'
             FLREQ(IFI,IFJ) = .FALSE.
           END IF
         END DO
@@ -305,10 +305,10 @@
         END IF
       END DO
       IF ( FLREQ(9,5) ) THEN
-        WRITE (NDSO,946) IDOUT(9,5),'*** NOT YET CODED INTO GXOUTF ***' 
+        WRITE (NDSO,946) IDOUT(9,5),'*** NOT YET CODED INTO GXOUTF ***'
         FLREQ(9,5) = .FALSE.
       END IF
-     
+
       WRITE (NDSO,945)
 !
       NVAR  = 1
@@ -773,7 +773,7 @@
 !     ----------------------------------------------------------------
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !      EXTCDE    Subr.   Id.    Abort program as graceful as possible.
-!      W3S2XY    Subr.   Id.    Convert from storage to spatial grid. 
+!      W3S2XY    Subr.   Id.    Convert from storage to spatial grid.
 !     ---------------------------------------------------------------
 !
 !  5. Called by :
@@ -788,7 +788,7 @@
 !
 !     - Note that arrays CX and CY of the main program now contain
 !       the absolute current speed and direction respectively.
-!     - VALLND added to assure that map with only land plots in 
+!     - VALLND added to assure that map with only land plots in
 !       GrADS.
 !
 !  8. Structure :
@@ -921,7 +921,7 @@
         FLTWO = .FALSE.
         FLDIR = .FALSE.
         FLTRI = .FALSE.
-        FLPRT = .FALSE. 
+        FLPRT = .FALSE.
 !
 !/T            WRITE (NDST,9020) IDOUT(J,K)
 !
@@ -1213,13 +1213,13 @@
                 FLONE = .TRUE.
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, CHARN , MAPSF, X1 )
 !
-!     Mean energy flux 
+!     Mean energy flux
 !
               ELSE IF ( J.EQ.5 .AND. K.EQ.3 ) THEN
                 FLONE = .TRUE.
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, CGE   , MAPSF, X1 )
 !
-!     Air-sea energy flux 
+!     Air-sea energy flux
 !
               ELSE IF ( J.EQ.5 .AND. K.EQ.4 ) THEN
                 FLONE = .TRUE.
@@ -1348,7 +1348,7 @@
 !
 !     Scalars
 !
-              ELSE IF ( FLONE ) THEN 
+              ELSE IF ( FLONE ) THEN
                 WRITE (NDSDAT)                                        &
                       ((X1(IX,IY),IX=IX0,IXN),IY=IY0,IYN)
               END IF

--- a/model/ftn/gx_outp.ftn
+++ b/model/ftn/gx_outp.ftn
@@ -43,7 +43,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -101,7 +101,7 @@
 !      STRACE    Subr.   Id.    Subroutine tracing.
 !      NEXTLN    Subr.   Id.    Get next line from input filw
 !      EXTCDE    Subr.   Id.    Abort program as graceful as possible.
-!      STME21    Subr. W3TIMEMD Convert time to string. 
+!      STME21    Subr. W3TIMEMD Convert time to string.
 !      TICK21    Subr.   Id.    Advance time.
 !      DSEC21    Func.   Id.    Difference between times.
 !      W3IOGR    Subr. W3IOGRMD Reading/writing model definition file.
@@ -180,7 +180,7 @@
                     'Nonlinear interactions   ' ,                     &
                     'Dissipation              ' ,                     &
                     'Wave-bottom interactions ' ,                     &
-                    'Wave-ice interactions ' ,                     &                
+                    'Wave-ice interactions ' ,                     &
                     'Sum of selected sources  ' /
       DATA FLSRCE / .FALSE. , .FALSE. , .FALSE. ,                     &
                     .FALSE. , .FALSE. , .FALSE., .FALSE. /
@@ -563,7 +563,7 @@
 !
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
-!      W3SPRn    Subr. W3SRCnMD Mean wave parameters for use in       
+!      W3SPRn    Subr. W3SRCnMD Mean wave parameters for use in
 !                               source terms.
 !      W3FLXn    Subr. W3FLXnMD Flux/stress computation.
 !      W3SLNn    Subr. W3SLNnMD Linear input.
@@ -691,7 +691,7 @@
       REAL                    :: WN(NK), CG(NK), E(NK,NTH), E1(NK),   &
                                  APM(NK), THBND(NK), SPBND(NK),       &
                                  A(NTH,NK), WN2(NTH,NK),WN_R(NK),     &
-                                 ALPHA_LIU(NK), CG_ICE(NK), R(NK) 
+                                 ALPHA_LIU(NK), CG_ICE(NK), R(NK)
       REAL                    :: DIA(NTH,NK), SWI(NK,NTH), SNL(NK,NTH),&
                                  SDS(NK,NTH), SBT(NK,NTH), SIS(NK,NTH),&
                                  STT(NK,NTH), DIA2(NK,NTH)
@@ -700,7 +700,7 @@
                                  XBT(NTH,NK), XBS(NTH,NK), XXX(NTH,NK),&
                                  XWL(NTH,NK), XIS(NTH,NK)
       LOGICAL                 :: LBREAK
-!/ST3      LOGICAL                :: LLWS(NTH,NK) 
+!/ST3      LOGICAL                :: LLWS(NTH,NK)
 !/ST4      LOGICAL                :: LLWS(NTH,NK)
 !/ST4      REAL                   :: LAMBDA(NSPEC)
       CHARACTER               :: DTME21*23
@@ -1021,16 +1021,16 @@
 !/IC2                CALL W3SIC2 ( A, DEPTH, ICETHICK, ICEF ,CG,  WN, IX, IY, XBT, DIA, WN_R, &
 !/IC2                              CG_ICE, ALPHA_LIU, R )
 !/IC3                CALL W3SIC3 ( A, DEPTH, CG,  WN, IX, IY, XBT, DIA )
-!/IC4                CALL W3SIC4 ( A, DEPTH, CG,      IX, IY, XBT, DIA ) 
+!/IC4                CALL W3SIC4 ( A, DEPTH, CG,      IX, IY, XBT, DIA )
 !/IC5                CALL W3SIC5 ( A, DEPTH, CG,  WN, IX, IY, XBT, DIA )
 
-!/BT4                    IX=1    ! to be fixed later 
-!/BT4                    IY=1    ! to be fixed later 
-!/BT4                    ISEA=1  ! to be fixed later 
+!/BT4                    IX=1    ! to be fixed later
+!/BT4                    IY=1    ! to be fixed later
+!/BT4                    ISEA=1  ! to be fixed later
 !/BT4                    D50 = SED_D50(ISEA)
 !/BT4                    PSIC= SED_PSIC(ISEA)
 
-!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   & 
+!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   &
 !/BT4                                       BEDFORM, XBT, DIA, IX, IY )
 !
 
@@ -1046,7 +1046,7 @@
            IF ( FLSRCE(6) ) THEN
 
 !/IS2           CALL W3SIS2(A, DEPTH, ICECON, ICETHICK, ICEF, ICEDMAX, IX, IY, &
-!/IS2                       XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)                    
+!/IS2                       XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)
            END IF
 !
 !/XXX            CALL W3SXXX
@@ -1058,7 +1058,7 @@
               DO ITH=1, NTH
                 ISPEC       = ITH + (IK-1)*NTH
                 E  (IK,ITH) = SPCO(ISPEC,J)
-                SWI(IK,ITH) = ( XWI(ITH,IK) + XLN(ITH,IK) ) * FACTOR 
+                SWI(IK,ITH) = ( XWI(ITH,IK) + XLN(ITH,IK) ) * FACTOR
                 SNL(IK,ITH) = ( XNL(ITH,IK) + XTR(ITH,IK) ) * FACTOR
                 SDS(IK,ITH) = ( XDS(ITH,IK) + XDB(ITH,IK) ) * FACTOR
 !/ST6               SDS(IK,ITH) =   SDS(IK,ITH) +(XWL(ITH,IK)   * FACTOR)

--- a/model/ftn/mod_fileio.f90
+++ b/model/ftn/mod_fileio.f90
@@ -77,7 +77,7 @@ implicit none
 !      5/10/2001  Form=fixed Record length, as specified in input argument
 !     17/06/2002  Initialisation of IUNIT=-1 included
 !     24/08/2002  Bug fixed when routine called with IUFIND=0
-!     08/02/2003  Bug fixed when file could not be created due to invalid path 
+!     08/02/2003  Bug fixed when file could not be created due to invalid path
 !
 !  1. Purpose
 !

--- a/model/ftn/pdlib_field_vec.ftn
+++ b/model/ftn/pdlib_field_vec.ftn
@@ -1,7 +1,7 @@
 MODULE PDLIB_FIELD_VEC
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -53,7 +53,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -63,7 +63,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Estimate arrays size for communication 
+!  1. Purpose : Estimate arrays size for communication
 !  2. Method :
 !  3. Parameters :
 !
@@ -243,63 +243,63 @@ MODULE PDLIB_FIELD_VEC
         IH = IH + 1
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 2) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 3) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 4) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 5) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 6) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 7) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 8) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5, 9) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 5,10) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 1) ) THEN
         IH = IH + 1
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 2) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 3) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 4) ) THEN
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 5) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 6) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 7) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 6, 8) ) THEN
         DO IK=1,2*NK
           IH = IH + 1
@@ -320,7 +320,7 @@ MODULE PDLIB_FIELD_VEC
       IF ( FLGRDALL( 7, 1) ) THEN
         IH = IH + 1
         IH = IH + 1
-      END IF 
+      END IF
       IF ( FLGRDALL( 7, 2) ) THEN
         IH = IH + 1
         IH = IH + 1
@@ -381,7 +381,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -391,7 +391,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : PDLIB read from file 
+!  1. Purpose : PDLIB read from file
 !  2. Method :
 !  3. Parameters :
 !
@@ -599,7 +599,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -609,7 +609,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : PDLIB write to file 
+!  1. Purpose : PDLIB write to file
 !  2. Method :
 !  3. Parameters :
 !
@@ -832,7 +832,7 @@ MODULE PDLIB_FIELD_VEC
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1013,31 +1013,31 @@ MODULE PDLIB_FIELD_VEC
               IH = IH + 1
               Arrexch(IH,JSEA)=WBT(JSEA)
             END IF
-            IF ( FLGRDALL( 3, 1) ) THEN 
+            IF ( FLGRDALL( 3, 1) ) THEN
               DO IK=E3DF(2,1),E3DF(3,1)
                 IH = IH + 1
                 Arrexch(IH,JSEA)=EF(JSEA,IK)
               END DO
             END IF
-            IF ( FLGRDALL( 3, 2) ) THEN 
+            IF ( FLGRDALL( 3, 2) ) THEN
               DO IK=E3DF(2,2),E3DF(3,2)
                 IH = IH + 1
                 Arrexch(IH,JSEA)=TH1M(JSEA,IK)
               END DO
             END IF
-            IF ( FLGRDALL( 3, 3) ) THEN 
+            IF ( FLGRDALL( 3, 3) ) THEN
               DO IK=E3DF(2,3),E3DF(3,3)
                 IH = IH + 1
                 Arrexch(IH,JSEA)=STH1M(JSEA,IK)
               END DO
             END IF
-            IF ( FLGRDALL( 3, 4) ) THEN 
+            IF ( FLGRDALL( 3, 4) ) THEN
               DO IK=E3DF(2,4),E3DF(3,4)
                 IH = IH + 1
                 Arrexch(IH,JSEA)=TH2M(JSEA,IK)
               END DO
             END IF
-            IF ( FLGRDALL( 3, 5) ) THEN 
+            IF ( FLGRDALL( 3, 5) ) THEN
               DO IK=E3DF(2,5),E3DF(3,5)
                 IH = IH + 1
                 Arrexch(IH,JSEA)=STH2M(JSEA,IK)
@@ -1148,7 +1148,7 @@ MODULE PDLIB_FIELD_VEC
               Arrexch(IH,JSEA)=USTDIR(JSEA)
               IH = IH + 1
               Arrexch(IH,JSEA)=ASF(JSEA)
-            END IF 
+            END IF
             IF ( FLGRDALL( 5, 2) ) THEN
               IH = IH + 1
               Arrexch(IH,JSEA)=CHARN(JSEA)
@@ -1474,13 +1474,13 @@ MODULE PDLIB_FIELD_VEC
                 IH = IH + 1
                 WBT(1:NSEA) = ARRtotal(IH,:)
               END IF
-              IF ( FLGRDALL( 3, 1) ) THEN 
+              IF ( FLGRDALL( 3, 1) ) THEN
                 DO IK=E3DF(2,1),E3DF(3,1)
                   IH = IH + 1
                   EF(1:NSEA,IK) = ARRtotal(IH,:)
                 END DO
               END IF
-              IF ( FLGRDALL( 3, 2) ) THEN 
+              IF ( FLGRDALL( 3, 2) ) THEN
                 DO IK=E3DF(2,2),E3DF(3,2)
                   IH = IH + 1
                   TH1M(1:NSEA,IK) = ARRtotal(IH,:)

--- a/model/ftn/w3adatmd.ftn
+++ b/model/ftn/w3adatmd.ftn
@@ -21,13 +21,13 @@
 !/    22-Feb-2008 ; Modify MAPTH2 declaration.          ( version 3.13 )
 !/    29-May-2009 : Preparing distribution version.     ( version 3.14 )
 !/    29-Oct-2010 : Adding unstructured grid data.      ( version 3.14 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    31-Oct-2010 : Adding output parameters            ( version 3.14 )
 !/    12-Dec-2012 : Adding SMC grid.  JG_Li             ( version 4.08 )
 !/    26-Dec-2012 : Memory reduction for outputs.       ( version 4.11 )
 !/                  Add W3XETA.
 !/    28-Jun-2013 : Bug fix initialization P2SMS.       ( version 4.11 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    14-Nov-2013 : Move orphaned arrays as scalar to W3SRCE.
 !/                  Here update of documentation only.
@@ -42,7 +42,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -203,7 +203,7 @@
 !     Empty dummy fields (NOEXTR)
 !
 !      USERO     R.A.  Public   Empty output arrays than can be
-!                               used by users as a simple means to 
+!                               used by users as a simple means to
 !                               add output.
 !
 !     Map data for propagation schemes (1Up).
@@ -214,13 +214,13 @@
 !     Map data for propagation schemes (UQ).
 !
 !      NMXn      Int.  Public    Counters for MAPX2, see W3MAP3.
-!      NMYn      Int.  Public 
+!      NMYn      Int.  Public
 !      NMXY      Int.  Public    Dimension of MAPXY.
 !      NACTn     Int.  Public    Dimension of MAPAXY.
 !      NCENT     Int.  Public    Dimension of MAPAXY.
 !      MAPX2     I.A.  Public    Map for prop. in 'x' (longitude) dir.
 !      MAPY2     I.A.  Public    Idem in y' (latitude) direction.
-!      MAPXY     I.A.  Public    
+!      MAPXY     I.A.  Public
 !      MAPAXY    I.A.  Public    List of active points used in W3QCK1.
 !      MAPCXY    I.A.  Public    List of central points used in avg.
 !      MAPTH2    I.A.  Public    Like MAPX2 for refraction (rotated
@@ -261,7 +261,7 @@
 !                               (1,NSPLOC,1).
 !      NSPLOC    Int.  Public   Total number of spectral bins for which
 !                               prop. is performed on present CPU.
-!      BSTAT     I.A.  Public   Status of buffer (size MPIBUF): 
+!      BSTAT     I.A.  Public   Status of buffer (size MPIBUF):
 !                                 0: Inactive.
 !                                 1: A --> STORE (active or finished).
 !                                 2: STORE --> A (active or finished).
@@ -342,7 +342,7 @@
       TYPE WADAT
 !
 ! The grid
-! 
+!
         REAL, POINTER         :: CG(:,:), WN(:,:)
 !/IC3   REAL, POINTER         :: IC3WN_R(:,:), IC3WN_I(:,:), IC3CG(:,:)
 !
@@ -472,7 +472,7 @@
 !/SMC        INTEGER, POINTER      :: MAPX2(:), MAPY2(:), MAPAXY(:),       &
 !/SMC                                 MAPXY(:), MAPTH2(:), MAPWN2(:)
 !
-! Warning Defined but not set if UGTYPE .EQ. .T. 
+! Warning Defined but not set if UGTYPE .EQ. .T.
             INTEGER, POINTER      :: ITER(:,:)
 !
 !/NL1        INTEGER               :: NFR, NFRHGH, NFRCHG, NSPECX, NSPECY
@@ -555,7 +555,7 @@
                                  BEDFORMS(:,:), PHIBBL(:), TAUBBL(:,:)
 !
       REAL, POINTER           :: MSSX(:), MSSY(:), MSSD(:),           &
-                                 MSCX(:), MSCY(:), MSCD(:) 
+                                 MSCX(:), MSCY(:), MSCD(:)
 !
       REAL, POINTER           :: DTDYN(:), FCUT(:), CFLXYMAX(:),      &
                                  CFLTHMAX(:), CFLKMAX(:)
@@ -801,7 +801,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETA needs to be called after allocation to point to 
+!     - W3SETA needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -890,8 +890,8 @@
 !
       CALL W3SETA ( IMOD, NDSE, NDST )
 
-! 
-!AR: Check this below more ... 
+!
+!AR: Check this below more ...
       NXXX   = NSEALM * NAPROC
 !
 !     Output and input parameteres by output type
@@ -900,13 +900,13 @@
 !
       ALLOCATE ( WADATS(IMOD)%DW(0:NSEA) , STAT=ISTAT )
       CHECK_ALLOC_STATUS ( ISTAT )
-      WADATS(IMOD)%DW(:)=0.            
+      WADATS(IMOD)%DW(:)=0.
 !
       ALLOCATE ( WADATS(IMOD)%CX(0:NSEA) , WADATS(IMOD)%CY(0:NSEA) , &
                  STAT=ISTAT )
       CHECK_ALLOC_STATUS ( ISTAT )
       WADATS(IMOD)%CX(:)=0.
-      WADATS(IMOD)%CY(:)=0.     
+      WADATS(IMOD)%CY(:)=0.
 !
       ALLOCATE ( WADATS(IMOD)%UA(0:NSEA) , WADATS(IMOD)%UD(0:NSEA) , &
                  WADATS(IMOD)%U10(NSEA)  , WADATS(IMOD)%U10D(NSEA) , &
@@ -974,8 +974,8 @@
 ! 3) Frequency-dependent standard parameters
 !
 ! For the 3D arrays: the allocation is performed only if these arrays are allowed
-!                    by specific variables defined through the mod_def file 
-!                    and read by w3iogr, which is called before W3DIMA. 
+!                    by specific variables defined through the mod_def file
+!                    and read by w3iogr, which is called before W3DIMA.
 !/DEBUGINIT      WRITE(740+IAPROC,*) 'Before the EF allocation'
 !/DEBUGINIT      WRITE(740+IAPROC,*) 'E3DF=', E3DF(1,1)
       IF (  E3DF(1,1).GT.0 ) THEN
@@ -1109,8 +1109,8 @@
       CHECK_ALLOC_STATUS ( ISTAT )
 !
 ! For the 3D arrays: the allocation is performed only if these arrays are allowed
-!                    by specific variables defined through the mod_def file 
-!                    and read by w3iogr, which is called before W3DIMA. 
+!                    by specific variables defined through the mod_def file
+!                    and read by w3iogr, which is called before W3DIMA.
       IF (  P2MSF(1).GT.0 ) THEN
           ALLOCATE(WADATS(IMOD)%P2SMS(NSEALM,P2MSF(2):P2MSF(3)), &
                    STAT=ISTAT )
@@ -1373,7 +1373,7 @@
 ! 5.  Restore previous grid setting if necessary
 !
       IF ( JGRID .NE. IMOD ) CALL W3SETG ( JGRID, NDSE, NDST )
- 
+
 !/MEMCHECK       WRITE(740+IAPROC,*) 'memcheck_____:', 'W3DIMA END'
 !/MEMCHECK       call getMallocInfo(mallinfos)
 !/MEMCHECK       call printMallInfo(IAPROC,mallInfos)
@@ -1639,7 +1639,7 @@
         ELSE
           ALLOCATE ( WADATS(IMOD)%XEF(1,1), STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
-        END IF 
+        END IF
 
         IF ( OUTFLAGS( 3, 2) ) THEN
           ALLOCATE ( WADATS(IMOD)%XTH1M(NXXX,E3DF(2,2):E3DF(3,2)), STAT=ISTAT )
@@ -1994,7 +1994,7 @@
         ELSE
           ALLOCATE ( WADATS(IMOD)%XUS3D(1,1), STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
-        END IF 
+        END IF
 !
       IF ( OUTFLAGS( 6, 9) ) THEN
           ALLOCATE ( WADATS(IMOD)%XP2SMS(NXXX,P2MSF(2):P2MSF(3)), STAT=ISTAT )
@@ -2002,7 +2002,7 @@
         ELSE
           ALLOCATE ( WADATS(IMOD)%XP2SMS(1,1), STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
-        END IF 
+        END IF
 !
       IF ( OUTFLAGS( 6,10) ) THEN
           ALLOCATE ( WADATS(IMOD)%XTAUICE(NXXX,2), STAT=ISTAT )
@@ -2300,7 +2300,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETA needs to be called after allocation to point to 
+!     - W3SETA needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -2524,7 +2524,7 @@
       IF ( NADATA .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
-        END IF   
+        END IF
 !
       IF ( IMOD.LT.1 .OR. IMOD.GT.NADATA ) THEN
           WRITE (NDSE,1002) IMOD, NADATA
@@ -2631,7 +2631,7 @@
           WLM    => WADATS(IMOD)%WLM
           T02    => WADATS(IMOD)%T02
           T0M1   => WADATS(IMOD)%T0M1
-          T01    => WADATS(IMOD)%T01 
+          T01    => WADATS(IMOD)%T01
           FP0    => WADATS(IMOD)%FP0
           THM    => WADATS(IMOD)%THM
           THS    => WADATS(IMOD)%THS
@@ -2909,7 +2909,7 @@
       IF ( NADATA .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
-        END IF   
+        END IF
 !
       IF ( IMOD.LT.1 .OR. IMOD.GT.NADATA ) THEN
           WRITE (NDSE,1002) IMOD, NADATA
@@ -2932,7 +2932,7 @@
           WLM    => WADATS(IMOD)%XWLM
           T02    => WADATS(IMOD)%XT02
           T0M1   => WADATS(IMOD)%XT0M1
-          T01    => WADATS(IMOD)%XT01 
+          T01    => WADATS(IMOD)%XT01
           FP0    => WADATS(IMOD)%XFP0
           THM    => WADATS(IMOD)%XTHM
           THS    => WADATS(IMOD)%XTHS

--- a/model/ftn/w3agcmmd.ftn
+++ b/model/ftn/w3agcmmd.ftn
@@ -15,12 +15,12 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Module used for coupling applications between atmospheric model and WW3 with OASIS3-MCT 
+!     Module used for coupling applications between atmospheric model and WW3 with OASIS3-MCT
 !
 !  2. Variables and types :
 !
@@ -53,7 +53,7 @@
       PRIVATE
 !
 ! * Accessibility
-      PUBLIC SND_FIELDS_TO_ATMOS 
+      PUBLIC SND_FIELDS_TO_ATMOS
       PUBLIC RCV_FIELDS_FROM_ATMOS
 !
       CONTAINS
@@ -87,7 +87,7 @@
 !
 !     Name            Type    Module     Description
 !     ------------------------------------------------------------------
-!     W3WAVE          Subr.   W3WAVEMD   Wave model 
+!     W3WAVE          Subr.   W3WAVEMD   Wave model
 !     ------------------------------------------------------------------
 !
 !  6. Error messages :
@@ -99,7 +99,7 @@
 !/ ------------------------------------------------------------------- /
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
-      USE W3GDATMD,  ONLY: NSEAL, NSEA 
+      USE W3GDATMD,  ONLY: NSEAL, NSEA
       USE W3ADATMD,  ONLY: CX, CY, CHARN, HS, FP0, TWS
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
 !
@@ -108,7 +108,7 @@
 !/
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO
-      LOGICAL                          :: LL_ACTION   
+      LOGICAL                          :: LL_ACTION
       REAL(kind=8), DIMENSION(NSEAL)   :: TMP
       INTEGER                          :: JSEA, ISEA
 !
@@ -120,7 +120,7 @@
          ! Ocean sea surface current (m.s-1) (u-component)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_WSSU') THEN
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEAL) = 0.0
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(CX(ISEA) /= UNDEF) TMP(JSEA)=CX(ISEA)
@@ -216,7 +216,7 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     ID_LCOMM          Char.     I     MPI communicator
-!     IDFLD             Int.      I     Name of the exchange fields    
+!     IDFLD             Int.      I     Name of the exchange fields
 !     FXN               Int.     I/O    First exchange field
 !     FYN               Int.     I/O    Second exchange field
 !     FAN               Int.     I/O    Third exchange field
@@ -261,7 +261,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      LOGICAL                          :: LL_ACTION   
+      LOGICAL                          :: LL_ACTION
       INTEGER                          :: IB_DO, IB_I, IB_J, IL_ERR
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_RCV
       REAL(kind=8), DIMENSION(NSEAL)   :: TMP

--- a/model/ftn/w3arrymd.ftn
+++ b/model/ftn/w3arrymd.ftn
@@ -11,7 +11,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -1915,7 +1915,7 @@
 !
 !  7. Remarks :
 !
-!       PNUM2: dimensioning changed from 51 to 71 due to "subscript out 
+!       PNUM2: dimensioning changed from 51 to 71 due to "subscript out
 !           of range" fault (Sep 28 2012)
 !
 !  8. Structure :

--- a/model/ftn/w3bullmd.ftn
+++ b/model/ftn/w3bullmd.ftn
@@ -27,13 +27,13 @@
       REAL, PARAMETER      :: BHSMIN = 0.15, BHSDROP = 0.05
       REAL                 :: HST(NPTAB,2), TPT(NPTAB,2),     &
                                       DMT(NPTAB,2)
-      CHARACTER(LEN=129)   :: ASCBLINE 
-      CHARACTER(LEN=664)   :: CSVBLINE 
-!/NCO      CHARACTER(LEN=67)    :: CASCBLINE 
+      CHARACTER(LEN=129)   :: ASCBLINE
+      CHARACTER(LEN=664)   :: CSVBLINE
+!/NCO      CHARACTER(LEN=67)    :: CASCBLINE
       LOGICAL              :: IYY(NPMAX)
-!/    
+!/
 !/ Conventional declarations
-!/     
+!/
 !/
 !/ Private parameter statements (ID strings)
 !/
@@ -41,7 +41,7 @@
       CONTAINS
 !/ ------------------------------------------------------------------- /
       SUBROUTINE W3BULL                                                &
-          ( NPART, XPART, DIMXP, UABS, UD, IPNT, IOUT, TIMEV ) 
+          ( NPART, XPART, DIMXP, UABS, UD, IPNT, IOUT, TIMEV )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH-III           NOAA/NCEP |
@@ -64,7 +64,7 @@
 !
 !  2. Method :
 !
-!     Partitioning is made using the built-in module w3partmd. Partitions 
+!     Partitioning is made using the built-in module w3partmd. Partitions
 !     are ranked and organized into coherent sequences that are then
 !     written as tables to output files. Input options for generating
 !     tables are defined in ww3_outp.inp. This module sorts the table
@@ -101,7 +101,7 @@
 !
 !  7. Remarks :
 !
-!     Current version does not allow generating tables for multiple 
+!     Current version does not allow generating tables for multiple
 !     points.
 !
 !  8. Structure :
@@ -140,7 +140,7 @@
       PARAMETER     ( DDMMAX =  15.   )
       PARAMETER     ( DDWMAX =  30.   )
       PARAMETER     ( AGEMIN =   0.8  )
-      INTEGER, INTENT(IN)     :: NPART, DIMXP, IOUT 
+      INTEGER, INTENT(IN)     :: NPART, DIMXP, IOUT
       INTEGER, INTENT(INOUT)  :: TIMEV(2)
       REAL, INTENT(IN)        :: UABS,    &
                                  UD, XPART(DIMP,0:DIMXP)
@@ -173,7 +173,7 @@
        FACT = 1.
      ELSE
        FACT = 1.E-3
-     ENDIF 
+     ENDIF
 !
 ! Convert wind direction to azimuthal reference
       UDIR   = MOD( UD+180., 360. )
@@ -275,7 +275,7 @@
             INT(TIME(1)/100)-100*INT(TIME(1)/10000)
       WRITE (CSVBLINE(14:15),'(I2)') MOD(TIME(1),100)
       WRITE (CSVBLINE(17:18),'(I2)') TIME(2)/10000
-      WRITE (CSVBLINE(20:24),'(F5.2)') UABS 
+      WRITE (CSVBLINE(20:24),'(F5.2)') UABS
       WRITE (CSVBLINE(26:28),'(I3)') INT(UDIR)
       IF ( HSTOT .GT. 0. ) WRITE (CSVBLINE(30:34),'(F5.2)') HSTOT
       IF ( HSTOT .GT. 0. ) WRITE (CSVBLINE(36:40),'(F5.2)') TP
@@ -403,7 +403,7 @@
            IPG1=IPG1+1
          ENDIF
          WRITE (PART2,'(",",F5.2,",",F5.2,",",I3)')                   &
-               HSD(IFLD), TPD(IFLD), NINT(WDD(IFLD))         
+               HSD(IFLD), TPD(IFLD), NINT(WDD(IFLD))
          CSVBLINE(25+IPI(IFLD)*16:40+IPI(IFLD)*16) = PART2
        ELSE
          ILEN(IFLD)=0

--- a/model/ftn/w3canomd.ftn
+++ b/model/ftn/w3canomd.ftn
@@ -9,44 +9,44 @@
 !/                  | Last update :         21-Aug-2014 |
 !/                  +-----------------------------------+
 !/
-!/    XX-Jul-2010 : Origination by  PAEM JANSSEN     
+!/    XX-Jul-2010 : Origination by  PAEM JANSSEN
 !/    18-Oct-2012 : Adapted to WAVEWATCH III: F. Ardhuin( version 4.07 )
 !/    21-Aug-2014 : Bug corrected: only first call wasOK( version 5.01 )
-!/ 
-!  0. Note by F. Ardhuin: 
-!     In adapting the orginal program to be a WAVEWATCH module, I 
-!     have so far strived to keep the original code. As a result 
-!     some routines are unnecessarily duplicated (e.g. the calculation of 
-!     the group velocity ...). But this can improve the traceability of 
-!     the code. 
+!/
+!  0. Note by F. Ardhuin:
+!     In adapting the orginal program to be a WAVEWATCH module, I
+!     have so far strived to keep the original code. As a result
+!     some routines are unnecessarily duplicated (e.g. the calculation of
+!     the group velocity ...). But this can improve the traceability of
+!     the code.
 !     The first spectrum (JONSWAP) has been removed from the code
 !
 !  1. Purpose :
 !
 !
-!     CALCULATION OF THE SECOND ORDER CORRECTION TO THE SURFACE GRAVITY 
+!     CALCULATION OF THE SECOND ORDER CORRECTION TO THE SURFACE GRAVITY
 !     WAVE SPECTRUM
 !
 !     DOCUMENTATION.
 !     -------------
 !
-!     PRESENTLY, THE SOFTWARE IS SET UP TO DO FOR A GIVING FIRST-ORDER 
-!     SPECTRUM AT A GIVEN DEPTH THE DETERMINATION OF THE SECOND ORDER 
+!     PRESENTLY, THE SOFTWARE IS SET UP TO DO FOR A GIVING FIRST-ORDER
+!     SPECTRUM AT A GIVEN DEPTH THE DETERMINATION OF THE SECOND ORDER
 !     CORRECTION (INCLUDING SECOND-HARMONICS, WAVE SET DOWN AND DOPPLER SHIFT
 !     OWING TO THE STOKES FREQUENCY CORRECTION.
 !
 !     EVALUATION OF THE INTERACTION COEFFICIENTS FOR ARBRITRARY DEPTH WOULD
-!     BE VERY TIME CONSUMING. THEREFORE, THE APPROACH IN THE WAM MODEL IS 
+!     BE VERY TIME CONSUMING. THEREFORE, THE APPROACH IN THE WAM MODEL IS
 !     FOLLOWED, WHERE TABLES ARE GENERATED FOR A LOGARITHMIC DEPTH TABLE
 !
 !               D(JD) = DEPTHA*DEPTHD**(JD-1)
 !
-!     WITH JD AN INTEGER. IN THE PRESENT OPERATIONAL VERSION OF ECWAM JD 
+!     WITH JD AN INTEGER. IN THE PRESENT OPERATIONAL VERSION OF ECWAM JD
 !     RANGES FROM 1 TO NDEPTH = 74, WHILE DEPTHA = 1. AND DEPTHD = 1.1
 !
-!     FINALLY, THIS IS A VERY TIME-CONSUMING CALCULATION, AT LEAST FOR AN 
-!     OPERATIONAL MODEL. i HAVE THEREFORE INTRODUCED THE OPTION THAT THE SECOND-ORDER 
-!     SPECTRUM IS CALCULATED ON A LOWER RESOLUTION GRID (TYPICALLY HALF THE 
+!     FINALLY, THIS IS A VERY TIME-CONSUMING CALCULATION, AT LEAST FOR AN
+!     OPERATIONAL MODEL. i HAVE THEREFORE INTRODUCED THE OPTION THAT THE SECOND-ORDER
+!     SPECTRUM IS CALCULATED ON A LOWER RESOLUTION GRID (TYPICALLY HALF THE
 !     RESOLUTION) WHILE THE INFORMATION CONTAINED IN THE FIRST-ORDER SPECTRUM
 !     IS KEPT ON THE ORIGINAL SPECTRAL GRID.
 !
@@ -94,7 +94,7 @@
       REAL                     :: DEPTHA         ! first depth in table
       REAL, SAVE , PRIVATE, ALLOCATABLE   :: OMEGA(:)
       INTEGER, SAVE , PRIVATE             :: COUNTER = 0
-! Tables for non-linear coefficients ...   
+! Tables for non-linear coefficients ...
       REAL, SAVE , PRIVATE, ALLOCATABLE   :: TA(:,:,:,:),TB(:,:,:,:),TC_QL(:,:,:,:),&
                                              TT_4M(:,:,:,:),TT_4P(:,:,:,:),TFAKH(:,:),    &
                                              TFAK(:,:)
@@ -123,7 +123,7 @@
 !  2. Method :
 !
 !     Uses P. Janssen's code for the inverse canonical transform
-!      
+!
 !
 !  3. Parameters :
 !
@@ -141,7 +141,7 @@
 !       DEPTH     Real I     Water depth
 !       WN        R.A.       wavenumbers
 !       CG        R.A.       group velocities
-!       IACTION   Int  I     Switch to specify if the input spectrum 
+!       IACTION   Int  I     Switch to specify if the input spectrum
 !                            is E(f,theta) or A(k,theta)
 !     ----------------------------------------------------------------
 !
@@ -197,7 +197,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/ 
+!/
       INTEGER           :: ISPEC, IK, ITH, M
       REAL              :: CO1, ATOE, DPTH
 !/S      INTEGER, SAVE           :: IENT = 0
@@ -213,7 +213,7 @@
 !
 ! 0.  Initializations ------------------------------------------------ *
 !
-       IF (FIRST) THEN 
+       IF (FIRST) THEN
          FIRST=.FALSE.
          NFRE=NK
          NANG=NTH
@@ -241,7 +241,7 @@
       DPTH = DEPTH
 
       DO IK=1,NK
-        IF (IACTION.EQ.0) THEN 
+        IF (IACTION.EQ.0) THEN
           ATOE=1
         ELSE
           ATOE=SIG(IK)*ZPI / CG(IK)
@@ -261,10 +261,10 @@
                               DTH,DPTH,+1., NFREH, NANGH)
 
 !
-! 2. Adds 2nd order spectrum to 1st order 
+! 2. Adds 2nd order spectrum to 1st order
 !
       DO IK=1,NK
-        IF (IACTION.EQ.0) THEN 
+        IF (IACTION.EQ.0) THEN
           ATOE=1
         ELSE
           ATOE=SIG(IK)*ZPI / CG(IK)
@@ -275,7 +275,7 @@
           END DO
          !WRITE(101,'(I3,100G16.8)') SIG(IK)*ZPI,(F3(ITH,IK),ITH=1,NTH)
         END DO
-      
+
 !/T      PRINT*,' END CAL_SEC_ORDER_SPEC'
       RETURN
 
@@ -310,11 +310,11 @@
 !                            *TH*    - DIRECTIONAL ARRAY
 !                            *DELTH* - DIRECTIONAL INCREMENT
 !                            *DPTH*  - DEPTH ARRAY
-!                            *SIGM*   - FOR SIGM = 1 FORWARD MAPPING 
+!                            *SIGM*   - FOR SIGM = 1 FORWARD MAPPING
 !                                      WHILE FOR SIGM = -1 INVERSE
 !                                      MAPPING.
 !
-!                       OUTPUT: 
+!                       OUTPUT:
 !                            *F3*    - 2-D SPECTRUM INCLUDING SECOND-ORDER
 !                                      CORRECTION
 !
@@ -334,10 +334,10 @@
       REAL, INTENT(OUT)       :: F3(NANG,NFRE)
 
       INTEGER, INTENT(IN)     :: NFRE,NANG,NFREH, NANGH
-      
+
       REAL, INTENT(IN)        :: DFIM(NFRE),FR(NFRE), TH(NANG), DELTH
       REAL, INTENT(IN)        :: DPTH, SIGM
- 
+
       LOGICAL FRSTIME,DOUBLEP
 
       INTEGER MDW,M,K, K0,M0,MP,KP,MM,KM,KL,KLL,ML,JD
@@ -352,7 +352,7 @@
 
       REAL DEPTH,ALPHA,GAM_J,DEPTHD
       REAL OM0,AA1,BB1,&
-     F,EPSMIN,DELFF,SPEC1,SQRTK  
+     F,EPSMIN,DELFF,SPEC1,SQRTK
       REAL FRAC,DEL,DELF,D1,D2,D3,D4,C1,&
      C2,XM,XK
       REAL, SAVE :: OMSTART
@@ -361,7 +361,7 @@
       REAL :: F13(NFREH,NANGH)
       REAL :: SUM0,AKMEAN
       REAL :: DELOM(NFREH),THH(NANGH),DFDTH(NFREH)
-     
+
       DATA FRSTIME/.TRUE./
 
       COMMON/CONST/DEPTH,ALPHA,MDW,GAM_J,DEPTHD
@@ -388,10 +388,10 @@
         XMA = 1./FLOAT(MA)
         DELTHH = FLOAT(MA)*DELTH
 
-       IF (FRSTIME) THEN 
-       ! IF (COUNTER.GT.0) THEN 
+       IF (FRSTIME) THEN
+       ! IF (COUNTER.GT.0) THEN
        !  DEALLOCATE(OMEGA,TFAK,TA,TB,TC_QL,TT_4M,TT_4P,IM_P,IM_M,TFAKH)
-       ! ENDIF 
+       ! ENDIF
         ALLOCATE(OMEGA(NFREH))
         ALLOCATE(TFAK(NFRE,NDEPTH))
         ALLOCATE(TA(NANGH,NFREH,NFREH,NDEPTH))
@@ -430,7 +430,7 @@
 !/T      PRINT*,' NMAX = ',NMAX
 
         DEPTHD = 1.1
- 
+
         DO JD=1,NDEPTH
           DEPTH = DEPTHA*DEPTHD**(JD-1)
           DO M=1,NFRE
@@ -466,7 +466,7 @@
       ENDDO
 !
 ! NB: AKMEAN is the mean wavenumber corresponding to Tm0,-1 in deep water
-!     
+!
       AKMEAN = (SUM0/AKMEAN)**2
 
 !
@@ -477,7 +477,7 @@
 !
 !***     2.21 NO INTERPOLATION.
 !        ----------------------
-! 
+!
 !/T         PRINT*,' NO THINNING AND INTERPOLATION'
 !/T         PRINT*,'nanG:',NANG,NMAX,NFRE,NDEPTH,DEPTHA,DEPTHD,DPTH,'##',DELTH,DELTHH
 
@@ -525,7 +525,7 @@
                  PF1(K,M)=PF1(K,M)+SPEC1*DEL
                ENDDO
              ENDDO
-             PF1(K,M) =PF1(K,M)/DELFF 
+             PF1(K,M) =PF1(K,M)/DELFF
            ENDDO
          ENDDO
 !
@@ -557,7 +557,7 @@
              MP = MIN(NFREH,M0+1)
              KP = K0+1
              IF (KP.GT.NANGH) KP = KP-NANGH
- 
+
              C1 = PF3(K0,M0)*D4+PF3(KP,M0)*D3
              C2 = PF3(KP,MP)*D3+PF3(K0,MP)*D4
 
@@ -565,7 +565,7 @@
              F3(K,M)=MAX(0.00000001,F1(K,M)+SIGM*DELF)
            ENDDO
          ENDDO
-   
+
       ENDIF
 
 
@@ -583,9 +583,9 @@
             ENDDO
             BB1 = MAX(BB1,EPSMIN)
             F   = OMEGA(M)/ZPI
-   
-!/T            WRITE(6,62) M,F,AA1,BB1,DELTHH     
-!/T            WRITE(80,62) M,F,AA1,BB1,DELTHH     
+
+!/T            WRITE(6,62) M,F,AA1,BB1,DELTHH
+!/T            WRITE(80,62) M,F,AA1,BB1,DELTHH
          ENDDO
 
          DO M=1,NFREH
@@ -597,7 +597,7 @@
 
 !
 !/T   62 FORMAT(I4,9F16.9)
-!      
+!
       RETURN
       END SUBROUTINE CAL_SEC_ORDER_SPEC
 !
@@ -633,7 +633,7 @@
 !
 !       NFRE      INTEGER   NUMBER OF FREQUENCIES
 !       NANG      INTEGER   NUMBER OF DIRECTIONS
-!       NDEPTH    INTEGER   NUMBER OF ENTRIES IN THE DEPTH TABLE 
+!       NDEPTH    INTEGER   NUMBER OF ENTRIES IN THE DEPTH TABLE
 !       OMSTART   REAL      START FREQUENCY
 !       FRAC      REAL      FRACTIONAL INCREASE IN FREQUENCY SPACE
 !       XMR       REAL      INVERSE OF THINNING FACTOR IN FREQUENCY SPACE
@@ -652,14 +652,14 @@
 !
 !     METHOD
 !     ------
-!             
+!
 !     EXTERNALS
 !     ---------
 !             NONE
 !
 !     REFERENCES
 !     ----------
-!             V.E. ZAKHAROV, HAMILTONIAN APPROACH (1968) 
+!             V.E. ZAKHAROV, HAMILTONIAN APPROACH (1968)
 !             M.A. SROKOSZ, J.G.R.,91,995-1006 (1986)
 !             P.A.E.M. JANSSEN, ECMWF TECH MEMO (2008),JFM PAPER (2009)
 !
@@ -667,11 +667,11 @@
 !--------------------------------------------------------------------
 !
 !
-!  
+!
       IMPLICIT NONE
-   
+
       INTEGER NFRE,NANG,NDEPTH,MDW,JD,M,K,M1,K1,MP,MM,L
-      
+
       REAL DEPTH,ALPHA,GAM_J,DEPTHA,DEPTHD
       REAL OM0,TH0,XK0,OM1,TH1,XK1,OM2,XK2,OM0P,XK0P,OM0M,XK0M,OMSTART,&
      FRAC,XMR,XM2,FAC
@@ -700,43 +700,43 @@
          DO M=1,NFRE
             OM0 = OMEGA(M)
             XK0 = TFAK(M,JD)
-          
+
             MP   = MIN(M+1,NFRE)
             OM0P = OMEGA(MP)
-            XK0P = TFAK(MP,JD) 
+            XK0P = TFAK(MP,JD)
 
-            MM   = MAX(M-1,1) 
+            MM   = MAX(M-1,1)
             OM0M = OMEGA(MM)
-            XK0M = TFAK(MM,JD) 
-                  
+            XK0M = TFAK(MM,JD)
+
             DO M1=1,NFRE
-                        
+
                OM1 = OMEGA(M1)
-           
+
                DO L=1,NANG
 !
-!              XK0-XK1 CASE 
-!           
+!              XK0-XK1 CASE
+!
                   K = K1+L
                   TH0 = TH(K)
                   OM2 = OM0-OM1
-         
-             
+
+
                   IF (ABS(OM1).LT.OM0/2.) THEN
                      XM2  = LOG(OM2/OMSTART)/LOG(1.+FRAC)
                      IM_M(M1,M) = NINT(XMR*(XM2+1.))
                      XK1 = TFAK(M1,JD)
-                     XK2 = AKI(OM2,DEPTH) 
+                     XK2 = AKI(OM2,DEPTH)
 
                      TA(L,M1,M,JD) = DFDTH(M1)*A(XK1,XK2,TH1,TH0)**2
                   ELSE
                      TA(L,M1,M,JD) = 0.
                      IM_M(M1,M) = 1
-                  ENDIF 
+                  ENDIF
 !
-!              XK1+XK0 CASE 
-!           
-                  OM2 = OM1+OM0 
+!              XK1+XK0 CASE
+!
+                  OM2 = OM1+OM0
                   XM2  = LOG(OM2/OMSTART)/LOG(1.+FRAC)
                   IM_P(M1,M) = NINT(XMR*(XM2+1.))
                   XK1 = TFAK(M1,JD)
@@ -745,13 +745,13 @@
                   TB(L,M1,M,JD) = DFDTH(M1)*B(XK1,XK2,TH1,TH0)**2
 !
 !              QUASI-LINEAR EFFECT
-!           
-!  
-                  TC_QL(L,M1,M,JD) = DFDTH(M1)*C_QL(XK0,XK1,TH0,TH1)
-!  
-!              STOKES-FREQUENCY CORRECTION 
 !
-!      
+!
+                  TC_QL(L,M1,M,JD) = DFDTH(M1)*C_QL(XK0,XK1,TH0,TH1)
+!
+!              STOKES-FREQUENCY CORRECTION
+!
+!
                   FAC = 2.*G/OM1*DFDTH(M1)
                   TT_4M(L,M1,M,JD) = &
                   FAC*(W2(XK0M,XK1,XK1,XK0M,TH0,TH1,TH1,TH0)+&
@@ -759,17 +759,17 @@
                   TT_4P(L,M1,M,JD) = &
                   FAC*(W2(XK0P,XK1,XK1,XK0P,TH0,TH1,TH1,TH0)+&
                        V2(XK0P,XK1,XK1,XK0P,TH0,TH1,TH1,TH0))
-! Table identical to Janssen: verified. 
+! Table identical to Janssen: verified.
 !              IF (JD.EQ.1) WRITE(998,'(F4.1,3I3,5G11.3)') DEPTH,M,M1,L, TB(L,M1,M,JD),  &
 !                           TC_QL(L,M1,M,JD) , FAC, TT_4M(L,M1,M,JD), TT_4P(L,M1,M,JD)
                ENDDO
             ENDDO
          ENDDO
        ENDDO
-! 
+!
 !
 !--------------------------------------------------------------------
-!      
+!
       RETURN
       END SUBROUTINE TABLES_2ND
 !
@@ -809,9 +809,9 @@
 !       F1        REAL      2D FREE WAVE SPECTRUM (INPUT)
 !       F3        REAL      BOUND WAVES SPECTRUM (OUTPUT)
 !       NFRE      INTEGER   NUMBER OF FREQUENCIES
-!       NANG      INTEGER   NUMBER OF DIRECTIONS 
+!       NANG      INTEGER   NUMBER OF DIRECTIONS
 !       NMAX      INTEGER   MAXIMUM INDEX CORRESPONDS TO TWICE THE CUT-OFF
-!                           FREQUENCY 
+!                           FREQUENCY
 !       NDEPTH    INTEGER   NUMBER OF ENTRIES IN DEPTH TABLE
 !       DEPTHA    REAL      START VALUE DEPTH ARRAY
 !       DEPTHD    REAL      INCREMENT DEPTH ARRAY
@@ -842,7 +842,7 @@
 !
 !     REFERENCES
 !     ----------
-!             V.E. ZAKHAROV, HAMILTONIAN APPROACH (1968) 
+!             V.E. ZAKHAROV, HAMILTONIAN APPROACH (1968)
 !             M.A. SROKOSZ, J.G.R.,91,995-1006 (1986)
 !             P.A.E.M. JANSSEN, JFM (2009)
 !
@@ -850,10 +850,10 @@
 !--------------------------------------------------------------------
 !
 !
-!     
+!
       USE W3GDATMD, ONLY: IGPARS
       IMPLICIT NONE
-   
+
       INTEGER NFRE,NANG,NDEPTH,M,K,M1,K1,M2_M,M2_P,K2,MP,&
         MM,L,MR,NMAX,JD,COUNTER
       INTEGER IM_P(NFRE,NFRE),IM_M(NFRE,NFRE),IL(NANG,NANG)
@@ -913,7 +913,7 @@
           G1(K,M) = OMEGA(NFRE)**5*G1(K,NFRE)/OMEGAHF(M)**5
         ENDDO
       ENDDO
-!     
+!
 !
 !
 !
@@ -923,10 +923,10 @@
 !
       DO M=1,NFRE
         OM0 = OMEGA(M)
-        OM0H = OM0/2.                  
+        OM0H = OM0/2.
         MP   = MIN(M+1,NFRE)
-        OM0P = OMEGA(MP) 
-        MM   = MAX(M-1,1) 
+        OM0P = OMEGA(MP)
+        MM   = MAX(M-1,1)
         OM0M = OMEGA(MM)
         DELM1 = 1./(OM0P-OM0M)
         DO K=1,NANG
@@ -945,7 +945,7 @@
 !
 !                   2.1 OM0-OM1 CASE: SECOND HARMONICS
 !                   OM2 = OM0-OM1
-!             
+!
               IF (LL2H) THEN
                 F2K2 = G1(K2,M2_M)
                 FAC1 = TA(L,M1,M,JD)
@@ -953,19 +953,19 @@
 
                 XINCR1 = FAC1*FAC2
                 G3(K,M) = G3(K,M)+XINCR1
-              ENDIF 
+              ENDIF
 !
 !                   2.2 OM1+OM0 CASE: INFRA-GRAVITY WAVES
-!                    OM2 = OM1+OM0 
+!                    OM2 = OM1+OM0
 !
               F2K2 = G1(K2,M2_P)
               FAC3 = 2.*TB(L,M1,M,JD)
               XINCR2 = FAC3*F2K2
 !
 !                   2.3 QUASI-LINEAR EFFECT
-!           
+!
               XINCR3 = TC_QL(L,M1,M,JD)*F2K
-!  
+!
 !                   2.4 STOKES-FREQUENCY CORRECTION
 !
               T_4M = TT_4M(L,M1,M,JD)
@@ -986,7 +986,7 @@
       ENDDO
 !
 !--------------------------------------------------------------------
-!      
+!
       RETURN
       END SUBROUTINE SECSPOM
 !
@@ -1038,7 +1038,7 @@
       RJ = XJ
       RK  = VABS(RI,RJ,THI,THJ)
       THK = VDIR(RI,RJ,THI,THJ)
-        
+
       OI=OMEG(RI)
       OJ=OMEG(RJ)
       OK=OMEG(RK)
@@ -1046,11 +1046,11 @@
       FI = SQRT(OI/(2.*G))
       FJ = SQRT(OJ/(2.*G))
       FK = SQRT(OK/(2.*G))
- 
-      
+
+
       A = FK/(FI*FJ)*(A1(RK,RI,RJ,THK,THI,THJ)+&
                 A3(RK,RI,RJ,THK-PI,THI,THJ))
-      
+
       RETURN
       END FUNCTION A
 !
@@ -1098,7 +1098,7 @@
       RI = XI
       RJ = XJ
       RK  = VABS(RJ,RI,THJ,THI-PI)
-      THK = VDIR(RJ,RI,THJ,THI-PI)      
+      THK = VDIR(RJ,RI,THJ,THI-PI)
 
       OI=OMEG(RI)+DEL
       OJ=OMEG(RJ)+DEL
@@ -1157,10 +1157,10 @@
 !
       OM1 = OMEG(XK1)
       F1  = SQRT(OM1/(2.*G))
-      
+
       C_QL = 2./F1**2*(B2(XK0,XK1,XK1,XK0,TH0,TH1,TH1,TH0)+&
                  B3(XK0,XK0,XK1,XK1,TH0-PI,TH0,TH1,TH1))
-           
+
       RETURN
       END FUNCTION C_QL
 
@@ -1173,7 +1173,7 @@
 !-----------------------------------------------------------------------
       REAL FUNCTION VPLUS(XI,XJ,XK,THI,THJ,THK)
 !
-!***  *VPLUS*  DETERMINES THE SECOND-ORDER TRANSFER COEFFICIENT 
+!***  *VPLUS*  DETERMINES THE SECOND-ORDER TRANSFER COEFFICIENT
 !              FOR THREE WAVE INTERACTIONS OF GRAVITY WAVES.
 !
 !     PETER JANSSEN
@@ -1249,7 +1249,7 @@
 !-----------------------------------------------------------------------
       REAL FUNCTION VMIN(XI,XJ,XK,THI,THJ,THK)
 !
-!***  *VMIN*  DETERMINES THE SECOND-ORDER TRANSFER COEFFICIENT FOR 
+!***  *VMIN*  DETERMINES THE SECOND-ORDER TRANSFER COEFFICIENT FOR
 !             THREE WAVE INTERACTIONS OF GRAVITY WAVES.
 !
 !     PETER JANSSEN
@@ -1391,7 +1391,7 @@
                   QIK+QJK+QIL+QJL) )
       RETURN
       END FUNCTION U
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *W2(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1440,10 +1440,10 @@
     U(XK,XJ,XI,XL,THK,THJ-PI,THI-PI,THL)-&
     U(XI,XK,XJ,XL,THI-PI,THK,THJ-PI,THL)-&
     U(XI,XL,XK,XJ,THI-PI,THL,THK,THJ-PI)-&
-    U(XL,XJ,XK,XI,THL,THJ-PI,THK,THI-PI) 
+    U(XL,XJ,XK,XI,THL,THJ-PI,THK,THI-PI)
       RETURN
       END FUNCTION W2
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *V2(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1451,7 +1451,7 @@
 !-----------------------------------------------------------------------
       REAL FUNCTION V2(XI,XJ,XK,XL,THI,THJ,THK,THL)
 !
-!***  *V2*  DETERMINES THE CONTRIBUTION OF THE VIRTUAL 
+!***  *V2*  DETERMINES THE CONTRIBUTION OF THE VIRTUAL
 !           FOUR-WAVE INTERACTIONS OF GRAVITY WAVES.
 !
 !     PETER JANSSEN
@@ -1461,7 +1461,7 @@
 !
 !              GIVES NONLINEAR TRANSFER COEFFICIENT FOR FOUR
 !              WAVE INTERACTIONS OF GRAVITY WAVES IN THE
-!              IDEAL CASE OF NO CURRENT. (CF.ZAKHAROV,AND 
+!              IDEAL CASE OF NO CURRENT. (CF.ZAKHAROV,AND
 !              CRAWFORD ET AL)
 !
 !     INTERFACE.
@@ -1530,24 +1530,24 @@
 
       RKL  = VABS(RK,RL,THK,THL)
       THKL = VDIR(RK,RL,THK,THL)
-   
+
       OIJ=OMEG(RIJ)
       OIK=OMEG(RIK)
       OJL=OMEG(RJL)
       OJK=OMEG(RJK)
       OLI=OMEG(RLI)
       OKL=OMEG(RKL)
-      
+
       XNIK = OK+OIK-OI
       XNJL = OJ+OJL-OL
       XNJK = OK+OJK-OJ
       XNIL = OI+OLI-OL
-      
+
       YNIL = OL+OLI-OI
       YNJK = OJ+OJK-OK
       YNJL = OL+OJL-OJ
       YNIK = OI+OIK-OK
-      
+
       ZNIJ = OIJ-OI-OJ
       ZNKL = OKL-OK-OL
       ZPIJ = OIJ+OI+OJ
@@ -1558,8 +1558,8 @@
       THKJ = THJK-PI
       THKI = THIK-PI
       THJI = THIJ-PI
-      THLK = THKL-PI 
-      
+      THLK = THKL-PI
+
       V2= VMIN(RI,RK,RIK,THI,THK,THIK)*VMIN(RL,RJ,RJL,THL,THJ,THLJ)*&
     (1./XNIK+1./XNJL)&
    +VMIN(RJ,RK,RJK,THJ,THK,THJK)*VMIN(RL,RI,RLI,THL,THI,THLI)*&
@@ -1577,7 +1577,7 @@
 
       RETURN
       END FUNCTION V2
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *W1(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1632,8 +1632,8 @@
      U(XJ,XL,XI,XK,THJ,THL,THI-PI,THK)+&
      U(XK,XL,XI,XJ,THK,THL,THI-PI,THJ)
 
-      W1=W1/3. 
-               
+      W1=W1/3.
+
       RETURN
       END FUNCTION W1
 !
@@ -1682,7 +1682,7 @@
 !***  1. DETERMINE NONLINEAR TRANSFER.
 !     --------------------------------
 !
- 
+
       W4= U(XI,XJ,XK,XL,THI,THJ,THK,THL)+&
     U(XI,XK,XJ,XL,THI,THK,THJ,THL)+&
     U(XI,XL,XJ,XK,THI,THL,THJ,THK)+&
@@ -1691,11 +1691,11 @@
     U(XK,XL,XI,XJ,THK,THL,THI,THJ)
 
 
-      W4=W4/3. 
-               
+      W4=W4/3.
+
       RETURN
       END FUNCTION W4
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *B3(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1811,7 +1811,7 @@
 
       RETURN
       END FUNCTION B3
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *B4(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1891,9 +1891,9 @@
       THJK = VDIR(RJ,RK,THJ,THK)
 
       RKL  = VABS(RK,RL,THK,THL)
-      THKL = VDIR(RK,RL,THK,THL)      
+      THKL = VDIR(RK,RL,THK,THL)
 
-      
+
       ZIJKL = OI+OJ+OK+OL
 
       B4= -1./ZIJKL*(2./3.*(    &
@@ -1907,7 +1907,7 @@
 
       RETURN
       END FUNCTION B4
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *B1(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -1995,10 +1995,10 @@
       THJK = VDIR(RJ,RK,THJ,THK)
 
       RKL  = VABS(RK,RL,THK,THL)
-      THKL = VDIR(RK,RL,THK,THL)      
-      
+      THKL = VDIR(RK,RL,THK,THL)
+
       ZIJKL = OI-OJ-OK-OL
-      
+
       B1= -1./ZIJKL*(2./3.*(    &
       MIN(RI,RJ,RIJ,THI,THJ,THIJ)*A1(RKL,RK,RL,THKL,THK,THL)&
     +VMIN(RI,RK,RIK,THI,THK,THIK)*A1(RJL,RJ,RL,THJL,THJ,THL)&
@@ -2006,11 +2006,11 @@
     +VMIN(RK,RI,RKI,THK,THI,THKI)*A3(RJL,RJ,RL,THJL-PI,THJ,THL)&
     +VMIN(RL,RI,RLI,THL,THI,THLI)*A3(RJK,RJ,RK,THJK-PI,THJ,THK)&
     +VMIN(RJ,RI,RJI,THJ,THI,THJI)*A3(RKL,RK,RL,THKL-PI,THK,THL) &
-    ) +W1(RI,RJ,RK,RL,THI,THJ,THK,THL) )    
+    ) +W1(RI,RJ,RK,RL,THI,THJ,THK,THL) )
       RETURN
       END FUNCTION B1
 
-!      
+!
 !-----------------------------------------------------------------------
 !
 !***  *REAL FUNCTION* *B2(XI,XJ,XK,XL,THI,THJ,THK,THL)
@@ -2096,7 +2096,7 @@
       THKJ = VDIR(RK,RJ,THK,THJ-PI)
 
       RKL  = VABS(RK,RL,THK,THL)
-      THKL = VDIR(RK,RL,THK,THL)   
+      THKL = VDIR(RK,RL,THK,THL)
 
       B2=  A3(RI,RJ,RIJ,THI,THJ,THIJ-PI)*A3(RK,RL,RKL,THK,THL,THKL-PI)&
     +A1(RJ,RK,RJK,THJ,THK,THJK)*A1(RL,RI,RLI,THL,THI,THLI)&
@@ -2254,7 +2254,7 @@
 !
 !***  1. DETERMINE NONLINEAR TRANSFER.
 !     --------------------------------
-!    
+!
       IF (DOUBLEP) THEN
          DEL1 = 10.**(-8)
       ELSE
@@ -2371,7 +2371,7 @@
       END FUNCTION VG
 !---------------------------------------------------------------------
       REAL FUNCTION AKI(OM,BETA)
-! This function gives the wavenumber ... 
+! This function gives the wavenumber ...
 !---------------------------------------------------------------------
 !
       IMPLICIT NONE

--- a/model/ftn/w3cspcmd.ftn
+++ b/model/ftn/w3cspcmd.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -34,7 +34,7 @@
 !     Elements of the data structure CASE are given below. The middle
 !     block pf parameters has pointer aliasses with the same name in
 !     the subroutine.
-!  
+!
 !      Name      Type  Description
 !     ----------------------------------------------------------------
 !      ICASE     Int.  Number of case.
@@ -109,7 +109,7 @@
 !/                  +-----------------------------------+
 !/
 !/    19-Sep-2005 : Origination.                        ( version 3.08 )
-!/    01-Nov-2012 : code clean up (tab spaces, comments)( version 4.08 ) 
+!/    01-Nov-2012 : code clean up (tab spaces, comments)( version 4.08 )
 !/
 !  1. Purpose :
 !
@@ -152,7 +152,7 @@
 !     ----------------------------------------------------------------
 !      W3IOBC    Subr. W3IOBCMD Updating boundary conditions.
 !                Subr           Multi scale model bound. data input.
-!     ---------------------------------------------------------------- 
+!     ----------------------------------------------------------------
 !
 !  6. Error messages :
 !
@@ -160,7 +160,7 @@
 !
 !  7. Remarks :
 !
-!     - The inner loop of the actual redistribution is over the 
+!     - The inner loop of the actual redistribution is over the
 !       individual spectra, optimizing this routine for large numbers
 !       of conversions in a single call.
 !
@@ -207,7 +207,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Pointers for aliases
-!/ 
+!/
       INTEGER, POINTER        :: IDTH(:,:), IDFR(:,:), NFR2T
       REAL, POINTER           :: DTH1, DTH2, RDTH(:,:), FRQ1(:),      &
                                  FRQ2(:), XDF1, XDF2, RDFR(:,:)
@@ -225,12 +225,12 @@
         END IF
 !
       IF ( NSP .LT. 0 ) THEN
-        WRITE (NDSE,901)   
+        WRITE (NDSE,901)
         CALL EXTCDE ( 2 )
         END IF
 !
       IF ( NSP .EQ. 0 ) THEN
-        WRITE (NDSE,902) 
+        WRITE (NDSE,902)
         RETURN
         END IF
 !
@@ -261,7 +261,7 @@
                 CURRENT%NTH1.EQ.NTH1 .AND. CURRENT%NTH2.EQ.NTH2 .AND. &
                 CURRENT%XF1 .EQ.XF1  .AND. CURRENT%XF2 .EQ.XF2  .AND. &
                 CURRENT%FR1 .EQ.FR1  .AND. CURRENT%FR2 .EQ.FR2  .AND. &
-                CURRENT%TH1 .EQ.TH1  .AND. CURRENT%TH2 .EQ.TH2 
+                CURRENT%TH1 .EQ.TH1  .AND. CURRENT%TH2 .EQ.TH2
         IF ( FOUND ) EXIT
 !
         END DO
@@ -302,7 +302,7 @@
         ELSE
           ALLOCATE ( CURRENT%NEXT )
           CURRENT => CURRENT%NEXT
-          END IF 
+          END IF
 !
 ! 2.b.2 Store test data
 !

--- a/model/ftn/w3dispmd.ftn
+++ b/model/ftn/w3dispmd.ftn
@@ -11,12 +11,12 @@
 !/
 !/    30-Nov-1999 : Fortran 90 version.                 ( version 2.00 )
 !/    29-May-2009 : Preparing distribution version.     ( version 3.14 )
-!/    10-Mar-2016 : Added Liu & Mollo-Christensen 
+!/    10-Mar-2016 : Added Liu & Mollo-Christensen
 !/                  dispersion with ice (E. Rogers)     ( version 5.10 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -270,7 +270,7 @@
 !
       !CALL WAVNU1(ABS(W),H,KTEST1,CGTEST1)
       !CALL WAVNU3(ABS(W),H,KTEST2,CGTEST2)
-  
+
       CG   = 0
       KOLD = 0
       ICON = 0
@@ -330,7 +330,7 @@
 !/ End of WAVNU2 ----------------------------------------------------- /
 !/
       END SUBROUTINE WAVNU2
-!/      
+!/
       PURE SUBROUTINE WAVNU3 (SI,H,K,CG)
 !/
 !/                  +-----------------------------------+
@@ -344,8 +344,8 @@
 !/
 !  1. Purpose :
 !
-!     Calculate wavenumber and group velocity from the improved 
-!     Eckard's formula by Beji (2003) 
+!     Calculate wavenumber and group velocity from the improved
+!     Eckard's formula by Beji (2003)
 !
 !  2. Method :
 !
@@ -437,8 +437,8 @@
       RETURN
 !/
 !/ End of WAVNU3 ----------------------------------------------------- /
-!/      
-      END SUBROUTINE WAVNU3 
+!/
+      END SUBROUTINE WAVNU3
 !/ ------------------------------------------------------------------- /
       SUBROUTINE DISTAB
 !/
@@ -586,15 +586,15 @@
 !
 !     Dispersion relation calculation: given frequency, find k
 !     This is for dispersion in ice, so it requires the ice thickness
-!     and viscosity also. (the latter is the "eddy viscosity in the 
+!     and viscosity also. (the latter is the "eddy viscosity in the
 !     turbulent boundary layer beneath the ice.").
 !     Please note that this is for a continuous ice cover (not broken in floes)
 !
 !     This subroutine also calculates Cg and alpha.
-!     alpha is the exponential decay rate of *energy* (not to be 
-!     confused with k_i which is the exponential decay rate of 
-!     amplitude) 
-!     
+!     alpha is the exponential decay rate of *energy* (not to be
+!     confused with k_i which is the exponential decay rate of
+!     amplitude)
+!
 !     Both alpha and k_i are for spatial decay rate, units (1/m)
 !     Neither is for temporal decay rate.
 !
@@ -603,7 +603,7 @@
 !
 !  2. Method :
 !
-!     Newton-Raphson. 
+!     Newton-Raphson.
 !     For actual dispersion relation, see documentation of subroutine
 !     "Liu_reverse_dispersion"
 !
@@ -616,8 +616,8 @@
 !      H_WDEPTH   Real    I  Water depth
 !      SIGMA      R.A.    I  Radian Wave frequency
 !      K_SOLUTION R.A.    O  Wave number
-!      CG         R.A.    O  Group velocity 
-!      ALPHA      R.A.    O  Exponential decay rate of energy 
+!      CG         R.A.    O  Group velocity
+!      ALPHA      R.A.    O  Exponential decay rate of energy
 !      NK         Int.    I  Number of frequencies
 !     ----------------------------------------------------------------
 !
@@ -625,7 +625,7 @@
 !
 !      Name                   | Type |  Module | Description
 !     ----------------------------------------------------------------
-!      Liu_reverse_dispersion | Subr.| W3SIC2MD| As name implies. 
+!      Liu_reverse_dispersion | Subr.| W3SIC2MD| As name implies.
 !      STRACE                 | Subr.| W3SERVMD| Subroutine tracing.
 !      WAVNU1                 | Subr.| W3DISPMD| Wavenumber for waves
 !                                                in open water.
@@ -644,11 +644,11 @@
 !
 !  7. Remarks :
 !
-!     Eventually, k and Cg should be used for propagation. This is not 
+!     Eventually, k and Cg should be used for propagation. This is not
 !     implemented yet. For now, it is only used to calculate the source
 !     term.
 !
-!     For discussion of the eddy viscosity term, see documentation of 
+!     For discussion of the eddy viscosity term, see documentation of
 !     subroutine "Liu_reverse_dispersion"
 !
 !     This subroutine expects eddy viscosity in units of m2/sec even
@@ -676,11 +676,11 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
-      
+
       REAL   , INTENT(IN)  :: H_ICE, H_WDEPTH, SIGMA(NK)
       REAL   , INTENT(IN)  :: VISC    ! in m2/sec
       REAL   , INTENT(OUT) :: K_SOLUTION(NK) ,CG(NK) ,ALPHA(NK)
-     
+
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -690,12 +690,12 @@
       INTEGER, PARAMETER :: N_ITER=20  ! number of iterations prior to
                                        ! failure
       LOGICAL            :: GET_CG     ! indicates whether to get Cg
-                                       ! and alpha 
+                                       ! and alpha
                                        ! from "Liu_reverse_dispersion"
-      REAL :: FREQ(20)    ! wave frequency at current 
-                                       ! iteration 
-      REAL  :: KWN(20)     ! wavenumber at current 
-                                       ! iteration 
+      REAL :: FREQ(20)    ! wave frequency at current
+                                       ! iteration
+      REAL  :: KWN(20)     ! wavenumber at current
+                                       ! iteration
       INTEGER            :: ITER       ! iteration number
       REAL               :: DK,DF,DFDK ! as name implies
       REAL               :: FDUMMY     ! as name implies
@@ -703,7 +703,7 @@
       REAL               :: K_OPEN     ! open-water value of k
       REAL               :: CG_OPEN    ! open-water value of Cg
       REAL               :: FWANTED    ! Freq. corresponding to sigma
-      REAL               :: FERROR     ! Max acceptable error after test to avoid crash    
+      REAL               :: FERROR     ! Max acceptable error after test to avoid crash
 
 !/
 !/ ------------------------------------------------------------------- /
@@ -711,9 +711,9 @@
 !/S      CALL STRACE (IENT, 'LIU_FORWARD_DISPERSION')
 !
 !/ 0) --- Initialize/allocate variables ------------------------------ /
-        
- 
-      
+
+
+
 
       DO IK = 1, NK
 
@@ -722,7 +722,7 @@
         !/T38                          H_ICE,VISC,H_WDEPTH,FWANTED
              FWANTED=SIGMA(IK)/TPI
         ! First guess for k :
-              
+
               CALL WAVNU1(SIGMA(IK),H_WDEPTH,K_OPEN,CG_OPEN)
         !     KWN(1)  = 0.2 ! (old method)
               KWN(1)  =K_OPEN ! new method, Mar 10 2014
@@ -761,8 +761,8 @@
 
                  ! Decide on next k to try
                  KWN(ITER+1) = KWN(ITER) + DK
-                 ! If we end up with a negative k for the next iteration, don't 
-                 !   allow this. 
+                 ! If we end up with a negative k for the next iteration, don't
+                 !   allow this.
                  IF(KWN(ITER+1) < 0.0)THEN
                     KWN(ITER+1) = TPI / 1000.0
                  ENDIF
@@ -773,12 +773,12 @@
         !     Success, so return K_SOLUTION, and call LIU_REVERSE_DISPERSION one
         !     last time, to get CG and ALPHA
 
-              K_SOLUTION(IK) = KWN(ITER)  
+              K_SOLUTION(IK) = KWN(ITER)
 
         GET_CG     = .TRUE.
       CALL LIU_REVERSE_DISPERSION(H_ICE,VISC,H_WDEPTH,K_SOLUTION(IK), &
            GET_CG,FDUMMY,CG(IK),ALPHA(IK))
-      END DO 
+      END DO
 !
 !/T38      WRITE(*,*)'FORWARD OUT: K_SOLUTION,CG,ALPHA = ', &
 !/T38                          K_SOLUTION,CG,ALPHA
@@ -812,25 +812,25 @@
 !
 !     Dispersion relation calculation: given k, find frequency.
 !     This is for dispersion in ice, so it requires the ice thickness
-!     and viscosity also. (the latter is the "eddy viscosity in the 
+!     and viscosity also. (the latter is the "eddy viscosity in the
 !     turbulent boundary layer beneath the ice.").
 !
 !     This subroutine also (optionally) calculates Cg and alpha.
-!     alpha is the exponential decay rate of *energy* (not to be 
-!     confused with k_i which is the exponential decay rate of 
+!     alpha is the exponential decay rate of *energy* (not to be
+!     confused with k_i which is the exponential decay rate of
 !     amplitude)
-!     
+!
 !     Both alpha and k_i are for spatial decay rate, units (1/m)
 !     Neither is for temporal decay rate.
 
-!     This calculation is optional for reasons of computational 
-!      efficiency (don't calculate if it will not be used). Note that 
+!     This calculation is optional for reasons of computational
+!      efficiency (don't calculate if it will not be used). Note that
 !      if Cg and alpha are not calculated, the value of input viscosity
 !      is irrelevant.
 !
 !     References:
 !       Liu et al.    1991: JGR 96 (C3), 4605-4621
-!       Liu and Mollo 1988: JPO 18       1720-1712 
+!       Liu and Mollo 1988: JPO 18       1720-1712
 !
 !  2. Method :
 !
@@ -864,7 +864,7 @@
 !
 !      Name                  | Type |  Module | Description
 !     ----------------------------------------------------------------
-!      Liu_forward_dispersion| Subr.| W3SIC2MD| As name implies. 
+!      Liu_forward_dispersion| Subr.| W3SIC2MD| As name implies.
 !     ----------------------------------------------------------------
 !
 !  6. Error messages :
@@ -873,11 +873,11 @@
 !
 !  7. Remarks :
 !
-!     Eventually, k and Cg should be used for propagation. This is not 
+!     Eventually, k and Cg should be used for propagation. This is not
 !     implemented yet. For now, it is only used to calculate the source
 !     term.
 !
-!     The eddy viscosity term given by Liu is unfortunately highly 
+!     The eddy viscosity term given by Liu is unfortunately highly
 !     variable, and "not a physical parameter", which suggests that it
 !     is difficult to specify in practice. In this paper, we see values
 !     of:
@@ -892,26 +892,26 @@
 !
 !     The paper states: "The only tuning parameter is the turbulent eddy
 !     viscosity, and it is a function of the flow conditions in the
-!     turbulent boundary layer which are determined by the ice 
+!     turbulent boundary layer which are determined by the ice
 !     thickness, floe sizes, ice concentration, and wavelength."
 !
-!     Another criticism of this source term is that it does not use the 
-!     ice concentration in actual calculations. The method appears to 
+!     Another criticism of this source term is that it does not use the
+!     ice concentration in actual calculations. The method appears to
 !     simply rely on concentration being high, "When the ice is highly
-!     compact with high concentration, the flexural waves obey the 
-!     dispersion relation (1) as similar waves in a continuous ice 
+!     compact with high concentration, the flexural waves obey the
+!     dispersion relation (1) as similar waves in a continuous ice
 !     sheet." Later, "Five of these  cases with high ice conentration
 !     (larger than 60%) in the MIZ have been selected"
 !
 !     This subroutine expects eddy viscosity in units of m2/sec even
 !     though values are given in units of cm2/sec in the Liu paper.
 !
-!     Cg used here is correct only for deep water. It is taken from 
+!     Cg used here is correct only for deep water. It is taken from
 !     Liu et al. (1991) equation 2. If we want to calculate for finite
 !     depths accurately, we need to use d_sigma/d_k. However, be warned
-!     that this calculation is sensitive to numerical error and so the 
-!     (potentially too coarse) computational grid for sigma and k should 
-!     *not* be used. 
+!     that this calculation is sensitive to numerical error and so the
+!     (potentially too coarse) computational grid for sigma and k should
+!     *not* be used.
 !
 !  8. Structure :
 !

--- a/model/ftn/w3fld1md.ftn
+++ b/model/ftn/w3fld1md.ftn
@@ -14,25 +14,25 @@
 !/                                                      ( B. G. Reichl )
 !/    27-Jul-2016 : Added Charnock output  (J.Meixner)  ( version 5.12 )
 !/    22-Jun-2018 : updated SIG2WN subroutine (X.Chen)  ( version 6.06 )
-!/                  modified the range of wind profile computation; 
+!/                  modified the range of wind profile computation;
 !/                  corrected direction of the shortest waves
-!/                  
+!/
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
 !     This Module contains routines to compute the wind stress vector
-!     from the wave spectrum, the wind vector, and the lower atmospheric 
+!     from the wave spectrum, the wind vector, and the lower atmospheric
 !     stability (the form included here is for neutral conditions, but
-!     the structure needed to include stability is included in comments).  
+!     the structure needed to include stability is included in comments).
 !     The stress calculated via this subroutine is
 !     intended for coupling to serve as the boundary condition
 !     between the ocean and atmosphere, and (for now)
-!     and has no impact on the wave spectrum calculated. 
+!     and has no impact on the wave spectrum calculated.
 !     The calculation in w3fld1 is based on the method
 !     presented in Reichl, Hara, and Ginis (2014), "Sea State Dependence
 !     of the Wind Stress under Hurricane Winds."
@@ -75,14 +75,14 @@
       ! Tail_Choice: Chose the method to determine the level of the tail
       INTEGER, SAVE :: Tail_Choice
       REAL, SAVE    :: Tail_Level !if Tail_Choice=0, tail is constant
-      REAL, SAVE    :: Tail_transition_ratio1! freq/fpi where tail 
+      REAL, SAVE    :: Tail_transition_ratio1! freq/fpi where tail
                                              !  adjustment begins
-      REAL, SAVE    :: Tail_transition_ratio2! freq/fpi where tail 
+      REAL, SAVE    :: Tail_transition_ratio2! freq/fpi where tail
                                              !  adjustment ends
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE W3FLD1( ASPC, FPI, WNDX,WNDY, ZWND,               & 
+      SUBROUTINE W3FLD1( ASPC, FPI, WNDX,WNDY, ZWND,               &
                     DEPTH, RIB, UST, USTD, Z0, TAUNUX,TAUNUY, CHARN)
 !/
 !/                  +-----------------------------------+
@@ -112,8 +112,8 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !       ASPC    Real   I   1-D Wave action spectrum.
-!       FPI     Real   I   Peak input frequency. 
-!       WNDX    Real   I   X-dir wind (assumed referenced to current)    
+!       FPI     Real   I   Peak input frequency.
+!       WNDX    Real   I   X-dir wind (assumed referenced to current)
 !       WNDY    Real   I   Y-dir wind (assumed referenced to current)
 !       ZWND    Real   I   Wind height.
 !       DEPTH   Real   I   Water depth.
@@ -125,7 +125,7 @@
 !       UST     Real   O   Friction velocity.
 !       USTD    Real   O   Direction of friction velocity.
 !       Z0      Real   O   Surface roughness length
-!       CHARN   Real   O,optional    Charnock parameter 
+!       CHARN   Real   O,optional    Charnock parameter
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -172,16 +172,16 @@
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
 !/
-      REAL, INTENT(IN)        :: ASPC(NSPEC), WNDX, WNDY,  & 
+      REAL, INTENT(IN)        :: ASPC(NSPEC), WNDX, WNDY,  &
                                  ZWND, DEPTH, RIB, FPI
-      REAL, INTENT(OUT)       :: UST, USTD, Z0 
+      REAL, INTENT(OUT)       :: UST, USTD, Z0
       REAL, INTENT(OUT), OPTIONAL :: CHARN
       REAL, INTENT(INOUT)     :: TAUNUX, TAUNUY
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      REAL, PARAMETER         ::  NU=0.105/10000.0 
+      REAL, PARAMETER         ::  NU=0.105/10000.0
       REAL, PARAMETER         ::  DELTA=0.03
       ! Commonly used parameters
       REAL                    ::  wnd_in_mag, wnd_in_dir
@@ -195,7 +195,7 @@
                                   USTSM, Z0SM, Z1
       !For stress calculation
       REAL                    ::  WAGE, CBETA, BP, CD,       &
-                                  USTRB, ANGDIF, USTAR, ZNU, & 
+                                  USTRB, ANGDIF, USTAR, ZNU, &
                                   TAUT, TAUX, TAUY, BETAG, TAUDIR, &
                                   TAUDIRB
       !For wind profile calculation
@@ -262,8 +262,8 @@
 ! 1.  Attach Tail ---------------------------------------------------- *
 !
 ! If the depth remains constant, the allocation could be limited to the
-!   first time step.  Since this code is designed for coupled 
-!   implementation where the water level can change, I keep it the 
+!   first time step.  Since this code is designed for coupled
+!   implementation where the water level can change, I keep it the
 !   allocation on every time step.  When computational efficiency is
 !   important, this process may be rethought.
 !
@@ -271,7 +271,7 @@
       call sig2wn(sig(nk),depth,kmax)
       NKT = NK
       ! ii. Find additional wavenumber bins to extended to cm scale waves
-      DO WHILE ( KMAX .LT. 366.0 ) 
+      DO WHILE ( KMAX .LT. 366.0 )
         NKT = NKT + 1
         KMAX = ( KMAX * XFR**2 )
       ENDDO!K<366
@@ -303,7 +303,7 @@
       DWN(NKT) = WN(NKT)*XFR**2 - WN(NKT)
 !
 ! 1b. Attach initial tail--------------------------------------------- *
-! 
+!
       !i. Convert action spectrum to variance spectrum
       !   SPC(k,theta) = A(k,theta) * sig(k)
       ! This could be redone for computational efficiency
@@ -351,7 +351,7 @@
 !
 ! 2.  Prepare for iterative calculation of wave-form stress----------- *
 !
-      DTX = 0.00005 
+      DTX = 0.00005
       DTY = 0.00005
       iter_thresh = 0.001
 !
@@ -404,7 +404,7 @@
 !|-----Calculate first guess at growth rate and local turbulent stress-|
 !|-----for integration as a function of wavedirection------------------|
 !|---------------------------------------------------------------------|
-          DO ZI = 2, NKT 
+          DO ZI = 2, NKT
             USTL=0.0
             TLTND(zi)=0.0
             TLTED(zi)=0.0
@@ -523,7 +523,7 @@
                  TLTE(ZI)=TAUNUX+TLTEA(ZI)
               endif
             ENDDO
-            TAUY=TLTN(NKT) !by NKT full stress is entirely 
+            TAUY=TLTN(NKT) !by NKT full stress is entirely
             TAUX=TLTE(NKT) !from turbulent stress
             TAUT=SQRT(TAUY**2.0+TAUX**2.0)
             USTAR=SQRT(SQRT(TAUY**2.0+TAUX**2.0)/DAIR)
@@ -601,10 +601,10 @@
             VPROF(ZI) = VPROF(ZI-1) + VP(ZI) * ( ZOFK(Z2) - ZOFK(Z2+1) )
           ENDDO
 !|---------------------------------------------------------------------|
-!|----Iteration completion/checks--------------------------------------| 
+!|----Iteration completion/checks--------------------------------------|
 !|---------------------------------------------------------------------|
           !ZI = ( KB + 1 )
-          ! Now solving for 'ZWND' height wind 
+          ! Now solving for 'ZWND' height wind
           UPROF(NKT+1) = UPROF(NKT) + ( SQRT( SQRT( TAUY**2.0 + &
                       TAUX**2.0 ) / DAIR ) ) / KAPPA * TAUX &
                       / SQRT( TAUY**2.0 +TAUX**2.0 ) * LOG( ZWND &
@@ -624,7 +624,7 @@
              WND_3Y = VPROF(NKT+1)
            ENDIF
 
-              
+
           !-------------------------------------+
           !  Guide for adding stability effects +
           !-------------------------------------+
@@ -839,7 +839,7 @@
       Tail_Level=TAIL_Lev
       Tail_transition_ratio1 = TAIL_TRAN1
       Tail_transition_ratio2 = TAIL_TRAN2
-      
+
 !
       RETURN
 !
@@ -1160,17 +1160,17 @@
 !/ ------------------------------------------------------------------- /
         wn1=sig**2/GRAV
         SWITCH=.true.
-!/ Updated code with Newton's method by XYC: 
+!/ Updated code with Newton's method by XYC:
       if (tanh(wn1*depth) .LT. 0.99) then
          do while (SWITCH)
            fk=grav*wn1*tanh(wn1*depth) - sig**2
            fk_slp = grav*tanh(wn1*depth) + grav*wn1*depth/(cosh(wn1*depth))**2
 
            wn2=wn1 - fk/fk_slp
-        
+
            if (abs(wn2-wn1)/wn1 .LT. 0.0001 ) then
               SWITCH = .FALSE.
-           else 
+           else
               wn1=wn2
            endif
          enddo
@@ -1195,7 +1195,7 @@
 !                    dsigdk=(sig2-sig1)/(wn2-wn1)
 !                    WN1=WN1+(SIG2-SIG1)/dsigdk
 !                    wn2=wn1+wn1*0.00001
-!                 else 
+!                 else
 !                    SWITCH = .FALSE.
 !                 endif
 !              endif
@@ -1225,15 +1225,15 @@
 !     Get bulk momentum z0 from 10-m wind.
 !          Bulk stress corresponds to 2015 GFDL Hurricane model
 !          Not published yet, but contact Brandon Reichl or
-!          Isaac Ginis (Univ. of Rhode Island) for further info 
+!          Isaac Ginis (Univ. of Rhode Island) for further info
 !
 !  2. Method :
-!          This has now been updated for 2016 HWRF z0 using routines 
+!          This has now been updated for 2016 HWRF z0 using routines
 !          from HWRF  znot_m_v1, Biju Thomas, 02/07/2014
 !           and       znot_wind10m Weiguo Wang, 02/24/2016
 !
 !  3. Parameters :
-!       Name  Unit  Type      Description 
+!       Name  Unit  Type      Description
 !     ----------------------------------------------------------------
 !       W10M   m/s  input    10 m neutral wind [m/s]
 !       ZNOTM  m    output   Roughness scale for momentum
@@ -1250,7 +1250,7 @@
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
 !      W3FLD1    Subr. W3FLD1MD Corresponding source term.
-!      W3FLD2    Subr. W3FLD2MD Corresponding source term. 
+!      W3FLD2    Subr. W3FLD2MD Corresponding source term.
 !     ----------------------------------------------------------------
 !
 !  6. Error messages :
@@ -1317,9 +1317,9 @@
               cf1*U10**5 + cf0*U10**6
       END IF
 
-      !Modifications as in znot_wind10m for icoef_sf=4 
+      !Modifications as in znot_wind10m for icoef_sf=4
 
-      !for wind<20, cd similar to icoef=2 at 10m, then reduced 
+      !for wind<20, cd similar to icoef=2 at 10m, then reduced
       TMP=0.4*0.4/(ALOG(10.0/ZNOTM))**2   ! cd at zlev
       AAA=0.75
       IF (U10 < 20) THEN
@@ -1344,7 +1344,7 @@
 !/
 !  1. Purpose :
 !
-!     Gives level of saturation spectrum to produce 
+!     Gives level of saturation spectrum to produce
 !         equivalent Cd as in wnd2z0m (for neutral 10m wind)
 !         tuned for method of Reichl et al. 2014
 !
@@ -1397,7 +1397,7 @@
 !/S      INTEGER, SAVE           :: IENT = 0
 !
 !/S      CALL STRACE (IENT, 'WND2SAT')
-!/ Old HWRF 2015 and ST2 
+!/ Old HWRF 2015 and ST2
 !        SAT =0.000000000001237 * WND10**6 +&
 !             -0.000000000364155 * WND10**5 +&
 !             0.000000037435015 * WND10**4 +&
@@ -1406,7 +1406,7 @@
 !             0.000778467452178 * WND10**1 +&
 !             0.002962335390055
 !
-!     SAT values based on 
+!     SAT values based on
 !     HWRF 2016 CD curve, created with  fetch limited cases ST4 physics
         IF (WND10<20.0) THEN
           SAT = -0.000018541921682*WND10**2  &

--- a/model/ftn/w3fld2md.ftn
+++ b/model/ftn/w3fld2md.ftn
@@ -17,15 +17,15 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
 !     This section of code has been designed to compute the wind
-!     stress vector from the wave spectrum, the wind speed 
-!     vector, and the lower atmosphere stability.  
-!     This code is based on the 2012 JGR paper, "Modeling Waves 
+!     stress vector from the wave spectrum, the wind speed
+!     vector, and the lower atmosphere stability.
+!     This code is based on the 2012 JGR paper, "Modeling Waves
 !     and Wind Stress" by Donelan, Curcic, Chen, and Magnusson.
 !
 !  2. Variables and types :
@@ -76,7 +76,7 @@
 !/
 !  1. Purpose :
 !
-!     Wind stress vector calculation from wave spectrum and 
+!     Wind stress vector calculation from wave spectrum and
 !        n-meter wind speed vector.
 !
 !  2. Method :
@@ -98,7 +98,7 @@
 !       UST     Real   O   Friction velocity.
 !       USTD    Real   O   Direction of friction velocity.
 !       Z0      Real   O   Surface roughness length
-!       CHARN   Real   O,optional   Charnock parameter 
+!       CHARN   Real   O,optional   Charnock parameter
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -110,7 +110,7 @@
 !      SIG2WN     Subr. W3FLD1MD  Depth-dependent dispersion relation
 !      MFLUX      Subr. W3FLD1MD  MO stability correction
 !      WND2Z0M    Subr. W3FLD1MD  Bulk Z0 from wind
-!      CALC_FPI   Subr. W3FLD1MD  Calculate peak frequency 
+!      CALC_FPI   Subr. W3FLD1MD  Calculate peak frequency
 !     ----------------------------------------------------------------
 !
 !  5. Called by :
@@ -154,8 +154,8 @@
 !/ Parameter list
 !/
       REAL, INTENT(IN)        :: ASPC(NSPEC), WNDX, WNDY, &
-                                 ZWND, DEPTH, RIB, FPI 
-      REAL, INTENT(OUT)       :: UST, USTD, Z0 
+                                 ZWND, DEPTH, RIB, FPI
+      REAL, INTENT(OUT)       :: UST, USTD, Z0
       REAL, INTENT(OUT),OPTIONAL :: CHARN
       REAL, INTENT(INOUT)     :: TAUNUX, TAUNUY
 !/
@@ -163,7 +163,7 @@
 !/ Local parameters
 !/
       !-Parameters
-      REAL, PARAMETER  :: NU=0.105/10000.0 
+      REAL, PARAMETER  :: NU=0.105/10000.0
       !-Commonly used values
       REAL :: UREF, UREFD
       !-Tail
@@ -294,7 +294,7 @@
 !|--------------------------------------------------------------------|
       DO K = 1, NK
          call sig2wn(sig(k),depth,wn(k))
-         CP(K) = sig(k) / WN(K) 
+         CP(K) = sig(k) / WN(K)
          sig2(k) = sig(k)
       ENDDO
       DO K = ( NK + 1 ), ( NKT)
@@ -405,7 +405,7 @@
                   !        * COS( TH(T) ) / CP(K) * DTH
                   !   TAUINTY(K) = TAUINTY(K) + SPC2(K,T) * SCIN &
                   !        * SIN( TH(T) ) / CP(K) * DTH
-                     
+
                      TAUINTX(K) = TAUINTX(K) + SPC2(K,T) * SCIN &
                           * COS( TH(T) ) *SIG2(K) * DTH
                      TAUINTY(K) = TAUINTY(K) + SPC2(K,T) * SCIN &
@@ -490,7 +490,7 @@
             !   !Approx as neutral inside 10 m (WBL) calculate z0
             !   wnd_ref_al=uref*cos(urefd-ustd)
             !   z0=10. / exp( wnd_10_mag * KAPPA / ustra )
-            !   ! Use that z0 to calculate stability 
+            !   ! Use that z0 to calculate stability
             !   ! Cd to ref height (based on input wind)
             ! Below is subroutine for computing stability effects
             !   call mflux(wnd_ref_al,zwnd,z0,rib,cd)
@@ -533,7 +533,7 @@
 
             ! Check for wind convergence
          !   WND_IT_FLG = (((du**2+dv**2)/(wndx**2+wndy**2)).GT.0.001)
-         !   
+         !
          !   IF ( WND_IT_FLG .AND. WI_COUNT.LT.10 ) THEN
          !      ! New guesses
          !      wnd_10_x=wnd_10_x-apar*( FD_D * DU - FD_B * DV )
@@ -592,7 +592,7 @@
 !/
 !  1. Purpose :
 !
-!     Gives level of saturation spectrum to produce 
+!     Gives level of saturation spectrum to produce
 !         equivalent Cd as in wnd2z0m (for neutral 10m wind)
 !         tuned for method of Donelan et al. 2012
 !
@@ -645,7 +645,7 @@
 !
 !/S      CALL STRACE (IENT, 'WND2SAT')
 !
-! ST2, previous HWRF relationship: 
+! ST2, previous HWRF relationship:
 !        SAT =0.000000000000349* WND10**6 +&
 !             -0.000000000250547* WND10**5 +&
 !             0.000000039543565* WND10**4 +&
@@ -653,22 +653,22 @@
 !             0.000034922624204* WND10**2 +&
 !             0.000339117617027* WND10**1 +&
 !             0.003521314236550
-!     SAT values based on 
+!     SAT values based on
 !     HWRF 2016 CD curve, created with  fetch limited cases ST4 physics
-        IF (WND10<20) THEN 
+        IF (WND10<20) THEN
           SAT = -0.022919753482426e-3* WND10**2 &
-                +0.960758623686446e-3* WND10    & 
+                +0.960758623686446e-3* WND10    &
                 -0.084461041915030e-3
-        ELSEIF (WND10<45) THEN 
+        ELSEIF (WND10<45) THEN
           SAT = -0.000000006585745* WND10**4 &
                 +0.000001058147954* WND10**3 &
                 -0.000065829151883* WND10**2 &
                 +0.001587028483595* WND10    &
                 -0.002857112191889
-        ELSE 
+        ELSE
           SAT = -0.000178498197241* WND10    &
                 +0.012706067280674
-        ENDIF 
+        ENDIF
         SAT = min(max(SAT,0.002),0.014)
 
       END SUBROUTINE WND2SAT

--- a/model/ftn/w3fldsmd.ftn
+++ b/model/ftn/w3fldsmd.ftn
@@ -25,10 +25,10 @@
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLO (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    30-Oct-2012 : Implement tidal analysis            ( version 4.08 ) 
+!/    30-Oct-2012 : Implement tidal analysis            ( version 4.08 )
 !/                  (F. Ardhuin)
 !/    26-Dec-2012 : Modified obsolete declarations.     ( version 4.OF )
-!/     5-Mar-2012 : Cleanup of tidal analysis           ( version 4.09 ) 
+!/     5-Mar-2012 : Cleanup of tidal analysis           ( version 4.09 )
 !/    24-Apr-2015 : Adding OASIS coupling calls         ( version 5.07 )
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
 !/    20-Jan-2017 : Update to new W3GSRUMD APIs         ( version 6.02 )
@@ -36,7 +36,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -104,7 +104,7 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    04-Apr-2010 : Adding iceberg field.               ( version 3.14 )
-!/    09-Sep-2012 : Implement tidal cons. (F. Ardhuin ) ( version 4.09 ) 
+!/    09-Sep-2012 : Implement tidal cons. (F. Ardhuin ) ( version 4.09 )
 !/    26-Dec-2012 : Modified obsolete declarations.     ( version 4.11 )
 !/
 !  1. Purpose :
@@ -242,7 +242,7 @@
       FILLER(:)=0
       IF ( PRESENT(TIDEFLAGIN) ) THEN
         TIDEFLAG = TIDEFLAGIN
-      ELSE 
+      ELSE
         TIDEFLAG = 0
         END IF
 
@@ -353,9 +353,9 @@
       IF ( WRITE ) THEN
           IF ( FDHDR ) THEN
              IF ( FORM .EQ. 'UNFORMATTED' ) THEN
-! 
+!
 ! The "filler" was added for compatibility with old binary forcing files
-! It is now also used for tidal info ... 
+! It is now also used for tidal info ...
 !
                  WRITE (NDS,ERR=804,IOSTAT=IERR)                      &
                        IDSTR, IDFLD, NX, NY, GTYPE, FILLER(1:2), TIDEFLAG
@@ -382,9 +382,9 @@
 !/DEBUGFLS       WRITE(740+IAPROC,*) '2: NXT=', NXT, ' NYT=', NYT
           END IF
           IF ((FILLER(1).NE.0.OR.FILLER(2).NE.0).AND.TIDEFLAG.GE.0) TIDEFLAG=0
-          IF (TIDEFLAG.NE.0.AND.(.NOT.TIDEOK)) THEN     
+          IF (TIDEFLAG.NE.0.AND.(.NOT.TIDEOK)) THEN
             GOTO 810
-            END IF          
+            END IF
 !
           IF ( IDSTR .NE. TSSTR ) GOTO 807
           IF (( IDFLD.EQ.'WND' .AND. TSFLD.EQ.'WNS') .OR.             &
@@ -394,7 +394,7 @@
             END IF
           IF ( IDFLD .NE. TSFLD ) GOTO 808
           IF ( IDFLD(1:2) .NE. 'DT' ) THEN
-            IF ( NX.NE.NXT .OR. NY.NE.NYT ) THEN 
+            IF ( NX.NE.NXT .OR. NY.NE.NYT ) THEN
 !/DEBUGFLS       WRITE(740+IAPROC,*) 'Dimension error'
 !/DEBUGFLS       WRITE(740+IAPROC,*) 'NX =', NX , ' NY =', NY
 !/DEBUGFLS       WRITE(740+IAPROC,*) 'NXT=', NXT, ' NYT=', NYT
@@ -495,7 +495,7 @@
                '                   SHOULD BE >',A,'<'/)
  1009 FORMAT (/' *** WAVEWATCH III ERROR IN W3FLDO : '/         &
          '     INCOMPATIBLE GRID DATA : ',3(1X,I10)/             &
-         '                  SHOULD BE : ',3(1X,I10)/)            
+         '                  SHOULD BE : ',3(1X,I10)/)
  1010 FORMAT (/' *** WAVEWATCH III ERROR IN W3FLDO : '/          &
          '     FILLER indicates use of tidal constituents',3I4, /&
          '     For this the code should be compiled with TIDE switch'/)
@@ -527,8 +527,8 @@
 !/                  | Last update :         30-Jun-2013 |
 !/                  +-----------------------------------+
 !/
-!/    24-Sep-2012 : Creation                            ( version 4.09 ) 
-!/    30-Jun-2013 : Split in 2 subroutines              ( version 4.11 ) 
+!/    24-Sep-2012 : Creation                            ( version 4.09 )
+!/    30-Jun-2013 : Split in 2 subroutines              ( version 4.11 )
 !/
 !  1. Purpose :
 !
@@ -705,8 +705,8 @@
 !/                  | Last update :         30-Jun-2013 |
 !/                  +-----------------------------------+
 !/
-!/    24-Sep-2012 : Creation                            ( version 4.09 ) 
-!/    30-Jun-2013 : Split in 2 subroutines              ( version 4.11 ) 
+!/    24-Sep-2012 : Creation                            ( version 4.09 )
+!/    30-Jun-2013 : Split in 2 subroutines              ( version 4.11 )
 !/
 !  1. Purpose :
 !
@@ -829,18 +829,18 @@
 !/TIDE                     CALL TIDE_FIND_INDICES_ANALYSIS(LIST)
 !/TIDE               IF (TIDE_MF1.NE.TIDE_MF) GOTO 807
 !/TIDE               CALL TIDE_SET_INDICES
-!/TIDE               IF(IDFLD.EQ.'LEV') THEN 
+!/TIDE               IF(IDFLD.EQ.'LEV') THEN
 !/TIDE                 IF (IDAT.EQ.1) WLTIDE(:,:,:,:)=TIDAL_CONST(:,:,:,1,:)
-!/TIDE               ELSE 
+!/TIDE               ELSE
 !/TIDE                 IF (IDAT.EQ.1) CXTIDE(:,:,:,:)=TIDAL_CONST(:,:,:,1,:)
 !/TIDE                 IF (IDAT.EQ.1) CYTIDE(:,:,:,:)=TIDAL_CONST(:,:,:,2,:)
-!/TIDE                 END IF 
+!/TIDE                 END IF
 !/TIDE               END IF
-!/TIDET DO I=1,NTIDE 
+!/TIDET DO I=1,NTIDE
 !/TIDET  WRITE(NDST,*) 'Tidal constituents for IX = 1:', IDFLD,' ',TIDECON_NAME(I),TIDAL_CONST(1,1,I,1,1),TIDAL_CONST(1,1,I,1,2), &
 !/TIDET                   '##',TIDAL_CONST(1,1,I,2,1),TIDAL_CONST(1,1,I,2,2)
 !/TIDET END DO
-!/TIDET DO I=1,NTIDE 
+!/TIDET DO I=1,NTIDE
 !/TIDET  WRITE(NDST,*) 'Tidal constituents for IX = 2:', IDFLD,' ',TIDECON_NAME(I),TIDAL_CONST(2,1,I,1,1),TIDAL_CONST(2,1,I,1,2), &
 !/TIDET                   '##',TIDAL_CONST(2,1,I,2,1),TIDAL_CONST(2,1,I,2,2)
 !/TIDET END DO
@@ -946,7 +946,7 @@
 !       INXOUT  C*(*)  I   Test string for read/write, valid are:
 !                          'READ' and 'WRITE'.
 !       IDFLD   C*3    I   ID string for field type, valid are: 'IC1',
-!                          'IC2', 'IC3', 'IC4', 'IC5', 'MDN', 'MTH', 'MVS', 
+!                          'IC2', 'IC3', 'IC4', 'IC5', 'MDN', 'MTH', 'MVS',
 !                          'LEV', 'CUR', 'WND', 'WNS', 'ICE' and 'ISI'.
 !       NDS     Int.   I   Dataset number for fields file.
 !       NDST    Int.   I   Dataset number for test output.
@@ -1024,7 +1024,7 @@
 !/OASACM      USE W3AGCMMD, ONLY: RCV_FIELDS_FROM_ATMOS
 !/OASOCM      USE W3OGCMMD, ONLY: RCV_FIELDS_FROM_OCEAN
 !/OASICM      USE W3IGCMMD, ONLY: RCV_FIELDS_FROM_ICE
-!/OASIS       USE W3ODATMD, ONLY: DTOUT 
+!/OASIS       USE W3ODATMD, ONLY: DTOUT
       IMPLICIT NONE
 !/
 !/ ------------------------------------------------------------------- /
@@ -1065,7 +1065,7 @@
 ! test input parameters ---------------------------------------------- *
 !
       IF (INXOUT.NE.'READ' .AND. INXOUT.NE.'WRITE') GOTO 801
-      IF ( IDFLD.NE.'IC1' .AND. IDFLD.NE.'IC2' .AND.                  & 
+      IF ( IDFLD.NE.'IC1' .AND. IDFLD.NE.'IC2' .AND.                  &
            IDFLD.NE.'IC3' .AND. IDFLD.NE.'IC4' .AND.                  &
            IDFLD.NE.'IC5' .AND. IDFLD.NE.'MDN' .AND.                  &
            IDFLD.NE.'MTH' .AND. IDFLD.NE.'MVS' .AND.                  &
@@ -1078,8 +1078,8 @@
       WRITE  = INXOUT .EQ. 'WRITE'
       FL2D   = IDFLD.EQ.'CUR' .OR. IDFLD.EQ.'WND' .OR. IDFLD.EQ.'WNS' &
                               .OR. IDFLD.EQ.'ISI'
-      FLBE   = IDFLD.EQ.'ISI'       
-      FLST   = IDFLD.EQ.'WNS' 
+      FLBE   = IDFLD.EQ.'ISI'
+      FLST   = IDFLD.EQ.'WNS'
 
       IF ( .NOT. PRESENT(FLAGSC) ) THEN
         FLCOUPL=FLAGSC_DEFAULT
@@ -1112,7 +1112,7 @@
             TF0(1) = TFN(1)
             TF0(2) = TFN(2)
 !/T            WRITE (NDST,9020)
-! unless TFN has been changed in the do loop, the following line is essentally 
+! unless TFN has been changed in the do loop, the following line is essentally
 !       "if not.flfrst"
             IF ( TFN(1) .NE. -1 ) THEN
                 DO IX=1, NX
@@ -1161,8 +1161,8 @@
 !
           ELSE
 !
-!/OASIS            IF (FLCOUPL) THEN 
-!/OASIS  ! Do not receive coupling fields at the end of the first integration time in case of  
+!/OASIS            IF (FLCOUPL) THEN
+!/OASIS  ! Do not receive coupling fields at the end of the first integration time in case of
 !/OASIS  ! forcing with a non interpolated field (like lev, ice, ...)
 !/OASIS              IF ((ID_OASIS_TIME.EQ.0 .AND. FLFRST) .OR. (ID_OASIS_TIME.GT.0)) THEN
 !
@@ -1181,7 +1181,7 @@
 !/OASIS                TFN(2)=T0(2)
 !/OASIS                CALL TICK21(TFN,DTOUT(7))
 !/OASIS              END IF
-!/OASIS            ELSE 
+!/OASIS            ELSE
               READ (NDS,END=800,ERR=805,IOSTAT=ISTAT) TFN
 !/T             WRITE (NDST,9031) TFN
               IF ( .NOT. FL2D ) THEN
@@ -1214,7 +1214,7 @@
 !
             DTTST  = DSEC21 ( T0 , TFN )
 
-! Exit if the time is the first time and the field is not interpolated in time 
+! Exit if the time is the first time and the field is not interpolated in time
 
             IF ( .NOT.FLINTERP .AND. FLFRST .AND. DTTST .EQ. 0. ) EXIT
 
@@ -1401,7 +1401,7 @@
 !                           'WRITE'  Write a data field to file.
 !                           'SIZE'   Get the number of records of
 !                                    next data set.
-!                           'READ'   Read the data set found by 
+!                           'READ'   Read the data set found by
 !                                    'SIZE' after allocating proper
 !                                    data array.
 !       IDFLD   C*3    I   ID string for field type, valid are:
@@ -1531,7 +1531,7 @@
 !
           DTTST  = DSEC21 ( TIME , TD )
           IF ( DTTST.LT.0. .OR. NDOUT.EQ.0 ) THEN
-              IF (NDOUT.GT.0) READ (NDS,END=806,ERR=807,IOSTAT=ISTAT) 
+              IF (NDOUT.GT.0) READ (NDS,END=806,ERR=807,IOSTAT=ISTAT)
               GOTO 100
            END IF
 !
@@ -1737,7 +1737,7 @@
 !     - The "CLOSED" variable comes from ww3_prep.inp and is associated
 !       with the input grid (e.g. grid that winds are provided on).
 !       It is a logical, not an integer, so it only allows two cases:
-!       no closure, or simple closure. "ww3_prep" only supports these 
+!       no closure, or simple closure. "ww3_prep" only supports these
 !       two (not tripole).
 !
 !  8. Structure :
@@ -2244,7 +2244,7 @@
           ! exit if field time is later than run time
           IF ( DTTST .GT. 0. ) EXIT
           ! exit if field is ic* or md* or lev or ice
-          ! and first forcing field has been stored 
+          ! and first forcing field has been stored
           ! at start run time
           IF ( J.LE.(1).OR.(J.EQ.4) ) THEN
             IF (FLFRST .AND. DTTST.EQ.0. ) EXIT

--- a/model/ftn/w3flx1md.ftn
+++ b/model/ftn/w3flx1md.ftn
@@ -14,7 +14,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3flx2md.ftn
+++ b/model/ftn/w3flx2md.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009-2010 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -151,7 +151,7 @@
 !
 ! ----- start of inlined and reduced WAVNU1 -----
 !
-        AFP    = TPI * MAX ( FP, 0.001) 
+        AFP    = TPI * MAX ( FP, 0.001)
 !
         SQRTH  = SQRT ( DEPTH )
         SIX    = AFP * SQRTH

--- a/model/ftn/w3flx3md.ftn
+++ b/model/ftn/w3flx3md.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009-2010 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -154,7 +154,7 @@
 !
 ! ----- start of inlined and reduced WAVNU1 -----
 !
-        AFP    = TPI * MAX ( FP, 0.001) 
+        AFP    = TPI * MAX ( FP, 0.001)
 !
         SQRTH  = SQRT ( DEPTH )
         SIX    = AFP * SQRTH

--- a/model/ftn/w3flxxmd.ftn
+++ b/model/ftn/w3flxxmd.ftn
@@ -14,7 +14,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -69,8 +69,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -81,14 +81,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3gdatmd.ftn
+++ b/model/ftn/w3gdatmd.ftn
@@ -46,7 +46,7 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.1 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
@@ -54,20 +54,20 @@
 !/                  factor with DXDP and DXDQ terms.    ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
 !/    05-Apr-2011 : Implement interations for DTMAX < 1s( version 3.14.1 )
-!/                  (F. Ardhuin) 
+!/                  (F. Ardhuin)
 !/    01-Jul-2011 : Movable bed bottom friction BT4     ( version 4.01 )
 !/    03-Nov-2011 : Bug fix: GUGINIT initialization     ( version 4.04 )
 !/    29-Nov-2011 : Adding ST6 source term option.      ( version 4.04 )
 !/                  (S. Zieger)
 !/    14-Mar-2012 : Add PSIC for BT4                    ( version 4.04 )
-!/    12-Jun-2012 : Add /RTD option or rotated grid variables. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid variables.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    13-Jul-2012 : Move data structures GMD (SNL3) and nonlinear
 !/                  filter (SNLS) from 3.15 (HLT).      ( version 4.08 )
 !/    03-Sep-2012 : Clean up of UG grids                ( version 4.08 )
 !/    12-Dec-2012 : Adding SMC grid.  JG_Li             ( version 4.09 )
 !/    16-Sep-2013 : Add Arctic part SMC grid.           ( version 4.11 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    16-Nov-2013 : Allows reflection on curvi grids    ( version 4.14 )
 !/    26-Jul-2013 : Adding IG waves                     ( version 4.16 )
@@ -85,7 +85,7 @@
 !/    07-Jan-2018 : Generalizes ICE100WIND to ICESCALES ( version 6.04 )
 !/    26-Mar-2018 : Add FSWND optional variable.  JGLi  ( version 6.02 )
 !/    05-Jun-2018 : Add PDLIB/DEBUGINIT and implcit scheme parameters
-!/                  for unstructured grids              ( version 6.04 ) 
+!/                  for unstructured grids              ( version 6.04 )
 !/    18-Aug-2018 : S_{ice} IC5 (Q. Liu)                ( version 6.06 )
 !/    20-Aug-2018:  Extra namelist variables for ST6    ( version 6.06)
 !/                  (Q. Liu, UoM)
@@ -95,12 +95,12 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Define data structures to set up wave model grids and aliases 
+!     Define data structures to set up wave model grids and aliases
 !     to use individual grids transparently. Also includes subroutines
 !     to manage data structure and pointing to individual models.
 !     Definition of grids and model set up.
@@ -109,7 +109,7 @@
 !
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
-!      NGRIDS    Int.  Public   Number of grids, initialized at -1 
+!      NGRIDS    Int.  Public   Number of grids, initialized at -1
 !                               to check proper model initialization.
 !      NAUXGR    Int.  Public   Auxiliary grids.
 !      IGRID     Int.  Public   Selected spatial grid, init. at -1.
@@ -137,7 +137,7 @@
 !      GTYPE     Int.  Public   Flag for type of grid
 !                               RLGTYPE: Rectilinear grid
 !                               CLGTYPE: Curvilinear grid
-!                               UNGTYPE: Unstructured triangular grid                       
+!                               UNGTYPE: Unstructured triangular grid
 !      ICLOSE    Int.  Public   Parameter indicating type of index closure of grid.
 !                               ICLOSE_NONE: No grid closure
 !                               ICLOSE_SMPL: Simple grid closure
@@ -151,10 +151,10 @@
 !                                 closure requires that NX be even.
 !      NX, NY    Int.  Public   Discrete dimensions of spatial grid.
 !      NSEA(L)   Int.  Public   Number of sea points (local for MPP).
-!      NU/VFc    Int.  Public   Number of U/V faces for SMC grid. 
-!      NRLv      Int.  Public   Number of refined levels for SMC grid. 
-!      NGLO      Int.  Public   Number of cells in global part for SMC grid. 
-!      NARC      Int.  Public   Number of cells in Arctic part for SMC grid. 
+!      NU/VFc    Int.  Public   Number of U/V faces for SMC grid.
+!      NRLv      Int.  Public   Number of refined levels for SMC grid.
+!      NGLO      Int.  Public   Number of cells in global part for SMC grid.
+!      NARC      Int.  Public   Number of cells in Arctic part for SMC grid.
 !      NBAC      Int.  Public   Number of boundary cells in Arctic part.
 !      NBGL      Int.  Public   Number of boundary cells in global part.
 !      TRFLAG    Int.  Public   Flag for use of transparencies
@@ -186,7 +186,7 @@
 !      IICEHFAC  Real  Public   Scale factor for sea ice thickness
 !      IICEHINIT Real  Public   Initial value of ice thickness
 !      ICESCALES R.A.  Publ.    Scaling coefficient for source terms in the presence of ice
-!                               Default is 1.0, meaning that 100% ice 
+!                               Default is 1.0, meaning that 100% ice
 !                               concentration result in zero source term
 !                               If set to 0.0, then ice has no direct impact on Sln / Sin / Snl / Sds
 !      IC3PARS   R.A.  Public   various parameters for use in IC4, handled as
@@ -197,10 +197,10 @@
 !                               for moving grids.
 !      GRIDSHIFT Real  Public   Grid offset for multi-grid w/SCRIP
 !      CMPRTRCK  Log.  Public   True for traditional compression of track output
-!      PoLat/Lon R.A.  Public   Rotated N-Pole standard latitude/longitude. 
+!      PoLat/Lon R.A.  Public   Rotated N-Pole standard latitude/longitude.
 !      AnglD     R.A.  Public   Rotation angle in degree to turn rotated grid
 !                               back to standard grid.  JGLi12Jun2012
-!      FLAGUNR   Log.  Public   True if rotating directions back to true north 
+!      FLAGUNR   Log.  Public   True if rotating directions back to true north
 !      STEXU     Real  Public   Length-scale (X) for space-time extreme averaging
 !      STEYU     Real  Public   Length-scale (Y) for space-time extreme averaging
 !      STEDU     Real  Public   Time-scale for space-time extreme averaging
@@ -209,8 +209,8 @@
 !      CTHG0S    R.A.  Public   Constant in great-circle refr. term at sea points.
 !      TRNX/Y    R.A.  Public   Transparencies in X/Y for sub-grid
 !      CTRNX/Y   R.A.  Public   Sub-grid transparencies for SMC grid.
-!      ANGARC    R.A.  Public   Rotation angle in degree for Arctic cells. 
-!      SPCBAC    R.A.  Public   Full 2-D spectra for Arctic boundary cells. 
+!      ANGARC    R.A.  Public   Rotation angle in degree for Arctic cells.
+!      SPCBAC    R.A.  Public   Full 2-D spectra for Arctic boundary cells.
 !      X/YGRD    R.A.  Public   Spatial grid coordinate arrays.
 !      SX/SYGRD  R.A.  Public   Spatial grid increment arrays.
 !      GINIT     Log.  Public   Flag identifying grid initialization.
@@ -218,14 +218,14 @@
 !                               processing only).
 !      FLCx      Log.  Public   Flags for prop. is different spaces.
 !      FLSOU     Log.  Public   Flag for source term calcualtion.
-!      FUNO3     Log.  Public   Flag for 3rd order UNO3 scheme on SMC grid. 
+!      FUNO3     Log.  Public   Flag for 3rd order UNO3 scheme on SMC grid.
 !      FVERG     Log.  Public   Flag for 1-2-1 averaging smoothing on SMC grid.
 !      FSWND     Log.  Public   Flag for sea-point only wind input on SMC grid.
-!      FLAGST    L.A.  Public   Flag for source term computations 
+!      FLAGST    L.A.  Public   Flag for source term computations
 !                               for individual grid points.
 !      IICEDISP   Log.  Public   Flag for use of the ice covered dispertion relation.
 !      IICESMOOTH Log.  Public   Flag to smooth the ice covered dispertion relation in broken ice.
-!       
+!
 !
 !      GNAME     C*30  Public   Grid name.
 !      FILEXT    C*13  Public   Extension of WAVEWATCH III file names
@@ -308,7 +308,7 @@
 !      XFC       Real  Public   Id.
 !      FACSD     Real  Public   Constant in seeding algorithm.
 !      FHMAX     Real  Public   Hs/depth ratio in limiter     (!/MLIM)
-!      RWINDC    Real  Public   Coefficient for current in relative 
+!      RWINDC    Real  Public   Coefficient for current in relative
 !                               wind                          (!/RWND)
 !      WWCOR     R.A.  Public   Wind correction factors       (!/WCOR)
 !     ----------------------------------------------------------------
@@ -419,14 +419,14 @@
 !      KDMN      Real  Public   Minimum relative depth.
 !      SNLSn     Real  Public   Constants in shallow water factor.
 !                                                             (!/NL2)
-!      IQTPE     Int.  Public   Type of depth treatment 
-!                                1 : Deep water         
+!      IQTPE     Int.  Public   Type of depth treatment
+!                                1 : Deep water
 !                                2 : Deep water / WAM scaling
-!                                3 : Finite water depth 
+!                                3 : Finite water depth
 !      NDPTHS    Int.  Public   Number of depth for which integration
 !                               space needs to be computed.
 !      NLTAIL    Real  Public   Tail factor for parametric tail.
-!      DPTHNL    R.A.  Public   Depths corresponding to NDPTHS.   
+!      DPTHNL    R.A.  Public   Depths corresponding to NDPTHS.
 !                               *** NOTE: This array is not allocated
 !                                         in the W3DIMP routine ***
 !                                                             (!/NL3)
@@ -510,7 +510,7 @@
 !     ----------------------------------------------------------------
 !     ----------------------------------------------------------------
 !
-!     The structure SICP contains parameters for arbitrary source 
+!     The structure SICP contains parameters for arbitrary source
 !     term and is aliased as above:
 !
 !      Name      Type  Scope    Description
@@ -519,7 +519,7 @@
 !     IS1C2      Real  Public   Offset for ice concentration (!/ISx)
 !     ----------------------------------------------------------------
 !
-!     The structure SXXP contains parameters for arbitrary source 
+!     The structure SXXP contains parameters for arbitrary source
 !     term and is aliased as above:
 !
 !      Name      Type  Scope    Description
@@ -557,7 +557,7 @@
 !     See subroutine documentation.
 !
 !     !/PRn  Select propagation scheme
-!     !/SMC  UNO2 propagation on SMC grid.   
+!     !/SMC  UNO2 propagation on SMC grid.
 !
 !     !/LNn  Select source terms
 !     !/STn
@@ -594,21 +594,21 @@
 !/IC4      INTEGER, PARAMETER      :: NIC4=10
       INTEGER, PARAMETER      :: RLGTYPE = 1
       INTEGER, PARAMETER      :: CLGTYPE = 2
-      INTEGER, PARAMETER      :: UNGTYPE = 3      
+      INTEGER, PARAMETER      :: UNGTYPE = 3
 
       INTEGER, PARAMETER      :: ICLOSE_NONE = ICLO_NONE
       INTEGER, PARAMETER      :: ICLOSE_SMPL = ICLO_SMPL
       INTEGER, PARAMETER      :: ICLOSE_TRPL = ICLO_TRPL
 !
-! Dimensions of tables for pre-computing of dissipation 
-!  
+! Dimensions of tables for pre-computing of dissipation
+!
 !/ST4      INTEGER,    PARAMETER   :: NKHS=2000, NKD=1300
-!/ST4      INTEGER,    PARAMETER   :: NDTAB=2000          
+!/ST4      INTEGER,    PARAMETER   :: NDTAB=2000
 !/
 !/ Data structures
 !/
 !/ Grid type
-      TYPE GRID          ! this is the geographical grid with all associated parameters 
+      TYPE GRID          ! this is the geographical grid with all associated parameters
         INTEGER          :: GTYPE
         INTEGER          :: ICLOSE
         INTEGER          :: NX, NY, NSEA, NSEAL, TRFLAG
@@ -616,7 +616,7 @@
         INTEGER, POINTER :: MAPSTA(:,:), MAPST2(:,:),            &
                             MAPFS(:,:), MAPSF(:,:)
 !
-!/SMC !!Li     Cell and face arrays for SMC grid.  
+!/SMC !!Li     Cell and face arrays for SMC grid.
 !/SMC        INTEGER               :: NCel, NUFc, NVFc, NRLv, MRFct
 !/SMC        INTEGER, POINTER      :: NLvCel(:), NLvUFc(:), NLvVFc(:)
 !/SMC        INTEGER, POINTER      :: IJKCel(:,:), IJKUFc(:,:), IJKVFc(:,:)
@@ -669,7 +669,7 @@
         TYPE(T_GSU) :: GSU ! Grid search utility object
 !
         REAL                  :: FFACBERG    ! mutiplicative factor for iceberg mask
-!/BT4   REAL, POINTER         :: SED_D50(:), SED_PSIC(:) 
+!/BT4   REAL, POINTER         :: SED_D50(:), SED_PSIC(:)
 !/REF1        LOGICAL, POINTER      :: RREF(:)
 !/REF1        REAL,    POINTER      :: REFPARS(:)
 !/IG1        REAL,    POINTER      :: IGPARS(:)
@@ -740,7 +740,7 @@
 !/PR2        REAL                  :: DTME, CLATMN
 !/PR3        REAL                  :: WDCG, WDTH
 !/SMC        REAL                  :: DTME, CLATMN, Refran
-!/SMC        LOGICAL               :: FUNO3, FVERG, FSWND 
+!/SMC        LOGICAL               :: FUNO3, FVERG, FSWND
       END TYPE PROP
 !
       TYPE FLDP
@@ -876,35 +876,35 @@
 !/XX0        REAL                  :: DUMMY
 !/XXX        REAL                  :: DUMMY
       END TYPE SXXP
-      
+
 ! specific type for unstructured scheme
       TYPE SCHM
-         LOGICAL :: FSN          = .FALSE. 
-         LOGICAL :: FSPSI        = .FALSE. 
-         LOGICAL :: FSFCT        = .FALSE. 
-         LOGICAL :: FSNIMP       = .FALSE. 
-         LOGICAL :: FSTOTALIMP   = .FALSE. 
-         LOGICAL :: FSTOTALEXP   = .FALSE. 
-         LOGICAL :: FSREFRACTION = .FALSE. 
-         LOGICAL :: FSFREQSHIFT  = .FALSE. 
-         LOGICAL :: FSSOURCE     = .FALSE. 
-         LOGICAL :: DO_CHANGE_WLV 
-         REAL(8) :: SOLVERTHR_STP 
+         LOGICAL :: FSN          = .FALSE.
+         LOGICAL :: FSPSI        = .FALSE.
+         LOGICAL :: FSFCT        = .FALSE.
+         LOGICAL :: FSNIMP       = .FALSE.
+         LOGICAL :: FSTOTALIMP   = .FALSE.
+         LOGICAL :: FSTOTALEXP   = .FALSE.
+         LOGICAL :: FSREFRACTION = .FALSE.
+         LOGICAL :: FSFREQSHIFT  = .FALSE.
+         LOGICAL :: FSSOURCE     = .FALSE.
+         LOGICAL :: DO_CHANGE_WLV
+         REAL(8) :: SOLVERTHR_STP
          REAL(8) :: CRIT_DEP_STP
-         LOGICAL :: B_JGS_TERMINATE_MAXITER 
-         LOGICAL :: B_JGS_TERMINATE_DIFFERENCE 
-         LOGICAL :: B_JGS_TERMINATE_NORM 
-         LOGICAL :: B_JGS_LIMITER 
+         LOGICAL :: B_JGS_TERMINATE_MAXITER
+         LOGICAL :: B_JGS_TERMINATE_DIFFERENCE
+         LOGICAL :: B_JGS_TERMINATE_NORM
+         LOGICAL :: B_JGS_LIMITER
          LOGICAL :: B_JGS_USE_JACOBI
-         LOGICAL :: B_JGS_BLOCK_GAUSS_SEIDEL 
-         INTEGER :: B_JGS_MAXITER 
+         LOGICAL :: B_JGS_BLOCK_GAUSS_SEIDEL
+         INTEGER :: B_JGS_MAXITER
          REAL*8  :: B_JGS_PMIN
-         REAL*8  :: B_JGS_DIFF_THR 
-         REAL*8  :: B_JGS_NORM_THR 
+         REAL*8  :: B_JGS_DIFF_THR
+         REAL*8  :: B_JGS_NORM_THR
          INTEGER :: B_JGS_NLEVEL
-         LOGICAL :: B_JGS_SOURCE_NONLINEAR 
-      END TYPE SCHM    
-!      
+         LOGICAL :: B_JGS_SOURCE_NONLINEAR
+      END TYPE SCHM
+!
 !
       TYPE MPAR
         LOGICAL               :: PINIT
@@ -943,13 +943,13 @@
       INTEGER, POINTER        :: NBEDGE
       INTEGER, POINTER        :: EDGES(:,:), NEIGH(:,:)
 !
-! Variables for unstructured grids 
+! Variables for unstructured grids
 !
       INTEGER, POINTER        :: NTRI,COUNTRI,COUNTOT,NNZ
       INTEGER                 :: optionCall = 3 ! take care all other options are basically wrong
 !  XYB may not be necessary now that we have XGRD and YGRD
 !  but these XGRD and YGRD should probably be double precision
-      DOUBLE PRECISION, POINTER  ::     XYB(:,:)   
+      DOUBLE PRECISION, POINTER  ::     XYB(:,:)
       INTEGER, POINTER        :: TRIGP(:,:)
 !/PDLIB      INTEGER, POINTER        :: NBND_MAP
 !/PDLIB      INTEGER, POINTER        :: INDEX_MAP(:)
@@ -964,8 +964,8 @@
                                  INDEX_CELL(:)
       REAL(8), POINTER        :: TRIA(:)
       REAL, POINTER           :: CROSSDIFF(:,:)
-      REAL,POINTER            :: MAXX, MAXY, DXYMAX 
-      LOGICAL, POINTER        :: GUGINIT       
+      REAL,POINTER            :: MAXX, MAXY, DXYMAX
+      LOGICAL, POINTER        :: GUGINIT
 !
       REAL,    POINTER        :: FFACBERG
 !/REF1      LOGICAL, POINTER        ::  RREF(:)
@@ -1054,7 +1054,7 @@
 !/PR2      REAL, POINTER           :: DTME, CLATMN
 !/PR3      REAL, POINTER           :: WDCG, WDTH
 !/SMC      REAL, POINTER           :: DTME, CLATMN, Refran
-!/SMC      LOGICAL, POINTER        :: FUNO3, FVERG, FSWND 
+!/SMC      LOGICAL, POINTER        :: FUNO3, FVERG, FSWND
 !/
 !/ Data aliasses for structure FLDP(S)
 !/
@@ -1311,11 +1311,11 @@
 !/
       END SUBROUTINE W3NMOD
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE W3DIMX  ( IMOD, MX, MY, MSEA, NDSE, NDST   & 
+      SUBROUTINE W3DIMX  ( IMOD, MX, MY, MSEA, NDSE, NDST   &
 !/SMC                    , MCel, MUFc, MVFc, MRLv           &
 !/ARC                    , MARC, MBAC, MSPEC                &
                          )
-!/SMC  !!Li    A few dimensional numbers for SMC grid.  
+!/SMC  !!Li    A few dimensional numbers for SMC grid.
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -1374,10 +1374,10 @@
 !
 !  7. Remarks :
 !
-!     - Grid dimensions apre passed through parameter list and then 
+!     - Grid dimensions apre passed through parameter list and then
 !       locally stored to assure consistency between allocation and
 !       data in structure.
-!     - W3SETG needs to be called after allocation to point to 
+!     - W3SETG needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -1401,8 +1401,8 @@
 !/ Parameter list
 !/
       INTEGER, INTENT(IN)     :: IMOD, MX, MY, MSEA, NDSE, NDST
-!/SMC       INTEGER, INTENT(IN)     :: MCel, MUFc, MVFc, MRLv 
-!/ARC       INTEGER, INTENT(IN)     :: MARC, MBAC, MSPEC 
+!/SMC       INTEGER, INTENT(IN)     :: MCel, MUFc, MVFc, MRLv
+!/ARC       INTEGER, INTENT(IN)     :: MARC, MBAC, MSPEC
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -1440,7 +1440,7 @@
 ! -------------------------------------------------------------------- /
 ! 2.  Allocate arrays
 !
-! NB: Some array start at 0 because MAPFS(IY,IX)=0 for missing points 
+! NB: Some array start at 0 because MAPFS(IY,IX)=0 for missing points
 !
       ALLOCATE ( GRIDS(IMOD)%MAPSTA(MY,MX),  &
                  GRIDS(IMOD)%MAPST2(MY,MX),  &
@@ -1482,7 +1482,7 @@
 !/SMC                 GRIDS(IMOD)%IJKCel(5, -9:MCel), &
 !/SMC                 GRIDS(IMOD)%IJKUFc(7,MUFc),     &
 !/SMC                 GRIDS(IMOD)%IJKVFc(8,MVFc),     &
-!/SMC                 GRIDS(IMOD)%CTRNX(-9:MCel),     &  
+!/SMC                 GRIDS(IMOD)%CTRNX(-9:MCel),     &
 !/SMC                 GRIDS(IMOD)%CTRNY(-9:MCel),     &
 !/SMC                 GRIDS(IMOD)%CLATF(MVFc),        &
 !/SMC                 STAT=ISTAT                      )
@@ -1505,8 +1505,8 @@
 !/REF1                 GRIDS(IMOD)%REFPARS(10), &
 !/REF1                 STAT=ISTAT               )
 !/REF1      CHECK_ALLOC_STATUS ( ISTAT )
-!/REF1! Memory footprint can be reduced by defining REFLC and REFLD only over nodes 
-!/REF1! where reflection can occur. 
+!/REF1! Memory footprint can be reduced by defining REFLC and REFLD only over nodes
+!/REF1! where reflection can occur.
 !/REF1      ALLOCATE ( GRIDS(IMOD)%REFLC(4,0:NSEA), &
 !/REF1                 GRIDS(IMOD)%REFLD(6,0:NSEA), &
 !/REF1                 STAT=ISTAT                    )
@@ -1632,10 +1632,10 @@
 !
 !  7. Remarks :
 !
-!     - Grid dimensions apre passed through parameter list and then 
+!     - Grid dimensions apre passed through parameter list and then
 !       locally stored to assure consistency between allocation and
 !       data in structure.
-!     - W3SETG needs to be called after allocation to point to 
+!     - W3SETG needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -1914,16 +1914,16 @@
       TRFLAG => GRIDS(IMOD)%TRFLAG
       FLAGLL => GRIDS(IMOD)%FLAGLL
 !
-!/SMC      NCel   => GRIDS(IMOD)%NCel 
-!/SMC      NUFc   => GRIDS(IMOD)%NUFc 
-!/SMC      NVFc   => GRIDS(IMOD)%NVFc 
-!/SMC      NRLv   => GRIDS(IMOD)%NRLv 
-!/SMC      MRFct  => GRIDS(IMOD)%MRFct 
+!/SMC      NCel   => GRIDS(IMOD)%NCel
+!/SMC      NUFc   => GRIDS(IMOD)%NUFc
+!/SMC      NVFc   => GRIDS(IMOD)%NVFc
+!/SMC      NRLv   => GRIDS(IMOD)%NRLv
+!/SMC      MRFct  => GRIDS(IMOD)%MRFct
 !
-!/ARC      NGLO   => GRIDS(IMOD)%NGLO 
-!/ARC      NARC   => GRIDS(IMOD)%NARC 
-!/ARC      NBGL   => GRIDS(IMOD)%NBGL 
-!/ARC      NBAC   => GRIDS(IMOD)%NBAC 
+!/ARC      NGLO   => GRIDS(IMOD)%NGLO
+!/ARC      NARC   => GRIDS(IMOD)%NARC
+!/ARC      NBGL   => GRIDS(IMOD)%NBGL
+!/ARC      NBAC   => GRIDS(IMOD)%NBAC
 !
       E3DF   => GRIDS(IMOD)%E3DF
       P2MSF  => GRIDS(IMOD)%P2MSF
@@ -1977,7 +1977,7 @@
       BTBETA => GRIDS(IMOD)%BTBETA
 !
       GINIT  => GRIDS(IMOD)%GINIT
-      GUGINIT  => GRIDS(IMOD)%GUGINIT      
+      GUGINIT  => GRIDS(IMOD)%GUGINIT
       FLDRY  => GRIDS(IMOD)%FLDRY
       FLCX   => GRIDS(IMOD)%FLCX
       FLCY   => GRIDS(IMOD)%FLCY
@@ -1999,8 +1999,8 @@
       SI     => GRIDS(IMOD)%SI
       COUNTOT    => GRIDS(IMOD)%COUNTOT
       IEN     => GRIDS(IMOD)%IEN
-      LEN     => GRIDS(IMOD)%LEN 
-      ANGLE     => GRIDS(IMOD)%ANGLE 
+      LEN     => GRIDS(IMOD)%LEN
+      ANGLE     => GRIDS(IMOD)%ANGLE
       ANGLE0     => GRIDS(IMOD)%ANGLE0
       CCON     => GRIDS(IMOD)%CCON
       COUNTCON     => GRIDS(IMOD)%COUNTCON
@@ -2026,7 +2026,7 @@
       CROSSDIFF => GRIDS(IMOD)%CROSSDIFF
       MAXX     => GRIDS(IMOD)%MAXX
       MAXY     => GRIDS(IMOD)%MAXY
-      DXYMAX   => GRIDS(IMOD)%DXYMAX      
+      DXYMAX   => GRIDS(IMOD)%DXYMAX
 
 !
       IF ( GINIT ) THEN
@@ -2151,8 +2151,8 @@
 !/SMC      DTME   => MPARS(IMOD)%PROPS%DTME
 !/SMC      CLATMN => MPARS(IMOD)%PROPS%CLATMN
 !/SMC      Refran => MPARS(IMOD)%PROPS%Refran
-!/SMC      FUNO3  => MPARS(IMOD)%PROPS%FUNO3 
-!/SMC      FVERG  => MPARS(IMOD)%PROPS%FVERG 
+!/SMC      FUNO3  => MPARS(IMOD)%PROPS%FUNO3
+!/SMC      FVERG  => MPARS(IMOD)%PROPS%FVERG
 !/SMC      FSWND  => MPARS(IMOD)%PROPS%FSWND
 !
 !     Structure FLDP
@@ -2261,9 +2261,9 @@
 !/ST4      SSTXFTWN => MPARS(IMOD)%SRCPS%SSTXFTWN
 !/ST4      SSDSCOS  => MPARS(IMOD)%SRCPS%SSDSCOS
 !/ST4      SSDSISO  => MPARS(IMOD)%SRCPS%SSDSISO
-!/ST4      IKTAB    => MPARS(IMOD)%SRCPS%IKTAB  
-!/ST4      DCKI     => MPARS(IMOD)%SRCPS%DCKI  
-!/ST4      QBI      => MPARS(IMOD)%SRCPS%QBI  
+!/ST4      IKTAB    => MPARS(IMOD)%SRCPS%IKTAB
+!/ST4      DCKI     => MPARS(IMOD)%SRCPS%DCKI
+!/ST4      QBI      => MPARS(IMOD)%SRCPS%QBI
 !/ST4      CUMULW   => MPARS(IMOD)%SRCPS%CUMULW
 !/ST4      SATINDICES    => MPARS(IMOD)%SRCPS%SATINDICES
 !/ST4      SATWEIGHTS   => MPARS(IMOD)%SRCPS%SATWEIGHTS
@@ -2619,7 +2619,7 @@
 !/ End of W3GNTX ----------------------------------------------------- /
 !/
       END SUBROUTINE W3GNTX
-!/ ------------------------------------------------------------------- /   
+!/ ------------------------------------------------------------------- /
       SUBROUTINE W3DIMUG  ( IMOD, MTRI, MX, COUNTOTA, NNZ, NDSE, NDST )
 !/
 !/                  +-----------------------------------+
@@ -2670,10 +2670,10 @@
 !
 !  7. Remarks :
 !
-!     - Grid dimensions apre passed through parameter list and then 
+!     - Grid dimensions apre passed through parameter list and then
 !       locally stored to assure consistency between allocation and
 !       data in structure.
-!     - W3SETG needs to be called after allocation to point to 
+!     - W3SETG needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -2739,7 +2739,7 @@
       ALLOCATE ( GRIDS(IMOD)%TRIGP(MTRI,3),                         &
                  GRIDS(IMOD)%XYB(MX,3),                             &
                  GRIDS(IMOD)%SI(MX),                                &
-                 GRIDS(IMOD)%TRIA(MTRI),                            & 
+                 GRIDS(IMOD)%TRIA(MTRI),                            &
                  GRIDS(IMOD)%CROSSDIFF(6,MTRI),                     &
                  GRIDS(IMOD)%IEN(MTRI,6),                           &
                  GRIDS(IMOD)%LEN(MTRI,3),                           &
@@ -2767,7 +2767,7 @@
       WRITE (NDST,9001)
 #endif
 !
-!some segmentation troubles can appear, they are related with the allocation of 
+!some segmentation troubles can appear, they are related with the allocation of
 !normal(1st dimension) and the nesting of the triangulated grid.
 ! -------------------------------------------------------------------- /
 ! 3.  Point to allocated arrays
@@ -2826,7 +2826,7 @@
 !/
 !  1. Purpose :
 !
-!     Update reflection directions at shoreline. 
+!     Update reflection directions at shoreline.
 !
 !  2. Method :
 !
@@ -2888,7 +2888,7 @@
 !
 ! 1.  Preparations --------------------------------------------------- *
 !
-!/REF1      RREF=.FALSE.  !JDM initializing to false helps with b4b mod_defs 
+!/REF1      RREF=.FALSE.  !JDM initializing to false helps with b4b mod_defs
 !/REF1      IF (REFPARS(2).GT.0) RREF(2)=.TRUE.
 !/REF1      IF (REFPARS(3).GT.0) RREF(3)=.TRUE.
 !/REF1      IF (REFPARS(4).GT.0) RREF(4)=.TRUE.
@@ -2896,7 +2896,7 @@
 !/REF1      DO IY=2, NY-1
 !/REF1        DO IX=2, NX-1
 !/REF1          IF (REFPARS(1).GT.0) RREF(1)=.TRUE.
-!/REF1!No reflection from artificial island on pole. 
+!/REF1!No reflection from artificial island on pole.
 !/REF1          IF (FLAGLL.AND.(YGRD(IY,IX).GT.85)) RREF(1)=.FALSE.
 !/REF1          IF (MAPSTA(IY,IX).GT.0) THEN
 !/REF1!
@@ -2912,11 +2912,11 @@
 !/REF1!
 !/REF1! resolved shoreline reflection
 !/REF1!
-!/REF1            IF (RREF(1)) THEN 
+!/REF1            IF (RREF(1)) THEN
 !/REF1              REFLC(1,  MAPFS(IY,IX)) = 0.
 !/REF1              REFLD(1:6,MAPFS(IY,IX)) = 0
 !/REF1!
-!/REF1! Search for neighboring coastline.        3 2 1 
+!/REF1! Search for neighboring coastline.        3 2 1
 !/REF1! around X. These are the neighbors of X:  4 X 0
 !/REF1!                                          5 6 7
 !/REF1!
@@ -2926,9 +2926,9 @@
 !/REF1              NEIGH1(4)=8*MAPST2(IY,IX-1)+MAPSTA(IY,IX-1)
 !/REF1              NEIGH1(5:7)=8*MAPST2(IY-1,IX-1:IX+1)+MAPSTA(IY-1,IX-1:IX+1)
 !/REF1!
-!/REF1! if one of the surrounding points is land: determines directions ... 
-!/REF1!              
-!/REF1              IF (MINVAL(ABS(NEIGH1)).EQ.0) THEN 
+!/REF1! if one of the surrounding points is land: determines directions ...
+!/REF1!
+!/REF1              IF (MINVAL(ABS(NEIGH1)).EQ.0) THEN
 !/REF1                IF ( FLAGLL ) THEN
 !/REF1                  CLAT   = COS(YGRD(IY,IX)*DERA)
 !/REF1                ELSE
@@ -2939,32 +2939,32 @@
 !/REF1                ANGLES(2)= ATAN2(DYDQ(IY,IX),DXDQ(IY,IX)*CLAT)
 !/REF1                ANGLES(3)= ATAN2(DYDQ(IY,IX)-DYDP(IY,IX),(DXDQ(IY,IX)-DXDP(IY,IX))*CLAT)
 !/REF1                ANGLES(4:7)= ANGLES(0:3)+PI
-!/REF1                IF ((NEIGH1(0).GE.1).AND.(NEIGH1(4).GE.1)) THEN 
+!/REF1                IF ((NEIGH1(0).GE.1).AND.(NEIGH1(4).GE.1)) THEN
 !/REF1                  REFLD(3,MAPFS(IY,IX))=0
-!/REF1                ELSE 
+!/REF1                ELSE
 !/REF1                  IF ((NEIGH1(0).GE.1).OR.(NEIGH1(4).GE.1)) REFLD(3,MAPFS(IY,IX))=1
 !/REF1                  END IF
-!/REF1                IF ((NEIGH1(2).EQ.1).AND.(NEIGH1(6).GE.1)) THEN 
+!/REF1                IF ((NEIGH1(2).EQ.1).AND.(NEIGH1(6).GE.1)) THEN
 !/REF1                  REFLD(4,MAPFS(IY,IX))=0
 !/REF1                ELSE
 !/REF1                  IF ((NEIGH1(2).GE.1).OR.(NEIGH1(6).GE.1)) REFLD(4,MAPFS(IY,IX))=1
 !/REF1                  END IF
 !/REF1!
-!/REF1! Looks for a locally straight coast in all 8 orientations 
+!/REF1! Looks for a locally straight coast in all 8 orientations
 !/REF1!
 !/REF1                J=0
 !/REF1                REFLD(1,MAPFS(IY,IX))=0
 !/REF1                COSAVG=0
 !/REF1                SINAVG=0
-!/REF1! Shore angle is corrected for grid rotation in w3ref1md.ftn with  REFLD(5:6,MAPFS(IY,IX)) 
+!/REF1! Shore angle is corrected for grid rotation in w3ref1md.ftn with  REFLD(5:6,MAPFS(IY,IX))
 !/REF1                REFLD(5,MAPFS(IY,IX))= MOD(NTH+NINT(ANGLES(0)/TPI*NTH),NTH)
 !/REF1                REFLD(6,MAPFS(IY,IX))= MOD(NTH+NINT((ANGLES(2)/TPI-0.25)*NTH),NTH)
-!/REFT                    IF (IY.EQ.4) THEN 
+!/REFT                    IF (IY.EQ.4) THEN
 !/REFT                      WRITE(6,*) 'POINT (IX,IY):',IX,IY
-!/REFT                      WRITE(6,*) 'REFT:',NEIGH1(3),NEIGH1(2), NEIGH1(1) 
-!/REFT                      WRITE(6,*) 'REFT:',NEIGH1(4),1, NEIGH1(0) 
+!/REFT                      WRITE(6,*) 'REFT:',NEIGH1(3),NEIGH1(2), NEIGH1(1)
+!/REFT                      WRITE(6,*) 'REFT:',NEIGH1(4),1, NEIGH1(0)
 !/REFT                      WRITE(6,*) 'REFT:',NEIGH1(5:7)
-!/REFT                      WRITE(6,*) 'ANG:',ANGLES(3)*RADE,ANGLES(2)*RADE, ANGLES(1)*RADE 
+!/REFT                      WRITE(6,*) 'ANG:',ANGLES(3)*RADE,ANGLES(2)*RADE, ANGLES(1)*RADE
 !/REFT                      WRITE(6,*) 'ANG:',ANGLES(4)*RADE,1, ANGLES(0) *RADE
 !/REFT                      WRITE(6,*) 'ANG:',ANGLES(5:7)*RADE
 !/REFT                      WRITE(6,*) 'REFT:',XGRD(IY+1,IX-1:IX+1), YGRD(IY+1,IX-1:IX+1)
@@ -2975,7 +2975,7 @@
 !/REF1                DO K=0,7
 !/REF1                  IF (NEIGH1(K).EQ.0.AND.NEIGH1(MOD(K+7,8)).EQ.0 &
 !/REF1                    .AND.NEIGH1(MOD(K+1,8)).EQ.0 &
-!/REF1                    .AND.NEIGH1(MOD(K+4,8)).NE.0) THEN 
+!/REF1                    .AND.NEIGH1(MOD(K+4,8)).NE.0) THEN
 !/REF1                    REFLC(1,MAPFS(IY,IX))= REFPARS(1)
 !/REF1!
 !/REF1! Defines direction index for specular reflection (normal to coast)
@@ -2984,7 +2984,7 @@
 !/REF1!  (NB: 1 is sea, 0 is land)             1 X 0
 !/REF1!                                        1 1 0
 !/REF1!
-!/REF1!  then there is only a coastline detection for K=0, giving J=1 
+!/REF1!  then there is only a coastline detection for K=0, giving J=1
 !/REF1!  and the final result will be REFLD(1,MAPFS(IY,IX))=1
 !/REF1!  Namely, the direction TH(REFLD) is the direction pointing INTO the coast
 !/REF1!
@@ -2994,9 +2994,9 @@
 !/REF1                    J=J+1
 !/REF1                    ENDIF
 !/REF1                  END DO
-!/REF1                IF (J.GT.0) THEN 
+!/REF1                IF (J.GT.0) THEN
 !/REF1                  IF (J.GT.1) REFLD(2,MAPFS(IY,IX))= 1
-!/REF1                  THAVG=ATAN2(SINAVG,COSAVG) 
+!/REF1                  THAVG=ATAN2(SINAVG,COSAVG)
 #if defined(TEST_W3GDATMD) || defined(TEST_W3GDATMD_W3SETREF)
 !/REF1                  !WRITE (6,*) 'COASTAL REFLECTION:',IX,IY,   &
 !/REF1                  !SINAVG,COSAVG,THAVG/TPI,NINT(THAVG/TPI*NTH),MOD(NTH+NINT(THAVG/TPI*NTH),NTH)
@@ -3004,12 +3004,12 @@
 !/REF1                  REFLD(1,MAPFS(IY,IX))=1+MOD(NTH+NINT(THAVG/TPI*NTH),NTH)
 !/REF1                ELSE
 !/REF1
-!/REF1!                             1 1 1 
+!/REF1!                             1 1 1
 !/REF1! Looks for mild corners like 1 1 1
-!/REF1!                             1 0 0          
+!/REF1!                             1 0 0
 !/REF1                  DO K=0,7
 !/REF1                    IF (NEIGH1(K).EQ.0.AND.NEIGH1(MOD(K+1,8)).EQ.0 &
-!/REF1                      .AND.NEIGH1(MOD(K+4,8)).NE.0) THEN 
+!/REF1                      .AND.NEIGH1(MOD(K+4,8)).NE.0) THEN
 !/REF1                      REFLC(1,MAPFS(IY,IX))= REFPARS(1)
 !/REF1                      REFLD(1,MAPFS(IY,IX))= 1+MOD((K*NTH+(K+1)*NTH)/16,NTH)
 !/REF1                      REFLD(2,MAPFS(IY,IX))= 1
@@ -3017,10 +3017,10 @@
 !/REF1                    END DO
 !/REF1!                              1 1 1                        1 1 1
 !/REF1! Looks for sharp corners like 1 1 1 but not diagonals like 1 1 1
-!/REF1!                              1 0 1                        1 1 0          
-!/REF1                  IF (REFLC(1,MAPFS(IY,IX)).LE.0) THEN 
+!/REF1!                              1 0 1                        1 1 0
+!/REF1                  IF (REFLC(1,MAPFS(IY,IX)).LE.0) THEN
 !/REF1                    DO K=0,7,2
-!/REF1                      IF ( NEIGH1(K).EQ.0.AND.NEIGH1(MOD(K+4,8)).NE.0) THEN 
+!/REF1                      IF ( NEIGH1(K).EQ.0.AND.NEIGH1(MOD(K+4,8)).NE.0) THEN
 !/REF1                        REFLC(1,MAPFS(IY,IX))= REFPARS(1)
 !/REF1                        REFLD(1,MAPFS(IY,IX))= 1+(K*NTH)/8
 !/REF1                        REFLD(2,MAPFS(IY,IX))= 0
@@ -3031,7 +3031,7 @@
 !/REF1                  END IF
 !/REF1! End of test if surrounding point is land
 !/REF1                END IF
-!/REFT                IF (REFLC(1,MAPFS(IY,IX)).GT.0)  THEN 
+!/REFT                IF (REFLC(1,MAPFS(IY,IX)).GT.0)  THEN
 !/REFT                  WRITE (6,*) 'COAST DIRECTION AT POINT:',IX,IY,' IS ', &
 !/REFT                    REFLD(:,MAPFS(IY,IX)),TH(REFLD(1,MAPFS(IY,IX)))*360/TPI
 !/REFT                  ENDIF
@@ -3049,7 +3049,7 @@
 !/ End of W3SETREF ----------------------------------------------------- /
 !/
       END SUBROUTINE W3SETREF
-           
+
 !/
 !/ End of module W3GDATMD -------------------------------------------- /
 !/

--- a/model/ftn/w3getmem.c
+++ b/model/ftn/w3getmem.c
@@ -48,7 +48,7 @@ double get_memory_(void)
   struct rusage RU;
 
   getrusage(RUSAGE_SELF, &RU);
- 
+
   Kbytes = RU.ru_maxrss;
 
   Mbytes = ((double) Kbytes) / 1024.0;

--- a/model/ftn/w3gig1md.ftn
+++ b/model/ftn/w3gig1md.ftn
@@ -10,10 +10,10 @@
 !/                  +-----------------------------------+
 !/
 !/    31-Mar-2010 : Origination.                        ( version 4.07 )
-!/ 
+!/
 !  1. Purpose :
 !
-!     This module computes : 
+!     This module computes :
 !        - the second order spectrum, in particular for infragravity waves
 !
 !  2. Variables and types :
@@ -72,12 +72,12 @@
 !/
 !  1. Purpose :
 !
-!      Computes the coupling coefficient between waves of frequencies f1 and f2 
-!      and an angle theta. 
+!      Computes the coupling coefficient between waves of frequencies f1 and f2
+!      and an angle theta.
 !       This is for the surface elevation variance
 !      See Okihiro et al. 1992
 !       Code adapted from Matlab by Arshad Rawat, 2012.
-! 
+!
 !  3. Parameters :
 !
 !     Parameter list
@@ -117,7 +117,7 @@
   REAL                    :: Df1f2theta,WN1,WN2
   REAL                    :: k1,k2,co,cok1,cok2,k3,C1,C2,C3,C4
   REAL                    :: C1b,s3,sk2,g2,g
-  
+
   k1=WN1
   k2=WN2
   co=cos(theta)
@@ -131,7 +131,7 @@
   C1b=(s3**2-s1*s2)/g2
   C2=s3
   C3=(s3**2-sk2)*s1*s2
- 
+
 ! C4 is Hasselmann's D times i
 
   C4=s3*(k1*k2*co-((s1*s2)**2)/g2)+0.5*(s1*k2**2+s2*k1**2-s1*s2*(s2**3+s1**3)/g2)
@@ -153,10 +153,10 @@ END FUNCTION Df1f2theta
 !/                  +-----------------------------------+
 !/
 !/    31-Mar-2010 : Origination.                        ( version 4.07 )
-!/ 
+!/
 !  1. Purpose :
 !
-!     This subroutine computes : 
+!     This subroutine computes :
 !        - the second order spectrum, in particular for infragravity waves
 !  2. Method :
 !     Uses 2nd order coupling coefficient (Biesel 1952, Hasselmann 1962)
@@ -169,7 +169,7 @@ END FUNCTION Df1f2theta
 !       DEPTH     Real I     Water depth
 !       WN        R.A.       wavenumbers
 !       CG        R.A.       group velocities
-!       IACTION   Int  I     Switch to specify if the input spectrum 
+!       IACTION   Int  I     Switch to specify if the input spectrum
 !                            is E(f,theta) or A(k,theta)
 !     ----------------------------------------------------------------
 !
@@ -245,41 +245,41 @@ END FUNCTION Df1f2theta
       REAL   , DIMENSION(:,:,:,:),  ALLOCATABLE :: DD
       REAL   , DIMENSION(NSPEC)                 :: ESPEC
       CHARACTER(120) ::path,filename,filename2
-  
+
 
 ! Defines the spectral domain for the IG computation
-      NKIG=IGPARS(5) 
+      NKIG=IGPARS(5)
       NSPECIG=NKIG*NTH
- 
+
       ALLOCATE(DD(NKIG,nk,nth,nth))
       ALLOCATE(wfr1(NKIG,nk))
       ALLOCATE(ifr2c(NKIG,nk))
       ALLOCATE(EfthIG(NSPECIG))
       EfthIG(:)=0.
-  
+
 !  WRITE(*,*) 'Computing coupling coefficient for SURFACE ELEVATION'
-  
-      IF (IACTION.EQ.0) THEN 
+
+      IF (IACTION.EQ.0) THEN
         ESPEC=E
-      ELSE 
+      ELSE
         DO IK = 1,NK
           DO ITH = 1, NTH
             ISP1=ITH+(IK-1)*NTH
             ESPEC(ISP1)=E(ISP1)*SIG(IK)*TPI / CG(IK)
             END DO
           END DO
-        END IF 
-!  
+        END IF
+!
       DO iIG=1,NKIG
         DO ifr=1,nk
           CALL WAVNU1 (SIG(ifr)+SIG(iIG),DEPTH,WN1,CG2)
           DO ith1=1,nth
-            DO ith2=1,nth 
+            DO ith2=1,nth
 !
 ! This is the coupling coefficient for the SURFACE ELEVATION. See .e.g. forristall (JPO 2000)
 !
               DD(iIG,ifr,ith1,ith2)=(Df1f2theta(SIG(ifr)+SIG(iIG),-SIG(ifr), WN1,WN(IFR), &
-                                 (abs(TH(ith1)-TH(ith2))+pi),DEPTH))**2 
+                                 (abs(TH(ith1)-TH(ith2))+pi),DEPTH))**2
 
               END DO
             END DO
@@ -301,9 +301,9 @@ END FUNCTION Df1f2theta
           if (iloc /= 0) THEN
             ifr2c(iIG,ifr)=iloc  ! index of frequency f+fIG
           else
-            ifr2c(iIG,ifr)=nk 
+            ifr2c(iIG,ifr)=nk
             end if
-            
+
             !wfr1(iIG,ifr)=0.0
           end if
         end do
@@ -313,32 +313,32 @@ END FUNCTION Df1f2theta
       DO iIG=1,NKIG
         DO IFR = 1,NK-1
 
-! AR calculating k1 and k2 before loops on th1 and th2      
-       
+! AR calculating k1 and k2 before loops on th1 and th2
+
             k1=WN(ifr)
                k2=WN(ifr2c(iIG,ifr))
 
           DO ith1 = 1,NTH
-            DO ith2 = 1,NTH 
-                
+            DO ith2 = 1,NTH
+
 ! Adds the effect of interaction of frequency f(ifr), theta(ith1) with f(ifr)+fIG(:), theta(ith2)
-              ISP1 = ITH1 + (ifr2c(iIG,ifr)-1)*NTH        
-              ISP2 = ITH2 + (ifr-1)*NTH        
- 
+              ISP1 = ITH1 + (ifr2c(iIG,ifr)-1)*NTH
+              ISP2 = ITH2 + (ifr-1)*NTH
+
               Eadd=DD(iIG,ifr,ith1,ith2)*wfr1(iIG,ifr) &
                               *ESPEC(ISP1)*ESPEC(ISP2) ! Rectangle rule by AR
               Dkx=k2*cos(dble(dth*ith2))- k1*cos(dble(dth*ith1))
-              Dky=k2*sin(dble(dth*ith2))- k1*sin(dble(dth*ith1)) 
+              Dky=k2*sin(dble(dth*ith2))- k1*sin(dble(dth*ith1))
 
               thetaIG=atan2(Dky,Dkx)
 
               if (thetaIG.LT.0) thetaIG=2*pi+thetaIG
 ! Finding corresponding index of theta IG in theta array
                 !I=INT((thetaIG/(2*pi))*nth)
-                
+
               I=minloc(abs(thetaIG-TH), 1)-1
                    if (I==0) I=nth
-              ISP3 = I + (iIG-1)*NTH        
+              ISP3 = I + (iIG-1)*NTH
 !            memo=EfthIG(ISP3)
                 EfthIG(ISP3)= EfthIG(ISP3)+Eadd;
 !              IF (EfthIG(ISP3).NE.EfthIG(ISP3).AND.Eadd.NE.0) WRITE(6,*) 'EfthIG:',IIG, IFR, ITH1,ITH2,ISP3, &
@@ -351,18 +351,18 @@ END FUNCTION Df1f2theta
 !   ESPEC(1:NSPECIG)=ESPEC(1:NSPECIG)+EfthIG(:)
    ESPEC(1:NSPECIG)=EfthIG(:)
 
-      IF (IACTION.EQ.0) THEN 
-        DO ISP1=1,NSPECIG 
+      IF (IACTION.EQ.0) THEN
+        DO ISP1=1,NSPECIG
           E(ISP1)=ESPEC(ISP1)
           END DO
-      ELSE 
+      ELSE
         DO IK = 1,NKIG
           DO ITH = 1, NTH
             ISP1=ITH+(IK-1)*NTH
             E(ISP1)=ESPEC(ISP1)*CG(IK)/(SIG(IK)*TPI)
             END DO
           END DO
-        END IF 
+        END IF
 
 ! OPEN(5555,FILE='testos.dat',status='unknown')
 ! WRITE(5555,*) E,EfthIG !f,fIG,tet!ifr2c !Efth, !!, Efth,

--- a/model/ftn/w3gsrumd.ftn
+++ b/model/ftn/w3gsrumd.ftn
@@ -91,7 +91,7 @@
 !     sequential index in a counterclockwise order beginning with the cell's
 !     lower-left corner grid point.  That is, when moving from vertex 1 to
 !     vertex 2 to vertex 3, etc., the grid cell interior is always to the left.
-!     Note that though cell will be counterclockwise w.r.t. indices, this does 
+!     Note that though cell will be counterclockwise w.r.t. indices, this does
 !     not necessarily mean that the cell will be counterclockwise geographically,
 !     specifically in situation of curvilinear grid.
 !
@@ -1518,7 +1518,7 @@
               'W3GFCL_R8 - ENCLOSING CELL:',IB,JB,K,(IS(L),JS(L),L=1,4)
               IF ( PRESENT(POLE) ) POLE = LPLC
               INGRID = .TRUE.
-              EXIT CELL_LOOP 
+              EXIT CELL_LOOP
             END IF !point in cell
         END DO CELL_LOOP
       IF ( INGRID ) RETURN
@@ -1610,7 +1610,7 @@
             IF ( NLEVEL .GE. MAX_FNCL_LEVEL ) EXIT LEVEL_LOOP
         END DO LEVEL_LOOP
 !
-!-----return cell that is shortest distance from target point 
+!-----return cell that is shortest distance from target point
       IS(:) = IS1(:)
       JS(:) = JS1(:)
       XS(:) = XS1(:)
@@ -1919,7 +1919,7 @@
                   WRITE(*,'(A,4(2I6))') &
                   'W3GFCD_R8 - ENCLOSING CELL:',(IS(L),JS(L),L=1,4)
                   IF ( PRESENT(POLE) ) POLE = LPLC
-                EXIT CELL_LOOP 
+                EXIT CELL_LOOP
               END IF !point in cell
             END DO !J
         END DO CELL_LOOP
@@ -2547,7 +2547,7 @@
       REAL(8), PARAMETER :: SMALL = 1D-6
       REAL(8) :: LEPS
       LOGICAL :: LDBG, FNCL, POLE
-      INTEGER :: I, J, L 
+      INTEGER :: I, J, L
       LOGICAL :: M, MSK(4)
       INTEGER :: LVL, N, NS, ICC, JCC
       REAL(8) :: XT, YT, XS(4), YS(4), DW(4)
@@ -3462,14 +3462,14 @@
 !
 !  2. Method :
 !
-!     Calculates cross products for vertex to vertex (i.e. cell side) 
+!     Calculates cross products for vertex to vertex (i.e. cell side)
 !     vs vertex to target. If all cross products have the same sign,
-!     the point is considered to be within the cell. Since they can 
+!     the point is considered to be within the cell. Since they can
 !     be "all positive" *or* "all negative", there are no pre-conditions
 !     that the order of specification of the vertices be clockwise vs.
 !     counter-clockwise geographically.  The logical variable POLE is
 !     set to true if the grid cell includes a pole.
-!     
+!
 !  3. Parameters :
 !
 !     Return parameter
@@ -3811,7 +3811,7 @@
 !     of the (P,Q) index coordinates:
 !
 !         x = x(p,q),  y = y(p,q),  dp = dq = 1.
-!  
+!
 !     When using spherical coordinates (llg=T) x = longitude and
 !     y = latitude in degrees.  The optional sphere input (default is true)
 !     controls whether or not the spherical coordinate metric is applied.
@@ -3861,7 +3861,7 @@
 !
 !         uvec_p = (1/h_p)*(dx/dp)*uvec_x + (1/h_p)*(dy/dp)*uvec_y,
 !         uvec_q = (1/h_q)*(dx/dq)*uvec_x + (1/h_q)*(dy/dq)*uvec_y.
-!  
+!
 !     The local cell rotation angle is (assuming orthogonal):
 !
 !         cos(theta) = (1/h_p)*dx/dp,
@@ -6538,7 +6538,7 @@
 !/
       SUBROUTINE W3FDWT_R4 ( N, ND, M, Z, X, C )
 !     Single precision interface
-      INTEGER, INTENT(IN)  :: N, ND, M 
+      INTEGER, INTENT(IN)  :: N, ND, M
       REAL(4), INTENT(IN)  :: Z
       REAL(4), INTENT(IN)  :: X(0:ND)
       REAL(4), INTENT(OUT) :: C(0:ND,0:M)
@@ -6581,7 +6581,7 @@
 !/
       SUBROUTINE W3FDWT_R8 ( N, ND, M, Z, X, C )
 !     Double precision interface
-      INTEGER, INTENT(IN)  :: N, ND, M 
+      INTEGER, INTENT(IN)  :: N, ND, M
       REAL(8), INTENT(IN)  :: Z
       REAL(8), INTENT(IN)  :: X(0:ND)
       REAL(8), INTENT(OUT) :: C(0:ND,0:M)

--- a/model/ftn/w3idatmd.ftn
+++ b/model/ftn/w3idatmd.ftn
@@ -20,7 +20,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -75,7 +75,7 @@
 !      FLCUR     Log.  Public   Flag for current input.
 !      FLWIND    Log.  Public   Flag for wind input.
 !      FLICE     Log.  Public   Flag for ice input.
-!      INFLAGS1  L.A.  Public   Array consolidating the above four 
+!      INFLAGS1  L.A.  Public   Array consolidating the above four
 !                               flags, as well as four additional
 !                               data flags.
 !      INFLAGS2  L.A.  Public   Like INFLAGS1 but does *not* get changed
@@ -116,7 +116,7 @@
 !     - The number of grids is taken from W3GDATMD, and needs to be
 !       set first with W3DIMG.
 !
-!     - INFLAGS1 dimensioning is hardwired as INFLAGS1(-7:12) where lowest possible 
+!     - INFLAGS1 dimensioning is hardwired as INFLAGS1(-7:12) where lowest possible
 !       value of JFIRST is JFIRST=-7
 !
 !  6. Switches :
@@ -175,7 +175,7 @@
                                  TW0(:), TWN(:), TIN(:), T0N(:),      &
                                  T1N(:), T2N(:), TDN(:), TG0(:),      &
                                  TGN(:), TTN(:), TVN(:), TZN(:),      &
-                                 TI1(:), TI2(:), TI3(:), TI4(:), TI5(:) 
+                                 TI1(:), TI2(:), TI3(:), TI4(:), TI5(:)
       REAL, POINTER           :: GA0, GD0, GAN, GDN
       REAL, POINTER           :: WX0(:,:), WY0(:,:), DT0(:,:),        &
                                  WXN(:,:), WYN(:,:), DTN(:,:),        &
@@ -190,7 +190,7 @@
       LOGICAL, POINTER        :: INFLAGS1(:), INFLAGS2(:), FLAGSC(:)
       LOGICAL, POINTER        :: FLLEV, FLCUR, FLWIND, FLICE
       LOGICAL, POINTER        :: FLMTH, FLMVS, FLMDN
-      LOGICAL, POINTER        :: FLIC1, FLIC2, FLIC3, FLIC4, FLIC5 
+      LOGICAL, POINTER        :: FLIC1, FLIC2, FLIC3, FLIC4, FLIC5
 !/TIDE      LOGICAL, POINTER        ::  FLLEVTIDE, FLCURTIDE,  &
 !/TIDE                                  FLLEVRESI, FLCURRESI
 !/
@@ -357,7 +357,7 @@
 !     See module documentation.
 !
 !  5. Called by :
-!       
+!
 !     Main wave model drivers.
 !
 !  6. Error messages :
@@ -367,7 +367,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETI needs to be called after allocation to point to 
+!     - W3SETI needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -454,12 +454,12 @@
 !/TIDE      FLLEVTIDE = FLAGSTIDE(1)
 !/TIDE      FLCURTIDE = FLAGSTIDE(2)
 !/TIDE      FLLEVRESI = FLAGSTIDE(3)
-!/TIDE      FLCURRESI = FLAGSTIDE(4)     
- 
+!/TIDE      FLCURRESI = FLAGSTIDE(4)
+
       FLWIND => INPUTS(IMOD)%INFLAGS1(3)
       FLICE  => INPUTS(IMOD)%INFLAGS1(4)
 !
-! notes: future improvement: flags for ICEPx should be 
+! notes: future improvement: flags for ICEPx should be
 !     "all or nothing" rather than 5 individual flags
 
       IF ( FLIC1  ) THEN
@@ -677,7 +677,7 @@
       IF ( NIDATA .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
-        END IF   
+        END IF
 !
       IF ( IMOD.LT.-NAUXGR .OR. IMOD.GT.NIDATA ) THEN
           WRITE (NDSE,1002) IMOD, -NAUXGR, NIDATA
@@ -787,10 +787,10 @@
               CXN    => INPUTS(IMOD)%CXN
               CYN    => INPUTS(IMOD)%CYN
             END IF
-!/TIDE          IF ( FLLEVTIDE ) THEN 
+!/TIDE          IF ( FLLEVTIDE ) THEN
 !/TIDE              WLTIDE => INPUTS(IMOD)%WLTIDE
 !/TIDE            END IF
-!/TIDE          IF ( FLCURTIDE ) THEN 
+!/TIDE          IF ( FLCURTIDE ) THEN
 !/TIDE              CXTIDE => INPUTS(IMOD)%CXTIDE
 !/TIDE              CYTIDE => INPUTS(IMOD)%CYTIDE
 !/TIDE            END IF

--- a/model/ftn/w3igcmmd.ftn
+++ b/model/ftn/w3igcmmd.ftn
@@ -13,12 +13,12 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Module used for coupling applications between ice model and WW3 with OASIS3-MCT 
+!     Module used for coupling applications between ice model and WW3 with OASIS3-MCT
 !
 !  2. Variables and types :
 !
@@ -51,7 +51,7 @@
       PRIVATE
 !
 ! * Accessibility
-      PUBLIC SND_FIELDS_TO_ICE 
+      PUBLIC SND_FIELDS_TO_ICE
       PUBLIC RCV_FIELDS_FROM_ICE
 !
       CONTAINS
@@ -84,7 +84,7 @@
 !
 !     Name            Type    Module     Description
 !     ------------------------------------------------------------------
-!     W3WAVE          Subr.   W3WAVEMD   Wave model 
+!     W3WAVE          Subr.   W3WAVEMD   Wave model
 !     ------------------------------------------------------------------
 !
 !  6. Error messages :
@@ -96,7 +96,7 @@
 !/ ------------------------------------------------------------------- /
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
-      USE W3GDATMD,  ONLY: NSEAL, NSEA 
+      USE W3GDATMD,  ONLY: NSEAL, NSEA
       USE W3WDATMD,  ONLY: ICEF
       USE W3ADATMD,  ONLY: TAUICE
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
@@ -106,7 +106,7 @@
 !/
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO, NDSO
-      LOGICAL                          :: LL_ACTION   
+      LOGICAL                          :: LL_ACTION
       REAL(kind=8), DIMENSION(NSEAL)   :: TMP
       INTEGER                          :: JSEA, ISEA
 !
@@ -119,9 +119,9 @@
 
          !
          ! Ice floe diameters (m)
-         ! ---------------------------------------------------------------------     
+         ! ---------------------------------------------------------------------
          CASE ('WW3_ICEF')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEAL) = 0.0
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(ICEF(ISEA) /= UNDEF) TMP(JSEA)=ICEF(ISEA)
@@ -130,13 +130,13 @@
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIX')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEAL) = 0.0
             WHERE(TAUICE(:,1) /= UNDEF) TMP(:)=TAUICE(:,1)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIY')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEAL) = 0.0
             WHERE(TAUICE(:,2) /= UNDEF) TMP(:)=TAUICE(:,2)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -178,7 +178,7 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     ID_LCOMM          Char.     I     MPI communicator
-!     IDFLD             Int.      I     Name of the exchange fields    
+!     IDFLD             Int.      I     Name of the exchange fields
 !     FXN               Int.     I/O    First exchange field
 !     FYN               Int.     I/O    Second exchange field
 !     FAN               Int.     I/O    Third exchange field
@@ -223,7 +223,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      LOGICAL                          :: LL_ACTION   
+      LOGICAL                          :: LL_ACTION
       INTEGER                          :: IB_DO, IB_I, IB_J, IL_ERR, NDSO
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_RCV
       REAL(kind=8), DIMENSION(NSEAL)   :: TMP
@@ -267,12 +267,12 @@
            CASE ('WW3__IC1')
            CASE DEFAULT
            ! WRITE (NDSO,1001) TRIM(RCV_FLD(IB_DO)%CL_FIELD_NAME)
-           END SELECT   
+           END SELECT
            !
-           ! Ice Concentration 
+           ! Ice Concentration
            ! ----------------------------------------------------------------------
-        ELSE IF (IDFLD == 'ICE') THEN  
-           SELECT CASE (RCV_FLD(IB_DO)%CL_FIELD_NAME)            
+        ELSE IF (IDFLD == 'ICE') THEN
+           SELECT CASE (RCV_FLD(IB_DO)%CL_FIELD_NAME)
            CASE ('WW3__ICE')
             CALL CPL_OASIS_RCV(IB_DO, ID_OASIS_TIME, RLA_OASIS_RCV, LL_ACTION)
             IF (LL_ACTION) THEN
@@ -282,7 +282,7 @@
                 IB_J = IAPROC + (IB_I-1)*NAPROC
                 SND_BUFF(IB_J) = TMP(IB_I)
               END DO
-              ! 
+              !
               !
               CALL MPI_ALLREDUCE(SND_BUFF(1:NSEA), &
                                  RCV_BUFF(1:NSEA), &
@@ -296,14 +296,14 @@
               CALL W3S2XY(NSEA,NSEA,NX,NY,RCV_BUFF(1:NSEA),MAPSF,FAN)
               !
             END IF
-          CASE ('WW3__IC5') 
+          CASE ('WW3__IC5')
           CASE ('WW3__IC1')
           CASE DEFAULT
-          !  WRITE (NDSO,1001) TRIM(RCV_FLD(IB_DO)%CL_FIELD_NAME)    
-          END SELECT  
+          !  WRITE (NDSO,1001) TRIM(RCV_FLD(IB_DO)%CL_FIELD_NAME)
+          END SELECT
           ! Ice Thickness
           ! ----------------------------------------------------------------------
-          ELSE IF (IDFLD == 'IC1') THEN  
+          ELSE IF (IDFLD == 'IC1') THEN
            SELECT CASE (RCV_FLD(IB_DO)%CL_FIELD_NAME)
            CASE ('WW3__IC1')
             CALL CPL_OASIS_RCV(IB_DO, ID_OASIS_TIME, RLA_OASIS_RCV, LL_ACTION)
@@ -328,13 +328,13 @@
             ENDIF
            !
            CASE ('WW3__IC5')
-           ! 
+           !
            CASE ('WW3__ICE')
-           ! 
+           !
            CASE DEFAULT
           !  WRITE (NDSO,1001) TRIM(RCV_FLD(IB_DO)%CL_FIELD_NAME)
-           END SELECT    
-       
+           END SELECT
+
         END IF
       END DO
 !

--- a/model/ftn/w3initmd.ftn
+++ b/model/ftn/w3initmd.ftn
@@ -60,7 +60,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !/    Note: Changes in version numbers not logged above.
@@ -151,14 +151,14 @@
 !/    01-May-2007 : Move O7a output to W3IOPP.          ( version 3.11 )
 !/    08-May-2007 : Starting from calm as an option.    ( version 3.11 )
 !/    17-May-2007 : Adding NTPROC/NAPROC separation.    ( version 3.11 )
-!/    21-Jun-2007 : Dedicated output processes.         ( version 3.11 
+!/    21-Jun-2007 : Dedicated output processes.         ( version 3.11
 !/    13-Sep-2009 : Add coupling option                 ( version 3.14 )
 !/    30-Oct-2009 : Implement run-time grid selection.  ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.1 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
@@ -181,14 +181,14 @@
 !     ----------------------------------------------------------------
 !       IMOD    Int.   I   Model number.
 !       FEXT    Char   I   Extension of data files.
-!       MDS     I.A.   I   Array with dataset numbers (see below), 
+!       MDS     I.A.   I   Array with dataset numbers (see below),
 !                          saved as NDS in W3ODATMD.
 !                           1: General output unit number ("log file").
 !                           2: Error output unit number.
 !                           3: Test output unit number.
 !                           4: "screen", i.e., direct output location,
 !                              can be the screen or the output file of
-!                              the shell. 
+!                              the shell.
 !                           5: Model definition file unit number.
 !                           6: Restart file unit number.
 !                           7: Grid output file unit number.
@@ -248,7 +248,7 @@
 !      W3IOGR    Subr. W3IOGRMD Read/write model definition file.
 !      W3IORS    Subr. W3IORSMD Read/write restart file.
 !      W3IOPP    Subr. W3IOPOMD Preprocess point output.
-!      CALL MPI_COMM_SIZE, CALL MPI_COMM_RANK 
+!      CALL MPI_COMM_SIZE, CALL MPI_COMM_RANK
 !                Subr. mpif.h   Standard MPI routines.
 !     ----------------------------------------------------------------
 !
@@ -271,9 +271,9 @@
 !       restart file. To assure consistency within the model, the
 !       water level and ice coverage are re-evaluated at the 0th
 !       time step in the actual wave model routine.
-!     - When running regtests in cases where disk is non-local 
+!     - When running regtests in cases where disk is non-local
 !       (i.e. NFS used), there can be a huge improvment in compute
-!       time by using /var/tmp/ for log files. 
+!       time by using /var/tmp/ for log files.
 !       See commented line at "OPEN (MDS(1),FILE=..."
 !
 !  8. Structure :
@@ -358,7 +358,7 @@
                           UA, UD, U10, U10D, AS
 !/MPI      USE W3ADATMD, ONLY: MPI_COMM_WAVE, MPI_COMM_WCMP
       USE W3IDATMD, ONLY: FLLEV, FLCUR, FLWIND, FLICE, FLMDN, FLMTH,  &
-                          FLMVS, FLIC1, FLIC2, FLIC3, FLIC4, FLIC5 
+                          FLMVS, FLIC1, FLIC2, FLIC3, FLIC4, FLIC5
       USE W3DISPMD, ONLY: WAVNU1, WAVNU3
       USE W3PARALL, ONLY : AC_tot
       USE W3PARALL, ONLY: SET_UP_NSEAL_NSEALM
@@ -542,7 +542,7 @@
 !/MPI      END IF
 !!!/PDLIB    CALL W3SETG(IMOD, NDSE, NDST)
 !
-           LPDLIB = .FALSE. 
+           LPDLIB = .FALSE.
 !/PDLIB    LPDLIB = .TRUE.
            IF (FSTOTALIMP .and. .NOT. LPDLIB) THEN
              WRITE(NDSE,*) 'IMPTOTAL is selected'
@@ -562,7 +562,7 @@
 !!/DEBUGMPI     CALL TEST_MPI_STATUS("Case 5")
 !/SHRD       TFILE  = 'test.' // FEXT(:IE)
 !/DIST      IW     = 1 + INT ( LOG10 ( REAL(NAPROC) + 0.5 ) )
-!/DIST      IW     = MAX ( 3 , MIN ( 9 , IW ) ) 
+!/DIST      IW     = MAX ( 3 , MIN ( 9 , IW ) )
 !/DIST      WRITE (FORMAT,'(A5,I1.1,A1,I1.1,A4)')                     &
 !/DIST                   '(A4,I', IW, '.', IW, ',2A)'
 !/DIST      WRITE (TFILE,FORMAT) 'test',                             &
@@ -655,7 +655,7 @@
 ! 2.b Save MAPSTA
 !
       ALLOCATE ( MAPTST(NY,NX) )
-      MAPTST  = MAPSTA 
+      MAPTST  = MAPSTA
 
 !/MEMCHECK       WRITE(740+IAPROC,*) 'memcheck_____:', 'WW3_INIT SECTION 2b'
 !/MEMCHECK       call getMallocInfo(mallinfos)
@@ -777,7 +777,7 @@
 !/DIST                    IAPPRO(ISP) = -1
 !/DIST                 END IF
 !/DIST              END IF
-!/DIST            END DO 
+!/DIST            END DO
 !/DIST          END DO
 !
 ! 2.c.6 Second sweep filling IAPPRO
@@ -947,10 +947,10 @@
 !
       DO J=1, NOTYPE
         J0 = (J-1)*5
-        TONEXT(1,J) =        ODAT(J0+1) 
+        TONEXT(1,J) =        ODAT(J0+1)
         TONEXT(2,J) =        ODAT(J0+2)
         DTOUT (  J) = REAL ( ODAT(J0+3) )
-        TOLAST(1,J) =        ODAT(J0+4) 
+        TOLAST(1,J) =        ODAT(J0+4)
         TOLAST(2,J) =        ODAT(J0+5)
       END DO
 !
@@ -1013,12 +1013,12 @@
 !/TIMINGS       CALL PRINT_MY_TIME("Before NOTYPE loop")
       DO J=1, NOTYPE
 !
-! ... check time step  
+! ... check time step
 !
         DTOUT(J) = MAX ( 0. , DTOUT(J) )
         FLOUT(J) = FLOUT(J) .AND. ( DTOUT(J) .GT. 0.5 )
 !
-! ... get first time 
+! ... get first time
 !
         IF ( FLOUT(J) ) THEN
             TOUT = TONEXT(:,J)
@@ -1083,7 +1083,7 @@
 !
 ! 5.  Define wavenumber grid ----------------------------------------- *
 ! 5.a Calculate depth
-! 
+!
 !/T      ALLOCATE ( MAPOUT(NX,NY), XOUT(NX,NY) )
 !/T      XOUT = -1.
 !
@@ -1192,7 +1192,7 @@
           DEPTH  = MAX ( DMIN , DW(IS) )
         ELSE
           DEPTH = DMIN
-          END IF 
+          END IF
 !
 !/T1        WRITE (NDST,9051) IS, DEPTH
 !
@@ -1209,7 +1209,7 @@
 !/DEBUGINIT     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.6'
 !/DEBUGINIT     FLUSH(740+IAPROC)
 !
-! Commented by FA with version 4.12 
+! Commented by FA with version 4.12
 !      DO IK=1, NK
 !        CG(IK,0) = CG(IK,1)
 !        WN(IK,0) = WN(IK,1)
@@ -1551,7 +1551,7 @@
 !     - Each processor has to be able to send out individual error
 !       messages in this routine !
 !     - No testing on IMOD, since only called by W3INIT.
-!     - In version 3.09 STORE was split into a send and receive 
+!     - In version 3.09 STORE was split into a send and receive
 !       buffer, to avoid/reduce possible conflicts between the FORTRAN
 !       and MPI standards when a gather is posted in a given buffer
 !       right after a send is completed.
@@ -1966,8 +1966,8 @@
 !/MPI      IF ((FLOUT(1) .OR. FLOUT(7)).and.(.not. LPDLIB .or.       &
 !/MPI          (GTYPE .ne. UNGTYPE).or. .TRUE.)) THEN
 !
-! NRQMAX is the maximum number of fields, it is the sum of the 
-! sizes of scalar fields (Hs) + 2-component vectors (CUR) + 3-comp ... 
+! NRQMAX is the maximum number of fields, it is the sum of the
+! sizes of scalar fields (Hs) + 2-component vectors (CUR) + 3-comp ...
 !
 !/MPI          NRQMAX = 0 + 12 + 0 + 2+(NOGE(4)-2)*(NOSWLL+1) + 10+4 + &
 !/MPI                   7+6 + 5+5 + 2+2 + 5+0 + NOEXTR
@@ -1980,7 +1980,7 @@
 !/MPI          IF ( FLGRDALL( 6, 8) ) NRQMAX = NRQMAX + 2*NK
 !/MPI          IF ( FLGRDALL( 6,12) ) NRQMAX = NRQMAX + 2*NK
 !
-!/MPI          IF ( NRQMAX .GT. 0 ) THEN 
+!/MPI          IF ( NRQMAX .GT. 0 ) THEN
 !/MPI              ALLOCATE ( OUTPTS(IMOD)%OUT1%IRQGO(NRQMAX) )
 !/MPI              ALLOCATE ( OUTPTS(IMOD)%OUT1%IRQGO2(NRQMAX*NAPROC) )
 !/MPI            END IF
@@ -2139,7 +2139,7 @@
 !/MPIT      WRITE (NDST,9011) IH, ' 2/17', IROOT, IT, IRQGO(IH), IERR
 !/MPI                END IF
 !
-!/MPI              IF ( FLGRDALL( 3, 1) ) THEN 
+!/MPI              IF ( FLGRDALL( 3, 1) ) THEN
 !/MPI                  DO IK=E3DF(2,1),E3DF(3,1)
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT + 1
@@ -2148,8 +2148,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'EF', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
 !/MPI                 END IF
-!      
-!/MPI              IF ( FLGRDALL( 3, 2) ) THEN 
+!
+!/MPI              IF ( FLGRDALL( 3, 2) ) THEN
 !/MPI                  DO IK=E3DF(2,2),E3DF(3,2)
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT + 1
@@ -2158,8 +2158,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'TH1M', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
 !/MPI                 END IF
-!      
-!/MPI              IF ( FLGRDALL( 3, 3) ) THEN 
+!
+!/MPI              IF ( FLGRDALL( 3, 3) ) THEN
 !/MPI                  DO IK=E3DF(2,3),E3DF(3,3)
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT + 1
@@ -2168,8 +2168,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'STH1M', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
 !/MPI                 END IF
-!       
-!/MPI              IF ( FLGRDALL( 3, 4) ) THEN 
+!
+!/MPI              IF ( FLGRDALL( 3, 4) ) THEN
 !/MPI                  DO IK=E3DF(2,4),E3DF(3,4)
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT + 1
@@ -2178,8 +2178,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'TH2M', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
 !/MPI                 END IF
-!      
-!/MPI              IF ( FLGRDALL( 3, 5) ) THEN 
+!
+!/MPI              IF ( FLGRDALL( 3, 5) ) THEN
 !/MPI                  DO IK=E3DF(2,5),E3DF(3,5)
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT + 1
@@ -2372,7 +2372,7 @@
 !/MPI      CALL MPI_SEND_INIT (ASF   (IAPROC), 1, WW3_FIELD_VEC,       &
 !/MPI                       IROOT, IT, MPI_COMM_WAVE, IRQGO(IH), IERR )
 !/MPIT      WRITE (NDST,9011) IH, ' 5/01', IROOT, IT, IRQGO(IH), IERR
-!/MPI                END IF 
+!/MPI                END IF
 !
 !/MPI              IF ( FLGRDALL( 5, 2) ) THEN
 !/MPI                  IH     = IH + 1
@@ -2559,8 +2559,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'US3D ', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
 !/MPI                END IF
-!      
-!/MPI             IF ( FLGRDALL( 6, 9) ) THEN     
+!
+!/MPI             IF ( FLGRDALL( 6, 9) ) THEN
 !/MPI                      DO K=P2MSF(2),P2MSF(3)
 !/MPI                        IH     = IH + 1
 !/MPI                        IT     = IT + 1
@@ -2599,7 +2599,7 @@
 !/MPI                                IT, MPI_COMM_WAVE, IRQGO(IH), IERR)
 !/MPIT      WRITE (NDST,9011) IH, 'USSP ', IROOT, IT, IRQGO(IH), IERR
 !/MPI                    END DO
-!/MPI                END IF 
+!/MPI                END IF
 !
 !/MPI              IF ( FLGRDALL( 7, 1) ) THEN
 !/MPI                  IH     = IH + 1
@@ -2939,7 +2939,7 @@
 !/MPIT      WRITE (NDST,9011) IH, ' 2/17', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                  END IF
 !
-!/MPI                IF ( FLGRDALL( 3, 1) ) THEN 
+!/MPI                IF ( FLGRDALL( 3, 1) ) THEN
 !/MPI                    DO IK=E3DF(2,1),E3DF(3,1)
 !/MPI                      IH     = IH + 1
 !/MPI                      IT     = IT + 1
@@ -2948,8 +2948,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'EF', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
 !/MPI                    END IF
-!       
-!/MPI                IF ( FLGRDALL( 3, 2) ) THEN 
+!
+!/MPI                IF ( FLGRDALL( 3, 2) ) THEN
 !/MPI                    DO IK=E3DF(2,2),E3DF(3,2)
 !/MPI                      IH     = IH + 1
 !/MPI                      IT     = IT + 1
@@ -2958,8 +2958,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'TH1M', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
 !/MPI                    END IF
-!      
-!/MPI                IF ( FLGRDALL( 3, 3) ) THEN 
+!
+!/MPI                IF ( FLGRDALL( 3, 3) ) THEN
 !/MPI                    DO IK=E3DF(2,3),E3DF(3,3)
 !/MPI                      IH     = IH + 1
 !/MPI                      IT     = IT + 1
@@ -2968,8 +2968,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'STH1M', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
 !/MPI                    END IF
-!       
-!/MPI                IF ( FLGRDALL( 3, 4) ) THEN 
+!
+!/MPI                IF ( FLGRDALL( 3, 4) ) THEN
 !/MPI                    DO IK=E3DF(2,4),E3DF(3,4)
 !/MPI                      IH     = IH + 1
 !/MPI                      IT     = IT + 1
@@ -2978,8 +2978,8 @@
 !/MPIT      WRITE (NDST,9011) IH, 'TH2M', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
 !/MPI                    END IF
-!      
-!/MPI               IF ( FLGRDALL( 3, 5) ) THEN 
+!
+!/MPI               IF ( FLGRDALL( 3, 5) ) THEN
 !/MPI                    DO IK=E3DF(2,5),E3DF(3,5)
 !/MPI                      IH     = IH + 1
 !/MPI                      IT     = IT + 1
@@ -3358,7 +3358,7 @@
 !/MPIT      WRITE (NDST,9011) IH, 'US3D ', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
 !/MPI                  END IF
-!      
+!
 !/MPI                IF (  FLGRDALL( 6, 9) ) THEN
 !/MPI                      DO K=P2MSF(2),P2MSF(3)
 !/MPI                        IH     = IH + 1
@@ -3398,7 +3398,7 @@
 !/MPI                               MPI_COMM_WAVE, IRQGO2(IH), IERR )
 !/MPIT      WRITE (NDST,9011) IH, 'USSP ', IFROM, IT, IRQGO2(IH), IERR
 !/MPI                      END DO
-!/MPI                  END IF  
+!/MPI                  END IF
 !
 !/MPI                IF ( FLGRDALL( 7, 1) ) THEN
 !/MPI                    IH     = IH + 1
@@ -3843,7 +3843,7 @@
 !/MPI              ALLOCATE ( OUTPTS(IMOD)%OUT3%IRQTR(2*NAPROC) )
 !/MPI              IRQTR  => OUTPTS(IMOD)%OUT3%IRQTR
 !/MPI              DO I0=1, NAPROC
-!/MPI                IFROM  = I0 - 1 
+!/MPI                IFROM  = I0 - 1
 !/MPI                IF ( I0 .NE. IAPROC ) THEN
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT0 + 1
@@ -3859,11 +3859,11 @@
 !/MPI                END DO
 !/MPI            END IF
 !
-!/MPI          NRQTR  = IH 
+!/MPI          NRQTR  = IH
 !/MPI          IT0    = IT0 + 2
 !
 !/MPIT          WRITE (NDST,9042)
-!/MPIT          WRITE (NDST,9043) NRQTR 
+!/MPIT          WRITE (NDST,9043) NRQTR
 !
 !/MPI        END IF
 !
@@ -4104,9 +4104,9 @@
 !
 !/MPI          DO I=1, NOPTS
 !/MPI            DO K=1,4
-!/MPI              IX(K)=IPTINT(1,K,I)  
+!/MPI              IX(K)=IPTINT(1,K,I)
 !/MPI              IY(K)=IPTINT(2,K,I)
-!/MPI              END DO 
+!/MPI              END DO
 !
 !/MPI            DO J=1, 4
 !

--- a/model/ftn/w3iobcmd.ftn
+++ b/model/ftn/w3iobcmd.ftn
@@ -13,7 +13,7 @@
 !/
 !/    Copyright 2009-2010 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -92,16 +92,16 @@
 !/    28-Jul-2010 : Moving NKI, NTHI, XFRI, FR1I and
 !/                  TH1I to W3ODATMD.                   ( version 3.14.3 )
 !/    31-Oct-2010 : Implementing unstructured grid      ( version 3.14.3 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    05-Apr-2011 : Moved the SPCONV call into loop     ( version 3.14.3 )
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    03-Jul-2013 : Corrected ABPIN indices             ( version 4.11 )
-!/    14-Jan-2014 : Corrected ABPIN indices for W3CSPC  ( version 4.18 ) 
+!/    14-Jan-2014 : Corrected ABPIN indices for W3CSPC  ( version 4.18 )
 !/    20-Jan-2017 : Allow input boundary points to lie outside the grid
 !/                  within a distance of 0.1 times the grid cell size.
 !/                  (T.J. Campbell, NRL)                ( version 6.02 )
-!/    01-Mar-2018 : Rotate boundary points and directions 
+!/    01-Mar-2018 : Rotate boundary points and directions
 !/                  of input spectra for rotated grids  ( version 6.02 )
 !/
 !  1. Purpose :
@@ -112,7 +112,7 @@
 !
 !     The file(s) are opened within the routine, the names are
 !     pre-defined as nest.FILEXT for the input file and nest1.FILEXT
-!     through nest9.FILEXT for up to 9 output files. 
+!     through nest9.FILEXT for up to 9 output files.
 !
 !  3. Parameters :
 !
@@ -182,13 +182,13 @@
       USE W3ADATMD, ONLY: W3SETA
       USE W3ODATMD, ONLY: W3SETO, W3DMO5
       USE W3CSPCMD, ONLY: W3CSPC
-      USE W3TRIAMD, ONLY: W3NESTUG      
+      USE W3TRIAMD, ONLY: W3NESTUG
 !
       USE W3GDATMD, ONLY: NK, NTH, NSPEC, NSEA, NSEAL, NX, NY,        &
                           X0, Y0, SX, SY, GSU, MAPSTA, MAPFS, MAPSF,  &
                           XFR, FR1, SIG2, TH, DTH, FILEXT, FACHFE,    &
                           GTYPE, UNGTYPE
-      USE W3GDATMD, ONLY: DXYMAX  
+      USE W3GDATMD, ONLY: DXYMAX
 !/T1      USE W3GDATMD, ONLY: SIG
 !/RTD !!   Use rotated N-Pole lat/lon and conversion sub.  JGLi12Jun2012
 !/RTD      USE W3GDATMD, ONLY: PoLat, PoLon, AnglD
@@ -229,7 +229,7 @@
 !/T1      REAL                  :: HS, HS0
 !/RTD  !!    Declare rotation angle and rotated lat/lon variables for
 !/RTD  !!    boundary points.   JGLi12Jun2012
-!/RTD      REAL, ALLOCATABLE      :: Anglbdy(:), ELatbdy(:), ELonbdy(:) 
+!/RTD      REAL, ALLOCATABLE      :: Anglbdy(:), ELatbdy(:), ELonbdy(:)
       REAL, ALLOCATABLE      :: XBPO2(:), YBPO2(:)
 !/RTD      REAL, ALLOCATABLE      :: ANG(:)
 !/RTD      REAL                   :: Spectr(NK*NTH)
@@ -390,12 +390,12 @@
               CALL EXTCDE ( 11 )
             END IF
 !
-! Determines if the spectrum in nest file needs to be converted 
+! Determines if the spectrum in nest file needs to be converted
 !
           SPCONV = NKI.NE.NK .OR. NTHI.NE.NTH .OR.                    &
                    ABS(XFRI/XFR-1.).GT.0.01 .OR.                      &
                    ABS(FR1I/FR1-1.).GT.0.01 .OR.                      &
-                   ABS(TH1I-TH(1)).GT.0.01*DTH 
+                   ABS(TH1I-TH(1)).GT.0.01*DTH
 !
           CALL W3DMO5 ( IGRD, NDSE, NDST, 1 )
 !
@@ -420,7 +420,7 @@
 !/RTD              IF ( XBPI(I) .GT. 180.0) XBPI(I) = XBPI(I) - 360.0
 !/RTD            ENDDO
 !/RTD          END IF
-!/RTD !!    The old (4.18) W3GFPT was very strict so this loop reassigns RTD 
+!/RTD !!    The old (4.18) W3GFPT was very strict so this loop reassigns RTD
 !/RTD !!    values to within a tolerance of the boundary - possibly this is
 !/RTD !!    no longer required after the 20-Jan-2017 change?
 !/RTD          XRLIM = X0 + (NX-1) * SX
@@ -436,8 +436,8 @@
 !/RTD
           FLOK   = .TRUE.
           IF (GTYPE .EQ. UNGTYPE) THEN
-            CALL W3NESTUG(DXYMAX,FLOK) 
-          ELSE 
+            CALL W3NESTUG(DXYMAX,FLOK)
+          ELSE
             DO I=1, NBI
               ! W3GFTP: find the nearest grid point to the input boundary point
               ! DCIN=0.1 is the distance outside of source grid in units of
@@ -455,7 +455,7 @@
               END IF
             ISBPI(I) = MAPFS(IY,IX)
             END DO
-          END IF    
+          END IF
 !
 !/T0          WRITE (NDST,9003)
 !/T0          DO I=1, NBI
@@ -578,7 +578,7 @@
                 END DO
             ELSE
 !
-! In this case the spectral resolution is not compatible and 
+! In this case the spectral resolution is not compatible and
 ! the spectrum TMPSPC in nest file must be re-gridded into ABPIN to fit the model run
 !
               ALLOCATE ( TMPSPC(NKI*NTHI,NBI2) )

--- a/model/ftn/w3iogrmd.ftn
+++ b/model/ftn/w3iogrmd.ftn
@@ -120,11 +120,11 @@
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    23-Dec-2009 : Addition of COU namelists           ( version 3.14 )
 !/    31-Oct-2010 : Implement unstructured grids        ( version 3.14 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    13-Jul-2012 : Move GMD (SNL3) and nonlinear filter (SNLS)
 !/                  from 3.15 (HLT).                    ( version 4.08 )
@@ -148,7 +148,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -182,7 +182,7 @@
 !     ----------------------------------------------------------------
 !      W3INIT    Subr. W3INITMD Wave model initialization routine.
 !      ......    Prog.   N/A    All WAVEWATCH III aux programs and
-!                               drivers.                
+!                               drivers.
 !     ----------------------------------------------------------------
 !
 !  6. Error messages :
@@ -226,7 +226,7 @@
 !/ST4      USE W3SRC4MD, ONLY: INSIN4, TAUT, TAUHFT, TAUHFT2, &
 !/ST4                          DELU, DELTAUW, DELUST, &
 !/ST4                          DELALP, DELTAIL, &
-!/ST4                          DIKCUMUL 
+!/ST4                          DIKCUMUL
 !/NL1      USE W3SNL1MD, ONLY: INSNL1
 !/NL2      USE W3SNL2MD, ONLY: INSNL2
 !/NL3      USE W3SNL3MD, ONLY: INSNL3
@@ -265,7 +265,7 @@
       LOGICAL                 :: WRITE, FLTEST = .FALSE., TESTLL,     &
                                  FLSNL2 = .FALSE.
       LOGICAL, SAVE           :: FLINP = .FALSE. , FLDISP = .FALSE.,  &
-                                 FLIS  = .FALSE. 
+                                 FLIS  = .FALSE.
       CHARACTER(LEN=10)       :: VERTST
       CHARACTER(LEN=13)       :: TEMPXT
       CHARACTER(LEN=30)       :: TNAME0, TNAME1, TNAME2, TNAME3,      &
@@ -461,7 +461,7 @@
 !/SMC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
 !/SMC                     NCel, NUFc, NVFc, NRLv, MRFct
 !/ARC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
-!/ARC                     NGLO, NARC, NBGL, NBAC 
+!/ARC                     NGLO, NARC, NBGL, NBAC
 !
           NK     = MK
           NTH    = MTH
@@ -591,7 +591,7 @@
             CASE ( CLGTYPE )
               WRITE (NDSM)                                            &
                    XGRD, YGRD
-            CASE (UNGTYPE) 
+            CASE (UNGTYPE)
               WRITE (NDSM)                                            &
                 FSN, FSPSI,FSFCT,FSNIMP,FSTOTALIMP,FSTOTALEXP,        &
                 FSREFRACTION, FSFREQSHIFT, FSSOURCE,                  &
@@ -624,15 +624,15 @@
 !
 !/SMC         WRITE (NDSM)  NLvCel, NLvUFc, NLvVFc
 !/SMC         WRITE (NDSM)  IJKCel, IJKUFc, IJKVFc
-!/ARC         WRITE (NDSM)  ICLBAC 
-!/ARC         WRITE (NDSM)  ANGARC 
+!/ARC         WRITE (NDSM)  ICLBAC
+!/ARC         WRITE (NDSM)  ANGARC
 !/SMC         WRITE (NDSM)  CTRNX,  CTRNY,  CLATF
 !/SMC         IF ( FLTEST ) THEN
 !/SMC            WRITE (NDSE,"('  NLvCel, NLvUFc, NLvVFc Write for',2I9)") NRLv, MRFct
-!/SMC            WRITE (NDSE,"('  IJKCel, IJKUFc, IJKVFc Write for',3I9)") NCel, NUFc, NVFc 
+!/SMC            WRITE (NDSE,"('  IJKCel, IJKUFc, IJKVFc Write for',3I9)") NCel, NUFc, NVFc
 !/SMC            WRITE (NDSE,"('  CTRNXY transparency write for 2x', I9)") NCel
 !/SMC         ENDIF
-! 
+!
           IF ( TRFLAG .NE. 0 ) WRITE (NDSM) TRNX, TRNY
           WRITE (NDSM)                     &
                DTCFL, DTCFLI, DTMAX, DTMIN, DMIN, CTMAX,              &
@@ -686,10 +686,10 @@
               !Set SX, SY, X0, Y0 to large values if curvilinear grid
               X0 = HUGE(X0); Y0 = HUGE(Y0)
               SX = HUGE(SX); SY = HUGE(SY)
-            CASE (UNGTYPE) 
+            CASE (UNGTYPE)
 !/DEBUGIOGR     WRITE(740+IAPROC,*) 'W3IOGR, step 7.4'
 !/DEBUGIOGR     FLUSH(740+IAPROC)
-              READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                 & 
+              READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                 &
                 FSN, FSPSI,FSFCT,FSNIMP,FSTOTALIMP,FSTOTALEXP,        &
                 FSREFRACTION, FSFREQSHIFT, FSSOURCE,                  &
                 DO_CHANGE_WLV, SOLVERTHR_STP, CRIT_DEP_STP,           &
@@ -738,7 +738,7 @@
 !
 !/DEBUGIOGR     WRITE(740+IAPROC,*) 'W3IOGR, step 7.8'
 !/DEBUGIOGR     FLUSH(740+IAPROC)
-          IF (GTYPE.NE.UNGTYPE) CALL W3GNTX ( IGRD, NDSE, NDST ) 
+          IF (GTYPE.NE.UNGTYPE) CALL W3GNTX ( IGRD, NDSE, NDST )
 !/DEBUGIOGR     WRITE(740+IAPROC,*) 'W3IOGR, step 7.9'
 !/DEBUGIOGR     FLUSH(740+IAPROC)
           READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
@@ -751,9 +751,9 @@
 !/SMC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
 !/SMC                     IJKCel, IJKUFc, IJKVFc
 !/ARC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
-!/ARC                     ICLBAC 
+!/ARC                     ICLBAC
 !/ARC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
-!/ARC                     ANGARC 
+!/ARC                     ANGARC
 !/SMC          READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                &
 !/SMC                     CTRNX,  CTRNY,  CLATF
 !
@@ -869,7 +869,7 @@
 !
 !
 ! Output flags for 3D parameters ------------------------------------- *
-!                                                 Module W3GDATMD 
+!                                                 Module W3GDATMD
       IF ( WRITE ) THEN
           WRITE (NDSM)                                                &
                 E3DF, P2MSF, US3DF,USSPF, USSP_WN
@@ -1009,7 +1009,7 @@
 !/FLX4          READ (NDSM,END=801,ERR=802,IOSTAT=IERR) FLX4A0
 !/FLX4        END IF
 !
-! 
+!
 !/LN1      IF ( WRITE ) THEN
 !/LN1          WRITE (NDSM)                            SLNC1, FSPM, FSHF
 !/LN1        ELSE

--- a/model/ftn/w3iopomd.ftn
+++ b/model/ftn/w3iopomd.ftn
@@ -22,21 +22,21 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Implement unstructured grid         ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    02-Sep-2012 : Clean up of open BC for UG grids    ( version 4.07 )
 !/    25-Feb-2013 : ITOUT=0 bug correction for UG grids ( version 4.08 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    05-Jun-2018 : Add SETUP                           ( version 6.04 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -70,7 +70,7 @@
 !      W3DMO2    Subr. W3ODATMD Data structure management.
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !      EXTCDE    Subr. W3SERVMD Program abort with exit code.
-!      MPI_STARTALL, MPIWAITALL 
+!      MPI_STARTALL, MPIWAITALL
 !                Subr.          MPI persistent communication routines.
 !     ----------------------------------------------------------------
 !
@@ -127,11 +127,11 @@
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    02-Sep-2012 : Clean up of open BC for UG grids    ( version 4.07 )
 !/    01-Mar-2018 : Add option to unrotate spectra      ( version 6.02 )
-!/                  from RTD grid models             
+!/                  from RTD grid models
 !/
 !  1. Purpose :
 !
@@ -181,8 +181,8 @@
 !       coverage, the actual interpolation factors can only be
 !       determined at the actual output time. Hence only the basic
 !       bilinear interpolation factors are stored.
-!     - Implementation of the /O7a diagnostic output section is 
-!       currently incomplete and non-functional for curvilinear grids 
+!     - Implementation of the /O7a diagnostic output section is
+!       currently incomplete and non-functional for curvilinear grids
 !       and/or tripole grids
 !
 !  8. Structure :
@@ -212,10 +212,10 @@
                           RLGTYPE, CLGTYPE, UNGTYPE, GTYPE, FLAGLL,   &
                           ICLOSE,ICLOSE_NONE,ICLOSE_SMPL,ICLOSE_TRPL, &
                           MAPSTA, MAPFS, FILEXT, ZB, TRNX, TRNY
-      USE W3GDATMD, ONLY: XYB, TRIGP,MAXX, MAXY, DXYMAX  
+      USE W3GDATMD, ONLY: XYB, TRIGP,MAXX, MAXY, DXYMAX
 !/RTD  !!  Use rotated N-Pole lat/lon and conversion sub.  JGLi12Jun2012
-!/RTD      USE W3GDATMD, ONLY: PoLat, PoLon, FLAGUNR    
-!/RTD      USE W3SERVMD, ONLY: W3LLTOEQ 
+!/RTD      USE W3GDATMD, ONLY: PoLat, PoLon, FLAGUNR
+!/RTD      USE W3SERVMD, ONLY: W3LLTOEQ
       USE W3ODATMD, ONLY: W3DMO2
       USE W3ODATMD, ONLY: NDSE, NDST, IAPROC, NAPERR, NAPOUT, SCREEN, &
                           NOPTS, PTLOC, PTNME, GRDID, IPTINT, PTIFAC
@@ -242,7 +242,7 @@
 !/O7a      INTEGER                 :: IX0, IXN, IY0, IYN, NNX,         &
 !/O7a                                 KX, KY, JX, IIX
       INTEGER                 :: IX(4), IY(4)   ! Indices of points used in interp.
-      REAL                    :: RD(4)          ! Interpolation coefficient 
+      REAL                    :: RD(4)          ! Interpolation coefficient
 !/O7a      REAL                    :: RD1, RD2, RDTOT, ZBOX(4), DEPTH
       REAL, PARAMETER         :: ACC = 0.05
       REAL                    :: FACTOR
@@ -301,11 +301,11 @@
 !
 !     Check if point within grid and compute interpolation weights
 !
-        IF (GTYPE .NE. UNGTYPE) THEN 
+        IF (GTYPE .NE. UNGTYPE) THEN
           INGRID = W3GRMP( GSU, XPT(IPT), YPT(IPT), IX, IY, RD )
-        ELSE 
+        ELSE
           CALL IS_IN_UNGRID(IMOD, XPT(IPT), YPT(IPT), itout, IX, IY, RD)
-          INGRID = (ITOUT.GT.0) 
+          INGRID = (ITOUT.GT.0)
           END IF
 !
         IF ( .NOT.INGRID ) THEN
@@ -358,7 +358,7 @@
 
         PTNME(NOPTS) = PNAMES(IPT)
 !
-        END DO ! End loop over output points (IPT). 
+        END DO ! End loop over output points (IPT).
 !
 !/RTD       DEALLOCATE( EquLon, EquLat, StdLon, StdLat, AnglPT )
 !
@@ -546,11 +546,11 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/                  (A. Roland and F. Ardhuin)
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    01-Mar-2018 : Add option to unrotate spectra      ( version 6.02 )
-!/                  from RTD grid models             
+!/                  from RTD grid models
 !/
 !  1. Purpose :
 !
@@ -615,9 +615,9 @@
       USE W3GDATMD, ONLY: NK, NTH, SIG, NX, NY, NSEA, NSEAL,          &
                           MAPSTA, MAPFS
 !/RTD !!   Use spectral rotation sub and angle.  JGLi12Jun2012
-!/RTD      USE W3GDATMD, ONLY: NSPEC, AnglD, FLAGUNR 
+!/RTD      USE W3GDATMD, ONLY: NSPEC, AnglD, FLAGUNR
 !/RTD      USE W3SERVMD, ONLY: W3ACTURN
-      USE W3WDATMD, ONLY: ICE, ICEH, ICEF 
+      USE W3WDATMD, ONLY: ICE, ICEH, ICEF
       USE W3ADATMD, ONLY: CG, DW, UA, UD, AS, CX, CY,                 &
                           SP => SPPNT
       USE W3ODATMD, ONLY: NDST, NOPTS, IPTINT, PTIFAC, IL, IW, II,    &
@@ -829,12 +829,12 @@
 !/RTD          CALL  W3ACTURN( NTH, NK, AnglDIS, Spectr )
 !/RTD          SPCO(:,I) = Spectr
 !/RTD        END IF
-!/RTD       
+!/RTD
 !
 !/T        WRITE (NDST,9004) DPO(I), WAO(I), WDO(I)*RADE,             &
 !/T                                  CAO(I), CDO(I)*RADE
 
-! FA COMMENTED OUT: BUG 
+! FA COMMENTED OUT: BUG
 !At line 1974 of file w3arrymd.f90
 !Fortran runtime error: Index '52' of dimension 1 of array 'pnum2' above upper bound of 51
 !/T       ! CALL PRT2DS (NDST, NK, NK, NTH, SPTEST, SIG(1:), ' ', 1.,0.,&

--- a/model/ftn/w3iorsmd.ftn
+++ b/model/ftn/w3iorsmd.ftn
@@ -100,7 +100,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -154,7 +154,7 @@
 !      W3INIT    Subr. W3INITMD Wave model initialization routine.
 !      W3WAVE    Subr. W3WAVEMD Actual wave model routine.
 !      WW3_STRT  Prog.   N/A    Initial conditions program.
-!     ---------------------------------------------------------------- 
+!     ----------------------------------------------------------------
 !
 !  6. Error messages :
 !
@@ -291,7 +291,7 @@
 !/S      CALL STRACE (IENT, 'W3IORS')
 !
 !
-! Constant NDSR for using mpiifort in ZEUS ... paralell runs crashing 
+! Constant NDSR for using mpiifort in ZEUS ... paralell runs crashing
 !  because compiler doesn't accept reciclyng of UNIT for FORMATTED or
 !  UNFORMATTED files in OPEN
 !
@@ -809,13 +809,13 @@
               MAPST2 = (MAPTMP-MAPSTA) / 8
               DEALLOCATE ( MAPTMP )
 !
-! Updates reflections maps: 
+! Updates reflections maps:
 !
-              IF (GTYPE.EQ.UNGTYPE) THEN 
+              IF (GTYPE.EQ.UNGTYPE) THEN
                 CALL SETUGIOBP
-!/REF1              ELSE 
+!/REF1              ELSE
 !/REF1                CALL W3SETREF
-                ENDIF 
+                ENDIF
 !
 !/DEBUGINIT         WRITE(740+IAPROC,*) 'Before reading UST'
               DO IPART=1,NPART

--- a/model/ftn/w3iosfmd.ftn
+++ b/model/ftn/w3iosfmd.ftn
@@ -21,14 +21,14 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    06-Mar-2012 : Reparing test output under MPI.     ( version 4.07 )
-!/    08-Jun-2018 : use W3ADATMD, W3PARALL, INIT_GET_ISEA and 
+!/    08-Jun-2018 : use W3ADATMD, W3PARALL, INIT_GET_ISEA and
 !/                            INIT_GET_JSEA_ISPROC      ( version 6.04 )
 !/    25-Jul-2018 : Changed DIMXP size for partitioning ( version 6.05 )
 !/                  methods 4 and 5. (C Bunney, UKMO)
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -217,7 +217,7 @@
         CALL INIT_GET_ISEA(ISEA, JSEA)
         IX     = MAPSF(ISEA,1)
         IY     = MAPSF(ISEA,2)
-        ICPRT(JSEA+1,2) = ICPRT(JSEA,2) 
+        ICPRT(JSEA+1,2) = ICPRT(JSEA,2)
 !
         IF ( MAPSTA(IY,IX) .LT. 0 ) CYCLE
 !
@@ -257,13 +257,13 @@
             IF ( ICPRT(JSEA,2)+NP .GT. TMPSIZ ) THEN
                 ALLOCATE ( TMP2(DIMP,TMPSIZ) )
                 TMP2   = TMP
-                DEALLOCATE ( TMP ) 
+                DEALLOCATE ( TMP )
                 OLDSIZ = TMPSIZ
                 TMPSIZ = TMPSIZ + MAX ( TSFAC*NSEAL , DIMXP )
                 ALLOCATE ( TMP(DIMP,TMPSIZ) )
                 TMP(:,1:OLDSIZ) = TMP2(:,1:OLDSIZ)
                 TMP(:,OLDSIZ+1:) = 0.
-                DEALLOCATE ( TMP2 ) 
+                DEALLOCATE ( TMP2 )
 !/T            WRITE (NDST,9050) JSEA, OLDSIZ, TMPSIZ
               END IF
 !
@@ -328,7 +328,7 @@
 !/
 !  1. Purpose :
 !
-!     Write partitioned spectrakl data to file. Unlike other 
+!     Write partitioned spectrakl data to file. Unlike other
 !     WAVEWATCH III IO routines, this one writes only.
 !     First ad-hoc version.
 !
@@ -510,7 +510,7 @@
       IF ( IAPROC .NE. NAPPRT ) RETURN
 !
 ! -------------------------------------------------------------------- /
-! 3.  Point to and/or gather data 
+! 3.  Point to and/or gather data
 ! 3.a Set up storage
 !
       ALLOCATE ( PROC(NAPROC) )

--- a/model/ftn/w3iotrmd.ftn
+++ b/model/ftn/w3iotrmd.ftn
@@ -98,7 +98,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -163,14 +163,14 @@
 !
 ! 10. Remarks :
 !
-!     Regarding section 3.e.2 "Optimize: omit points that are not 
-!       strictly required.". This optimization saves disk space but 
-!       results in output files that are more difficult to use. For 
+!     Regarding section 3.e.2 "Optimize: omit points that are not
+!       strictly required.". This optimization saves disk space but
+!       results in output files that are more difficult to use. For
 !       example, matlab built-in function "griddata" requires all four
 !       bounding points. This means that a post-processing code must
 !       have extra logic do deal with cases without all four bounding
-!       points (interpolation along a line, or nearest neighbor). 
-!       A namelist variable has been add to make this feature optional. 
+!       points (interpolation along a line, or nearest neighbor).
+!       A namelist variable has been add to make this feature optional.
 !       Default, original behavior: TRCKCMPR = T (in /MISC/ namelist).
 !       Save all points: TRCKCMPR =  F (in /MISC/ namelist).
 !       Within the present routine, the logical is named "CMPRTRCK".
@@ -190,7 +190,7 @@
                           DPDX, DPDY, DQDX, DQDY, MAPSTA, MAPST2,     &
                           MAPFS, TH, DTH, SIG, DSIP, XFR, FILEXT
       USE W3GSRUMD, ONLY: W3GFCL
-!/T      USE W3GSRUMD, ONLY: W3GSUP      
+!/T      USE W3GSRUMD, ONLY: W3GSUP
       USE W3GDATMD, ONLY: XYB, MAXX, MAXY, GTYPE, UNGTYPE
       USE W3WDATMD, ONLY: TIME, UST
       USE W3ADATMD, ONLY: CG, DW, CX, CY, UA, UD, AS
@@ -260,11 +260,11 @@
       FORMI  = NDSINP .GT. 0
       NDSTI  = ABS(NDSINP)
       NDSTO  = ABS(NDSOUT)
-      
+
       IF (GTYPE .EQ. UNGTYPE) THEN
         XN     = MAXX
         YN     = MAXY
-        ENDIF       
+        ENDIF
 !
       ISPROC = IAPROC
       IPASS  = IPASS + 1
@@ -461,7 +461,7 @@
               IYY(2) = IYY(4)
           END IF
 
-        END IF ! IF(CMPRTRCK)THEN 
+        END IF ! IF(CMPRTRCK)THEN
 !
 ! 3.f Mark the four corner points
 !

--- a/model/ftn/w3meminfo.ftn
+++ b/model/ftn/w3meminfo.ftn
@@ -2,7 +2,7 @@ module MallocInfo_m
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -59,59 +59,59 @@ module MallocInfo_m
 !/ ------------------------------------------------------------------- /
 !/
 !/S      CALL STRACE (IENT, 'W3XXXX')
-  
+
     !> This structure type is used to return information about the dynamic memory allocator.
     type, bind(c) :: MallInfo_t
       !> This is the total size of memory allocated with sbrk by malloc, in bytes.
-      integer(c_int) :: arena                  
+      integer(c_int) :: arena
       !> This is the number of chunks not in use. (The memory allocator internally gets chunks of memory from the operating system, and then carves them up to satisfy individual malloc requests; see Efficiency and Malloc.)
-      integer(c_int) :: ordblks        
+      integer(c_int) :: ordblks
       !> This field is unused.
-      integer(c_int) :: smblks        
+      integer(c_int) :: smblks
       !> This is the total number of chunks allocated with mmap.
-      integer(c_int) :: hblks        
+      integer(c_int) :: hblks
       !> This is the total size of memory allocated with mmap, in bytes.
-      integer(c_int) :: hblkhd        
+      integer(c_int) :: hblkhd
       !> This field is unused.
-      integer(c_int) :: usmblks        
+      integer(c_int) :: usmblks
       !> This field is unused.
-      integer(c_int) :: fsmblks        
+      integer(c_int) :: fsmblks
       !> This is the total size of memory occupied by chunks handed out by malloc.
-      integer(c_int) :: uordblks        
+      integer(c_int) :: uordblks
       !> This is the total size of memory occupied by free (not in use) chunks.
-      integer(c_int) :: fordblks        
+      integer(c_int) :: fordblks
       !> This is the size of the top-most releasable chunk that normally borders the end of the heap (i.e., the high end of the virtual address space’s data segment).
-      integer(c_int) :: keepcost      
+      integer(c_int) :: keepcost
     end type
-    
+
     interface
       function mallinfo() bind(c, name="mallinfo") result(data)
         use :: iso_c_binding
         implicit none
-        
-        type, bind(c) :: MallInfo_t      
-          integer(c_int) :: arena                        
-          integer(c_int) :: ordblks              
-          integer(c_int) :: smblks        
-          integer(c_int) :: hblks        
-          integer(c_int) :: hblkhd        
-          integer(c_int) :: usmblks        
-          integer(c_int) :: fsmblks        
-          integer(c_int) :: uordblks        
-          integer(c_int) :: fordblks        
-          integer(c_int) :: keepcost      
+
+        type, bind(c) :: MallInfo_t
+          integer(c_int) :: arena
+          integer(c_int) :: ordblks
+          integer(c_int) :: smblks
+          integer(c_int) :: hblks
+          integer(c_int) :: hblkhd
+          integer(c_int) :: usmblks
+          integer(c_int) :: fsmblks
+          integer(c_int) :: uordblks
+          integer(c_int) :: fordblks
+          integer(c_int) :: keepcost
         end type
         type(MallInfo_t) :: data
       end function
     end interface
-  
+
   contains
-  
+
   subroutine getMallocInfo(malinfo)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | THomas Huxhorn (BGS IT&E GmbH     |
 !/                  |                                   |
@@ -170,12 +170,12 @@ module MallocInfo_m
     type(MallInfo_t), intent(out) :: malinfo
     malinfo = mallinfo()
   end subroutine
-  
+
   subroutine printMallInfo(ihdnl,malinfo)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -233,7 +233,7 @@ module MallocInfo_m
 !/S      CALL STRACE (IENT, 'W3XXXX')
     real :: ib2m
     integer(8) :: vmsize, vmRSS
-    integer, intent(in)          :: ihdnl 
+    integer, intent(in)          :: ihdnl
     type(MallInfo_t), intent(in) :: malinfo
     ib2m=1./REAL(1024**2)
     vmsize = getVmSize()
@@ -244,8 +244,8 @@ module MallocInfo_m
     !write(*,'(A72,I10)') "Total number of chunks allocated with mmap.                  ", malinfo%hblks
     !write(*,'(A72,I10)') "Number of chunks not in use.                                 ", malinfo%ordblks
     !write(*,'(A72,2F20.10)') "Total size of memory occupied by free (not in use) chunks.   ", malinfo%fordblks*ib2m
-    !write(*,'(A72,2F20.10)') "Size of the top-most releasable chunk borders end of the heap", malinfo%keepcost*ib2m    
-    write(740+ihdnl,'(A72,2F20.10)') "VM size in proc ", vmsize/1024. 
+    !write(*,'(A72,2F20.10)') "Size of the top-most releasable chunk borders end of the heap", malinfo%keepcost*ib2m
+    write(740+ihdnl,'(A72,2F20.10)') "VM size in proc ", vmsize/1024.
     write(740+ihdnl,'(A72,2F20.10)') "RSS size in prof ", vmRSS/1024.
     call flush(740+ihdnl)
   end subroutine
@@ -266,7 +266,7 @@ module MallocInfo_m
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -346,7 +346,7 @@ module MallocInfo_m
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -421,16 +421,16 @@ module MallocInfo_m
     99 print *, 'ERROR: procfs not mounted or not compatible'
     vmRSS = -1
   end function getVmRSS
-  
+
 end module
 
 !program test
 !  use MallocInfo_m
 !  implicit none
-!  type(MallInfo_t) :: mallinfos(10000)  
+!  type(MallInfo_t) :: mallinfos(10000)
 !  integer :: i, nInfos
 !  integer, allocatable :: data(:)
-!  
+!
 !  allocate(data(0))
 !  nInfos = 0
 !  do i=1, 10
@@ -438,20 +438,20 @@ end module
 !    deallocate(data)
 !    allocate(data(i*100000))
 !    nInfos = nInfos+1
-!    call getMallocInfo(mallinfos(nInfos))    
+!    call getMallocInfo(mallinfos(nInfos))
 !    call printMallInfo(IAPROC,mallInfos(nInfos))
 !    call sleep(1)
 !  end do
-  
+
 !   do i=10, 1, -1
 !    write(*,*) "Iteration",i
 !    deallocate(data)
 !    allocate(data(i*100000))
 !    nInfos = nInfos+1
-!    call getMallocInfo(mallinfos(nInfos))    
-!    call printMallInfo(IAPROC,mallInfos(nInfos))    
+!    call getMallocInfo(mallinfos(nInfos))
+!    call printMallInfo(IAPROC,mallInfos(nInfos))
 !    call sleep(1)
 !  end do
-  
+
 !  write(*,*) "Total size of memory allocated with sbrk. min, mean, max", minval(mallinfos(1:nInfos)%arena), sum(mallinfos(1:nInfos)%arena)/nInfos, maxval(mallinfos(1:nInfos)%arena)
 !end program

--- a/model/ftn/w3netcdf.ftn
+++ b/model/ftn/w3netcdf.ftn
@@ -1,7 +1,7 @@
       MODULE W3NETCDF
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -62,7 +62,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -72,7 +72,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : date conversion 
+!  1. Purpose : date conversion
 !  2. Method :
 !  3. Parameters :
 !
@@ -148,7 +148,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -158,8 +158,8 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : date conversion 
-!  2. Method : 
+!  1. Purpose : date conversion
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -222,7 +222,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -233,7 +233,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : linear shape function 
+!  2. Method : linear shape function
 !  3. Parameters :
 !
 !     Parameter list
@@ -313,7 +313,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -324,7 +324,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -384,7 +384,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -395,7 +395,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : days in month
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -477,7 +477,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -488,7 +488,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -556,7 +556,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -567,7 +567,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -632,7 +632,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -643,7 +643,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -703,7 +703,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -714,7 +714,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -818,7 +818,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -829,7 +829,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -891,7 +891,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -902,7 +902,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : date conversion
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -964,7 +964,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -974,8 +974,8 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : time managment 
-!  2. Method : 
+!  1. Purpose : time managment
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1041,7 +1041,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1052,7 +1052,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : error handling
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1116,7 +1116,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1127,7 +1127,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : boundary status (code duplication)
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1255,7 +1255,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1265,8 +1265,8 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : define netcdfvar 
-!  2. Method : 
+!  1. Purpose : define netcdfvar
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1335,7 +1335,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1346,7 +1346,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : put value
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1435,7 +1435,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1446,7 +1446,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : output driver
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -1514,7 +1514,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1525,7 +1525,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : actual output routine
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list

--- a/model/ftn/w3nmlbouncmd.ftn
+++ b/model/ftn/w3nmlbouncmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLBOUNCMD
 !/

--- a/model/ftn/w3nmlgridmd.ftn
+++ b/model/ftn/w3nmlgridmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLGRIDMD
 !/
@@ -249,7 +249,7 @@
                         NML_TIMESTEPS, NML_GRID, NML_RECT, NML_CURV,   &
                         NML_UNST, NML_SMC, NML_DEPTH, NML_MASK,        &
                         NML_OBST, NML_SLOPE, NML_SED, NML_INBND_COUNT, &
-                        NML_INBND_POINT, NML_EXCL_COUNT,               &                  
+                        NML_INBND_POINT, NML_EXCL_COUNT,               &
                         NML_EXCL_POINT, NML_EXCL_BODY,                 &
                         NML_OUTBND_COUNT, NML_OUTBND_LINE, IERR)
 !/

--- a/model/ftn/w3nmlmultimd.ftn
+++ b/model/ftn/w3nmlmultimd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLMULTIMD
 !/
@@ -68,7 +68,7 @@
     LOGICAL                     :: BOUND_FLAG
   END TYPE NML_MODEL_RESOURCE_T
 !
-  TYPE NML_MODEL_GRID_T 
+  TYPE NML_MODEL_GRID_T
     CHARACTER(13)               :: NAME
     TYPE(NML_MODEL_FORCING_T)   :: FORCING
     TYPE(NML_MODEL_ASSIM_T)     :: ASSIM
@@ -147,7 +147,7 @@
 
 
   ! output date structure
-  TYPE NML_OUTPUT_TIME_T 
+  TYPE NML_OUTPUT_TIME_T
     CHARACTER(15)               :: START
     CHARACTER(15)               :: STRIDE
     CHARACTER(15)               :: STOP
@@ -203,7 +203,7 @@
 !
 !  1. Purpose :
 !
-!     Reads the domain definition namelist to define the number of 
+!     Reads the domain definition namelist to define the number of
 !     model and forcing grids
 !
 !  2. Method :
@@ -261,7 +261,7 @@
 
     INTEGER, INTENT(IN)                       :: MPI_COMM, NDSI
     CHARACTER*(*), INTENT(IN)                 :: INFILE
-    TYPE(NML_DOMAIN_T), INTENT(OUT)           :: NML_DOMAIN 
+    TYPE(NML_DOMAIN_T), INTENT(OUT)           :: NML_DOMAIN
     INTEGER, INTENT(OUT)                      :: IERR
 
     ! locals
@@ -403,8 +403,8 @@
     INTEGER, INTENT(IN)                       :: MPI_COMM, NDSI
     CHARACTER*(*), INTENT(IN)                 :: INFILE
     TYPE(NML_DOMAIN_T), INTENT(INOUT)         :: NML_DOMAIN
-    TYPE(NML_INPUT_GRID_T), INTENT(INOUT)     :: NML_INPUT_GRID(:) 
-    TYPE(NML_MODEL_GRID_T), INTENT(INOUT)     :: NML_MODEL_GRID(:) 
+    TYPE(NML_INPUT_GRID_T), INTENT(INOUT)     :: NML_INPUT_GRID(:)
+    TYPE(NML_MODEL_GRID_T), INTENT(INOUT)     :: NML_MODEL_GRID(:)
     TYPE(NML_OUTPUT_TYPE_T), INTENT(INOUT)    :: NML_OUTPUT_TYPE(:)
     TYPE(NML_OUTPUT_DATE_T), INTENT(INOUT)    :: NML_OUTPUT_DATE(:)
     TYPE(NML_HOMOG_COUNT_T), INTENT(INOUT)    :: NML_HOMOG_COUNT
@@ -1039,7 +1039,7 @@
     ! save namelist
     NML_OUTPUT_TYPE = ITYPE(1:NRGRD)
 
-   
+
   END SUBROUTINE READ_OUTPUT_TYPE_NML
 
 !/ ------------------------------------------------------------------- /
@@ -1348,7 +1348,7 @@
     NML_HOMOG_COUNT = HOMOG_COUNT
     NML_HOMOG_INPUT = HOMOG_INPUT
 
-    
+
   END SUBROUTINE READ_HOMOGENEOUS_NML
 
 !/ ------------------------------------------------------------------- /

--- a/model/ftn/w3nmlounfmd.ftn
+++ b/model/ftn/w3nmlounfmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLOUNFMD
 !/

--- a/model/ftn/w3nmlounpmd.ftn
+++ b/model/ftn/w3nmlounpmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLOUNPMD
 !/

--- a/model/ftn/w3nmlprncmd.ftn
+++ b/model/ftn/w3nmlprncmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLPRNCMD
 !/

--- a/model/ftn/w3nmlshelmd.ftn
+++ b/model/ftn/w3nmlshelmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLSHELMD
 !/
@@ -98,7 +98,7 @@
 
 
   ! output date structure
-  TYPE NML_OUTPUT_TIME_T 
+  TYPE NML_OUTPUT_TIME_T
     CHARACTER(15)               :: START
     CHARACTER(15)               :: STRIDE
     CHARACTER(15)               :: STOP
@@ -915,7 +915,7 @@
     NML_HOMOG_COUNT = HOMOG_COUNT
     NML_HOMOG_INPUT = HOMOG_INPUT
 
-    
+
   END SUBROUTINE READ_HOMOGENEOUS_NML
 
 !/ ------------------------------------------------------------------- /

--- a/model/ftn/w3nmltrncmd.ftn
+++ b/model/ftn/w3nmltrncmd.ftn
@@ -1,4 +1,4 @@
-#include "w3macros.h" 
+#include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3NMLTRNCMD
 !/

--- a/model/ftn/w3oacpmd.ftn
+++ b/model/ftn/w3oacpmd.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -33,7 +33,7 @@
 !      CPL_OASIS_DEFINE    Subr. Public   Partition definition
 !      CPL_OASIS_SND       Subr. Public   Send fields to ocean/atmos model
 !      CPL_OASIS_RCV       Subr. Public   Receive fields from ocean/atmos model
-!      CPL_OASIS_FINALIZE  Subr. Public   Finalize the coupling  
+!      CPL_OASIS_FINALIZE  Subr. Public   Finalize the coupling
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines and functions used :
@@ -54,20 +54,20 @@
 !
 !/ ------------------------------------------------------------------- /
 !
-      USE MOD_OASIS                                      ! OASIS3-MCT module 
+      USE MOD_OASIS                                      ! OASIS3-MCT module
 !
       IMPLICIT NONE
       PRIVATE
 !
       INTEGER               :: IL_COMPID                 ! Component model ID returned by oasis_init_comp
-      CHARACTER(LEN=6)      :: CL_MODEL_NAME = 'wwatch'  ! Model name (same as in namcouple)   
+      CHARACTER(LEN=6)      :: CL_MODEL_NAME = 'wwatch'  ! Model name (same as in namcouple)
       INTEGER               :: IL_ERR                    ! Return error code
-      INTEGER, PUBLIC       :: IL_NB_RCV, IL_NB_SND      ! Number of coupling fields    
+      INTEGER, PUBLIC       :: IL_NB_RCV, IL_NB_SND      ! Number of coupling fields
       INTEGER, PARAMETER    :: IP_MAXFLD=50              ! Maximum number of coupling fields
       INTEGER               :: NNODES                    ! Total numbers of cell in the grid
-!   
+!
       TYPE, PUBLIC          :: CPL_FIELD                 ! Type for coupling field information
-         CHARACTER(LEN = 8) :: CL_FIELD_NAME             ! Name of the coupling field   
+         CHARACTER(LEN = 8) :: CL_FIELD_NAME             ! Name of the coupling field
          INTEGER            :: IL_FIELD_ID               ! Field ID
       END TYPE CPL_FIELD
 !
@@ -78,7 +78,7 @@
 ! * Accessibility
       PUBLIC CPL_OASIS_INIT
       PUBLIC CPL_OASIS_GRID
-      PUBLIC CPL_OASIS_DEFINE 
+      PUBLIC CPL_OASIS_DEFINE
       PUBLIC CPL_OASIS_SND
       PUBLIC CPL_OASIS_RCV
       PUBLIC CPL_OASIS_FINALIZE
@@ -128,7 +128,7 @@
 !
 ! * Argument
       INTEGER, INTENT(OUT) :: ID_LCOMM                   ! Model local communicator
-!   
+!
 !----------------------------------------------------------------------
 ! * Executable part
 !
@@ -236,9 +236,9 @@
             NXE=NX
             NYS=1
             NYN=NY
-            ! 
+            !
             ! lat/lon
-            ALLOCATE ( LON(NNODES,1), LAT(NNODES,1) ) 
+            ALLOCATE ( LON(NNODES,1), LAT(NNODES,1) )
             I = 0
             DO IY = NYS, NYN
                DO IX = NXW, NXE
@@ -390,7 +390,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Executable part
 !/
-      IF (GTYPE .EQ. RLGTYPE .OR. GTYPE .EQ. CLGTYPE) THEN 
+      IF (GTYPE .EQ. RLGTYPE .OR. GTYPE .EQ. CLGTYPE) THEN
          !
          ! 1.1. regular and curvilinear grids
          ! ----------------------------------
@@ -439,7 +439,7 @@
       ENDIF
       !
       ! 3. Coupling fields declaration
-      ! ----------------------------------      
+      ! ----------------------------------
       ILA_SHAPE(:) = (/1, NSEAL, 1, 1 /)
       !
       ILA_VAR_NODIMS(1) = 2    ! rank of fields array
@@ -448,46 +448,46 @@
       CALL GET_LIST_EXCH_FIELD(NDSO, RCV_FLD, SND_FLD, IL_NB_RCV, IL_NB_SND, RCV_STR, SND_STR)
       !
       ! 3.1 Send coupling fields
-      ! ---------------------------------- 
+      ! ----------------------------------
       DO IB_I = 1, IL_NB_SND
          CALL OASIS_DEF_VAR (SND_FLD(IB_I)%IL_FIELD_ID     &
               &            , SND_FLD(IB_I)%CL_FIELD_NAME   &
-              &            , IL_PART_ID                    & 
+              &            , IL_PART_ID                    &
               &            , ILA_VAR_NODIMS                &
               &            , OASIS_OUT                     &
               &            , ILA_SHAPE                     &
               &            , OASIS_REAL                    &
               &            , IL_ERR )
-      
+
          IF (IL_ERR /= 0) THEN
             CALL OASIS_ABORT(IL_COMPID, 'CPL_OASIS_DEFINE', 'Problem during oasis_def_var')
-         ENDIF         
+         ENDIF
       ENDDO
-      !   
+      !
       ! 3.2 Received coupling fields
-      ! ---------------------------------- 
+      ! ----------------------------------
       DO IB_I = 1, IL_NB_RCV
          CALL OASIS_DEF_VAR (RCV_FLD(IB_I)%IL_FIELD_ID    &
               &            , RCV_FLD(IB_I)%CL_FIELD_NAME  &
-              &            , IL_PART_ID                   & 
+              &            , IL_PART_ID                   &
               &            , ILA_VAR_NODIMS               &
               &            , OASIS_IN                     &
               &            , ILA_SHAPE                    &
               &            , OASIS_REAL                   &
               &            , IL_ERR )
-         !      
+         !
          IF (IL_ERR /= 0) THEN
             CALL OASIS_ABORT(IL_COMPID, 'CPL_OASIS_DEFINE', 'Problem during oasis_def_var')
-         ENDIF         
-      ENDDO   
+         ENDIF
+      ENDDO
       !
       ! 4. End of definition phase
-      ! ---------------------------------- 
+      ! ----------------------------------
       CALL OASIS_ENDDEF(IL_ERR)
 
       IF (IL_ERR /= 0) THEN
          CALL OASIS_ABORT(IL_COMPID, 'CPL_OASIS_DEFINE', 'Problem during oasis_enddef')
-      ENDIF         
+      ENDIF
 !
 !/ ------------------------------------------------------------------- /
       END SUBROUTINE CPL_OASIS_DEFINE
@@ -561,7 +561,7 @@
       &           IL_INFO == OASIS_SENTOUT  .OR. IL_INFO == OASIS_TORESTOUT
 
 !/ ------------------------------------------------------------------- /
-     END SUBROUTINE CPL_OASIS_SND    
+     END SUBROUTINE CPL_OASIS_SND
 !/ ------------------------------------------------------------------- /
      SUBROUTINE CPL_OASIS_RCV(ID_NB, ID_TIME, RDA_FIELD, LD_ACTION)
 !/
@@ -627,7 +627,7 @@
       &              , RDA_FIELD                  &
       &              , IL_INFO                    &
       &                )
-!   
+!
       LD_ACTION = IL_INFO == OASIS_RECVD   .OR. IL_INFO == OASIS_FROMREST .OR.   &
       &           IL_INFO == OASIS_RECVOUT .OR. IL_INFO == OASIS_FROMRESTOUT
 !
@@ -670,10 +670,10 @@
 !/ Executable part
 !/
       CALL OASIS_TERMINATE(IL_ERR)
-!   
+!
       IF (IL_ERR /= 0) THEN
          CALL OASIS_ABORT(IL_COMPID, 'CPL_OASIS_FINALIZE', 'Problem during oasis_terminate')
-      ENDIF  
+      ENDIF
 !
 !/ ------------------------------------------------------------------- /
       END SUBROUTINE CPL_OASIS_FINALIZE
@@ -707,9 +707,9 @@
 !     RCV          Type     I/O      Received variables
 !     SND          Type     I/O      Send variables
 !     ID_NB_RCV    Int.     I/O      Number of received variables
-!     ID_NB_SND    Int.     I/O      Number of send variables 
+!     ID_NB_SND    Int.     I/O      Number of send variables
 !     RCV_STR      Char.     I       Name of the received variables
-!     SND_STR      Char      I       Name of the send variables 
+!     SND_STR      Char      I       Name of the send variables
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -740,7 +740,7 @@
 !/ Parameter list
 !/
       TYPE(CPL_FIELD), DIMENSION(IP_MAXFLD), INTENT (INOUT)   :: RCV, SND
-      INTEGER, INTENT(INOUT)                                  :: ID_NB_RCV, ID_NB_SND 
+      INTEGER, INTENT(INOUT)                                  :: ID_NB_RCV, ID_NB_SND
       INTEGER, INTENT(IN)                                     :: NDSO
       CHARACTER(LEN=1024), INTENT(IN)                         :: RCV_STR, SND_STR
 !/
@@ -776,7 +776,7 @@
 !/OASOCM         ! wet-drying at u-location
 !/OASOCM         ID_NB_RCV=ID_NB_RCV+1
 !/OASOCM         RCV(ID_NB_RCV)%CL_FIELD_NAME='WW3_OWDU'
-!  
+!
 !/OASOCM         ! wet-drying at v-location
 !/OASOCM         ID_NB_RCV=ID_NB_RCV+1
 !/OASOCM         RCV(ID_NB_RCV)%CL_FIELD_NAME='WW3_OWDV'
@@ -832,11 +832,11 @@
             WRITE (NDSO,1001) TRIM(TESTSTR(1:6))
          END SELECT
          IOUT=IOUT+1
-      END DO 
+      END DO
       !
       ! 2. Coupling fields sent by WW3
       ! ----------------------------------
-      ID_NB_SND = 0   
+      ID_NB_SND = 0
       !
       OUT_NAMES(:)=''
       CALL STRSPLIT(SND_STR,OUT_NAMES)
@@ -1010,7 +1010,7 @@
             WRITE (NDSO,1002) TRIM(TESTSTR(1:6))
          END SELECT
          IOUT=IOUT+1
-      END DO 
+      END DO
 !
 ! Formats
 !

--- a/model/ftn/w3odatmd.ftn
+++ b/model/ftn/w3odatmd.ftn
@@ -29,7 +29,7 @@
 !/    14-Jul-2010 : Fix VAAUX declaration bug.        ( version 3.14.2 )
 !/    27-Jul-2010 : Add NKI, NTHI, XFRI, FR1I, TH1I.  ( version 3.14.3 )
 !/    08-Nov-2010 : Implementing unstructured grids     ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    18-Dec-2012 : New 2D field output structure,      ( version 4.11 )
 !/                  reducing memory footprint for fields.
 !/    19-Dec-2012 : Move NOSWLL to data structure.      ( version 4.11 )
@@ -46,12 +46,12 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Define data structures to set up wave model grids and aliases 
+!     Define data structures to set up wave model grids and aliases
 !     to use individual grids transparently. Also includes subroutines
 !     to manage data structure and pointing to individual models.
 !     This module considers the parameters required for model output.
@@ -63,11 +63,11 @@
 !      NOUTP     Int.  Public   Number of models in array dim.
 !      IOUTP     Int.  Public   Selected model for output, init. at -1.
 !      IOSTYP    Int.  Public   Output data server type.
-!      NOGRP     I.P.  Public   Number of output field groups 
+!      NOGRP     I.P.  Public   Number of output field groups
 !      NGRPP     I.P.  Public   Max numb of parameters per output group
 !      NOGE      I.P.  Public   Number of output group elements
 !      NOTYPE    I.P.  Public   Number of output types
-!      NOEXTR    I.P.  Public   Number of extra (user available) 
+!      NOEXTR    I.P.  Public   Number of extra (user available)
 !                               output fields.
 !      DIMP      I.P.  Public   Number of parameters in partition
 !                               output group
@@ -302,9 +302,9 @@
 !/ Module private variable for checking error returns
 !/
       INTEGER, PRIVATE        :: ISTAT
-!/    
+!/
 !/ Conventional declarations
-!/     
+!/
       INTEGER                 :: NOUTP = -1, IOUTP = -1, IOSTYP = 1
 !
       INTEGER, PARAMETER      :: NOGRP = 10
@@ -753,7 +753,7 @@
 !
 ! 6) Wave-ocean layer
 !
-      NOGE(6) = 12 
+      NOGE(6) = 12
 !
       IDOUT( 6, 1)  = 'Radiation stresses  '
       IDOUT( 6, 2)  = 'Wave-ocean mom. flux'
@@ -891,7 +891,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETO needs to be called after allocation to point to 
+!     - W3SETO needs to be called after allocation to point to
 !       proper allocated arrays.
 !     - Note that NOPTS is overwritten in W3IOPP.
 !
@@ -969,7 +969,7 @@
                  OUTPTS(IMOD)%OUT2%CDO(NPT)        ,                  &
                  OUTPTS(IMOD)%OUT2%ICEO(NPT)       ,                  &
                  OUTPTS(IMOD)%OUT2%ICEHO(NPT)      ,                  &
-                 OUTPTS(IMOD)%OUT2%ICEFO(NPT)      ,                  &  
+                 OUTPTS(IMOD)%OUT2%ICEFO(NPT)      ,                  &
                  OUTPTS(IMOD)%OUT2%SPCO(NSPEC,NPT) ,                  &
                  OUTPTS(IMOD)%OUT2%PTLOC(2,NPT)    , STAT=ISTAT       )
       CHECK_ALLOC_STATUS ( ISTAT )
@@ -1066,7 +1066,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETO needs to be called after allocation to point to 
+!     - W3SETO needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -1537,7 +1537,7 @@
           ASO    => OUTPTS(IMOD)%OUT2%ASO
           CAO    => OUTPTS(IMOD)%OUT2%CAO
           CDO    => OUTPTS(IMOD)%OUT2%CDO
-          ICEO   => OUTPTS(IMOD)%OUT2%ICEO         
+          ICEO   => OUTPTS(IMOD)%OUT2%ICEO
           ICEHO  => OUTPTS(IMOD)%OUT2%ICEHO
           ICEFO  => OUTPTS(IMOD)%OUT2%ICEFO
           SPCO   => OUTPTS(IMOD)%OUT2%SPCO

--- a/model/ftn/w3ogcmmd.ftn
+++ b/model/ftn/w3ogcmmd.ftn
@@ -15,12 +15,12 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Module used for coupling applications between oceanic model and WW3 with OASIS3-MCT 
+!     Module used for coupling applications between oceanic model and WW3 with OASIS3-MCT
 !
 !  2. Variables and types :
 !
@@ -87,7 +87,7 @@
 !
 !      Name            Type    Module     Description
 !     ------------------------------------------------------------------
-!     W3WAVE           Subr.   W3WAVEMD   Wave model 
+!     W3WAVE           Subr.   W3WAVEMD   Wave model
 !     ------------------------------------------------------------------
 !
 !  6. Error messages :
@@ -125,7 +125,7 @@
       INTEGER, DIMENSION(NSEAL)      :: MASK
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                        :: IB_DO
-      LOGICAL                        :: LL_ACTION   
+      LOGICAL                        :: LL_ACTION
       REAL(kind=8), DIMENSION(NSEAL) :: TMP
 !
 !----------------------------------------------------------------------
@@ -173,7 +173,7 @@
          !
          ! Cosinus of Mean wave direction (cos(theta) in radians)
          ! ---------------------------------------------------------------------
-         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_CDIR') THEN
             TMP(1:NSEAL) = 0.0
@@ -184,7 +184,7 @@
          !
          ! Sinus of Mean wave direction (sin(theta) in radians)
          ! ---------------------------------------------------------------------
-         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_SDIR') THEN
             TMP(1:NSEAL) = 0.0
@@ -369,7 +369,7 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     ID_LCOMM          Char.     I     MPI communicator
-!     IDFLD             Int.      I     Name of the exchange fields    
+!     IDFLD             Int.      I     Name of the exchange fields
 !     FXN               Int.     I/O    First exchange field
 !     FYN               Int.     I/O    Second exchange field
 !     FAN               Int.     I/O    Third exchange field
@@ -417,7 +417,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      LOGICAL                          :: LL_ACTION   
+      LOGICAL                          :: LL_ACTION
       INTEGER                          :: IB_DO, IB_I, IB_J, IL_ERR
       INTEGER, SAVE                    :: ID_OASIS_TIME_WETDRYONLYONCE = -1
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_RCV
@@ -437,7 +437,7 @@
 ! ---------------------------------------------------------------------
 !
 ! For the same coupling time, W3FLDG is called for the level and current variables.
-! As RCV_FIELDS_FROM_OCEAN is called from W3FLDG, the following test prevents to 
+! As RCV_FIELDS_FROM_OCEAN is called from W3FLDG, the following test prevents to
 ! exchange the wet-dry variables more than once per coupling time.
 !cval well but it cannot work because MASKT,MASKU,MASKV variable are not global variable
 !cval Anyway we will give up the exchange of mask, it is not a good idea at all

--- a/model/ftn/w3parall.ftn
+++ b/model/ftn/w3parall.ftn
@@ -5,14 +5,14 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Parallel routines for implicit solver 
+!  1. Purpose : Parallel routines for implicit solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -59,7 +59,7 @@
       REAL, ALLOCATABLE    :: AC_tot(:,:)
       INTEGER, ALLOCATABLE :: ListISPnextDir(:), ListISPprevDir(:)
       INTEGER, ALLOCATABLE :: ListISPnextFreq(:), ListISPprevFreq(:)
-      INTEGER, PARAMETER   :: IMEM = 2 
+      INTEGER, PARAMETER   :: IMEM = 2
 
       REAL,  PARAMETER     :: ONESIXTH  = 1.0d0/6.0d0
       REAL,  PARAMETER     :: ONETHIRD  = 1.0d0/3.0d0
@@ -78,7 +78,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -148,14 +148,14 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Print timings 
+!  1. Purpose : Print timings
 !  2. Method :
 !  3. Parameters :
 !
@@ -217,14 +217,14 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Compute refraction part in matrix 
+!  1. Purpose : Compute refraction part in matrix
 !  2. Method :
 !  3. Parameters :
 !
@@ -369,7 +369,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -495,7 +495,7 @@
            + FRK(MAPWN(ISP)) * (ESIN(ISP)*eDDDX - ECOS(ISP)*eDDDY)
 !
 ! Puts filtering on total velocity (including currents and great circle effects)
-! the filtering limits VCFLT to be less than CTMAX 
+! the filtering limits VCFLT to be less than CTMAX
 ! this modification was proposed by F. Ardhuin 2011/03/06
 !
         IF (DoLimiter .eqv. .TRUE.) THEN
@@ -519,7 +519,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -634,7 +634,7 @@
 !/DEBUG      FLUSH(740+IAPROC)
       DO IK=0, NK+1
         FKD0   = FKD / CG(IK,ISEA) * DSDD(IK)
-        VELFAC =  FACK/DB(IK+1) 
+        VELFAC =  FACK/DB(IK+1)
         DO ITH=1, NTH
           VELNOFILT = ( FKD0 + WN(IK,ISEA)*FKC(ITH) ) * VELFAC
           CFLK(IK+1,ITH) = VELNOFILT/VELFAC
@@ -662,14 +662,14 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Compute freq. shift alternative approach 
+!  1. Purpose : Compute freq. shift alternative approach
 !  2. Method :
 !  3. Parameters :
 !
@@ -834,18 +834,18 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Sync global local arrays 
+!  1. Purpose : Sync global local arrays
 !  2. Method :
-! 		All the process need to have IPGL_tot and IPGL_TO_PROC             
-! 		This is especially the case for the output process.                
-! 		So we need some painful exportation business                       
+! 		All the process need to have IPGL_tot and IPGL_TO_PROC
+! 		This is especially the case for the output process.
+! 		So we need some painful exportation business
 !  3. Parameters :
 !
 !     Parameter list
@@ -883,7 +883,7 @@
 !/PDLIB   USE W3ADATMD, ONLY: MPI_COMM_WAVE, MPI_COMM_WCMP
 !/PDLIB   USE yowRankModule, only : IPGL_TO_PROC, IPGL_tot
 !/PDLIB   USE WMMDATMD, ONLY: MDATAS
-          IMPLICIT NONE 
+          IMPLICIT NONE
 !/PDLIB   INCLUDE "mpif.h"
           INTEGER, intent(in) :: IMOD
           logical, intent(in) :: IsMulti
@@ -934,7 +934,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -1034,14 +1034,14 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
 !/
 !/   01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Set Jsea for all schemes  
+!  1. Purpose : Set Jsea for all schemes
 !  2. Method :
 !  3. Parameters :
 !
@@ -1126,7 +1126,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -1195,7 +1195,7 @@
           IBELONG=0
         END IF
       ELSE
-!/PDLIB      IF (GTYPE .ne. UNGTYPE) THEN       
+!/PDLIB      IF (GTYPE .ne. UNGTYPE) THEN
 !/PDLIB        JSEA   = 1 + (ISEA-1)/NAPROC
 !/PDLIB        ISPROC = ISEA - (JSEA-1)*NAPROC
 !/PDLIB        IF (ISPROC .eq. IAPROC) THEN
@@ -1233,7 +1233,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -1325,7 +1325,7 @@
 !/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
-!/                  |                                   | 
+!/                  |                                   |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :        01-June-2018 |
 !/                  +-----------------------------------+
@@ -1334,8 +1334,8 @@
 !/
 !  1. Purpose : Sync global array in context of pdlib
 !  2. Method :
-!			An array of size (NSEA) is send but only the (1:NSEAL) values    
-! 			are correct. The program synchonizes everything on all nodes.    
+!			An array of size (NSEA) is send but only the (1:NSEAL) values
+! 			are correct. The program synchonizes everything on all nodes.
 !  3. Parameters :
 !
 !     Parameter list

--- a/model/ftn/w3partmd.ftn
+++ b/model/ftn/w3partmd.ftn
@@ -129,7 +129,7 @@
 !
 !  7. Remarks :
 !
-!     - To achieve minimum storage but guaranteed storage of all 
+!     - To achieve minimum storage but guaranteed storage of all
 !       partitions DIMXP = ((NK+1)/2) * ((NTH-1)/2) unless specified
 !       otherwise below.
 !
@@ -241,7 +241,7 @@
         RETURN
       ENDIF ! PTMETH == 4
 !
-! PTMETH == 5 : produce "high" and "low" band partitions 
+! PTMETH == 5 : produce "high" and "low" band partitions
 ! using a frequency cutoff:
 !
       IF( PTMETH .EQ. 5 ) THEN
@@ -253,7 +253,7 @@
           ELSE
             IP = 1
           ENDIF
-       
+
           DO ITH=1, NTH
             ISP = IK + (ITH-1) * NK ! index into partition array IMO
             IMO(ISP) = IP
@@ -273,8 +273,8 @@
 !
 ! 1.b Invert spectrum and 'digitize'
 !
-      ZMIN   = MINVAL ( ZP ) 
-      ZMAX   = MAXVAL ( ZP ) 
+      ZMIN   = MINVAL ( ZP )
+      ZMAX   = MAXVAL ( ZP )
       IF ( ZMAX-ZMIN .LT. 1.E-9 ) RETURN
 !
       Z      = ZMAX - ZP
@@ -304,7 +304,7 @@
 !
 ! 2.d PTMETH == 2: move the wind sea part of the partitions into a
 !     seperate partition and recalculate the mean parameters.
-! 
+!
       IF ( NP .GT. 0 .AND. PTMETH .EQ. 2 ) THEN
          WIND_PART = NP_MAX
 
@@ -355,7 +355,7 @@
 
         RETURN ! Don't process any further
       ENDIF ! PTMETH == 3
-     
+
       ! -----------------------------------------------------------------
       ! PTMETH == 1: Default WW3 partitioning.
       ! -----------------------------------------------------------------
@@ -375,7 +375,7 @@
 ! 3.b Combine wind seas as needed and resort
 !
       IF ( NWS.GT.1 .AND. FLCOMB ) THEN
-          IPW    = PMAP(INDEX(1))                         
+          IPW    = PMAP(INDEX(1))
           DO IP=2, NWS
              IPT    = PMAP(INDEX(IP))
              DO ISP=1, NSPEC
@@ -528,7 +528,7 @@
 !/
       END SUBROUTINE PTSORT
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE PTNGHB 
+      SUBROUTINE PTNGHB
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III          USACE/NOAA |
@@ -618,7 +618,7 @@
 !
 ! ... Point at the right (2)
 !
-        IF ( I .NE. NK ) THEN 
+        IF ( I .NE. NK ) THEN
             K           = K + 1
             NEIGH(K, N) = N + 1
           END IF
@@ -1214,7 +1214,7 @@
         !     the form used in w3iogomd and scaling should be
         !     based on the relationship between FTE and FT1, FTTR etc.
         !     as per w3iogomd and ww3_grid
-        FTEII = FTE / (DTH * SIG(NK)) 
+        FTEII = FTE / (DTH * SIG(NK))
         SUME (IP) = SUME (IP) + SUMF (NK,IP) * FTEII
         SUME1(IP) = SUME1(IP) + SUMF (NK,IP) * SIG(NK) * FTEII * (0.3333 / 0.25)
         SUME2(IP) = SUME2(IP) + SUMF (NK,IP) * SIG(NK)**2 * FTEII * (0.5 / 0.25)
@@ -1239,7 +1239,7 @@
         M0 = SUME(IP)  * DTH * TPIINV
         HS     = 4. * SQRT ( MAX( M0 , 0. ) )
         IF ( HS .LT. HSPMIN ) THEN
-          ! For wind cutoff and 2-band partitioning methods, keep the 
+          ! For wind cutoff and 2-band partitioning methods, keep the
           ! partition, but set the integrated parameters to UNDEF
           ! for Hs values less that HSPMIN:
           IF( PTMETH .EQ. 4 .OR. PTMETH .EQ. 5 ) THEN

--- a/model/ftn/w3pro1md.ftn
+++ b/model/ftn/w3pro1md.ftn
@@ -33,7 +33,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -118,7 +118,7 @@
 !  5. Called by :
 !
 !      Name      Type  Module   Description
-!     ---------------------------------------------------------------- 
+!     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ----------------------------------------------------------------
 !
@@ -321,7 +321,7 @@
 !  5. Called by :
 !
 !      Name      Type  Module   Description
-!     ---------------------------------------------------------------- 
+!     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ----------------------------------------------------------------
 !
@@ -345,13 +345,13 @@
 !       This is to calculate the flux VCY(IY+0.5). For the tripole grid,
 !       we cannot do it this way, since the sign of VCY flips as we jump
 !       over the seam. If we were to do it this way, VCY(IY) and VCY(IY+1)
-!       are two numbers of similar magnitude and opposite sign, so the 
-!       average of the two gives something close to zero, so energy does 
+!       are two numbers of similar magnitude and opposite sign, so the
+!       average of the two gives something close to zero, so energy does
 !       not leave via VCY(IY+0.5). One alternative is:
-!               VCB       = VCY2D(IY,IX) 
+!               VCB       = VCY2D(IY,IX)
 !       Another alternative is :
 !               VCB       = FACVY(IXY) * ( VCY2D(IY,IX) - VCY2D(IY+1,IX) )
-!       Both appear to give correct results for ww3_tp2.13. We use the 
+!       Both appear to give correct results for ww3_tp2.13. We use the
 !       second alternative.
 !
 !  8. Structure :
@@ -524,7 +524,7 @@
 
             END DO
         END IF
-          
+
         IF ( FLCX ) THEN
            DO ISEA=1, NSEA
               IX     = MAPSF(ISEA,1)
@@ -683,7 +683,7 @@
                                  + ATRNX(IXY,JXN) * VFLX2D(IY,IX-1)   &
                                  - ATRNX(IXY,JXP) * VFLX2D(IY,IX)     &
                                  + ATRNY(IXY,JYN) * VFLY2D(IY-1,IX)   &
-                                 - ATRNY(IXY,JYP) * VFLY2D(IY,IX)   
+                                 - ATRNY(IXY,JYP) * VFLY2D(IY,IX)
 
 !/T3              WRITE (NDST,9041) ISEA, IXY, IXY-NY, IXY-1,         &
 !/T3                 VFLX2D(IY,IX-1), VFLX2D(IY,IX), VFLY2D(IY-1,IX), &
@@ -822,7 +822,7 @@
 !  5. Called by :
 !
 !      Name      Type  Module   Description
-!     ---------------------------------------------------------------- 
+!     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ----------------------------------------------------------------
 !

--- a/model/ftn/w3pro2md.ftn
+++ b/model/ftn/w3pro2md.ftn
@@ -36,7 +36,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -155,7 +155,7 @@
 !
 !  5. Called by :
 !
-!      Name      Type  Module   Description 
+!      Name      Type  Module   Description
 !     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ---------------------------------------------------------------
@@ -503,7 +503,7 @@
 !
 !  5. Called by :
 !
-!      Name      Type  Module   Description 
+!      Name      Type  Module   Description
 !     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ---------------------------------------------------------------
@@ -542,14 +542,14 @@
 !       can significantly reduce size/cost of code. These variants are marked as
 !       CURV1 or CURV2. NCEP will make final decision re: which version to adopt.
 !       CURV1 is the shorter version and results do not match the original code
-!       for all test cases. CURV2 is the longer version and results do match the 
-!       original. DETAILED EXPLANATION: Discrepancies occur at the boundaries. 
-!       This is because, at the boundaries, the pre-curvilinear version zeros out 
-!       some terms in the diffusion calculation. Since they are zeroed out, 
+!       for all test cases. CURV2 is the longer version and results do match the
+!       original. DETAILED EXPLANATION: Discrepancies occur at the boundaries.
+!       This is because, at the boundaries, the pre-curvilinear version zeros out
+!       some terms in the diffusion calculation. Since they are zeroed out,
 !       they aren't there to *cancel* certain other terms: these "other terms"
-!       affect the result, so they have to be retained in the long vesion (CURV2) 
-!       to get an exact match. In the short version, the "canceling out" is 
-!       performed prior to coding the scheme, so both the canceled and canceling 
+!       affect the result, so they have to be retained in the long vesion (CURV2)
+!       to get an exact match. In the short version, the "canceling out" is
+!       performed prior to coding the scheme, so both the canceled and canceling
 !       terms are always omitted.
 !
 !  8. Structure :

--- a/model/ftn/w3pro3md.ftn
+++ b/model/ftn/w3pro3md.ftn
@@ -36,7 +36,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -48,7 +48,7 @@
 !
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
-!      TRNMIN    R.P.  Private   Minimum transparancy for local 
+!      TRNMIN    R.P.  Private   Minimum transparancy for local
 !                                switching off of averaging.
 !     ----------------------------------------------------------------
 !
@@ -192,7 +192,7 @@
 !
 ! 10. Source code :
 !/ ------------------------------------------------------------------- /
-      USE W3GDATMD, ONLY: NK, NTH, NSPEC, NX, NY, NSEA, MAPSTA, MAPSF,& 
+      USE W3GDATMD, ONLY: NK, NTH, NSPEC, NX, NY, NSEA, MAPSTA, MAPSF,&
                           GTYPE
       USE W3ADATMD, ONLY: NMX0, NMX1, NMX2, NMY0, NMY1, NMY2, NACT,   &
                           NCENT, MAPX2, MAPY2, MAPAXY, MAPCXY,        &
@@ -523,15 +523,15 @@
       DO ISEA=1, NSEA
         IXY         = MAPSF(ISEA,3)
 
-!notes: Oct 22 2012: I changed this because it *looks* like a bug. 
+!notes: Oct 22 2012: I changed this because it *looks* like a bug.
 !       I have not confirmed that it is a bug.
-!       Old code is given (2 lines). Only the first line is 
+!       Old code is given (2 lines). Only the first line is
 !       changed.
 
-!old    MAPTRN(IXY) = MIN( ATRNX(IXY,1) ,ATRNY(IXY,-1) ,              & 
+!old    MAPTRN(IXY) = MIN( ATRNX(IXY,1) ,ATRNY(IXY,-1) ,              &
 !old                       ATRNY(IXY,1), ATRNY(IXY,-1) ) .LT. TRNMIN
 
-        MAPTRN(IXY) = MIN( ATRNX(IXY,1) ,ATRNX(IXY,-1) ,              & 
+        MAPTRN(IXY) = MIN( ATRNX(IXY,1) ,ATRNX(IXY,-1) ,              &
                            ATRNY(IXY,1), ATRNY(IXY,-1) ) .LT. TRNMIN
         END DO
 !
@@ -861,7 +861,7 @@
         IX  = MAPSF(ISEA,1)
         IY  = MAPSF(ISEA,2)
 !
-! 1.c.1 Normal and parallel width ... 
+! 1.c.1 Normal and parallel width ...
 !
         TMPX   = FTHX / CLATS(ISEA)
         TMPY   = FTHY
@@ -1039,10 +1039,10 @@
           IF ( MAPSTA(IXY) .LE. 0 ) CYCLE
           IF ( MAPTRN(IXY) ) THEN
               VQ(IXY) = AQ(IXY)
-            ELSE          
+            ELSE
               RD1     = RDI1(ISEA)
               RD3     = RDI3(ISEA)
-              RD2     = MIN ( 1. , RDI2(ISEA) * CG(IK,ISEA) )           
+              RD2     = MIN ( 1. , RDI2(ISEA) * CG(IK,ISEA) )
               RD4     = MIN ( 1. , RDI4(ISEA) * CG(IK,ISEA) )
               VQ(IXY          ) = VQ(IXY          )                   &
                                    + AQ(IXY) * (3.-RD2-RD4)/3.
@@ -1067,7 +1067,7 @@
                        VQ(IXY          ) = VQ(IXY          )          &
                                             + AQ(IXY) * RD2*RD1/6.
                 END IF
- 
+
               IF ( MAPSTX(IXY+IIXY2(ISEA)) .GE. 1 ) THEN
                        VQ(IXY+IIXY2(ISEA)) = VQ(IXY+IIXY2(ISEA))      &
                                             + AQ(IXY) * (1.-RD1)*RD2/6.
@@ -1220,7 +1220,7 @@
 !/T2              END IF
 !/T2            END DO
 !
-        IF ( FLBPI ) THEN 
+        IF ( FLBPI ) THEN
             RD1    = DSEC21 ( TBPI0, TIME ) - DTG *                   &
                                       REAL(NTLOC-ITLOC)/REAL(NTLOC)
             RD2    = DSEC21 ( TBPI0, TBPIN )
@@ -1444,7 +1444,7 @@
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Initialize arrays
 !
-     DEPTH  = MAX ( DMIN, DW )  
+     DEPTH  = MAX ( DMIN, DW )
      VQ       = 0.
      IF ( FLCTH ) VCFLT    = 0.
      IF ( FLCK  ) CFLK     = 0.
@@ -1548,7 +1548,7 @@
             CFLTHMAX = MAX(CFLTHMAX, ABS(VELNOFILT))
 !
 ! Puts filtering on total velocity (including currents and great circle effects)
-! the filtering limits VCFLT to be less than CTMAX 
+! the filtering limits VCFLT to be less than CTMAX
 ! this modification was proposed by F. Ardhuin 2011/03/06
 !
             VCFLT(MAPTH2(ISP))=SIGN(MIN(ABS(VELNOFILT),CTMAX),VELNOFILT)
@@ -1593,15 +1593,15 @@
 !
           DO IK=0, NK+1
             FKD0   = FKD / CG(IK) * DSDD(IK)
-            VELFAC =  FACK/DB(IK+1,1) 
+            VELFAC =  FACK/DB(IK+1,1)
             DO ITH=1, NTH
 !
-! Puts filtering on velocity (needs the band widths) 
-!             
-              VELNOFILT = ( FKD0 + WN(IK)*FKC(ITH) ) * VELFAC   ! this is velocity * DT / DK 
+! Puts filtering on velocity (needs the band widths)
+!
+              VELNOFILT = ( FKD0 + WN(IK)*FKC(ITH) ) * VELFAC   ! this is velocity * DT / DK
               CFLKMAX = MAX(CFLKMAX, ABS(VELNOFILT))
               CFLK(IK+1,ITH) = SIGN(MIN(ABS(VELNOFILT),CTMAX),VELNOFILT)/VELFAC
-              !CFLK(IK+1,ITH) = FKD0 + WN(IK)*FKC(ITH)          ! this was without the limiter ... 
+              !CFLK(IK+1,ITH) = FKD0 + WN(IK)*FKC(ITH)          ! this was without the limiter ...
               END DO
             END DO
 !

--- a/model/ftn/w3profsmd.ftn
+++ b/model/ftn/w3profsmd.ftn
@@ -32,7 +32,7 @@
 !
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
-!      W3XYPUG       Subr. Public   Generic fluctuation splitting operations 
+!      W3XYPUG       Subr. Public   Generic fluctuation splitting operations
 !      W3XYPFSN2     Subr. Public   advection with N scheme (Csik et al. 2002)
 !      W3XYPFSPSI    Subr. Public   advection with FCT scheme
 !      W3XYPFSFCT2   Subr. Public   advection with FCT scheme
@@ -46,7 +46,7 @@
 !
 !  5. Remarks :
 !     For a detailed description of the schemes and their properties, see
-!     Roland (2008), Ph.D. Thesis, T. U. Darmstadt. 
+!     Roland (2008), Ph.D. Thesis, T. U. Darmstadt.
 !
 !  6. Switches :
 !
@@ -58,7 +58,7 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
-   SUBROUTINE W3XYPUG ( ISP, FACX, FACY, DTG, VQ, VGX, VGY, LCALC )    
+   SUBROUTINE W3XYPUG ( ISP, FACX, FACY, DTG, VQ, VGX, VGY, LCALC )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -77,7 +77,7 @@
 !
 !  2. Method :
 !
-!     
+!
 !
 !  3. Parameters :
 !
@@ -110,7 +110,7 @@
 !       None.
 !
 !  7. Remarks :
-!              make the interface between the WAVEWATCH and the WWM code. 
+!              make the interface between the WAVEWATCH and the WWM code.
 !
 !  8. Structure :
 !
@@ -120,7 +120,7 @@
 !       !/S     Enable subroutine tracing.
 !
 !
-! 10. Source code :     
+! 10. Source code :
 !/ ------------------------------------------------------------------- /
 !/
 !
@@ -142,7 +142,7 @@
 !      USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN,       &
 !                          ISBPI, BBPI0, BBPIN
 !/S      USE W3SERVMD, ONLY: STRACE
-      
+
       IMPLICIT NONE
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -166,33 +166,33 @@
 !/
       REAL                    :: VLCFLX((NX+1)*NY), VLCFLY(NX*NY)
       DOUBLE PRECISION        :: AC(NX)
-!/ ------------------------------------------------------------------- /                                     
+!/ ------------------------------------------------------------------- /
 !
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Set constants
-!      
-      
-!/S      CALL STRACE (IENT, 'W3XYPUG')      
+!
+
+!/S      CALL STRACE (IENT, 'W3XYPUG')
       ITH    = 1 + MOD(ISP-1,NTH)
-      IK     = 1 + (ISP-1)/NTH     
-   
-      CCOS   = FACX * ECOS(ITH) 
-      CSIN   = FACY * ESIN(ITH) 
-      CCURX  = FACX 
-      CCURY  = FACY  
+      IK     = 1 + (ISP-1)/NTH
+
+      CCOS   = FACX * ECOS(ITH)
+      CSIN   = FACY * ESIN(ITH)
+      CCURX  = FACX
+      CCURY  = FACY
 !
 ! 1.b Initialize arrays
 !
       VLCFLX = 0.
       VLCFLY = 0.
 !
-! 1.c Set depth 
+! 1.c Set depth
 !
       CALL SETDEPTH
 !
 !
 ! 2.  Calculate velocities ---------------- *
-! 
+!
       DO ISEA=1, NSEA
         IXY         =  MAPSF(ISEA,3)
         VQ(IXY)     = VQ(IXY) / CG(IK,ISEA) * CLATS(ISEA)
@@ -200,25 +200,25 @@
         VLCFLY(IXY) = CSIN * CG(IK,ISEA)
 !/MGP        VLCFLX(IXY) = VLCFLX(IXY) - CCURX*VGX/CLATS(ISEA)
 !/MGP        VLCFLY(IXY) = VLCFLY(IXY) - CCURY*VGY
-      END DO  
+      END DO
 
-      IF ( FLCUR ) THEN   
+      IF ( FLCUR ) THEN
         DO ISEA=1, NSEA
           IXY =  MAPSF(ISEA,3)
 !
 ! Currents are not included on coastal boundaries (IOBP(IXY).EQ.0)
 !
-          IF (IOBP(IXY) .EQ. 1) THEN                                  
+          IF (IOBP(IXY) .EQ. 1) THEN
             VLCFLX(IXY) = VLCFLX(IXY) + CCURX*CX(ISEA)/CLATS(ISEA)
             VLCFLY(IXY) = VLCFLY(IXY) + CCURY*CY(ISEA)
-          END IF    
-        END DO     
+          END IF
+        END DO
       END IF
 
 !
-! 3. initialize fluctuation splitting arrays ( to fit with WWM notations)    
+! 3. initialize fluctuation splitting arrays ( to fit with WWM notations)
 !
-      AC(1:NX) = DBLE(VQ(1:NX))  
+      AC(1:NX) = DBLE(VQ(1:NX))
       C(1:NX,1)  = VLCFLX(1:NX)
       C(1:NX,2)  = VLCFLY(1:NX)
 !
@@ -232,8 +232,8 @@
         RD2=0.
       END IF
 !
-! 4. propagate using the selected scheme 
-!      
+! 4. propagate using the selected scheme
+!
        IF (FSN) THEN
          CALL W3XYPFSN2 (ISP, C, LCALC, RD1, RD2, DTG, AC)
        ELSE IF (FSPSI) THEN
@@ -242,13 +242,13 @@
          CALL W3XYPFSFCT2 (ISP, C, LCALC, RD1, RD2, DTG, AC)
        ELSE IF (FSNIMP) THEN
          CALL W3XYPFSNIMP(ISP, C, LCALC, RD1, RD2, DTG, AC)
-       ENDIF  
+       ENDIF
 !
        DO IX=1,NX
          ISEA=MAPFS(1,IX)
          VQ(IX)=REAL(AC(IX))
-         ENDDO          
-    
+         ENDDO
+
 ! 6.  Store results in VQ in proper format --------------------------- *
 !
 !/C90/!DIR$ IVDEP
@@ -260,7 +260,7 @@
    END SUBROUTINE W3XYPUG
 !/ ------------------------------------------------------------------- /
    SUBROUTINE W3CFLUG ( ISEA, NKCFL, FACX, FACY, DT, MAPFS, CFLXYMAX,    &
-                          VGX, VGY )    
+                          VGX, VGY )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -271,7 +271,7 @@
 !/
 !/    01-Mar-2011 : Origination.                        ( version 3.14 )
 !/    20-Jun-2013 : Computes only up to NKCFL for tests ( version 4.10 )
-!/     1-Jun-2017 : Rewrite routine for performance     ( version 5.xx ) 
+!/     1-Jun-2017 : Rewrite routine for performance     ( version 5.xx )
 !/
 !  1. Purpose :
 !
@@ -279,7 +279,7 @@
 !
 !  2. Method :
 !
-!     
+!
 !
 !  3. Parameters :
 !
@@ -314,7 +314,7 @@
 !       None.
 !
 !  7. Remarks :
-!              make the interface between the WAVEWATCH and the WWM code. 
+!              make the interface between the WAVEWATCH and the WWM code.
 !
 !  8. Structure :
 !
@@ -324,7 +324,7 @@
 !       !/S     Enable subroutine tracing.
 !
 !
-! 10. Source code :     
+! 10. Source code :
 !/ ------------------------------------------------------------------- /
 !/
 !
@@ -343,7 +343,7 @@
 !/T      USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN,       &
 !/T                          ISBPI, BBPI0, BBPIN
 !/S      USE W3SERVMD, ONLY: STRACE
-      
+
       IMPLICIT NONE
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -355,7 +355,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      INTEGER                 :: ITH, IK    
+      INTEGER                 :: ITH, IK
       INTEGER                 :: IP, IP2, ISEA2, I, J, IE, IV, I1, I2, I3
 !/S      INTEGER, SAVE           :: IENT = 0
       REAL                    :: CCOS, CSIN, CCURX, CCURY
@@ -363,40 +363,40 @@
       REAL*8                  :: KELEM(3), KTMP(3), LAMBDA(2)
       REAL*8                  :: KKSUM, DTMAXEXP
 !/
-!/  Velocities 
+!/  Velocities
 !/
        REAL*8,  PARAMETER :: ONESIXTH  = 1.0d0/6.0d0
        REAL*8,  PARAMETER :: THR8      = TINY(1.0d0)
-       REAL,    PARAMETER :: THR       = TINY(1.0) 
+       REAL,    PARAMETER :: THR       = TINY(1.0)
 
-!/ ------------------------------------------------------------------- /                                     
+!/ ------------------------------------------------------------------- /
 !
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Set constants
-!      
-      
-!/S      CALL STRACE (IENT, 'W3CFLUG')      
+!
+
+!/S      CALL STRACE (IENT, 'W3CFLUG')
       CFLXYMAX=1E-10
       IP = MAPSF(ISEA,3)
 !
-! CFL no important on boundary 
+! CFL no important on boundary
 !
-      IF (IOBP(IP).EQ.1) THEN       
-      CCURX  = FACX 
-      CCURY  = FACY  
+      IF (IOBP(IP).EQ.1) THEN
+      CCURX  = FACX
+      CCURY  = FACY
 !
 ! Loop over spectral components
 !
       DO IK=1,NKCFL
         DO ITH=1,NTH
-          CCOS   = FACX * ECOS(ITH) 
-          CSIN   = FACY * ESIN(ITH) 
+          CCOS   = FACX * ECOS(ITH)
+          CSIN   = FACY * ESIN(ITH)
           C(:,:)=0.
 
 !
 ! 2.  Calculate advection velocities: group speed ---------------- *
-! 
-!AR: needs to be rewritten for speed ... single node computation is costly ... 
+!
+!AR: needs to be rewritten for speed ... single node computation is costly ...
 !MA: you are right but now it is only called if CFX and UNST for CFL profiling
 
           DO I = INDEX_CELL(IP), INDEX_CELL(IP+1)-1
@@ -408,11 +408,11 @@
               C(IP2,2) = CSIN * CG(IK,ISEA2)
 !/MGP              C(IP2,1) = C(IP2,1) - CCURX*VGX/CLATS(ISEA2)
 !/MGP              C(IP2,2) = C(IP2,2) - CCURY*VGY
-              IF ( FLCUR ) THEN   
-                IF (IOBP(IP2) .EQ. 1) THEN                                  
+              IF ( FLCUR ) THEN
+                IF (IOBP(IP2) .EQ. 1) THEN
                   C(IP2,1) = C(IP2,1) + CCURX*CX(ISEA2)/CLATS(ISEA2)
                   C(IP2,2) = C(IP2,2) + CCURY*CY(ISEA2)
-                  END IF    
+                  END IF
                 END IF  ! end of ( FLCUR )
               END DO
             END DO
@@ -421,16 +421,16 @@
 !
           KKSUM = 0.d0
           DO I = INDEX_CELL(IP), INDEX_CELL(IP+1)-1
-            IE=IE_CELL(I)       ! TRIGP(IE,IV)=IP  
+            IE=IE_CELL(I)       ! TRIGP(IE,IV)=IP
             IV=POS_CELL(I)
-            I1 = TRIGP(IE,1) 
+            I1 = TRIGP(IE,1)
             I2 = TRIGP(IE,2)
             I3 = TRIGP(IE,3)
             LAMBDA(1) = ONESIXTH *(C(I1,1)+C(I2,1)+C(I3,1)) ! Advection speed in X direction
             LAMBDA(2) = ONESIXTH *(C(I1,2)+C(I2,2)+C(I3,2)) ! Advection speed in Y direction
-            KELEM(1) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians 
-            KELEM(2) = LAMBDA(1) * IEN(IE,3) + LAMBDA(2) * IEN(IE,4) ! K-Values - so called Flux Jacobians 
-            KELEM(3) = LAMBDA(1) * IEN(IE,5) + LAMBDA(2) * IEN(IE,6) ! K-Values - so called Flux Jacobians 
+            KELEM(1) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians
+            KELEM(2) = LAMBDA(1) * IEN(IE,3) + LAMBDA(2) * IEN(IE,4) ! K-Values - so called Flux Jacobians
+            KELEM(3) = LAMBDA(1) * IEN(IE,5) + LAMBDA(2) * IEN(IE,6) ! K-Values - so called Flux Jacobians
 
             KTMP        = KELEM ! Copy
             KELEM       = MAX(0.d0,KTMP)
@@ -444,12 +444,12 @@
         END DO
         END IF
 !
-      RETURN    
- END SUBROUTINE W3CFLUG    
+      RETURN
+ END SUBROUTINE W3CFLUG
 !/ ------------------------------------------------------------------- /
 
       SUBROUTINE W3XYPFSN2 ( ISP, C, LCALC, RD10, RD20, DT, AC)
-     
+
 !/
 !/
 !/                  +-----------------------------------+
@@ -508,16 +508,16 @@
        USE W3GDATMD, ONLY : NK, NTH, NTRI, NX, CCON, IE_CELL,POS_CELL, SI, &
                             IEN, TRIGP, CLATS, MAPSF, IOBPD, IOBP, IOBDP, IOBPA, XYB
 !/REF1   USE W3GDATMD, ONLY : REFPARS
-       USE W3WDATMD, ONLY: TIME      
-       USE W3ADATMD, ONLY: CG, ITER    
+       USE W3WDATMD, ONLY: TIME
+       USE W3ADATMD, ONLY: CG, ITER
        USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN, ISBPI, BBPI0, BBPIN
        USE W3TIMEMD, ONLY: DSEC21
 !/S      USE W3SERVMD, ONLY: STRACE
-       IMPLICIT NONE  
-     
+       IMPLICIT NONE
+
        INTEGER, INTENT(IN)    :: ISP                   ! Actual Frequency/Wavenumber, actual Wave Direction
        REAL,    INTENT(IN)    :: DT                    ! Time intervall for which the advection should be computed for the given velocity field
-       REAL,    INTENT(IN)    :: C(:,:)                ! Velocity field in it's X- and Y- Components, 
+       REAL,    INTENT(IN)    :: C(:,:)                ! Velocity field in it's X- and Y- Components,
        DOUBLE PRECISION, INTENT(INOUT):: AC(:)         ! Wave Action before and after advection
        REAL,    INTENT(IN)    :: RD10, RD20            ! Time interpolation coefficients for boundary conditions
        LOGICAL, INTENT(IN)    :: LCALC                 ! Switch for the calculation of the max. Global Time step
@@ -533,14 +533,14 @@
 
        REAL*8,  PARAMETER :: ONESIXTH  = 1.0d0/6.0d0
        REAL*8,  PARAMETER :: THR8      = TINY(1.0d0)
-       REAL,    PARAMETER :: THR       = TINY(1.0) 
+       REAL,    PARAMETER :: THR       = TINY(1.0)
 !/
 !/ ------------------------------------------------------------------- /
 !/
 !
 ! local integer
 !
-         INTEGER :: IP, IE, IT, I1, I2, I3, ITH, IK    
+         INTEGER :: IP, IE, IT, I1, I2, I3, ITH, IK
          INTEGER :: IBI, NI(3)
 !
 ! local real
@@ -558,33 +558,33 @@
          REAL*8  :: LAMBDA(2), KTMP(3)
          REAL*8  :: KELEM(3,NTRI), FLALL(3,NTRI)
          REAL*8  :: KKSUM(NX), ST(NX)
-         REAL*8  :: NM(NTRI) 
+         REAL*8  :: NM(NTRI)
 
 !/S      CALL STRACE (IENT, 'W3XYPFSN')
 
 ! 1. initialisation
 
          ITH    = 1 + MOD(ISP-1,NTH)
-         IK     = 1 + (ISP-1)/NTH 
+         IK     = 1 + (ISP-1)/NTH
          DTMAXGL = DBLE(10.E10)
 !
-!2       Propagation 
+!2       Propagation
 !2.a     Calculate K-Values and contour based quantities ...
 !
-         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ... 
+         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ...
            I1 = TRIGP(IE,1) ! Index of the Element Nodes (TRIGP)
            I2 = TRIGP(IE,2)
            I3 = TRIGP(IE,3)
            LAMBDA(1) = ONESIXTH *(C(I1,1)+C(I2,1)+C(I3,1)) ! Linearized advection speed in X and Y direction
            LAMBDA(2) = ONESIXTH *(C(I1,2)+C(I2,2)+C(I3,2))
-           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians 
+           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians
            KELEM(2,IE) = LAMBDA(1) * IEN(IE,3) + LAMBDA(2) * IEN(IE,4)
            KELEM(3,IE) = LAMBDA(1) * IEN(IE,5) + LAMBDA(2) * IEN(IE,6)
 !
            KTMP        = KELEM(:,IE) ! Copy
-           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values 
+           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values
            KELEM(:,IE) = MAX(0.d0,KTMP)
-           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration 
+           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration
            FL12  = C(I3,1) * IEN(IE,1) + C(I3,2) * IEN(IE,2)
            FL21  = C(I3,1) * IEN(IE,3) + C(I3,2) * IEN(IE,4)
            FL22  = C(I1,1) * IEN(IE,3) + C(I1,2) * IEN(IE,4)
@@ -608,7 +608,7 @@
                NI = TRIGP(IE,:)
                KKSUM(NI) = KKSUM(NI) + KELEM(:,IE)
              END DO ! IE
-             DTMAXEXP = 1E10 ! initialize to large number 
+             DTMAXEXP = 1E10 ! initialize to large number
              DO IP = 1, NX
                DTMAXEXP = SI(IP)/MAX(DBLE(10.E-10),KKSUM(IP)*IOBDP(IP))
                DTMAXGL  = MIN( DTMAXGL, DTMAXEXP)
@@ -623,8 +623,8 @@
                ITER(IK,ITH) = ABS(NINT(CFLXY))
              END IF
            END IF ! LCALC
- 
-           DO IP = 1, NX               
+
+           DO IP = 1, NX
              DTSI(IP) = DBLE(DT)/DBLE(ITER(IK,ITH))/SI(IP) ! Some precalculations for the time integration.
            END DO
 
@@ -639,20 +639,20 @@
 
              DO IP = 1, NX
 !
-! IOBPD=0  : waves coming from land (or outside grid) 
+! IOBPD=0  : waves coming from land (or outside grid)
 ! Possibly set flux to zero by multiplying ST by IOBPD but also in UTILDE multiply U(NI) by IOBPD ...
 !
                U(IP) = MAX(0.d0,U(IP)-DTSI(IP)*ST(IP)*(1-IOBPA(IP)))*DBLE(IOBPD(ITH,IP))
-!/REF1             IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values 
+!/REF1             IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values
                END DO
-! update spectrum 
+! update spectrum
              AC = U
 !
-! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn) 
+! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn)
 !
-             IF ( FLBPI ) THEN 
+             IF ( FLBPI ) THEN
 !
-! 4.1 In this case the boundary is read from the nest.ww3 file 
+! 4.1 In this case the boundary is read from the nest.ww3 file
 !
                RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
                RD2=RD20
@@ -664,7 +664,7 @@
                  RD2    = 1.
                  END IF
 !
-! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0) 
+! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0)
 !
                 DO IBI=1, NBI
                   IP = MAPSF(ISBPI(IBI),1)
@@ -674,16 +674,16 @@
 
             ENDIF
 !
-           END DO ! End of loop on time steps        
+           END DO ! End of loop on time steps
 !        CALL EXTCDE ( 99 )
 !/
 !/ End of W3XYPFSN ----------------------------------------------------- /
 !/
       END SUBROUTINE W3XYPFSN2
-      
-!/ ------------------------------------------------------------------- /  
+
+!/ ------------------------------------------------------------------- /
       SUBROUTINE W3XYPFSPSI2 ( ISP, C, LCALC, RD10, RD20, DT, AC)
-     
+
 !/
 !/
 !/                  +-----------------------------------+
@@ -736,16 +736,16 @@
        USE W3GDATMD, ONLY : NK, NTH, NTRI, NX, CCON, IE_CELL,POS_CELL, SI, &
                             IEN, TRIGP, CLATS, MAPSF, IOBPA, IOBPD, IOBP, NNZ, IOBDP
 !/REF1   USE W3GDATMD, ONLY :  REFPARS
-       USE W3WDATMD, ONLY: TIME     
-       USE W3ADATMD, ONLY: CG, ITER    
+       USE W3WDATMD, ONLY: TIME
+       USE W3ADATMD, ONLY: CG, ITER
        USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN, ISBPI, BBPI0, BBPIN
        USE W3TIMEMD, ONLY: DSEC21
 !/S      USE W3SERVMD, ONLY: STRACE
-       IMPLICIT NONE  
-     
+       IMPLICIT NONE
+
        INTEGER, INTENT(IN)    :: ISP                   ! Actual Frequency/Wavenumber, actual Wave Direction
        REAL,    INTENT(IN)    :: DT                    ! Time intervall for which the advection should be computed for the given velocity field
-       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components, 
+       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components,
        DOUBLE PRECISION,INTENT(INOUT) :: AC(:)         ! Wave Action before and after advection
        REAL,    INTENT(IN)    :: RD10, RD20            ! Time interpolation coefficients for boundary conditions
        LOGICAL, INTENT(IN)    :: LCALC                 ! Switch for the calculation of the max. Global Time step
@@ -761,14 +761,14 @@
 
        REAL*8,  PARAMETER :: ONESIXTH  = 1.0d0/6.0d0
        REAL*8,  PARAMETER :: THR8      = TINY(1.0d0)
-       REAL,    PARAMETER :: THR       = TINY(1.0) 
+       REAL,    PARAMETER :: THR       = TINY(1.0)
 !/
 !/ ------------------------------------------------------------------- /
 !/
 !
 ! local integer
 !
-         INTEGER :: IP, IE, IT, I1, I2, I3, ITH, IK    
+         INTEGER :: IP, IE, IT, I1, I2, I3, ITH, IK
          INTEGER :: IBI, NI(3)
 !
 ! local real
@@ -787,32 +787,32 @@
          REAL*8  :: THETA_L(3), BET1(3), BETAHAT(3)
          REAL*8  :: KELEM(3,NTRI), FLALL(3,NTRI)
          REAL*8  :: KKSUM(NX), ST(NX)
-         REAL*8  :: NM(NTRI) 
+         REAL*8  :: NM(NTRI)
 
 !/S      CALL STRACE (IENT, 'W3XYPFSN')
 
 ! 1. initialisation
 
          ITH    = 1 + MOD(ISP-1,NTH)
-         IK     = 1 + (ISP-1)/NTH 
+         IK     = 1 + (ISP-1)/NTH
          DTMAXGL = DBLE(10.E10)
 !
-!2       Propagation 
+!2       Propagation
 !2.a     Calculate K-Values and contour based quantities ...
 !
-         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ... 
+         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ...
            I1 = TRIGP(IE,1) ! Index of the Element Nodes (TRIGP)
            I2 = TRIGP(IE,2)
            I3 = TRIGP(IE,3)
            LAMBDA(1) = ONESIXTH *(C(I1,1)+C(I2,1)+C(I3,1)) ! Linearized advection speed in X and Y direction
            LAMBDA(2) = ONESIXTH *(C(I1,2)+C(I2,2)+C(I3,2))
-           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians 
+           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians
            KELEM(2,IE) = LAMBDA(1) * IEN(IE,3) + LAMBDA(2) * IEN(IE,4)
            KELEM(3,IE) = LAMBDA(1) * IEN(IE,5) + LAMBDA(2) * IEN(IE,6)
            KTMP        = KELEM(:,IE) ! Copy
-           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values 
+           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values
            KELEM(:,IE) = MAX(0.d0,KTMP)
-           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration 
+           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration
            FL12  = C(I3,1) * IEN(IE,1) + C(I3,2) * IEN(IE,2)
            FL21  = C(I3,1) * IEN(IE,3) + C(I3,2) * IEN(IE,4)
            FL22  = C(I1,1) * IEN(IE,3) + C(I1,2) * IEN(IE,4)
@@ -835,7 +835,7 @@
                NI = TRIGP(IE,:)
                KKSUM(NI) = KKSUM(NI) + KELEM(:,IE)
              END DO ! IE
-             DTMAXEXP = 1E10 ! initialize to large number 
+             DTMAXEXP = 1E10 ! initialize to large number
              DO IP = 1, NX
                DTMAXEXP = SI(IP)/MAX(DBLE(10.E-10),KKSUM(IP)*IOBDP(IP))
                DTMAXGL  = MIN( DTMAXGL, DTMAXEXP)
@@ -850,8 +850,8 @@
                ITER(IK,ITH) = ABS(NINT(CFLXY))
              END IF
            END IF ! LCALC
- 
-           DO IP = 1, NX               
+
+           DO IP = 1, NX
              DTSI(IP) = DBLE(DT)/DBLE(ITER(IK,ITH))/SI(IP) ! Some precalculations for the time integration.
            END DO
 
@@ -884,17 +884,17 @@
 
              DO IP = 1, NX
                U(IP) = MAX(0.d0,U(IP)-DTSI(IP)*ST(IP)*(1-IOBPA(IP)))*DBLE(IOBPD(ITH,IP))
-!/REF1               IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values 
+!/REF1               IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values
                END DO
 
-! update spectrum 
+! update spectrum
              AC = U
 !
-! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn) 
+! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn)
 !
              IF ( FLBPI ) THEN
 !
-! 4.1 In this case the boundary is read from the nest.ww3 file 
+! 4.1 In this case the boundary is read from the nest.ww3 file
 !
                RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
                RD2=RD20
@@ -906,7 +906,7 @@
                  RD2    = 1.
                  END IF
 !
-! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0) 
+! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0)
 !
                 DO IBI=1, NBI
                   IP = MAPSF(ISBPI(IBI),1)
@@ -916,16 +916,16 @@
 
             ENDIF
 !
-           END DO ! End of loop on time steps      
+           END DO ! End of loop on time steps
 !      CALL EXTCDE ( 99 )
 !/
 !/ End of W3XYPFSN ----------------------------------------------------- /
 !/
       END SUBROUTINE W3XYPFSPSI2
-      
-!/ ------------------------------------------------------------------- /  
+
+!/ ------------------------------------------------------------------- /
       SUBROUTINE W3XYPFSNIMP ( ISP, C, LCALC, RD10, RD20, DT, AC)
-     
+
 !/
 !/
 !/                  +-----------------------------------+
@@ -981,16 +981,16 @@
                             IEN, TRIGP, CLATS, MAPSF, IOBPD, IOBPA, IOBP, IAA, JAA, POSI, &
                             TRIA, NNZ
 !/REF1  USE W3GDATMD, ONLY : REFPARS
-       USE W3WDATMD, ONLY: TIME      
-       USE W3ADATMD, ONLY: CG, ITER    
+       USE W3WDATMD, ONLY: TIME
+       USE W3ADATMD, ONLY: CG, ITER
        USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN, ISBPI, BBPI0, BBPIN
        USE W3TIMEMD, ONLY: DSEC21
 !/S      USE W3SERVMD, ONLY: STRACE
-       IMPLICIT NONE  
-     
+       IMPLICIT NONE
+
        INTEGER, INTENT(IN)    :: ISP                   ! Actual Frequency/Wavenumber, actual Wave Direction
        REAL,    INTENT(IN)    :: DT                    ! Time intervall for which the advection should be computed for the given velocity field
-       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components, 
+       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components,
        DOUBLE PRECISION,INTENT(INOUT) :: AC(:)         ! Wave Action before and after advection
        REAL,    INTENT(IN)    :: RD10, RD20            ! Time interpolation coefficients for boundary conditions
        LOGICAL, INTENT(IN)    :: LCALC                 ! Switch for the calculation of the max. Global Time step
@@ -1007,14 +1007,14 @@
        REAL*8,  PARAMETER :: ONESIXTH  = 1.0d0/6.0d0
        REAL*8,  PARAMETER :: ONETHIRD  = 1.0d0/3.0d0
        REAL*8,  PARAMETER :: THR8      = TINY(1.0d0)
-       REAL,    PARAMETER :: THR       = TINY(1.0) 
+       REAL,    PARAMETER :: THR       = TINY(1.0)
 !/
 !/ ------------------------------------------------------------------- /
 !/
 !
 ! local integer
 !
-         INTEGER :: IP, IE, POS, I1, I2, I3, I, J, ITH, IK    
+         INTEGER :: IP, IE, POS, I1, I2, I3, I, J, ITH, IK
          INTEGER :: IBI
 !
 ! local real
@@ -1064,7 +1064,7 @@
 ! 1. initialisation
 
          ITH    = 1 + MOD(ISP-1,NTH)
-         IK     = 1 + (ISP-1)/NTH 
+         IK     = 1 + (ISP-1)/NTH
          DTMAXGL = DBLE(10.E10)
 
         IF (.FALSE.) THEN
@@ -1075,10 +1075,10 @@
            WRITE(*,*) 'AC, AQ', SUM(AC)
          END IF
 !
-!2       Propagation 
+!2       Propagation
 !2.a     Calculate K-Values and contour based quantities ...
 !
-         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ... 
+         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ...
            I1 = TRIGP(IE,1) ! Index of the Element Nodes (TRIGP)
            I2 = TRIGP(IE,2)
            I3 = TRIGP(IE,3)
@@ -1105,12 +1105,12 @@
            DELTAL(:,IE) = CRFS(:)- KP(:,IE)
            NM(IE)       = 1.d0/MIN(DBLE(THR),SUM(KM(:)))
          END DO ! NTRI
- 
+
          U = DBLE(AC)
-         J = 0 
+         J = 0
          ASPAR = 0.d0
          B     = 0.d0
-         DO IP = 1, NX 
+         DO IP = 1, NX
            DO I = 1, CCON(IP)
              J = J + 1
              IE    =  IE_CELL(J)
@@ -1122,9 +1122,9 @@
                I1    =  POSI(1,J)
                I2    =  POSI(2,J)
                I3    =  POSI(3,J)
-               ASPAR(I1) =  ONETHIRD * TRIA(IE) + DTK - TMP3 * DELTAL(POS,IE)              + ASPAR(I1) 
+               ASPAR(I1) =  ONETHIRD * TRIA(IE) + DTK - TMP3 * DELTAL(POS,IE)              + ASPAR(I1)
                ASPAR(I2) =                         - TMP3 * DELTAL(POS_TRICK(POS,1),IE) + ASPAR(I2)
-               ASPAR(I3) =                         - TMP3 * DELTAL(POS_TRICK(POS,2),IE) + ASPAR(I3) 
+               ASPAR(I3) =                         - TMP3 * DELTAL(POS_TRICK(POS,2),IE) + ASPAR(I3)
                B(IP)     =  B(IP) + ONETHIRD * TRIA(IE) * U(IP)
              ELSE
                I1    =  POSI(1,J)
@@ -1168,7 +1168,7 @@
            WRITE(*,*) 'AU, FLJAU, FLJU',SUM(AU), SUM(FLJAU), SUM(FLJU)
          END IF
 
-          INIU = U 
+          INIU = U
           X    = 0.d0
 
           CALL RUNRC (NX, B, X, IPAR, FPAR, WKSP, INIU, ASPAR, JAA, IAA, AU, FLJAU, FLJU, BCGSTAB)
@@ -1184,13 +1184,13 @@
 
           DO IP = 1,NX
             U(IP) = MAX(0.d0,X(IP)*DBLE(IOBPD(ITH,IP)))
-!/REF1      IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values 
+!/REF1      IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values
            END DO
 !
-! update spectrum 
+! update spectrum
              AC = REAL(U)
 !
-! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn) 
+! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn)
 !
             IF ( FLBPI ) THEN
              RD1=RD10
@@ -1217,8 +1217,8 @@
 !/ End of W3XYPFSNIMP------------------------------------------------- /
 !/
       END SUBROUTINE W3XYPFSNIMP
-      
-!/ ------------------------------------------------------------------- /  
+
+!/ ------------------------------------------------------------------- /
 
       SUBROUTINE W3XYPFSFCT2 ( ISP, C, LCALC, RD10, RD20, DT, AC)
 !/
@@ -1272,16 +1272,16 @@
        USE W3GDATMD, ONLY : NK, NTH, NTRI, NX, CCON, IE_CELL,POS_CELL, SI, &
                             IEN, TRIGP, CLATS, MAPSF, IOBPD, IOBPA, TRIA, IOBDP
 !/REF1  USE W3GDATMD, ONLY : REFPARS
-       USE W3WDATMD, ONLY: TIME               
-       USE W3ADATMD, ONLY: CG, ITER    
+       USE W3WDATMD, ONLY: TIME
+       USE W3ADATMD, ONLY: CG, ITER
        USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, TBPI0, TBPIN, ISBPI, BBPI0, BBPIN
        USE W3TIMEMD, ONLY: DSEC21
 !/S      USE W3SERVMD, ONLY: STRACE
-       IMPLICIT NONE  
-     
+       IMPLICIT NONE
+
        INTEGER, INTENT(IN)    :: ISP                   ! Actual Frequency/Wavenumber, actual Wave Direction
        REAL,    INTENT(IN)    :: DT                    ! Time intervall for which the advection should be computed for the given velocity field
-       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components, 
+       REAL,    INTENT(IN)    :: C(:,:)              ! Velocity field in it's X- and Y- Components,
        DOUBLE PRECISION,    INTENT(INOUT) :: AC(:)               ! Wave Action before and after advection
        REAL,    INTENT(IN)    :: RD10, RD20            ! Time interpolation coefficients for boundary condition
        LOGICAL, INTENT(IN)    :: LCALC                 ! Switch for the calculation of the max. Global Time step
@@ -1298,14 +1298,14 @@
        REAL*8,  PARAMETER :: ONESIXTH  = 1.0d0/6.0d0
        REAL*8,  PARAMETER :: ONETHIRD  = 1.0d0/3.0d0
        REAL*8,  PARAMETER :: THR8      = TINY(1.0d0)
-       REAL,    PARAMETER :: THR       = TINY(1.0) 
+       REAL,    PARAMETER :: THR       = TINY(1.0)
 !/
 !/ ------------------------------------------------------------------- /
 !/
 !
 ! local integer
 !
-         INTEGER :: IP, IE, IT, I1, I2, I3, I, ITH, IK    
+         INTEGER :: IP, IE, IT, I1, I2, I3, I, ITH, IK
          INTEGER :: IBI, NI(3)
 !
 ! local real
@@ -1329,31 +1329,31 @@
 
          REAL*8  :: KELEM(3,NTRI), FLALL(3,NTRI)
          REAL*8  :: KKSUM(NX), ST(NX), BETA
-         REAL*8  :: NM(NTRI) 
+         REAL*8  :: NM(NTRI)
 
 !/S      CALL STRACE (IENT, 'W3XYPFSFCT2')
 
 ! 1. initialisation
 
          ITH    = 1 + MOD(ISP-1,NTH)
-         IK     = 1 + (ISP-1)/NTH 
+         IK     = 1 + (ISP-1)/NTH
          DTMAXGL = DBLE(10.E10)
 !
-!2       Propagation 
+!2       Propagation
 !2.a     Calculate K-Values and contour based quantities ...
 !
-         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ... 
+         DO IE = 1, NTRI ! I precacalculate this arrays below as I assume that current velocity  changes continusly ...
            I1 = TRIGP(IE,1) ! Index of the Element Nodes (TRIGP)
            I2 = TRIGP(IE,2)
            I3 = TRIGP(IE,3)
            LAMBDA(1) = ONESIXTH *(C(I1,1)+C(I2,1)+C(I3,1)) ! Linearized advection speed in X and Y direction
            LAMBDA(2) = ONESIXTH *(C(I1,2)+C(I2,2)+C(I3,2))
-           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians 
+           KELEM(1,IE) = LAMBDA(1) * IEN(IE,1) + LAMBDA(2) * IEN(IE,2) ! K-Values - so called Flux Jacobians
            KELEM(2,IE) = LAMBDA(1) * IEN(IE,3) + LAMBDA(2) * IEN(IE,4)
            KELEM(3,IE) = LAMBDA(1) * IEN(IE,5) + LAMBDA(2) * IEN(IE,6)
            KTMP        = KELEM(:,IE) ! Copy
-           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values 
-           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration 
+           NM(IE)      = - 1.D0/MIN(-THR8,SUM(MIN(0.d0,KTMP))) ! N-Values
+           FL11  = C(I2,1) * IEN(IE,1) + C(I2,2) * IEN(IE,2) ! Weights for Simpson Integration
            FL12  = C(I3,1) * IEN(IE,1) + C(I3,2) * IEN(IE,2)
            FL21  = C(I3,1) * IEN(IE,3) + C(I3,2) * IEN(IE,4)
            FL22  = C(I1,1) * IEN(IE,3) + C(I1,2) * IEN(IE,4)
@@ -1376,7 +1376,7 @@
              NI = TRIGP(IE,:)
              KKSUM(NI) = KKSUM(NI) + KELEM(:,IE)
            END DO ! IE
-           DTMAXEXP = 1E10 ! initialize to large number 
+           DTMAXEXP = 1E10 ! initialize to large number
            DO IP = 1, NX
              DTMAXEXP = SI(IP)/MAX(DBLE(10.E-10),KKSUM(IP)*IOBDP(IP))
              DTMAXGL  = MIN( DTMAXGL, DTMAXEXP)
@@ -1392,7 +1392,7 @@
            END IF
          END IF ! LCALC
 
-         DT4AI = DBLE(DT)/DBLE(ITER(IK,ITH)) 
+         DT4AI = DBLE(DT)/DBLE(ITER(IK,ITH))
          DTSI(:)  = DT4AI/SI(:) ! Some precalculations for the time integration.
 
          U = AC
@@ -1403,8 +1403,8 @@
          DO IT = 1, ITER(IK,ITH)
 
            ST = 0.d0
-         
-           DO IE = 1, NTRI 
+
+           DO IE = 1, NTRI
               NI      = TRIGP(IE,:)
               UTMP    = U(NI)
               FT      =  - ONESIXTH*DOT_PRODUCT(UTMP,FLALL(:,IE))
@@ -1431,33 +1431,33 @@
               THETA_ACE(:,IE) = ((THETA_H(:,IE) - THETA_L(:,IE))) * DT4AI/SI(NI)
               ST(NI)          = ST(NI) + THETA_L(:,IE)*DT4AI/SI(NI)
             END DO
-         
+
 !            UL          = MAX(0.d0,U-ST)*DBLE(IOBPD(ITH,:))!*DBLE(IOBDP(:)) ... add for IOBDP dry/wet flag.
-         
+
             DO IP = 1,NX
               UL(IP) = MAX(0.d0,U(IP)-ST(IP))*DBLE(IOBPD(ITH,IP))
               END DO
-         
+
             USTARI(1,:) = MAX(UL,U)
             USTARI(2,:) = MIN(UL,U)
-         
+
             UIP = -THR8
             UIM =  THR8
             PP  = 0.d0
             PM  = 0.d0
-            DO IE = 1, NTRI 
+            DO IE = 1, NTRI
               NI = TRIGP(IE,:)
-              PP(NI)  = PP(NI) + MAX(  THR8, -THETA_ACE(:,IE)) 
-              PM(NI)  = PM(NI) + MIN( -THR8, -THETA_ACE(:,IE)) 
+              PP(NI)  = PP(NI) + MAX(  THR8, -THETA_ACE(:,IE))
+              PM(NI)  = PM(NI) + MIN( -THR8, -THETA_ACE(:,IE))
               UIP(NI) = MAX (UIP(NI), MAXVAL( USTARI(1,NI) ))
               UIM(NI) = MIN (UIM(NI), MINVAL( USTARI(2,NI) ))
             END DO
-         
+
             WII(1,:) = MIN(1.0d0,(UIP-UL)/MAX( THR8,PP))
             WII(2,:) = MIN(1.0d0,(UIM-UL)/MIN(-THR8,PM))
-         
+
             ST = 0.d0
-            DO IE = 1, NTRI 
+            DO IE = 1, NTRI
               DO I = 1, 3
                 IP = TRIGP(IE,I)
                 IF (-THETA_ACE(I,IE) .GE. 0.) THEN
@@ -1470,23 +1470,23 @@
               NI = TRIGP(IE,:)
               ST(NI) = ST(NI) + BETA * THETA_ACE(:,IE)
             END DO
-         
+
             DO IP = 1,NX
 !
-! IOBPD is the switch for removing energy coming from the shoreline 
+! IOBPD is the switch for removing energy coming from the shoreline
 !
-              U(IP) = MAX(0.d0,UL(IP)-ST(IP))*DBLE(IOBPD(ITH,IP)) 
-!/REF1               IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values 
+              U(IP) = MAX(0.d0,UL(IP)-ST(IP))*DBLE(IOBPD(ITH,IP))
+!/REF1               IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) U(IP)= AC(IP) ! restores reflected boundary values
                END DO
 !
-! update spectrum 
+! update spectrum
              AC = U
 !
-! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn) 
+! 4 Update boundaries: performs interpolation in time as done in rect grids (e.g. w3pro1md.ftn)
 !
              IF ( FLBPI ) THEN
 !
-! 4.1 In this case the boundary is read from the nest.ww3 file 
+! 4.1 In this case the boundary is read from the nest.ww3 file
 !
                RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
                RD2=RD20
@@ -1498,7 +1498,7 @@
                  RD2    = 1.
                  END IF
 !
-! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0) 
+! Overwrites only the incoming energy ( IOBPD(ITH,IP) = 0)
 !
                 DO IBI=1, NBI
                   IP = MAPSF(ISBPI(IBI),1)
@@ -1508,18 +1508,18 @@
 
               ENDIF
 !
-           END DO ! End of loop on time steps      
+           END DO ! End of loop on time steps
 !      CALL EXTCDE ( 99 )
 !/
 !/ End of W3XYPFSN ----------------------------------------------------- /
 !/
-      END SUBROUTINE W3XYPFSFCT2 
+      END SUBROUTINE W3XYPFSFCT2
 !/ ------------------------------------------------------------------- /
       SUBROUTINE SETDEPTH
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1590,8 +1590,8 @@
      END SUBROUTINE
 
 !/ ------------------------------------------------------------------- /
-        
-END MODULE W3PROFSMD 
+
+END MODULE W3PROFSMD
 
 
 !--------------------------------------------------------------------------
@@ -1649,7 +1649,7 @@ END MODULE W3PROFSMD
 !       BCGSTAB == 8 * n
 !       TFQMR   == 11 * n
 !       FOM     == (n+3)*(m+2) + (m+1)*m/2 (m = ipar(5), default m=15)
-!       GMRES   == (n+3)*(m+2) + (m+1)*m/2 (m = ipar(5), default m=15) 
+!       GMRES   == (n+3)*(m+2) + (m+1)*m/2 (m = ipar(5), default m=15)
 !          GMRES is no longer available
 !       FGMRES  == 2*n*(m+1) + (m+1)*m/2 + 3*m + 2 (m = ipar(5),
 !                  default m=15)
@@ -2289,7 +2289,7 @@ END MODULE W3PROFSMD
 
       integer   :: k,np,n,npm1,j,ju,indp,lbp
       real*8    :: p(n,lbp), y(*), u(*), usav(*), x, flops
-      
+
 !-----------------------------------------------------------------------
 !     updates the conjugate directions p given the upper part of the
 !     banded upper triangular matrix u.  u contains the non zero
@@ -2434,7 +2434,7 @@ END MODULE W3PROFSMD
       parameter(zero=0.0D0)
 !
       if (ipar(12).ne.0) then
-         ipar(1) = ipar(12) 
+         ipar(1) = ipar(12)
       else if (ipar(1).gt.0) then
          if ((ipar(3).eq.999 .and. ipar(11).eq.1) .or. &
      &        fpar(6).le.fpar(4)) then
@@ -2445,7 +2445,7 @@ END MODULE W3PROFSMD
             ipar(1) = -10
          endif
       endif
-      if (fpar(3).gt.zero .and. fpar(6).gt.zero .and. ipar(7).gt.ipar(13)) then 
+      if (fpar(3).gt.zero .and. fpar(6).gt.zero .and. ipar(7).gt.ipar(13)) then
         fpar(7) = log10(fpar(3) / fpar(6)) / dble(ipar(7)-ipar(13))
       else
          fpar(7) = zero
@@ -2667,7 +2667,7 @@ END MODULE W3PROFSMD
 !
       nrm1 = sqrt(ddot(n,vec(1,ind),vec(1,ind)))
       ops = ops + n + n
-      hh(ind) = nrm1    ! statement label 75 
+      hh(ind) = nrm1    ! statement label 75
       if (nrm1.le.zero) then
          ierr = -3
          return
@@ -2720,12 +2720,12 @@ END MODULE W3PROFSMD
 !----------------------------------------------------------------------c
 ! 1)     M A T R I X    B Y    V E C T O R     P R O D U C T S         c
 !----------------------------------------------------------------------c
-      subroutine amux (n, x, y, a,ja,ia) 
-      real*8  x(*), y(*), a(*) 
+      subroutine amux (n, x, y, a,ja,ia)
+      real*8  x(*), y(*), a(*)
       integer n, ja(*), ia(*)
 !-----------------------------------------------------------------------
 !         A times a vector
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! multiplies a matrix by a vector using the dot product form
 ! Matrix A is stored in compressed sparse row storage.
 !
@@ -2750,13 +2750,13 @@ END MODULE W3PROFSMD
       do 100 i = 1,n
 !
 !     compute the inner product of row i with vector x
-! 
+!
          t = 0.0d0
          do 99 k=ia(i), ia(i+1)-1
             t = t + a(k)*x(ja(k))
  99      continue
 !
-!     store result in y(i) 
+!     store result in y(i)
 !
          y(i) = t
  100  continue
@@ -2809,11 +2809,11 @@ END MODULE W3PROFSMD
       end
 !-----------------------------------------------------------------------
       subroutine atmux (n, x, y, a, ja, ia)
-      real*8 x(*), y(*), a(*) 
+      real*8 x(*), y(*), a(*)
       integer n, ia(*), ja(*)
 !-----------------------------------------------------------------------
 !         transp( A ) times a vector
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! multiplies the transpose of a matrix by a vector when the original
 ! matrix is stored in compressed sparse row storage. Can also be
 ! viewed as the product of a matrix by a vector when the original
@@ -2833,13 +2833,13 @@ END MODULE W3PROFSMD
 ! y     = real array of length n, containing the product y=transp(A)*x
 !
 !-----------------------------------------------------------------------
-!     local variables 
+!     local variables
 !
-      integer i, k 
+      integer i, k
 !-----------------------------------------------------------------------
 !
 !     zero out output vector
-! 
+!
       do 1 i=1,n
          y(i) = 0.0
  1    continue
@@ -2847,24 +2847,24 @@ END MODULE W3PROFSMD
 ! loop over the rows
 !
       do 100 i = 1,n
-         do 99 k=ia(i), ia(i+1)-1 
+         do 99 k=ia(i), ia(i+1)-1
             y(ja(k)) = y(ja(k)) + x(i)*a(k)
  99      continue
  100  continue
 !
       return
-!-------------end-of-atmux---------------------------------------------- 
+!-------------end-of-atmux----------------------------------------------
 !-----------------------------------------------------------------------
       end
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
       subroutine atmuxr (m, n, x, y, a, ja, ia)
-      real*8 x(*), y(*), a(*) 
+      real*8 x(*), y(*), a(*)
       integer m, n, ia(*), ja(*)
 !-----------------------------------------------------------------------
 !         transp( A ) times a vector, A can be rectangular
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! See also atmux.  The essential difference is how the solution vector
-! is initially zeroed.  If using this to multiply rectangular CSC 
+! is initially zeroed.  If using this to multiply rectangular CSC
 ! matrices by a vector, m number of rows, n is number of columns.
 !-----------------------------------------------------------------------
 !
@@ -2882,13 +2882,13 @@ END MODULE W3PROFSMD
 ! y     = real array of length n, containing the product y=transp(A)*x
 !
 !-----------------------------------------------------------------------
-!     local variables 
+!     local variables
 !
-      integer i, k 
+      integer i, k
 !-----------------------------------------------------------------------
 !
 !     zero out output vector
-! 
+!
       do 1 i=1,m
          y(i) = 0.0
  1    continue
@@ -2896,26 +2896,26 @@ END MODULE W3PROFSMD
 ! loop over the rows
 !
       do 100 i = 1,n
-         do 99 k=ia(i), ia(i+1)-1 
+         do 99 k=ia(i), ia(i+1)-1
             y(ja(k)) = y(ja(k)) + x(i)*a(k)
  99      continue
  100  continue
 !
       return
-!-------------end-of-atmuxr--------------------------------------------- 
+!-------------end-of-atmuxr---------------------------------------------
 !-----------------------------------------------------------------------
       end
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
       subroutine amuxe (n,x,y,na,ncol,a,ja)
         implicit none
 
       integer     :: n, na, ncol, ja(na,*)
       real*8      :: x(n), y(n), a(na,*)
-      
+
 !-----------------------------------------------------------------------
-!        A times a vector in Ellpack Itpack format (ELL)               
-!----------------------------------------------------------------------- 
-! multiplies a matrix by a vector when the original matrix is stored 
+!        A times a vector in Ellpack Itpack format (ELL)
+!-----------------------------------------------------------------------
+! multiplies a matrix by a vector when the original matrix is stored
 ! in the ellpack-itpack sparse format.
 !-----------------------------------------------------------------------
 !
@@ -2930,7 +2930,7 @@ END MODULE W3PROFSMD
 !         (i.e., the number of generalized diagonals in matrix.)
 ! a, ja = the real and integer arrays of the itpack format
 !         (a(i,k),k=1,ncol contains the elements of row i in matrix
-!          ja(i,k),k=1,ncol contains their column numbers) 
+!          ja(i,k),k=1,ncol contains their column numbers)
 !
 ! on return:
 !-----------
@@ -2939,10 +2939,10 @@ END MODULE W3PROFSMD
 !-----------------------------------------------------------------------
 ! local variables
 !
-      integer i, j 
+      integer i, j
 !-----------------------------------------------------------------------
       do 1 i=1, n
-         y(i) = 0.0 
+         y(i) = 0.0
  1    continue
       do 10 j=1,ncol
          do 25 i = 1,n
@@ -2951,17 +2951,17 @@ END MODULE W3PROFSMD
  10   continue
 !
       return
-!--------end-of-amuxe--------------------------------------------------- 
+!--------end-of-amuxe---------------------------------------------------
 !-----------------------------------------------------------------------
       end
 !-----------------------------------------------------------------------
-      subroutine amuxd (n,x,y,diag,ndiag,idiag,ioff) 
-      integer n, ndiag, idiag, ioff(idiag) 
+      subroutine amuxd (n,x,y,diag,ndiag,idiag,ioff)
+      integer n, ndiag, idiag, ioff(idiag)
       real*8 x(n), y(n), diag(ndiag,idiag)
 !-----------------------------------------------------------------------
-!        A times a vector in Diagonal storage format (DIA) 
-!----------------------------------------------------------------------- 
-! multiplies a matrix by a vector when the original matrix is stored 
+!        A times a vector in Diagonal storage format (DIA)
+!-----------------------------------------------------------------------
+! multiplies a matrix by a vector when the original matrix is stored
 ! in the diagonal storage format.
 !-----------------------------------------------------------------------
 !
@@ -2976,7 +2976,7 @@ END MODULE W3PROFSMD
 ! diag   = real array containing the diagonals stored of A.
 ! idiag  = number of diagonals in matrix.
 ! diag   = real array of size (ndiag x idiag) containing the diagonals
-!          
+!
 ! ioff   = integer array of length idiag, containing the offsets of the
 !          diagonals of the matrix:
 !          diag(i,k) contains the element a(i,i+ioff(k)) of the matrix.
@@ -2986,9 +2986,9 @@ END MODULE W3PROFSMD
 ! y     = real array of length n, containing the product y=A*x
 !
 !-----------------------------------------------------------------------
-!       local variables 
+!       local variables
 !
-      integer j, k, io, i1, i2 
+      integer j, k, io, i1, i2
 !-----------------------------------------------------------------------
       do 1 j=1, n
          y(j) = 0.0d0
@@ -2997,11 +2997,11 @@ END MODULE W3PROFSMD
          io = ioff(j)
          i1 = max0(1,1-io)
          i2 = min0(n,n-io)
-         do 9 k=i1, i2  
+         do 9 k=i1, i2
             y(k) = y(k)+diag(k,j)*x(k+io)
  9       continue
  10   continue
-! 
+!
       return
 !----------end-of-amuxd-------------------------------------------------
 !-----------------------------------------------------------------------
@@ -3011,9 +3011,9 @@ END MODULE W3PROFSMD
       integer n, jdiag, ja(*), ia(*)
       real*8 x(n), y(n), a(*)
 !-----------------------------------------------------------------------
-!        A times a vector in Jagged-Diagonal storage format (JAD) 
-!----------------------------------------------------------------------- 
-! multiplies a matrix by a vector when the original matrix is stored 
+!        A times a vector in Jagged-Diagonal storage format (JAD)
+!-----------------------------------------------------------------------
+! multiplies a matrix by a vector when the original matrix is stored
 ! in the jagged diagonal storage format.
 !-----------------------------------------------------------------------
 !
@@ -3024,8 +3024,8 @@ END MODULE W3PROFSMD
 !         the A matrix.
 ! jdiag  = integer. The number of jadded-diagonals in the data-structure.
 ! a      = real array containing the jadded diagonals of A stored
-!          in succession (in decreasing lengths) 
-! j      = integer array containing the colum indices of the 
+!          in succession (in decreasing lengths)
+! j      = integer array containing the colum indices of the
 !          corresponding elements in a.
 ! ia     = integer array containing the lengths of the  jagged diagonals
 !
@@ -3034,16 +3034,16 @@ END MODULE W3PROFSMD
 ! y      = real array of length n, containing the product y=A*x
 !
 ! Note:
-!------- 
+!-------
 ! Permutation related to the JAD format is not performed.
 ! this can be done by:
-!     call permvec (n,y,y,iperm) 
+!     call permvec (n,y,y,iperm)
 ! after the call to amuxj, where iperm is the permutation produced
 ! by csrjad.
 !-----------------------------------------------------------------------
-! local variables 
+! local variables
 !
-      integer i, ii, k1, ilen, j 
+      integer i, ii, k1, ilen, j
 !-----------------------------------------------------------------------
       do 1 i=1, n
          y(i) = 0.0d0
@@ -3052,12 +3052,12 @@ END MODULE W3PROFSMD
          k1 = ia(ii)-1
          ilen = ia(ii+1)-k1-1
          do 60 j=1,ilen
-            y(j)= y(j)+a(k1+j)*x(ja(k1+j)) 
+            y(j)= y(j)+a(k1+j)*x(ja(k1+j))
  60      continue
  70   continue
 !
       return
-!----------end-of-amuxj------------------------------------------------- 
+!----------end-of-amuxj-------------------------------------------------
 !-----------------------------------------------------------------------
       end
 !-----------------------------------------------------------------------
@@ -3116,85 +3116,85 @@ END MODULE W3PROFSMD
 ! 2)     T R I A N G U L A R    S Y S T E M    S O L U T I O N S       c
 !----------------------------------------------------------------------c
       subroutine lsol (n,x,y,al,jal,ial)
-      integer n, jal(*),ial(n+1) 
-      real*8  x(n), y(n), al(*) 
+      integer n, jal(*),ial(n+1)
+      real*8  x(n), y(n), al(*)
 !-----------------------------------------------------------------------
 !   solves    L x = y ; L = lower unit triang. /  CSR format
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
 ! solves a unit lower triangular system by standard (sequential )
-! forward elimination - matrix stored in CSR format. 
+! forward elimination - matrix stored in CSR format.
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right side.
 !
 ! al,
 ! jal,
 ! ial,    = Lower triangular matrix stored in compressed sparse row
-!          format. 
+!          format.
 !
 ! On return:
-!----------- 
+!-----------
 !          x  = The solution of  L x  = y.
 !--------------------------------------------------------------------
-! local variables 
+! local variables
 !
-      integer k, j 
+      integer k, j
       real*8  t
 !-----------------------------------------------------------------------
-      x(1) = y(1) 
+      x(1) = y(1)
       do 150 k = 2, n
-         t = y(k) 
+         t = y(k)
          do 100 j = ial(k), ial(k+1)-1
             t = t-al(j)*x(jal(j))
  100     continue
-         x(k) = t 
+         x(k) = t
  150  continue
 !
       return
-!----------end-of-lsol-------------------------------------------------- 
+!----------end-of-lsol--------------------------------------------------
 !-----------------------------------------------------------------------
       end
-!----------------------------------------------------------------------- 
-      subroutine ldsol (n,x,y,al,jal) 
-      integer n, jal(*) 
-      real*8 x(n), y(n), al(*) 
-!----------------------------------------------------------------------- 
-!     Solves L x = y    L = triangular. MSR format 
 !-----------------------------------------------------------------------
-! solves a (non-unit) lower triangular system by standard (sequential) 
-! forward elimination - matrix stored in MSR format 
+      subroutine ldsol (n,x,y,al,jal)
+      integer n, jal(*)
+      real*8 x(n), y(n), al(*)
+!-----------------------------------------------------------------------
+!     Solves L x = y    L = triangular. MSR format
+!-----------------------------------------------------------------------
+! solves a (non-unit) lower triangular system by standard (sequential)
+! forward elimination - matrix stored in MSR format
 ! with diagonal elements already inverted (otherwise do inversion,
 ! al(1:n) = 1.0/al(1:n),  before calling ldsol).
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right hand side.
 !
 ! al,
-! jal,   = Lower triangular matrix stored in Modified Sparse Row 
-!          format. 
+! jal,   = Lower triangular matrix stored in Modified Sparse Row
+!          format.
 !
 ! On return:
-!----------- 
+!-----------
 !        x = The solution of  L x = y .
 !--------------------------------------------------------------------
-! local variables 
+! local variables
 !
-      integer k, j 
-      real*8 t 
+      integer k, j
+      real*8 t
 !-----------------------------------------------------------------------
-      x(1) = y(1)*al(1) 
+      x(1) = y(1)*al(1)
       do 150 k = 2, n
-         t = y(k) 
+         t = y(k)
          do 100 j = jal(k), jal(k+1)-1
             t = t - al(j)*x(jal(j))
  100     continue
-         x(k) = al(k)*t 
+         x(k) = al(k)*t
  150  continue
       return
 !----------end-of-ldsol-------------------------------------------------
@@ -3202,63 +3202,63 @@ END MODULE W3PROFSMD
       end
 !-----------------------------------------------------------------------
       subroutine lsolc (n,x,y,al,jal,ial)
-      integer n, jal(*),ial(*) 
-      real*8  x(n), y(n), al(*) 
+      integer n, jal(*),ial(*)
+      real*8  x(n), y(n), al(*)
 !-----------------------------------------------------------------------
 !       SOLVES     L x = y ;    where L = unit lower trang. CSC format
 !-----------------------------------------------------------------------
 ! solves a unit lower triangular system by standard (sequential )
-! forward elimination - matrix stored in CSC format. 
+! forward elimination - matrix stored in CSC format.
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real*8 array containg the right side.
 !
 ! al,
 ! jal,
-! ial,    = Lower triangular matrix stored in compressed sparse column 
-!          format. 
+! ial,    = Lower triangular matrix stored in compressed sparse column
+!          format.
 !
 ! On return:
-!----------- 
+!-----------
 !         x  = The solution of  L x  = y.
 !-----------------------------------------------------------------------
-! local variables 
+! local variables
 !
       integer k, j
       real*8 t
 !-----------------------------------------------------------------------
       do 140 k=1,n
-         x(k) = y(k) 
+         x(k) = y(k)
  140  continue
       do 150 k = 1, n-1
-         t = x(k) 
+         t = x(k)
          do 100 j = ial(k), ial(k+1)-1
-            x(jal(j)) = x(jal(j)) - t*al(j) 
+            x(jal(j)) = x(jal(j)) - t*al(j)
  100     continue
  150  continue
 !
       return
-!----------end-of-lsolc------------------------------------------------- 
+!----------end-of-lsolc-------------------------------------------------
 !-----------------------------------------------------------------------
       end
 !-----------------------------------------------------------------------
-      subroutine ldsolc (n,x,y,al,jal) 
+      subroutine ldsolc (n,x,y,al,jal)
       integer n, jal(*)
       real*8 x(n), y(n), al(*)
 !-----------------------------------------------------------------------
-!    Solves     L x = y ;    L = nonunit Low. Triang. MSC format 
-!----------------------------------------------------------------------- 
-! solves a (non-unit) lower triangular system by standard (sequential) 
-! forward elimination - matrix stored in Modified Sparse Column format 
+!    Solves     L x = y ;    L = nonunit Low. Triang. MSC format
+!-----------------------------------------------------------------------
+! solves a (non-unit) lower triangular system by standard (sequential)
+! forward elimination - matrix stored in Modified Sparse Column format
 ! with diagonal elements already inverted (otherwise do inversion,
 ! al(1:n) = 1.0/al(1:n),  before calling ldsol).
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right hand side.
 !
@@ -3268,45 +3268,45 @@ END MODULE W3PROFSMD
 !           format.
 !
 ! On return:
-!----------- 
+!-----------
 !         x = The solution of  L x = y .
 !--------------------------------------------------------------------
 ! local variables
 !
       integer k, j
-      real*8 t 
+      real*8 t
 !-----------------------------------------------------------------------
       do 140 k=1,n
-         x(k) = y(k) 
+         x(k) = y(k)
  140  continue
-      do 150 k = 1, n 
-         x(k) = x(k)*al(k) 
-         t = x(k) 
+      do 150 k = 1, n
+         x(k) = x(k)*al(k)
+         t = x(k)
          do 100 j = jal(k), jal(k+1)-1
-            x(jal(j)) = x(jal(j)) - t*al(j) 
+            x(jal(j)) = x(jal(j)) - t*al(j)
  100     continue
  150  continue
 !
       return
-!----------end-of-lsolc------------------------------------------------ 
+!----------end-of-lsolc------------------------------------------------
 !-----------------------------------------------------------------------
       end
-!-----------------------------------------------------------------------  
-      subroutine ldsoll (n,x,y,al,jal,nlev,lev,ilev) 
+!-----------------------------------------------------------------------
+      subroutine ldsoll (n,x,y,al,jal,nlev,lev,ilev)
       integer n, nlev, jal(*), ilev(nlev+1), lev(n)
       real*8 x(n), y(n), al(*)
 !-----------------------------------------------------------------------
-!    Solves L x = y    L = triangular. Uses LEVEL SCHEDULING/MSR format 
+!    Solves L x = y    L = triangular. Uses LEVEL SCHEDULING/MSR format
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right hand side.
 !
 ! al,
-! jal,   = Lower triangular matrix stored in Modified Sparse Row 
-!          format. 
+! jal,   = Lower triangular matrix stored in Modified Sparse Row
+!          format.
 ! nlev   = number of levels in matrix
 ! lev    = integer array of length n, containing the permutation
 !          that defines the levels in the level scheduling ordering.
@@ -3316,28 +3316,28 @@ END MODULE W3PROFSMD
 !          ordering.
 !
 ! On return:
-!----------- 
+!-----------
 !        x = The solution of  L x = y .
 !--------------------------------------------------------------------
       integer ii, jrow, i, k
-      real*8 t 
-!     
+      real*8 t
+!
 !     outer loop goes through the levels. (SEQUENTIAL loop)
-!     
+!
       do 150 ii=1, nlev
-!     
+!
 !     next loop executes within the same level. PARALLEL loop
-!     
-         do 100 i=ilev(ii), ilev(ii+1)-1 
+!
+         do 100 i=ilev(ii), ilev(ii+1)-1
             jrow = lev(i)
 !
 ! compute inner product of row jrow with x
-! 
-            t = y(jrow) 
-            do 130 k=jal(jrow), jal(jrow+1)-1 
+!
+            t = y(jrow)
+            do 130 k=jal(jrow), jal(jrow+1)-1
                t = t - al(k)*x(jal(k))
  130        continue
-            x(jrow) = t*al(jrow) 
+            x(jrow) = t*al(jrow)
  100     continue
  150  continue
       return
@@ -3345,150 +3345,150 @@ END MODULE W3PROFSMD
       end
 !-----------------------------------------------------------------------
       subroutine usol (n,x,y,au,jau,iau)
-      integer n, jau(*),iau(n+1) 
-      real*8  x(n), y(n), au(*) 
-!----------------------------------------------------------------------- 
-!             Solves   U x = y    U = unit upper triangular. 
+      integer n, jau(*),iau(n+1)
+      real*8  x(n), y(n), au(*)
+!-----------------------------------------------------------------------
+!             Solves   U x = y    U = unit upper triangular.
 !-----------------------------------------------------------------------
 ! solves a unit upper triangular system by standard (sequential )
-! backward elimination - matrix stored in CSR format. 
+! backward elimination - matrix stored in CSR format.
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right side.
 !
 ! au,
 ! jau,
 ! iau,    = Lower triangular matrix stored in compressed sparse row
-!          format. 
+!          format.
 !
 ! On return:
-!----------- 
-!         x = The solution of  U x = y . 
-!-------------------------------------------------------------------- 
-! local variables 
+!-----------
+!         x = The solution of  U x = y .
+!--------------------------------------------------------------------
+! local variables
 !
-      integer k, j 
+      integer k, j
       real*8  t
 !-----------------------------------------------------------------------
-      x(n) = y(n) 
-      do 150 k = n-1,1,-1 
-         t = y(k) 
+      x(n) = y(n)
+      do 150 k = n-1,1,-1
+         t = y(k)
          do 100 j = iau(k), iau(k+1)-1
             t = t - au(j)*x(jau(j))
  100     continue
-         x(k) = t 
+         x(k) = t
  150  continue
 !
       return
-!----------end-of-usol-------------------------------------------------- 
+!----------end-of-usol--------------------------------------------------
 !-----------------------------------------------------------------------
       end
-!----------------------------------------------------------------------- 
-      subroutine udsol (n,x,y,au,jau) 
-      integer n, jau(*) 
-      real*8  x(n), y(n),au(*) 
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
+      subroutine udsol (n,x,y,au,jau)
+      integer n, jau(*)
+      real*8  x(n), y(n),au(*)
+!-----------------------------------------------------------------------
 !             Solves   U x = y  ;   U = upper triangular in MSR format
 !-----------------------------------------------------------------------
 ! solves a non-unit upper triangular matrix by standard (sequential )
-! backward elimination - matrix stored in MSR format. 
+! backward elimination - matrix stored in MSR format.
 ! with diagonal elements already inverted (otherwise do inversion,
 ! au(1:n) = 1.0/au(1:n),  before calling).
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real array containg the right side.
 !
 ! au,
 ! jau,    = Lower triangular matrix stored in modified sparse row
-!          format. 
+!          format.
 !
 ! On return:
-!----------- 
+!-----------
 !         x = The solution of  U x = y .
 !--------------------------------------------------------------------
-! local variables 
+! local variables
 !
       integer k, j
       real*8 t
 !-----------------------------------------------------------------------
       x(n) = y(n)*au(n)
       do 150 k = n-1,1,-1
-         t = y(k) 
+         t = y(k)
          do 100 j = jau(k), jau(k+1)-1
             t = t - au(j)*x(jau(j))
  100     continue
-         x(k) = au(k)*t 
+         x(k) = au(k)*t
  150  continue
 !
       return
 !----------end-of-udsol-------------------------------------------------
 !-----------------------------------------------------------------------
       end
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
       subroutine usolc (n,x,y,au,jau,iau)
-      real*8  x(*), y(*), au(*) 
+      real*8  x(*), y(*), au(*)
       integer n, jau(*),iau(*)
 !-----------------------------------------------------------------------
 !       SOUVES     U x = y ;    where U = unit upper trang. CSC format
 !-----------------------------------------------------------------------
 ! solves a unit upper triangular system by standard (sequential )
-! forward elimination - matrix stored in CSC format. 
+! forward elimination - matrix stored in CSC format.
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real*8 array containg the right side.
 !
 ! au,
 ! jau,
-! iau,    = Uower triangular matrix stored in compressed sparse column 
-!          format. 
+! iau,    = Uower triangular matrix stored in compressed sparse column
+!          format.
 !
 ! On return:
-!----------- 
+!-----------
 !         x  = The solution of  U x  = y.
 !-----------------------------------------------------------------------
-! local variables 
-!     
+! local variables
+!
       integer k, j
       real*8 t
 !-----------------------------------------------------------------------
       do 140 k=1,n
-         x(k) = y(k) 
+         x(k) = y(k)
  140  continue
       do 150 k = n,1,-1
-         t = x(k) 
+         t = x(k)
          do 100 j = iau(k), iau(k+1)-1
-            x(jau(j)) = x(jau(j)) - t*au(j) 
+            x(jau(j)) = x(jau(j)) - t*au(j)
  100     continue
  150  continue
 !
       return
-!----------end-of-usolc------------------------------------------------- 
+!----------end-of-usolc-------------------------------------------------
 !-----------------------------------------------------------------------
       end
 !-----------------------------------------------------------------------
-      subroutine udsolc (n,x,y,au,jau)   
-      integer n, jau(*) 
-      real*8 x(n), y(n), au(*)  
+      subroutine udsolc (n,x,y,au,jau)
+      integer n, jau(*)
+      real*8 x(n), y(n), au(*)
 !-----------------------------------------------------------------------
-!    Solves     U x = y ;    U = nonunit Up. Triang. MSC format 
-!----------------------------------------------------------------------- 
-! solves a (non-unit) upper triangular system by standard (sequential) 
-! forward elimination - matrix stored in Modified Sparse Column format 
+!    Solves     U x = y ;    U = nonunit Up. Triang. MSC format
+!-----------------------------------------------------------------------
+! solves a (non-unit) upper triangular system by standard (sequential)
+! forward elimination - matrix stored in Modified Sparse Column format
 ! with diagonal elements already inverted (otherwise do inversion,
 ! auuuul(1:n) = 1.0/au(1:n),  before calling ldsol).
 !-----------------------------------------------------------------------
 !
 ! On entry:
-!---------- 
+!----------
 ! n      = integer. dimension of problem.
 ! y      = real*8 array containg the right hand side.
 !
@@ -3497,27 +3497,27 @@ END MODULE W3PROFSMD
 !          format.
 !
 ! On return:
-!----------- 
+!-----------
 !         x = The solution of  U x = y .
 !--------------------------------------------------------------------
-! local variables 
-! 
+! local variables
+!
       integer k, j
       real*8 t
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
       do 140 k=1,n
-         x(k) = y(k) 
+         x(k) = y(k)
  140  continue
       do 150 k = n,1,-1
-         x(k) = x(k)*au(k) 
-         t = x(k) 
+         x(k) = x(k)*au(k)
+         t = x(k)
          do 100 j = jau(k), jau(k+1)-1
-            x(jau(j)) = x(jau(j)) - t*au(j) 
+            x(jau(j)) = x(jau(j)) - t*au(j)
  100     continue
  150  continue
 !
       return
-!----------end-of-udsolc------------------------------------------------ 
+!----------end-of-udsolc------------------------------------------------
 !-----------------------------------------------------------------------
       end
 !-----------------------------------------------------------------------
@@ -3526,7 +3526,7 @@ END MODULE W3PROFSMD
 
         integer    :: n, jlu(*), ju(*)
         real*8     :: x(n), y(n), alu(*)
-        
+
 !-----------------------------------------------------------------------
         integer    :: i,k
 !
@@ -3549,12 +3549,12 @@ END MODULE W3PROFSMD
 !----------------end of lusol ------------------------------------------
         end
 !-----------------------------------------------------------------------
-        subroutine lutsol(n, y, x, alu, jlu, ju) 
+        subroutine lutsol(n, y, x, alu, jlu, ju)
           implicit none
 
         integer     :: n, jlu(*), ju(*)
         real*8      :: x(n), y(n), alu(*)
-        
+
 !-----------------------------------------------------------------------
 ! local variables
 !
@@ -3572,10 +3572,10 @@ END MODULE W3PROFSMD
               x(jlu(k)) = x(jlu(k)) - alu(k)* x(i)
  30        continue
  20     continue
-!     
+!
 !     backward solve (with L^T)
-!     
-        do 40 i = n, 1, -1 
+!
+        do 40 i = n, 1, -1
            do 50 k=jlu(i),ju(i)-1
               x(jlu(k)) = x(jlu(k)) - alu(k)*x(i)
  50        continue
@@ -3585,13 +3585,13 @@ END MODULE W3PROFSMD
 !----------------end of lutsol -----------------------------------------
 !-----------------------------------------------------------------------
          end
-!----------------------------------------------------------------------- 
+!-----------------------------------------------------------------------
         subroutine qsplit(a,ind,n,ncut)
           implicit none
 
         integer    :: n, ind(n), ncut
         real*8     :: a(n)
-        
+
 !-----------------------------------------------------------------------
 !     does a quick-sort split of a real array.
 !     on input a(1:n). is a real array
@@ -3729,8 +3729,8 @@ END MODULE W3PROFSMD
 !
       subroutine ilut(n,a,ja,ia,lfil,droptol,alu,jlu,ju,iwk,w,jw,ierr)
 !-----------------------------------------------------------------------
-      implicit none 
-      integer n 
+      implicit none
+      integer n
       real*8 a(*),alu(*),w(n+1),droptol
       integer ja(*),ia(n+1),jlu(*),ju(n),jw(2*n),lfil,iwk,ierr
 !----------------------------------------------------------------------*
@@ -3739,28 +3739,28 @@ END MODULE W3PROFSMD
 !----------------------------------------------------------------------*
 !     Author: Yousef Saad *May, 5, 1990, Latest revision, August 1996  *
 !----------------------------------------------------------------------*
-! PARAMETERS                                                           
-!-----------                                                           
+! PARAMETERS
+!-----------
 !
 ! on entry:
-!========== 
-! n       = integer. The row dimension of the matrix A. The matrix 
+!==========
+! n       = integer. The row dimension of the matrix A. The matrix
 !
-! a,ja,ia = matrix stored in Compressed Sparse Row format.              
+! a,ja,ia = matrix stored in Compressed Sparse Row format.
 !
 ! lfil    = integer. The fill-in parameter. Each row of L and each row
-!           of U will have a maximum of lfil elements (excluding the 
+!           of U will have a maximum of lfil elements (excluding the
 !           diagonal element). lfil must be .ge. 0.
 !           ** WARNING: THE MEANING OF LFIL HAS CHANGED WITH RESPECT TO
-!           EARLIER VERSIONS. 
+!           EARLIER VERSIONS.
 !
 ! droptol = real*8. Sets the threshold for dropping small terms in the
 !           factorization. See below for details on dropping strategy.
 !
-!  
+!
 ! iwk     = integer. The lengths of arrays alu and jlu. If the arrays
 !           are not big enough to store the ILU factorizations, ilut
-!           will stop with an error message. 
+!           will stop with an error message.
 !
 ! On return:
 !===========
@@ -3789,24 +3789,24 @@ END MODULE W3PROFSMD
 !=============
 ! jw      = integer work array of length 2*n.
 ! w       = real work array of length n+1.
-!  
+!
 !----------------------------------------------------------------------
-! w, ju (1:n) store the working array [1:ii-1 = L-part, ii:n = u] 
+! w, ju (1:n) store the working array [1:ii-1 = L-part, ii:n = u]
 ! jw(n+1:2n)  stores nonzero indicators
-! 
+!
 ! Notes:
 ! ------
 ! The diagonal elements of the input matrix must be  nonzero (at least
-! 'structurally'). 
+! 'structurally').
 !
-!----------------------------------------------------------------------* 
+!----------------------------------------------------------------------*
 !---- Dual drop strategy works as follows.                             *
 !                                                                      *
 !     1) Theresholding in L and U as set by droptol. Any element whose *
 !        magnitude is less than some tolerance (relative to the abs    *
 !        value of diagonal element in u) is dropped.                   *
 !                                                                      *
-!     2) Keeping only the largest lfil elements in the i-th row of L   * 
+!     2) Keeping only the largest lfil elements in the i-th row of L   *
 !        and the largest lfil elements in the i-th row of U (excluding *
 !        diagonal elements).                                           *
 !                                                                      *
@@ -3816,8 +3816,8 @@ END MODULE W3PROFSMD
 ! (however, fill-in is then mpredictible).                             *
 !----------------------------------------------------------------------*
 !     locals
-      integer ju0,k,j1,j2,j,ii,i,lenl,lenu,jj,jrow,jpos,lenn 
-      real*8 tnorm, t, abs, s, fact 
+      integer ju0,k,j1,j2,j,ii,i,lenl,lenu,jj,jrow,jpos,lenn
+      real*8 tnorm, t, abs, s, fact
       if (lfil .lt. 0) goto 998
 !-----------------------------------------------------------------------
 !     initialize ju0 (points to next element to be added to alu,jlu)
@@ -3826,7 +3826,7 @@ END MODULE W3PROFSMD
       ju0 = n+2
       jlu(1) = ju0
 !
-!     initialize nonzero indicator array. 
+!     initialize nonzero indicator array.
 !
       do 1 j=1,n
          jw(n+j)  = 0
@@ -3846,9 +3846,9 @@ END MODULE W3PROFSMD
          if (abs(tnorm) .lt. tiny(1.)) goto 999
 
          tnorm = tnorm/real(j2-j1+1)
-!     
-!     unpack L-part and U-part of row of A in arrays w 
-!     
+!
+!     unpack L-part and U-part of row of A in arrays w
+!
          lenu = 1
          lenl = 0
          jw(ii) = ii
@@ -3867,17 +3867,17 @@ END MODULE W3PROFSMD
                w(ii) = t
             else
                lenu = lenu+1
-               jpos = ii+lenu-1 
+               jpos = ii+lenu-1
                jw(jpos) = k
                w(jpos) = t
                jw(n+k) = jpos
             endif
  170     continue
          jj = 0
-         lenn = 0 
-!     
+         lenn = 0
+!
 !     eliminate previous rows
-!     
+!
  150     jj = jj+1
          if (jj .gt. lenl) goto 160
 !-----------------------------------------------------------------------
@@ -3886,9 +3886,9 @@ END MODULE W3PROFSMD
 !-----------------------------------------------------------------------
          jrow = jw(jj)
          k = jj
-!     
+!
 !     determine smallest column index
-!     
+!
          do 151 j=jj+1,lenl
             if (jw(j) .lt. jrow) then
                jrow = jw(j)
@@ -3911,14 +3911,14 @@ END MODULE W3PROFSMD
          endif
 !
 !     zero out element in row by setting jw(n+jrow) to zero.
-!     
+!
          jw(n+jrow) = 0
 !
 !     get the multiplier for row to be eliminated (jrow).
-!     
+!
          fact = w(jj)*alu(jrow)
          if (abs(fact) .le. droptol) goto 150
-!     
+!
 !     combine current row and row jrow
 !
          do 203 k = ju(jrow), jlu(jrow+1)-1
@@ -3926,13 +3926,13 @@ END MODULE W3PROFSMD
             j = jlu(k)
             jpos = jw(n+j)
             if (j .ge. ii) then
-!     
+!
 !     dealing with upper part.
-!     
+!
                if (jpos .eq. 0) then
 !
 !     this is a fill-in element
-!     
+!
                   lenu = lenu+1
                   if (lenu .gt. n) goto 995
                   i = ii+lenu-1
@@ -3941,78 +3941,78 @@ END MODULE W3PROFSMD
                   w(i) = - s
                else
 !
-!     this is not a fill-in element 
+!     this is not a fill-in element
 !
                   w(jpos) = w(jpos) - s
 
                endif
             else
-!     
+!
 !     dealing  with lower part.
-!     
+!
                if (jpos .eq. 0) then
 !
 !     this is a fill-in element
-!     
+!
                   lenl = lenl+1
                   if (lenl .gt. n) goto 995
                   jw(lenl) = j
                   jw(n+j) = lenl
                   w(lenl) = - s
                else
-!     
-!     this is not a fill-in element 
-!     
+!
+!     this is not a fill-in element
+!
                   w(jpos) = w(jpos) - s
                endif
             endif
  203     continue
-!     
+!
 !     store this pivot element -- (from left to right -- no danger of
-!     overlap with the working elements in L (pivots). 
-!     
-         lenn = lenn+1 
+!     overlap with the working elements in L (pivots).
+!
+         lenn = lenn+1
          w(lenn) = fact
          jw(lenn)  = jrow
          goto 150
  160     continue
-!     
+!
 !     reset double-pointer to zero (U-part)
-!     
+!
          do 308 k=1, lenu
             jw(n+jw(ii+k-1)) = 0
  308     continue
-!     
+!
 !     update L-matrix
-!     
-         lenl = lenn 
+!
+         lenl = lenn
          lenn = min0(lenl,lfil)
-!     
+!
 !     sort by quick-split
 !
          call qsplit (w,jw,lenl,lenn)
 !
 !     store L-part
-! 
-         do 204 k=1, lenn 
+!
+         do 204 k=1, lenn
             if (ju0 .gt. iwk) goto 996
             alu(ju0) =  w(k)
             jlu(ju0) =  jw(k)
             ju0 = ju0+1
  204     continue
-!     
+!
 !     save pointer to beginning of row ii of U
-!     
+!
          ju(ii) = ju0
 !
-!     update U-matrix -- first apply dropping strategy 
+!     update U-matrix -- first apply dropping strategy
 !
          lenn = 0
          do k=1, lenu-1
-            if (abs(w(ii+k)) .gt. droptol*tnorm) then 
+            if (abs(w(ii+k)) .gt. droptol*tnorm) then
                lenn = lenn+1
-               w(ii+lenn) = w(ii+k) 
-               jw(ii+lenn) = jw(ii+k) 
+               w(ii+lenn) = w(ii+k)
+               jw(ii+lenn) = jw(ii+k)
             endif
          enddo
          lenu = lenn+1
@@ -4021,25 +4021,25 @@ END MODULE W3PROFSMD
          call qsplit (w(ii+1), jw(ii+1), lenu-1,lenn)
 !
 !     copy
-! 
+!
          t = abs(w(ii))
          if (lenn + ju0 .gt. iwk) goto 997
-         do 302 k=ii+1,ii+lenn-1 
+         do 302 k=ii+1,ii+lenn-1
             jlu(ju0) = jw(k)
             alu(ju0) = w(k)
             t = t + abs(w(k) )
             ju0 = ju0+1
  302     continue
-!     
+!
 !     store inverse of diagonal element of u
-!     
+!
 !2do check if it works ... after correction ...
          if (abs(w(ii)) .lt.  tiny(1.d0)) w(ii) = (0.0001d0 + droptol)*tnorm
-!     
-         alu(ii) = 1.0d0/ w(ii) 
-!     
+!
+         alu(ii) = 1.0d0/ w(ii)
+!
 !     update pointer to beginning of next row of U.
-!     
+!
          jlu(ii+1) = ju0
 !-----------------------------------------------------------------------
 !     end main loop
@@ -4049,27 +4049,27 @@ END MODULE W3PROFSMD
       return
 !
 !     incomprehensible error. Matrix must be wrong.
-!     
+!
  995  ierr = -1
       return
-!     
+!
 !     insufficient storage in L.
-!     
+!
  996  ierr = -2
       return
-!     
+!
 !     insufficient storage in U.
-!     
+!
  997  ierr = -3
       return
-!     
+!
 !     illegal lfil entered.
-!     
+!
  998  ierr = -4
       return
-!     
+!
 !     zero row encountered
-!     
+!
  999  ierr = -5
       return
 !----------------end-of-ilut--------------------------------------------
@@ -4391,7 +4391,7 @@ END MODULE W3PROFSMD
  999   continue
        ierr = -1
        return
-!--------------------------------------------------------------------- 
+!---------------------------------------------------------------------
        end
 !-----------------------------------------------------------------------
 

--- a/model/ftn/w3profsmd_pdlib.ftn
+++ b/model/ftn/w3profsmd_pdlib.ftn
@@ -4,7 +4,7 @@
       MODULE PDLIB_W3PROFSMD
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -14,44 +14,44 @@
 !/
 !/    01-June-2016 : Origination                        ( version 6.04 )
 !/
-!  1. Purpose : PDLIB version of UGTYPE including fully implicit 
-!               discretization. This works is based on the thesis 
-!               of Roland, 2008 and represents the continues 
-!               development of the solution of the WAE on unstructured 
-!               grids. Following the quest since one decade we 
-!               continuesly improve the aplicability and robustness of 
-!               the source code and the methods. The development and 
-!               implementation of the involved schemes was funded over 
+!  1. Purpose : PDLIB version of UGTYPE including fully implicit
+!               discretization. This works is based on the thesis
+!               of Roland, 2008 and represents the continues
+!               development of the solution of the WAE on unstructured
+!               grids. Following the quest since one decade we
+!               continuesly improve the aplicability and robustness of
+!               the source code and the methods. The development and
+!               implementation of the involved schemes was funded over
 !               the past decade by IFREMER, SHOM, USACE, NCEP/NOAA,
 !               BGS IT&E GmbH, Zanke & Partner and Roland & Partner.
-!               The PDLIB (Parallel Decomposition Library) library, 
+!               The PDLIB (Parallel Decomposition Library) library,
 !               which is used here is courtesy to BGS IT&E GmbH and
-!               has it's own license, which is the same as WW3. As of 
-!               the origin of the methods, ideas and source code. This 
+!               has it's own license, which is the same as WW3. As of
+!               the origin of the methods, ideas and source code. This
 !               code was 1st developed in the WWM-III (Roland, 2008) and
 !               the ported to WW3. This is true for all source code
-!               related to UGTYPE. 
-!             
+!               related to UGTYPE.
 !
-!  2. Method :  We apply here the framework of Residual Distributions 
-!               schemes for hyperbolic problems for nonlinear propagation 
-!               laws based on the work of Richiuotto et al. 2005. 
+!
+!  2. Method :  We apply here the framework of Residual Distributions
+!               schemes for hyperbolic problems for nonlinear propagation
+!               laws based on the work of Richiuotto et al. 2005.
 !               We supply the N-scheme, PSI-scheme and Lax-FCT-scheme
 !               as explicit methods ranging from 1st order time space
 !               to most optimal PSI method up to 2nd order Lax-FCT-scheme.
-!               For the implicit implementation we used up to now ONLY 
+!               For the implicit implementation we used up to now ONLY
 !               the N-Scheme. Higher order schemes are up to now rather
-!               a research feature than for practical application. The 
-!               reason is given in Cavalleri et al. 2018, we do not 
-!               resolve enough physics in order to be able to run 
-!               2nd or even higher order schemes. 
-!               Use the numerical schemes with the needed care and 
-!               do proper convergence analysis on the time step and 
-!               grid size as well as solver threshold depedency. 
-!               Think about the time and spatial scales of your 
-!               u r intending to resolve! Multiscale modelling needs 
-!               much work on the side of the modeler and much more 
-!               time for the grid generation and the validation of the 
+!               a research feature than for practical application. The
+!               reason is given in Cavalleri et al. 2018, we do not
+!               resolve enough physics in order to be able to run
+!               2nd or even higher order schemes.
+!               Use the numerical schemes with the needed care and
+!               do proper convergence analysis on the time step and
+!               grid size as well as solver threshold depedency.
+!               Think about the time and spatial scales of your
+!               u r intending to resolve! Multiscale modelling needs
+!               much work on the side of the modeler and much more
+!               time for the grid generation and the validation of the
 !               final model
 !
 !  3. Parameters :
@@ -122,7 +122,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -132,7 +132,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Setup boundary pointer 
+!  1. Purpose : Setup boundary pointer
 !  2. Method :
 !  3. Parameters :
 !
@@ -201,7 +201,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -357,7 +357,7 @@
 !/DEBUGSOLVER     FLUSH(740+IAPROC)
         !
         ! Map a point in (1:PDLIB_NSEAL) to a point in (1:NSEA)
-        ! 
+        !
         nb=0
         DO IX=1,NX
           IF (MAPFS(1,IX) .gt. 0) nb = nb + 1
@@ -448,7 +448,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -549,7 +549,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -561,7 +561,7 @@
 !/    10-Jan-2011 : Addition of implicit scheme         ( version 3.14.4 )
 !/    06-Feb-2014 : PDLIB parallelization
 !/
-!  1. Purpose : Explicit advection schemes driver 
+!  1. Purpose : Explicit advection schemes driver
 !
 !     Propagation in physical space for a given spectral component.
 !     Gives the choice of scheme on unstructured grid
@@ -600,7 +600,7 @@
 !       !/S     Enable subroutine tracing.
 !
 !
-! 10. Source code :     
+! 10. Source code :
 !/ ------------------------------------------------------------------- /
 !/
 !
@@ -651,14 +651,14 @@
 !
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Set constants
-!      
-      
-!/S      CALL STRACE (IENT, 'W3XYPUG')      
+!
+
+!/S      CALL STRACE (IENT, 'W3XYPUG')
 !/DEBUGSOLVER     WRITE(740+IAPROC,*) 'Begin of PDLIB_W3XYPUG'
 !/DEBUGSOLVER     FLUSH(740+IAPROC)
       ITH    = 1 + MOD(ISP-1,NTH)
       IK     = 1 + (ISP-1)/NTH
-   
+
       CCOS   = FACX * ECOS(ITH)
       CSIN   = FACY * ESIN(ITH)
       CCURX  = FACX
@@ -673,7 +673,7 @@
       CALL SETDEPTH_PDLIB
 !
 ! 2.  Calculate velocities ---------------- *
-! 
+!
       DO JSEA = 1, NSEAL
         IP      = JSEA
         IP_glob = iplg(IP)
@@ -777,7 +777,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -787,7 +787,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Explicit N-Scheme 
+!  1. Purpose : Explicit N-Scheme
 !  2. Method :
 !  3. Parameters :
 !
@@ -875,7 +875,7 @@
       REAL  :: LAMBDA(2), KTMP(3)
       REAL  :: KELEM(3,NE), FLALL(3,NE)
       REAL  :: KKSUM(npa), ST(npa)
-      REAL  :: NM(NE) 
+      REAL  :: NM(NE)
       INTEGER :: ISPROC, JSEA, IP_glob, ierr, IX
       REAL  :: eSumAC, sumAC, sumBPI0, sumBPIN, sumCG, sumCLATS
       LOGICAL :: testWrite
@@ -928,7 +928,7 @@
         KTMP        = KELEM(:,IE) ! Copy
         NM(IE)      = - 1.D0/MIN(-THR,SUM(MIN(ZERO,KTMP))) ! N-Values
         KELEM(:,IE) = MAX(ZERO,KTMP)
-        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration 
+        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration
         FL12  = C(I3,1) * PDLIB_IEN(1,IE) + C(I3,2) * PDLIB_IEN(2,IE)
         FL21  = C(I3,1) * PDLIB_IEN(3,IE) + C(I3,2) * PDLIB_IEN(4,IE)
         FL22  = C(I1,1) * PDLIB_IEN(3,IE) + C(I1,2) * PDLIB_IEN(4,IE)
@@ -1012,7 +1012,7 @@
         DO IP = 1, npa
           IP_glob=iplg(IP)
           U(IP) = MAX(ZERO,U(IP)-DTSI(IP)*ST(IP)*(1-IOBPA(IP_glob)))*DBLE(IOBPD(ITH,IP_glob))*IOBDP(IP_glob)
-!/REF1    IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP_glob).EQ.0.AND.IOBPA(IP_glob).EQ.0) U(IP) = AC(IP) ! restores reflected boundary values 
+!/REF1    IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP_glob).EQ.0.AND.IOBPA(IP_glob).EQ.0) U(IP) = AC(IP) ! restores reflected boundary values
          END DO
 !/DEBUGSOLVER     IF (testWrite) THEN
 !/DEBUGSOLVER       CALL SCAL_INTEGRAL_PRINT_R8(U, "U in loop")
@@ -1029,8 +1029,8 @@
 !
 ! 5 Update boundaries ... would be better to omit any if clause in this loop ...
 !   a possibility would be to use NBI = 0 when FLBPI is FALSE and loop on IBI whatever the value of NBI
-! 
-        IF ( FLBPI ) THEN 
+!
+        IF ( FLBPI ) THEN
           RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
           RD2=RD20
           IF ( RD2 .GT. 0.001 ) THEN
@@ -1082,7 +1082,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1127,7 +1127,7 @@
 !
       USE W3GDATMD, ONLY : NK, NTH, NX, &
                             IEN, CLATS, MAPSF, IOBPD, IOBP, IOBPA, NNZ, IOBDP
-      USE W3WDATMD, ONLY: TIME     
+      USE W3WDATMD, ONLY: TIME
       USE W3ADATMD, ONLY: CG, ITER, CFLXYMAX
       USE W3ODATMD, ONLY: NDSE, NDST, FLBPI, NBI, ISBPI, BBPI0, BBPIN
       USE W3TIMEMD, ONLY: DSEC21
@@ -1143,15 +1143,15 @@
       USE W3PARALL, ONLY : INIT_GET_JSEA_ISPROC
       USE W3PARALL, ONLY : ONESIXTH, THR, ZERO
       USE yowRankModule, ONLY : IPGL_npa
-      IMPLICIT NONE  
-     
+      IMPLICIT NONE
+
       INTEGER, INTENT(IN)    :: ISP  ! Actual Frequency/Wavenumber,
                                      ! actual Wave Direction
       REAL,    INTENT(IN)    :: DT   ! Time interval for which the
                                      ! advection should be computed
                                      ! for the given velocity field
       REAL,    INTENT(IN)    :: C(npa,2)  ! Velocity field in its
-                                          ! X- and Y- Components, 
+                                          ! X- and Y- Components,
       REAL,    INTENT(INOUT) :: AC(npa)   ! Wave Action before and
                                           ! after advection
       REAL,    INTENT(IN)    :: RD10, RD20   ! Time interpolation
@@ -1161,11 +1161,11 @@
                                         ! the max. Global Time step
 !/REF1       INTEGER(KIND=1)    :: IOBPDR(NX)
 !/S      INTEGER, SAVE           :: IENT = 0
-      INTEGER :: IP, IE, POS, IT, I1, I2, I3, I, J, ITH, IK    
+      INTEGER :: IP, IE, POS, IT, I1, I2, I3, I, J, ITH, IK
       INTEGER :: IBI, NI(3), JX
       INTEGER :: ISPROC, IP_glob, JSEA, ierr
       REAL    :: RD1, RD2
-      REAL  :: UTILDE 
+      REAL  :: UTILDE
       REAL  :: SUMTHETA
       REAL  :: FL1, FL2, FL3
       REAL  :: FT, CFLXY
@@ -1177,7 +1177,7 @@
       REAL  :: THETA_L(3), BET1(3), BETAHAT(3)
       REAL  :: KELEM(3,NE), FLALL(3,NE)
       REAL  :: KKSUM(npa), ST(npa)
-      REAL  :: NM(NE) 
+      REAL  :: NM(NE)
 !/S      CALL STRACE (IENT, 'W3XYPFSN')
       ITH    = 1 + MOD(ISP-1,NTH)
       IK     = 1 + (ISP-1)/NTH
@@ -1195,7 +1195,7 @@
         KTMP        = KELEM(:,IE) ! Copy
         NM(IE)      = - 1.D0/MIN(-THR,SUM(MIN(ZERO,KTMP))) ! N-Values
         KELEM(:,IE) = MAX(ZERO,KTMP)
-        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration 
+        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration
         FL12  = C(I3,1) * PDLIB_IEN(1,IE) + C(I3,2) * PDLIB_IEN(2,IE)
         FL21  = C(I3,1) * PDLIB_IEN(3,IE) + C(I3,2) * PDLIB_IEN(4,IE)
         FL22  = C(I1,1) * PDLIB_IEN(3,IE) + C(I1,2) * PDLIB_IEN(4,IE)
@@ -1269,7 +1269,7 @@
 !
 ! 5 Update boundaries ... this should be implemented differently ... it is better to omit any if clause in this loop ...
 !
-        IF ( FLBPI ) THEN 
+        IF ( FLBPI ) THEN
           RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
           RD2=RD20
           IF ( RD2 .GT. 0.001 ) THEN
@@ -1281,7 +1281,7 @@
           END IF
 !
 ! NB: this treatment of the open boundary (time interpolation) is different from
-! the constant boundary in the structured grids ... which restores the boundary 
+! the constant boundary in the structured grids ... which restores the boundary
 ! to the initial value: IF ( MAPSTA(IXY).EQ.2 ) VQ(IXY) = AQ(IXY)
 ! Why this difference ?
 !
@@ -1302,7 +1302,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1312,7 +1312,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Source code for parallel debugging 
+!  1. Purpose : Source code for parallel debugging
 !  2. Method :
 !  3. Parameters :
 !
@@ -1398,7 +1398,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1470,7 +1470,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1542,7 +1542,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1612,7 +1612,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1622,7 +1622,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Source code for parallel Debugging 
+!  1. Purpose : Source code for parallel Debugging
 !  2. Method :
 !  3. Parameters :
 !
@@ -1786,7 +1786,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1853,7 +1853,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1863,7 +1863,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Source code for parallel debugging 
+!  1. Purpose : Source code for parallel debugging
 !  2. Method :
 !  3. Parameters :
 !
@@ -1949,7 +1949,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2013,7 +2013,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2267,7 +2267,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2353,7 +2353,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2415,7 +2415,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2609,7 +2609,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2713,7 +2713,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2794,7 +2794,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2856,15 +2856,15 @@
       USE W3PARALL, ONLY : THR
       use yowExchangeModule, ONLY : PDLIB_exchange1DREAL
       USE yowRankModule, ONLY : IPGL_npa
-      IMPLICIT NONE  
-     
+      IMPLICIT NONE
+
       INTEGER, INTENT(IN)    :: ISP   ! Actual Frequency/Wavenumber,
                                       ! actual Wave Direction
       REAL,    INTENT(IN)    :: DT    ! Time intervall for which the
                                       ! advection should be computed
                                       ! for the given velocity field
       REAL,    INTENT(IN)    :: C(npa,2)   ! Velocity field in its
-                                           ! X- and Y- Components, 
+                                           ! X- and Y- Components,
       REAL,    INTENT(INOUT) :: AC(npa)    ! Wave Action before and after
                                            ! advection
       REAL,    INTENT(IN)    :: RD10, RD20  ! Time interpolation
@@ -2872,10 +2872,10 @@
                                             ! condition
       LOGICAL, INTENT(IN)    :: LCALC  ! Switch for the calculation of
                                        ! the max. Global Time step
-      INTEGER :: IP, IE, POS, IT, I1, I2, I3, I, J, ITH, IK    
+      INTEGER :: IP, IE, POS, IT, I1, I2, I3, I, J, ITH, IK
       INTEGER :: IBI, NI(3), JX
       REAL    :: RD1, RD2
-      REAL  :: UTILDE 
+      REAL  :: UTILDE
       REAL  :: SUMTHETA
       REAL  :: FL1, FL2, FL3
       REAL  :: FT, CFLXY
@@ -2890,7 +2890,7 @@
       REAL  :: PM(npa), PP(npa), UIM(npa), UIP(npa)
       REAL  :: KELEM(3,NE), FLALL(3,NE)
       REAL  :: KKSUM(npa), ST(npa), BETA
-      REAL  :: NM(NE) 
+      REAL  :: NM(NE)
       INTEGER :: ISproc, IP_glob, JSEA, ierr
       REAL  :: eScal
 !/REF1       INTEGER(KIND=1)    :: IOBPDR(NX)
@@ -2909,7 +2909,7 @@
         KELEM(3,IE) = LAMBDA(1) * PDLIB_IEN(5,IE) + LAMBDA(2) * PDLIB_IEN(6,IE)
         KTMP        = KELEM(:,IE) ! Copy
         NM(IE)      = - 1.D0/MIN(-THR,SUM(MIN(ZERO,KTMP))) ! N-Values
-        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration 
+        FL11  = C(I2,1) * PDLIB_IEN(1,IE) + C(I2,2) * PDLIB_IEN(2,IE) ! Weights for Simpson Integration
         FL12  = C(I3,1) * PDLIB_IEN(1,IE) + C(I3,2) * PDLIB_IEN(2,IE)
         FL21  = C(I3,1) * PDLIB_IEN(3,IE) + C(I3,2) * PDLIB_IEN(4,IE)
         FL22  = C(I1,1) * PDLIB_IEN(3,IE) + C(I1,2) * PDLIB_IEN(4,IE)
@@ -3019,7 +3019,7 @@
           ST(NI) = ST(NI) + BETA * THETA_ACE(:,IE)
         END DO
 !
-! IOBPD is the switch for removing energy coming from the shoreline 
+! IOBPD is the switch for removing energy coming from the shoreline
 !
         DO IP = 1,npa
           IP_glob=iplg(IP)
@@ -3030,7 +3030,7 @@
 !
 ! 5 Update open boundaries ... this should be implemented differently ... it is better to omit any if clause in this loop ...
 !
-        IF ( FLBPI ) THEN 
+        IF ( FLBPI ) THEN
           RD1=RD10 - DT * REAL(ITER(IK,ITH)-IT)/REAL(ITER(IK,ITH))
           RD2=RD20
           IF ( RD2 .GT. 0.001 ) THEN
@@ -3042,7 +3042,7 @@
           END IF
 !
 ! NB: this treatment of the open boundary (time interpolation) is different from
-! the constant boundary in the structured grids ... which restores the boundary 
+! the constant boundary in the structured grids ... which restores the boundary
 ! to the initial value: IF ( MAPSTA(IXY).EQ.2 ) VQ(IXY) = AQ(IXY)
 ! Why this difference ?
 !
@@ -3057,7 +3057,7 @@
         END IF
         CALL PDLIB_exchange1DREAL(AC)
         U = DBLE(AC)
-      END DO ! IT        
+      END DO ! IT
 !      CALL EXTCDE ( 99 )
 !/
 !/ End of W3XYPFSN --------------------------------------------------- /
@@ -3069,7 +3069,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3079,7 +3079,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Block Explicit N-Scheme 
+!  1. Purpose : Block Explicit N-Scheme
 !  2. Method :
 !  3. Parameters :
 !
@@ -3137,7 +3137,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3194,7 +3194,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3204,7 +3204,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Source code for parallel debugging 
+!  1. Purpose : Source code for parallel debugging
 !  2. Method :
 !  3. Parameters :
 !
@@ -3273,7 +3273,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3404,7 +3404,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3490,7 +3490,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3599,7 +3599,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3609,7 +3609,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Compute matrix coefficients for advection part  
+!  1. Purpose : Compute matrix coefficients for advection part
 !  2. Method :
 !  3. Parameters :
 !
@@ -3727,10 +3727,10 @@
         I2 = INE(2,IE)
         I3 = INE(3,IE)
         NI = INE(:,IE)
-        DO IS = 1, NSPEC 
+        DO IS = 1, NSPEC
           ITH    = 1 + MOD(IS-1,NTH)
           IK     = 1 + (IS-1)/NTH
-          CCOS   = FACX * ECOS(ITH)  
+          CCOS   = FACX * ECOS(ITH)
           CSIN   = FACY * ESIN(ITH)
           CXY(:,1) = CCOS * CG(IK,NI) / CLATS(NI)
           CXY(:,2) = CSIN * CG(IK,NI)
@@ -3760,7 +3760,7 @@
           NM(IS,IE) = 1.d0/MIN(-THR,SUM(KM))
         ENDDO
       END DO
- 
+
       J = 0
       DO IP = 1, npa
         IP_glob=iplg(IP)
@@ -3785,12 +3785,12 @@
             TMP3  =  DTK * NM(ISP,IE)
             IF (FSGEOADVECT) THEN
               ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03 + DTK - TMP3*DELTAL(POS,ISP,IE)
-              ASPAR_JAC(ISP,I2) = ASPAR_JAC(ISP,I2)                - TMP3*DELTAL(POS_TRICK(POS,1),ISP,IE) 
-              ASPAR_JAC(ISP,I3) = ASPAR_JAC(ISP,I3)                - TMP3*DELTAL(POS_TRICK(POS,2),ISP,IE) 
+              ASPAR_JAC(ISP,I2) = ASPAR_JAC(ISP,I2)                - TMP3*DELTAL(POS_TRICK(POS,1),ISP,IE)
+              ASPAR_JAC(ISP,I3) = ASPAR_JAC(ISP,I3)                - TMP3*DELTAL(POS_TRICK(POS,2),ISP,IE)
             ELSE
               ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03
             END IF
-            B_JAC(ISP,IP)=B_JAC(ISP,IP) + TRIA03 * VA(ISP,IP) * IOBDP(IP_glob) * IOBPD(ITH,IP_glob) 
+            B_JAC(ISP,IP)=B_JAC(ISP,IP) + TRIA03 * VA(ISP,IP) * IOBDP(IP_glob) * IOBPD(ITH,IP_glob)
           END DO
         END DO
       END DO
@@ -3809,7 +3809,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -3975,11 +3975,11 @@
             DTK    =  K1 * DTG * IOBDP(IP_glob) * IOBPD(ITH,IP_glob) * (1-IOBPA(IP_glob))
             TMP3   =  DTK * NM
             IF (FSGEOADVECT) THEN
-              ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03 + DTK - TMP3*DELTAL(POS) 
+              ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03 + DTK - TMP3*DELTAL(POS)
               ASPAR_JAC(ISP,I2) = ASPAR_JAC(ISP,I2)                - TMP3*DELTAL(IPP1)
               ASPAR_JAC(ISP,I3) = ASPAR_JAC(ISP,I3)                - TMP3*DELTAL(IPP2)
             ELSE
-              ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03 
+              ASPAR_JAC(ISP,I1) = ASPAR_JAC(ISP,I1) + TRIA03
             END IF
             B_JAC(ISP,IP)=B_JAC(ISP,IP) + TRIA03 * VA(ISP,IP) * IOBDP(IP_glob) * IOBPD(ITH,IP_glob)
           END DO
@@ -3998,7 +3998,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4184,7 +4184,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4289,11 +4289,11 @@
       POS_TRICK(2,2) = 1
       POS_TRICK(3,1) = 1
       POS_TRICK(3,2) = 2
- 
+
       ASPAR_DIAG_LOCAL     = ZERO
       B_JAC_LOCAL          = ZERO
       ASPAR_OFF_DIAG_LOCAL = ZERO
- 
+
       IP_glob=iplg(IP)
 
       DO I = 1, PDLIB_CCON(IP)
@@ -4398,7 +4398,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4502,13 +4502,13 @@
       POS_TRICK(2,2) = 1
       POS_TRICK(3,1) = 1
       POS_TRICK(3,2) = 2
- 
+
       TRIA03    = ONETHIRD * PDLIB_TRIA(IE)
       IEN_LOCAL = PDLIB_IEN(:,IE)
       NI        = INE(:,IE)
       NI_GLOB   = iplg(NI)
-      NI_ISEA   = MAPFS(1,NI_GLOB)      
-      
+      NI_ISEA   = MAPFS(1,NI_GLOB)
+
       CRFS_U    = ZERO
       K_U       = ZERO
 
@@ -4576,7 +4576,7 @@
         DTK     = KP * DTG * IOBDP(NI_ISEA) * IOBPD(ITH,NI_ISEA) * (1-IOBPA(NI_ISEA))
         TMP3(ISP,:) = DTK * NM
       ENDDO
-      
+
       DO I = 1, 3
         IP        = NI(I)
         IP1       = INE(POS_TRICK(I,1),IE)
@@ -4587,13 +4587,13 @@
         !ASPAR_OFF_DIAG(:,IP1) = ASPAR_OFF_DIAG(:,IP1)              - TMP3(:,IPP1) * DELTAL(:,IPP1) * VA(:,IP1)
         !ASPAR_OFF_DIAG(:,IP2) = ASPAR_OFF_DIAG(:,IP2)              - TMP3(:,IPP2) * DELTAL(:,IPP2) * VA(:,IP2)
       ENDDO
-      END SUBROUTINE      
+      END SUBROUTINE
 !/ ------------------------------------------------------------------- /
       SUBROUTINE calcARRAY_JACOBI_SPECTRAL(DTG,ASPAR_DIAG_LOCAL)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4660,7 +4660,7 @@
       LOGICAL :: DoLimiterFreqShit   = .FALSE. !AR: This one is missing ...
       INTEGER :: ITH0
 
-      LOGICAL :: LSIG = .FALSE. 
+      LOGICAL :: LSIG = .FALSE.
 
 !AR: this is missing in init ... but there is a design error in ww3_grid with FLCUR and FLLEV
       LSIG = FLCUR .OR. FLLEV
@@ -4718,7 +4718,7 @@
                   ASPAR_JAC(ITH0 + ITH,PDLIB_I_DIAG(IP)) = ASPAR_JAC(ITH0 + ITH,PDLIB_I_DIAG(IP)) + eSI * eVal
                 ELSE IF (IMEM == 2) THEN
                   ASPAR_DIAG_LOCAL(ITH0 + ITH,IP) = ASPAR_DIAG_LOCAL(ITH0 + ITH,IP) + eSI * eVal
-                ENDIF 
+                ENDIF
               END DO
             ELSE
               CWNB_M2=0
@@ -4762,7 +4762,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4847,7 +4847,7 @@
           END DO
           eSI    = PDLIB_SI(IP)
           SIDT   = eSI * DTG
-          DEPTH  = DW(ISEA) 
+          DEPTH  = DW(ISEA)
 !/DB1          VSDB   = 0.
 !/DB1          VDDB   = 0.
 !/DB1          CG1 = CG(1:NK,ISEA)
@@ -4896,7 +4896,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -4947,7 +4947,7 @@
       USE W3GDATMD, ONLY: IOBP, MAPSTA, FACP, SIG, IOBPD, IOBPA, IOBDP
       USE W3GDATMD, ONLY: NSEAL, CLATS
       USE W3WDATMD, ONLY: VA, VSTOT, VDTOT, SHAVETOT
-!/DB1      USE W3SDB1MD 
+!/DB1      USE W3SDB1MD
       USE constants, ONLY : TPI, TPIINV, GRAV
       IMPLICIT NONE
       REAL, INTENT(in) :: DTG
@@ -5021,7 +5021,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -5123,16 +5123,16 @@
         CALL COMPUTE_MEAN_PARAM(SPEC_VA, CG1, WN1, EMEAN, FMEAN, WNMEAN, AMAX)
 
 !/DB1        VSDB = 0.
-!/TR1        VSTR = 0. 
+!/TR1        VSTR = 0.
 !/BT1        VSBT = 0.
 !/DB1        VDDB = 0.
-!/TR1        VDTR = 0. 
+!/TR1        VDTR = 0.
 !/BT1        VDBT = 0.
 
 !/TR1        CALL W3STR1 ( SPEC_VA, CG1, WN1, DEPTH, IX,VSTR, VDTR )
 !/TRX        CALL W3STRX
 
-!/DB1        CALL W3SDB1 ( JSEA, SPEC_VA, DEPTH, EMEAN, FMEAN, WNMEAN, CG1, LBREAK, VSDB, VDDB ) 
+!/DB1        CALL W3SDB1 ( JSEA, SPEC_VA, DEPTH, EMEAN, FMEAN, WNMEAN, CG1, LBREAK, VSDB, VDDB )
 !/BT1        CALL W3SBT1 ( SPEC_VA, CG1, WN1, DEPTH,            VSBT, VDBT )
 
 !/BT4        D50=SED_D50(ISEA)
@@ -5153,9 +5153,9 @@
             ISP=ITH + (IK-1)*NTH
             PreVS=0
             eVD=0
-!/DB1            PreVS = PreVS + VSDB(ISP)  
-!/TR1            PreVS = PreVS + VSTR(ISP) 
-!/BT1            PreVS = PreVS + VSBT(ISP) 
+!/DB1            PreVS = PreVS + VSDB(ISP)
+!/TR1            PreVS = PreVS + VSTR(ISP)
+!/BT1            PreVS = PreVS + VSBT(ISP)
 !/BS1            PreVS = PreVS + VSBS(ISP)
             eVS=DBLE(PreVS) / CG(IK,ISEA) * CLATS(ISEA)
 !/DB1            eVD=eVD+DBLE(MIN(0., VDDB(ISP)))
@@ -5181,7 +5181,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -5291,7 +5291,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -5301,7 +5301,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Apply boundary conditions 
+!  1. Purpose : Apply boundary conditions
 !  2. Method :
 !  3. Parameters :
 !
@@ -5370,7 +5370,7 @@
         RD10=1.
         RD20=0.
       END IF
-      IF ( FLBPI ) THEN 
+      IF ( FLBPI ) THEN
         RD1=RD10 ! I am not completely sure about that
         RD2=RD20
         IF ( RD2 .GT. 0.001 ) THEN
@@ -5439,7 +5439,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -5449,7 +5449,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Computation of the limiter function 
+!  1. Purpose : Computation of the limiter function
 !  2. Method :
 !  3. Parameters :
 !
@@ -5502,8 +5502,8 @@
       REAL, INTENT(in) :: ACOLD(NSPEC)
       REAL, INTENT(inout) :: ACLOC(NSPEC)
       REAL, INTENT(in) :: DTG
-      INTEGER :: MELIM = 1 
-      REAL :: LIMFAK = 0.1 
+      INTEGER :: MELIM = 1
+      REAL :: LIMFAK = 0.1
       REAL :: CONST, SND, eWN, eWK, eWKpow
       REAL :: eFact, eSPSIG
       REAL :: NewVAL
@@ -5512,7 +5512,7 @@
       REAL :: dac, limac, eDam
       INTEGER IP_glob, ISEA
       INTEGER :: IK, ITH, ISP
-      LOGICAL :: LLIMITER_WWM 
+      LOGICAL :: LLIMITER_WWM
 !/S      CALL STRACE (IENT, 'ACTION_LIMITER_LOCAL')!
       IP_glob=iplg(IP)
       ISEA=MAPFS(1,IP_glob)
@@ -5559,7 +5559,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -5569,7 +5569,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Block Gauss Seidel and Jacobi solver 
+!  1. Purpose : Block Gauss Seidel and Jacobi solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -5630,7 +5630,7 @@
       USE W3WDATMD, ONLY: VA, VAOLD, VSTOT, VDTOT
       USE W3ADATMD, ONLY: CG, CX, CY
       USE W3ODATMD, ONLY: TBPIN, FLBPI, IAPROC
-      USE W3PARALL, ONLY : IMEM 
+      USE W3PARALL, ONLY : IMEM
       USE W3PARALL, ONLY : INIT_GET_JSEA_ISPROC, ZERO, THR8
       USE W3PARALL, ONLY : ListISPprevDir, ListISPnextDir
       USE W3PARALL, ONLY : JX_TO_JSEA
@@ -5718,7 +5718,7 @@
       CALL SETDEPTH_PDLIB
 !
 ! 2.  Convert to Wave Action ---------------- *
-! 
+!
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'NSEAL =', NSEAL, 'NP    =', NP, 'NPA   =', NPA
       DO JSEA=1,NSEAL
         IP      = JSEA
@@ -5765,7 +5765,7 @@
 !/MEMCHECK      call getMallocInfo(mallinfos)
 !/MEMCHECK      call printMallInfo(IAPROC,mallInfos)
 !
-!     source terms 
+!     source terms
 !
       IF (FSSOURCE .and. B_JGS_NLEVEL .eq. 0) THEN
         IF (B_JGS_SOURCE_NONLINEAR) THEN
@@ -5780,7 +5780,7 @@
 !/MEMCHECK      call printMallInfo(IAPROC,mallInfos)
 
 !
-!     geographical advection  
+!     geographical advection
 !
       IF (IMEM == 1) call calcARRAY_JACOBI2(DTG,FACX,FACY,VGX,VGY)
 
@@ -5793,7 +5793,7 @@
 !/DEBUGSOLVER     !WRITE(740+IAPROC,'(A20,20E20.10)') 'SUM BJAC 1', sum(B_JAC), SUM(ASPAR_JAC)
 
 !
-!     spectral advection  
+!     spectral advection
 !
       IF (FSFREQSHIFT .or. FSREFRACTION) THEN
         call calcARRAY_JACOBI_SPECTRAL(DTG,ASPAR_DIAG_ALL)
@@ -5827,7 +5827,7 @@
 
         ICOUNT1 = 0
         ICOUNT2 = 0
-!AR: 
+!AR:
 !ADD LOOP OVER ELEMENTS HERE FOR ALL ASPAR STUFF
 !/MEMCHECK      write(740+IAPROC,*) 'memcheck_____:', 'WW3_PROP SECTION SOLVER LOOP 1'
 !/MEMCHECK      call getMallocInfo(mallinfos)
@@ -5857,7 +5857,7 @@
 !!/DEBUGFREQSHIFT          WRITE(740+IAPROC,*) 'eVal12=', eVal1, eVal2
 !!/DEBUGFREQSHIFT        END DO
             Sum_Prev=sum(ACLOC)
-            IF (IMEM == 2) THEN 
+            IF (IMEM == 2) THEN
               CALL calcARRAY_JACOBI4(IP,ICOUNT2,DTG,FACX,FACY,VGX,VGY,ASPAR_DIAG_LOCAL,ASPAR_OFF_DIAG_LOCAL,B_JAC_LOCAL)
               !WRITE(*,'(A10,10F20.10)') 'JAC4', SUM(ASPAR_DIAG_LOCAL), SUM(ASPAR_OFF_DIAG_LOCAL), SUM(B_JAC_LOCAL)
               !CALL calcARRAY_JACOBI3(IP,ICOUNT1,DTG,FACX,FACY,VGX,VGY,ASPAR_DIAG_LOCAL,ASPAR_OFF_DIAG_LOCAL,B_JAC_LOCAL)
@@ -6012,8 +6012,8 @@
             ELSE
               U_JAC(:,IP)=eSum
             END IF
-          ELSE 
-            esum = VA(:,IP) 
+          ELSE
+            esum = VA(:,IP)
             DO I = 1, PDLIB_CCON(IP)
               ICOUNT1 = ICOUNT1 + 1
               ICOUNT2 = ICOUNT2 + 1
@@ -6038,7 +6038,7 @@
           END IF
             !IF (IP == 2) STOP
 !/DEBUGSRC          WRITE(740+IAPROC,*) 'sum(VA)out=', sum(VA(:,IP))
-        END DO ! IP 
+        END DO ! IP
 
 !/MEMCHECK      write(740+IAPROC,*) 'memcheck_____:', 'WW3_PROP SECTION SOLVER LOOP 2'
 !/MEMCHECK      call getMallocInfo(mallinfos)
@@ -6167,7 +6167,7 @@
 !/MEMCHECK      write(740+IAPROC,*) 'memcheck_____:', 'WW3_PROP SECTION SOLVER LOOP 6'
 !/MEMCHECK      call getMallocInfo(mallinfos)
 !/MEMCHECK      call printMallInfo(IAPROC,mallInfos)
-      END DO ! Open Do Loop ... End of Time Interval 
+      END DO ! Open Do Loop ... End of Time Interval
 !/DEBUGSOLVER     WRITE(740+IAPROC,*) 'nbIter=', nbIter, ' B_JGS_MAXITER=', B_JGS_MAXITER
 !/DEBUGSOLVER     FLUSH(740+IAPROC)
 ! Tihs is below also goes into the matrix ... like the wave boundary ...
@@ -6213,7 +6213,7 @@
 !/DEBUGSRC          SumVAin = SumVAin + abs(VA(ISP,JSEA))
 !/DEBUGSRC          SumVAout = SumVAout + abs(eVA)
 !/DEBUGSRC          SumVAw3srce = SumVAw3srce + abs(eVA_w3srce)
-            VA(ISP,JSEA) = eVA 
+            VA(ISP,JSEA) = eVA
           END DO
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'ISEA=', ISEA, ' IntDiff=', IntDiff, ' DTG=', DTG
 !/DEBUGSRC        IF (ISEA .eq. TESTNODE) THEN
@@ -6249,7 +6249,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -6259,7 +6259,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Explicit block solver 
+!  1. Purpose : Explicit block solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -6380,7 +6380,7 @@
       CALL SETDEPTH_PDLIB
 !
 ! 2.  Calculate velocities ---------------- *
-! 
+!
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'NSEAL =', NSEAL
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'NP    =', NP
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'NPA   =', NPA
@@ -6416,7 +6416,7 @@
 !/DEBUGSOLVER     WRITE(740+IAPROC,*) 'min,max(0)=', 0
 !/DEBUGSOLVER     FLUSH(740+IAPROC)
 
-      DO IE = 1, NE 
+      DO IE = 1, NE
         I1 = INE(1,IE)
         I2 = INE(2,IE)
         I3 = INE(3,IE)
@@ -6455,19 +6455,19 @@
         NI = INE(:,IE)
         KKSUM(:,NI) = KKSUM(:,NI) + KELEMGL(:,:,IE)
       END DO
-      DTMAX_GLOBAL_EXP = 1.d0/THR 
+      DTMAX_GLOBAL_EXP = 1.d0/THR
       DO IP = 1, NP
         DTMAX_EXP        = PDLIB_SI(IP)/MAX(THR,MAXVAL(KKSUM(:,IP)))
         DTMAX_GLOBAL_EXP = MIN ( DTMAX_GLOBAL_EXP, DTMAX_EXP)
         CFLXYMAX(IP)     = DBLE(DTG)/DTMAX_EXP
       END DO
-      rest = CFLXYMAX(1) 
+      rest = CFLXYMAX(1)
       DO IP = 2, NP
         if (rest .lt. CFLXYMAX(IP)) then
           rest = CFLXYMAX(IP)
           iter_max = ip
-        endif    
-      END DO 
+        endif
+      END DO
 
       DTMAX_EXP=DTMAX_GLOBAL_EXP
       call mpi_allreduce(DTMAX_EXP,DTMAX_GLOBAL_EXP,1,rtype,MPI_MIN,MPI_COMM_WCMP,ierr)
@@ -6483,7 +6483,7 @@
 
       DT4AI = DTG/ITER_MAX
       DO IT = 1, ITER_MAX
-        DO IP = 1, NPA 
+        DO IP = 1, NPA
           ST3 = ZERO
           DO I = 1, PDLIB_CCON(IP)
             IE       = PDLIB_IE_CELL2(IP,I)
@@ -6506,7 +6506,7 @@
         END DO
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'IOBPD loop, After, sum(VA)=', sum(VA(:,IP))
       END DO
-      
+
 !/DEBUGSOLVERCOH      CALL CHECK_ARRAY_INTEGRAL_NX_R8(VA, "VA(npa) after loop", npa)
 !/DEBUGSOLVER     WRITE(740+IAPROC,*) 'FLBPI=', FLBPI
 !/DEBUGSOLVER     FLUSH(740+IAPROC)
@@ -6540,7 +6540,7 @@
 !/DEBUGSRC          SumVAin = SumVAin + abs(VA(ISP,JSEA))
 !/DEBUGSRC          SumVAout = SumVAout + abs(eVA)
 !/DEBUGSRC          SumVAw3srce = SumVAw3srce + abs(eVA_w3srce)
-            VA(ISP,JSEA) = eVA 
+            VA(ISP,JSEA) = eVA
           END DO
 
 !/DEBUGSRC        WRITE(740+IAPROC,*) 'ISEA=', ISEA, ' IntDiff=', IntDiff, ' DTG=', DTG
@@ -6573,7 +6573,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -6583,7 +6583,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Initialization of the block solver 
+!  1. Purpose : Initialization of the block solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -6691,7 +6691,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -6772,7 +6772,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -6782,7 +6782,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Finalize Solver 
+!  1. Purpose : Finalize Solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -6842,7 +6842,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -6852,7 +6852,7 @@
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Init jacobi solver 
+!  1. Purpose : Init jacobi solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -6960,7 +6960,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |

--- a/model/ftn/w3proxmd.ftn
+++ b/model/ftn/w3proxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -84,7 +84,7 @@
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
 !         dynamic data structure.
-!      b) Preprocessing should be done in W3MAPX, and this reoutine 
+!      b) Preprocessing should be done in W3MAPX, and this reoutine
 !         needs to be able o be called multiple times, as propagation
 !         schemes are re-initialized every time propagation 'maps'
 !         change (see established routines).
@@ -99,7 +99,7 @@
 !     ***    Declare saved variables here   ***
 !     ***  public or private as appropriate ***
 !     *****************************************
-!     
+!
       PUBLIC
 !/
       CONTAINS
@@ -223,7 +223,7 @@
 !     ----------------------------------------------------------------
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !     ----------------------------------------------------------------
-! 
+!
 !  5. Called by :
 !
 !      Name      Type  Module   Description
@@ -311,7 +311,7 @@
 !     ----------------------------------------------------------------
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !     ----------------------------------------------------------------
-! 
+!
 !  5. Called by :
 !
 !      Name      Type  Module   Description

--- a/model/ftn/w3psmcmd.ftn
+++ b/model/ftn/w3psmcmd.ftn
@@ -18,25 +18,25 @@
 !/    16-Jun-2011 : Add refraction limter to gradient direction.
 !/     1-Jul-2011 : New refraction using Cg and gradient limiter.
 !/    28-Jul-2011 : Finalise with old refraction scheme and gradient limiter.
-!/     4-Nov-2011 : Separate x and y obstruction coefficients. 
-!/     5-Jan-2012 : Update to multi-resolution SMC grid with sub-time-steps. 
+!/     4-Nov-2011 : Separate x and y obstruction coefficients.
+!/     5-Jan-2012 : Update to multi-resolution SMC grid with sub-time-steps.
 !/     2-Feb-2012 : Separate single- and multi-resolution advection.
-!/     6-Mar-2012 : Tidy up code and minor adjustments, CLATF. 
+!/     6-Mar-2012 : Tidy up code and minor adjustments, CLATF.
 !/    12-Mar-2012 : Remove net flux bug and optimise upstream code.
 !/    16-Jan-2013 : Adapted for Version 4.08, removing FACX/Y.
-!/    16-Sep-2013 : Add Arctic part for SMC grid in WW3 V4.11 
-!/     3-Jan-2014 : Remove bug in SMCDHXY for AU/V as cell size.  
-!/     7-Jan-2014 : Remove bug in SMCGtCrfr for K definition.     
-!/    28-Jan-2014 : Move Arctic boundary condition update out.  
-!/    18-Aug-2015 : New gradient, average and 3rd order advection subs. 
-!/     3-Sep-2015 : UNO3 advection scheme by logical option FUNO3. 
-!/    14-Sep-2015 : Modify DHDX/Y for Arctic part refraction term.  
-!/     8-Aug-2017 : Update SMCGradn for 0 or 1 boundary conditions. 
-!/     9-Jan-2018 : Parallelization by adding OpenMP directives. 
+!/    16-Sep-2013 : Add Arctic part for SMC grid in WW3 V4.11
+!/     3-Jan-2014 : Remove bug in SMCDHXY for AU/V as cell size.
+!/     7-Jan-2014 : Remove bug in SMCGtCrfr for K definition.
+!/    28-Jan-2014 : Move Arctic boundary condition update out.
+!/    18-Aug-2015 : New gradient, average and 3rd order advection subs.
+!/     3-Sep-2015 : UNO3 advection scheme by logical option FUNO3.
+!/    14-Sep-2015 : Modify DHDX/Y for Arctic part refraction term.
+!/     8-Aug-2017 : Update SMCGradn for 0 or 1 boundary conditions.
+!/     9-Jan-2018 : Parallelization by adding OpenMP directives.
 !/
 !  1. Purpose :
 !
-!     Bundles routines for SMC advection (UNO2) and diffusion schemes in 
+!     Bundles routines for SMC advection (UNO2) and diffusion schemes in
 !     single module, including GCT and refraction rotation schemes.
 !
 !  2. Variables and types :
@@ -134,7 +134,7 @@
 !  2. Method :
 !
 !     Unstructured SMC grid, point-oriented face and cell loops.
-!     UNO2 advection scheme and isotropic FTCS diffusion scheme. 
+!     UNO2 advection scheme and isotropic FTCS diffusion scheme.
 !
 !  3. Parameters :
 !
@@ -169,7 +169,7 @@
 !
 !  5. Called by :
 !
-!      Name      Type  Module   Description 
+!      Name      Type  Module   Description
 !     ----------------------------------------------------------------
 !      W3WAVE    Subr. W3WAVEMD Wave model routine.
 !     ---------------------------------------------------------------
@@ -222,8 +222,8 @@
                           NSEA, SX, SY, MAPSF, FUNO3, FVERG,           &
                           IJKCel, IJKUFc, IJKVFc, NCel, NUFc, NVFc,    &
                           NLvCel, NLvUFc, NLvVFc, NRLv, MRFct,         &
-                          DTCFL, CLATS, DTME, CLATMN, CTRNX, CTRNY 
-!/ARC      USE W3GDATMD, ONLY: NGLO, ANGARC 
+                          DTCFL, CLATS, DTME, CLATMN, CTRNX, CTRNY
+!/ARC      USE W3GDATMD, ONLY: NGLO, ANGARC
       USE W3WDATMD, ONLY: TIME
       USE W3ADATMD, ONLY: CG, WN, U10, CX, CY, ATRNX, ATRNY, ITIME
 !
@@ -253,12 +253,12 @@
 !/S      INTEGER, SAVE           :: IENT = 0
       REAL                    :: CG0, CGA, CGN, CGX, CGY, FMR, RD1,   &
                                  RD2, CXMIN, CXMAX, CYMIN, CYMAX,     &
-                                 CXC, CYC, DTLDX, DTLDY 
+                                 CXC, CYC, DTLDX, DTLDY
       REAL                    :: DTLOC, CGCOS, CGSIN, FUTRN, FVTRN,   &
                                  DFRR, DX0I, DY0I, CGD, DSSD,         &
                                  DNND, DCELL, XWIND, TFAC, DSS, DNN
-!/ARC      REAL                    :: PCArea, ARCTH 
-      LOGICAL                 :: YFIRST 
+!/ARC      REAL                    :: PCArea, ARCTH
+      LOGICAL                 :: YFIRST
 !/
 !/ Automatic work arrays
 !
@@ -282,12 +282,12 @@
       CG0    = 0.6 * GRAV / SIG(1)
       CGA    = 0.6 * GRAV / SIG(IK)
 
-!!Li  Maximum group speed for given spectral bin. First bin speed is 
+!!Li  Maximum group speed for given spectral bin. First bin speed is
 !!Li  used to avoid zero speed component.
 !     CGX    = ABS( CGA * ECOS(ITH) )
 !     CGY    = ABS( CGA * ESIN(ITH) )
-      CGX    =  CGA * ECOS(ITH) 
-      CGY    =  CGA * ESIN(ITH) 
+      CGX    =  CGA * ECOS(ITH)
+      CGY    =  CGA * ESIN(ITH)
 
 !!Li  Add maximum current components to maximum group components.
       IF ( FLCUR ) THEN
@@ -321,18 +321,18 @@
 !!Li  Minimum time step should not be less than sub w3init requirement,
 !!Li  where IAPPRO array is initialised for propagation parallization.
       CGN   = 0.9999 * MAX( ABS(CGX), ABS(CGY), CXC, CYC, 0.001*CG0 )
-      DTLOC = DTCFL*CG0/CGN 
+      DTLOC = DTCFL*CG0/CGN
       NTLOC  = 1 + INT(DTG/DTLOC - 0.001)
       DTLOC  = DTG / REAL(NTLOC)
 
-!!Li  Group speed component common factors, FACX=DTG*DX0I 
+!!Li  Group speed component common factors, FACX=DTG*DX0I
 !!Li  FACX and FACY are evaluated here directly.  JGLi16Jan2013
 !     CGCOS   = FACX * ECOS(ITH) / REAL(NTLOC)
 !     CGSIN   = FACY * ESIN(ITH) / REAL(NTLOC)
-      CGCOS   = ECOS(ITH) 
-      CGSIN   = ESIN(ITH) 
-      DTLDX   = DTLOC * DX0I 
-      DTLDY   = DTLOC * DY0I 
+      CGCOS   = ECOS(ITH)
+      CGSIN   = ESIN(ITH)
+      DTLDX   = DTLOC * DX0I
+      DTLDY   = DTLOC * DY0I
 !
       YFIRST = MOD(ITIME,2) .EQ. 0
 !
@@ -362,7 +362,7 @@
 !$OMP Parallel DO Private(ISEA)
       DO ISEA=1, NSEA
 !Li  Transported variable is divided by CG as in WW3 (???)
-           CQ(ISEA) = VQ(ISEA)/CG(IK,ISEA) 
+           CQ(ISEA) = VQ(ISEA)/CG(IK,ISEA)
 !Li  Resetting NaNQ VQ to zero if any.   JGLi18Mar2013
          IF( .NOT. (CQ(ISEA) .EQ. CQ(ISEA)) )  CQ(ISEA) = 0.0
       END DO
@@ -374,32 +374,32 @@
          DO ISEA=1, NSEA
             CXTOT(ISEA) = (CGCOS * CG(IK,ISEA) + CX(ISEA))
             CYTOT(ISEA) = (CGSIN * CG(IK,ISEA) + CY(ISEA))
-         ENDDO 
+         ENDDO
 !$OMP END Parallel DO
       ELSE
 !Li   No current case use group speed only.
 !$OMP Parallel DO Private(ISEA)
          DO ISEA=1, NSEA
-            CXTOT(ISEA) =  CGCOS * CG(IK,ISEA) 
+            CXTOT(ISEA) =  CGCOS * CG(IK,ISEA)
             CYTOT(ISEA) =  CGSIN * CG(IK,ISEA)
          END DO
 !$OMP END Parallel DO
 !Li   End of IF( FLCUR ) block.
       ENDIF
 
-!/ARC  !Li   Arctic cell velocity components need to be rotated 
+!/ARC  !Li   Arctic cell velocity components need to be rotated
 !/ARC  !Li   back to local east referenence system for propagation.
 !/ARC         DO ISEA=NGLO+1, NSEA
-!/ARC            ARCTH = ANGARC(ISEA-NGLO)*DERA 
+!/ARC            ARCTH = ANGARC(ISEA-NGLO)*DERA
 !/ARC            CXC = CXTOT(ISEA)*COS(ARCTH) + CYTOT(ISEA)*SIN(ARCTH)
 !/ARC            CYC = CYTOT(ISEA)*COS(ARCTH) - CXTOT(ISEA)*SIN(ARCTH)
-!/ARC            CXTOT(ISEA) = CXC 
-!/ARC            CYTOT(ISEA) = CYC 
+!/ARC            CXTOT(ISEA) = CXC
+!/ARC            CYTOT(ISEA) = CYC
 !/ARC         END DO
-!/ARC  !Li   Polar cell area factor for V-flux update 
+!/ARC  !Li   Polar cell area factor for V-flux update
 !/ARC        PCArea = DY0I/(MRFct*PI*DX0I*FLOAT(IJKCel(4,NSEA)))
 !/ARC  !Li   V-component is reset to zero for Polar cell as direction
-!/ARC  !Li   is undefined there.  
+!/ARC  !Li   is undefined there.
 !/ARC         CYTOT(NSEA) = 0.0
 !/ARC
 
@@ -407,8 +407,8 @@
 !$OMP Parallel DO Private(ISEA)
          DO ISEA=1, NSEA
             UCFL(ISEA) = DTLDX*CXTOT(ISEA)/CLATS(ISEA)
-            VCFL(ISEA) = DTLDY*CYTOT(ISEA) 
-         ENDDO 
+            VCFL(ISEA) = DTLDY*CYTOT(ISEA)
+         ENDDO
 !$OMP END Parallel DO
 
 !Li  Initialise boundary cell CQ and Velocity values.
@@ -445,7 +445,7 @@
 
 !! Add sub-grid transparency for input flux update.  JGLi16May2011
 !! Transparency is also applied on diffusion flux.   JGLi12Mar2012
-!$OMP CRITICAL 
+!$OMP CRITICAL
               IF( (CTRNX(M)+CTRNX(N)) .GE. 1.96 )  THEN
                 FCNt(M) = FCNt(M) - FUTRN
                 FCNt(N) = FCNt(N) + FUTRN
@@ -454,12 +454,12 @@
                 FCNt(N) = FCNt(N) + FUTRN*CTRNX(M)*CTRNX(N)
               ELSE
                 FCNt(M) = FCNt(M) - FUTRN*CTRNX(N)*CTRNX(M)
-                FCNt(N) = FCNt(N) + FUTRN*CTRNX(N) 
+                FCNt(N) = FCNt(N) + FUTRN*CTRNX(N)
               ENDIF
 !  Also divided by another cell length as UCFL is in basic unit.
               AFCN(M) = AFCN(M) - FUMD(i)*UCFL(M) + FUDIFX(i)
               AFCN(N) = AFCN(N) + FUMD(i)*UCFL(N) - FUDIFX(i)
-!$OMP END CRITICAL 
+!$OMP END CRITICAL
            ENDDO
 !$OMP END Parallel DO
 
@@ -490,18 +490,18 @@
 
 !! Add sub-grid transparency for input flux update.  JGLi16May2011
 !! Transparency is also applied on diffusion flux.   JGLi12Mar2012
-!$OMP CRITICAL 
+!$OMP CRITICAL
               IF( (CTRNY(M)+CTRNY(N)) .GE. 1.96 )  THEN
                 BCNt(M) = BCNt(M) - FVTRN
                 BCNt(N) = BCNt(N) + FVTRN
               ELSE IF( VLCFLY(j) .GE. 0.0 )  THEN
                 BCNt(M) = BCNt(M) - FVTRN*CTRNY(M)
-                BCNt(N) = BCNt(N) + FVTRN*CTRNY(M)*CTRNY(N) 
+                BCNt(N) = BCNt(N) + FVTRN*CTRNY(M)*CTRNY(N)
               ELSE
-                BCNt(M) = BCNt(M) - FVTRN*CTRNY(N)*CTRNY(M) 
-                BCNt(N) = BCNt(N) + FVTRN*CTRNY(N) 
+                BCNt(M) = BCNt(M) - FVTRN*CTRNY(N)*CTRNY(M)
+                BCNt(N) = BCNt(N) + FVTRN*CTRNY(N)
               ENDIF
-!$OMP END CRITICAL 
+!$OMP END CRITICAL
            ENDDO
 !$OMP END Parallel DO
 
@@ -532,10 +532,10 @@
               LvR=2**(LL - 1)
               FMR=FLOAT( LvR )
 !
-! 3.c    Calculate this level only if size is factor of LMN 
+! 3.c    Calculate this level only if size is factor of LMN
            IF( MOD(LMN, LvR) .EQ. 0 ) THEN
 !
-! 3.d    Select cell and face ranges 
+! 3.d    Select cell and face ranges
            icl=NLvCel(LL-1)+1
            iuf=NLvUFc(LL-1)+1
            ivf=NLvVFc(LL-1)+1
@@ -553,25 +553,25 @@
 
 !  Store fineset level conservative flux in FCNt advective one in AFCN
 !$OMP Parallel DO Private(i, L, M, FUTRN)
-           DO i=iuf, juf 
+           DO i=iuf, juf
               L=IJKUFc(5,i)
               M=IJKUFc(6,i)
               FUTRN = FUMD(i)*ULCFLX(i) - FUDIFX(i)
-!$OMP CRITICAL 
-!! Add sub-grid blocking for refined cells.   JGLi18Apr2018 
+!$OMP CRITICAL
+!! Add sub-grid blocking for refined cells.   JGLi18Apr2018
               IF( (CTRNX(M)+CTRNX(L)) .GE. 1.96 )  THEN
                 FCNt(L) = FCNt(L) - FUTRN
                 FCNt(M) = FCNt(M) + FUTRN
               ELSE IF( ULCFLX(i) .GE. 0.0 ) THEN
-                FCNt(L) = FCNt(L) - FUTRN*CTRNX(L) 
-                FCNt(M) = FCNt(M) + FUTRN*CTRNX(M)*CTRNX(L) 
+                FCNt(L) = FCNt(L) - FUTRN*CTRNX(L)
+                FCNt(M) = FCNt(M) + FUTRN*CTRNX(M)*CTRNX(L)
               ELSE
-                FCNt(L) = FCNt(L) - FUTRN*CTRNX(L)*CTRNX(M) 
-                FCNt(M) = FCNt(M) + FUTRN*CTRNX(M) 
-              ENDIF 
+                FCNt(L) = FCNt(L) - FUTRN*CTRNX(L)*CTRNX(M)
+                FCNt(M) = FCNt(M) + FUTRN*CTRNX(M)
+              ENDIF
               AFCN(L) = AFCN(L) - FUMD(i)*UCFL(L)*FMR + FUDIFX(i)
               AFCN(M) = AFCN(M) + FUMD(i)*UCFL(M)*FMR - FUDIFX(i)
-!$OMP END CRITICAL 
+!$OMP END CRITICAL
            ENDDO
 !$OMP END Parallel DO
 
@@ -579,7 +579,7 @@
 !  The side length in MF value has to be cancelled with cell y-length.
 !  Also divided by another cell x-size as UCFL is in size-1 unit.
 !$OMP Parallel DO Private(n)
-           DO n=icl, jcl 
+           DO n=icl, jcl
               CQA(n)=CQ(n) + FCNt(n)/FLOAT( IJKCel(3, n)*IJKCel(4, n) )
               CQ (n)=CQ(n) + AFCN(n)/FLOAT( IJKCel(3, n)*IJKCel(4, n) )
               FCNt(n)=0.0
@@ -597,28 +597,28 @@
 !
 !  Store conservative flux in BCNt
 !$OMP Parallel DO Private(j, L, M, FVTRN)
-           DO j=ivf, jvf 
+           DO j=ivf, jvf
               L=IJKVFc(5,j)
               M=IJKVFc(6,j)
               FVTRN = FVMD(j)*VLCFLY(j) - FVDIFY(j)
-!$OMP CRITICAL 
-!! Add sub-grid blocking for refined cells.   JGLi18Apr2018 
+!$OMP CRITICAL
+!! Add sub-grid blocking for refined cells.   JGLi18Apr2018
               IF( (CTRNY(M)+CTRNY(L)) .GE. 1.96 )  THEN
                 BCNt(L) = BCNt(L) - FVTRN
                 BCNt(M) = BCNt(M) + FVTRN
               ELSE IF( VLCFLY(j) .GE. 0.0 )  THEN
-                BCNt(L) = BCNt(L) - FVTRN*CTRNY(L) 
-                BCNt(M) = BCNt(M) + FVTRN*CTRNY(M)*CTRNY(L) 
+                BCNt(L) = BCNt(L) - FVTRN*CTRNY(L)
+                BCNt(M) = BCNt(M) + FVTRN*CTRNY(M)*CTRNY(L)
               ELSE
-                BCNt(L) = BCNt(L) - FVTRN*CTRNY(L)*CTRNY(M) 
-                BCNt(M) = BCNt(M) + FVTRN*CTRNY(M) 
+                BCNt(L) = BCNt(L) - FVTRN*CTRNY(L)*CTRNY(M)
+                BCNt(M) = BCNt(M) + FVTRN*CTRNY(M)
               ENDIF
-!$OMP END CRITICAL 
+!$OMP END CRITICAL
            ENDDO
 !$OMP END Parallel DO
 
 !  Store conservative update of CQA in CQ
-!  The v side length in MF value has to be cancelled with x-size. 
+!  The v side length in MF value has to be cancelled with x-size.
 !  Also divided by cell y-size as VCFL is in size-1 unit.
 !! One cosine factor is also needed to be divided for SMC grid.
 !$OMP Parallel DO Private(n)
@@ -633,7 +633,7 @@
 !/ARC         CQ(NSEA) = CQA(NSEA) + BCNt(NSEA)*PCArea
 !/ARC       ENDIF
 !
-!  End of refine level if block  MOD(LMN, LvR) .EQ. 0 
+!  End of refine level if block  MOD(LMN, LvR) .EQ. 0
            ENDIF
 
 !  End of refine level loop LL=1, NRLv
@@ -660,13 +660,13 @@
             DO IBI=1, NBI
                ISEA     = ISBPI(IBI)
                CQ(ISEA) = (RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI))   &
-                          /CG(IK,ISEA) 
+                          /CG(IK,ISEA)
             END DO
          ENDIF
 !
 !!    End of ITLOC DO
        ENDDO
- 
+
 !  Average with 1-2-1 scheme.  JGLi20Aug2015
        IF(FVERG) CALL SMCAverg(CQ)
 
@@ -730,10 +730,10 @@
 !
 !  2. Method :
 !
-!     Linear interpolation equivalent to 1st order upstream scheme 
-!     but without restriction on rotation angle.  However, refraction 
+!     Linear interpolation equivalent to 1st order upstream scheme
+!     but without restriction on rotation angle.  However, refraction
 !     is limited towards the depth gradient direction (< 90 degree).
-!     Refraction induced spectral shift in the k-space will remain 
+!     Refraction induced spectral shift in the k-space will remain
 !     to be advected using the UNO2 scheme.
 !
 !  3. Parameters :
@@ -828,15 +828,15 @@
 !/S      INTEGER, SAVE       :: IENT = 0
       REAL, INTENT(IN)    :: FACTH, FACK, CTHG0, CG(0:NK+1),      &
                              WN(0:NK+1), DEPTH, DDDX, DDDY,       &
-                             ALFLMT(NTH), CX, CY, DCXDX, DCXDY,   & 
-                             DCYDX, DCYDY, DCDX(0:NK+1), DCDY(0:NK+1) 
+                             ALFLMT(NTH), CX, CY, DCXDX, DCXDY,   &
+                             DCYDX, DCYDY, DCDX(0:NK+1), DCDY(0:NK+1)
       REAL, INTENT(INOUT) :: VA(NSPEC)
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
       INTEGER    :: ITH, IK, ISP
-      REAL       :: FGC, FKD, FKS, FRK(NK), FRG(NK), DDNorm(NTH),     & 
+      REAL       :: FGC, FKD, FKS, FRK(NK), FRG(NK), DDNorm(NTH),     &
                     FKC(NTH), VQ(NSPEC), VCFLT(NSPEC), DEPTH30,       &
                     DB(0:NK+1), DM(-1:NK+1), CFLK(NTH,0:NK),          &
 !Li   For new refraction scheme using Cg.  JGLi26Jul2011
@@ -859,7 +859,7 @@
 !        SNH2K(IK) = SINH( DPH2K(IK) )
 !Li   For new refraction scheme using Cg.  JGLi3Jun2011
 !!        SIGSNH(IK) = SIG(IK)/SINH(2.0*WN(IK)*DEPTH)
-!!AC  Replacing SIGSINH with a delimiter to prevent the SINH value from 
+!!AC  Replacing SIGSINH with a delimiter to prevent the SINH value from
 !!AC  becoming significantly large. Right now set to a max around 1E21
 !         SIGSNH(IK) = SIG(IK)/SINH(MIN(2.0*WN(IK)*DEPTH,50.0))
 !Li   Refraction factor uses minimum depth of 30 m.  JGLi12Feb2014
@@ -884,7 +884,7 @@
           DO IK=1, NK
 !Li   New refraction formulation using Cg only.  JGLi3Jun2011
 !         FRK(IK) = FACTH*2.0*SIG(IK)*(1.-DEPTH*SIG(IK)*SIG(IK)/GRAV)  &
-!     &                                /(DPH2K(IK)+SNH2K(IK))   
+!     &                                /(DPH2K(IK)+SNH2K(IK))
 !Li   Old refraction formulation using phase speed.  JGLi8Jun2011
             FRK(IK) = FACTH * SIGSNH(IK)
 !Li
@@ -895,8 +895,8 @@
           IF ( FLCUR ) THEN
              DO ITH=1, NTH
 !Li   Put a CTMAX limit on current theta rotation.  JGLi02Mar2017
-!               FKC(ITH) = FACTH*( DCYDX*ES2(ITH) - DCXDY*EC2(ITH) +  & 
-                FGC      = FACTH*( DCYDX*ES2(ITH) - DCXDY*EC2(ITH) +  & 
+!               FKC(ITH) = FACTH*( DCYDX*ES2(ITH) - DCXDY*EC2(ITH) +  &
+                FGC      = FACTH*( DCYDX*ES2(ITH) - DCXDY*EC2(ITH) +  &
                                   (DCXDX - DCYDY)*ESC(ITH) )
                 FKC(ITH) = SIGN( MIN(ABS(FGC), CTMAX), FGC )
              END DO
@@ -911,7 +911,7 @@
              DO IK=1, NK
                 ISP = (IK-1)*NTH + ITH
 !Li   Apply depth gradient limited refraction, current and GCT term
-                VCFLT(ISP)=FRG(IK)*ECOS(ITH) + FKC(ITH) +          & 
+                VCFLT(ISP)=FRG(IK)*ECOS(ITH) + FKC(ITH) +          &
                 SIGN( MIN(ABS(FRK(IK)*DDNorm(ITH)), ALFLMT(ITH)),  &
 !Li   For new refraction scheme using Cg.  JGLi26Jul2011
 !                             FRK(IK)*DDNorm(ITH) )
@@ -951,7 +951,7 @@
           DB(NK+1) = DSIP(NK+1) / CG(NK+1)
           DM(NK+1) = DM(NK)
           DM(  -1) = DM( 0)
-         
+
 ! 4.c Courant number of k-velocity without dividing by dk
 !!Li  FACK = DTG / REAL(NTLOC)
 !
@@ -995,7 +995,7 @@
 !
 ! 6.  Store reults --------------------------------------------------- *
 !
-        VA = VQ 
+        VA = VQ
 !
       RETURN
 !
@@ -1005,13 +1005,13 @@
 
 
 
-! Subroutine that calculate mid-flux values for x dimension 
+! Subroutine that calculate mid-flux values for x dimension
        SUBROUTINE SMCxUNO2(NUA, NUB, CF, UC, UFLX, AKDif, FU, FX, FTS)
 !!Li         CALL SMCxUNO2(iuf, juf, CQ, UCFL, ULCFLX, DNND, FUMD, FUDIFX, FMR)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NCel, MRFct, NUFc, IJKCel, IJKUFc, CLATS
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
          INTEGER, INTENT( IN):: NUA, NUB
@@ -1092,7 +1092,7 @@
            CNST1=FLOAT( IJKCel(3,N) )
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
-!    Use minimum gradient outside monotonic region. 
+!    Use minimum gradient outside monotonic region.
            CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
 !    Mid-flux value inside central cell M
@@ -1100,14 +1100,14 @@
 
          ENDIF
 
-!    Diffusion flux by face gradient x DT 
+!    Diffusion flux by face gradient x DT
          FX(i)=CNST0*CNST5*CNST8*CNST9
 
       END DO
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCxUNO2 ended.'
 
@@ -1115,7 +1115,7 @@
       END SUBROUTINE SMCxUNO2
 
 
-! Subroutine that calculate mid-flux values for x dimension 
+! Subroutine that calculate mid-flux values for x dimension
       SUBROUTINE SMCyUNO2(NVA, NVB, CF, VC, VFLY, AKDif, FV, FY, FTS)
 !!Li        CALL SMCyUNO2(ivf, jvf, CQ, VCFL, VLCFLY, DNND, FVMD, FVDIFY, FMR)
 
@@ -1160,21 +1160,21 @@
            CNST3=FLOAT( IJKCel(4,M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
-!    Courant number in local size-1 cell unit 
+!    Courant number in local size-1 cell unit
 !    Multiply by multi-resolution time step factor  FTS
            CNST6=0.5*( VC(L)+VC(M) )*FTS
            VFLY(j) = CNST6
 
-!    Face size integer and cosine factor.  
+!    Face size integer and cosine factor.
 !    CLATF is defined on V-face for SMC grid.  JGLi28Feb2012
          CNST8=CLATF(j)*FLOAT( IJKVFc(3,j) )
 
 !    For positive velocity case
          IF(CNST6 >= 0.0)  THEN
 
-!    Boundary cell y-size is set equal to central cell y-size 
-!    as y-boundary cell sizes are not proportional to refined 
-!    inner cells but constant of the base cell y-size, and  
+!    Boundary cell y-size is set equal to central cell y-size
+!    as y-boundary cell sizes are not proportional to refined
+!    inner cells but constant of the base cell y-size, and
 !    Use central cell speed for face speed.  JGLi06Apr2011
            IF( M .LE. 0 ) THEN
               VFLY(j) = VC(L)*FTS
@@ -1194,7 +1194,7 @@
 !    For negative velocity case
          ELSE
 
-!    Set boundary cell y-size equal to central cell y-size and 
+!    Set boundary cell y-size equal to central cell y-size and
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( L .LE. 0 ) THEN
                VFLY(j) = VC(M)*FTS
@@ -1210,7 +1210,7 @@
            CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
 !    Mid-flux value multiplied by face width and cosine factor
-           FV(j)=( CF(M) - CNST*(CNST3 + VFLY(j)) )*CNST8 
+           FV(j)=( CF(M) - CNST*(CNST3 + VFLY(j)) )*CNST8
 
          ENDIF
 
@@ -1222,7 +1222,7 @@
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCyUNO2 ended.'
 
@@ -1230,13 +1230,13 @@
       END SUBROUTINE SMCyUNO2
 
 
-! Subroutine that calculate mid-flux values for x dimension 
+! Subroutine that calculate mid-flux values for x dimension
        SUBROUTINE SMCxUNO2r(NUA, NUB, CF, UC, UFLX, AKDif, FU, FX)
 !!Li         CALL SMCxUNO2r(1, NUFc, CQ, UCFL, ULCFLX, DNND, FUMD, FUDIFX)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA, NY, NCel, NUFc, IJKCel, IJKUFc, CLATS
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
          INTEGER, INTENT( IN):: NUA, NUB
@@ -1271,7 +1271,7 @@
            CNST3=FLOAT( IJKCel(3,M) )
            CNST5=(CF(M)-CF(L))
 
-!    Averaged Courant number for base-level cell face 
+!    Averaged Courant number for base-level cell face
            CNST6= 0.5*( UC(L)+UC(M) )
            UFLX(i) = CNST6
 
@@ -1294,14 +1294,14 @@
 
 !    Mid-flux value inside central cell
            FU(i)=(CF(L) + CNST*(1.0-UFLX(i)/CNST2))
-           
+
 !    For negative velocity case
          ELSE
 
 !    Use central cell velocity for boundary flux.  JGLi06Apr2011
            IF( L .LE. 0) UFLX(i) = UC(M)
 
-!    Side gradient for upstream cell, depneding on UFLX sign. 
+!    Side gradient for upstream cell, depneding on UFLX sign.
            CNST4=(CF(N)-CF(M))
 
 !    Use minimum gradient outside monotonic region, include 0.5 factor
@@ -1312,14 +1312,14 @@
 
          ENDIF
 
-!    Diffusion flux by face gradient x DT 
+!    Diffusion flux by face gradient x DT
          FX(i)=AKDif*CNST0*CNST5/(CNST2 + CNST3)
 
       END DO
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCxUNO2r ended.'
 
@@ -1327,7 +1327,7 @@
       END SUBROUTINE SMCxUNO2r
 
 
-! Subroutine that calculate mid-flux values for y dimension 
+! Subroutine that calculate mid-flux values for y dimension
       SUBROUTINE SMCyUNO2r(NVA, NVB, CF, VC, VFLY, AKDif, FV, FY)
 !!Li        CALL SMCyUNO2r(1, NVFc, CQ, VCFL, VLCFLY, DNND, FVMD, FVDIFY)
 
@@ -1376,10 +1376,10 @@
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( M .LE. 0 ) VFLY(j) = VC(L)
 
-!    Upstream face gradient, depending on VFLY sign. 
+!    Upstream face gradient, depending on VFLY sign.
            CNST4=(CF(L)-CF(K))
 
-!    Use minimum gradient, including 0.5 factor and central sign. 
+!    Use minimum gradient, including 0.5 factor and central sign.
            CNST=Sign(0.5, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
 !    Mid-flux value multiplied by face width and cosine factor
@@ -1391,14 +1391,14 @@
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( L .LE. 0 ) VFLY(j) = VC(M)
 
-!    Side gradients for upstream face, depending on VFLY sign. 
+!    Side gradients for upstream face, depending on VFLY sign.
            CNST4=(CF(N)-CF(M))
 
 !    Use minimum gradient, including 0.5 factor and central sign.
            CNST=Sign(0.5, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
 !    Mid-flux value multiplied by face width and cosine factor
-           FV(j)=( CF(M) - CNST*(1.0+VFLY(j)) )*CNST8 
+           FV(j)=( CF(M) - CNST*(1.0+VFLY(j)) )*CNST8
 
          ENDIF
 
@@ -1409,7 +1409,7 @@
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCyUNO2r ended.'
 
@@ -1417,13 +1417,13 @@
       END SUBROUTINE SMCyUNO2r
 
 
-! Subroutine that calculate mid-flux values for x dimension with UNO3 scheme 
+! Subroutine that calculate mid-flux values for x dimension with UNO3 scheme
        SUBROUTINE SMCxUNO3(NUA, NUB, CF, UC, UFLX, AKDif, FU, FX, FTS)
 !!Li         CALL SMCxUNO3(iuf, juf, CQ, UCFL, ULCFLX, DNND, FUMD, FUDIFX, FMR)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NCel, MRFct, NUFc, IJKCel, IJKUFc, CLATS
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
          INTEGER, INTENT( IN):: NUA, NUB
@@ -1489,15 +1489,15 @@
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Second order gradient
-           CNST7 = CNST5 - CNST4 
+           CNST7 = CNST5 - CNST4
            CNST9 = 2.0/( CNST3+CNST2+CNST2+CNST1 )
 
 !    Use 3rd order scheme
            IF( Abs(CNST7) .LT. 0.6*CNST9*Abs(CF(M)-CF(K)) ) THEN
-               CNST= CNST5 - ( CNST3+UFLX(i) )*CNST7*CNST9/1.5 
+               CNST= CNST5 - ( CNST3+UFLX(i) )*CNST7*CNST9/1.5
 
 !    Use doubled UNO2 scheme
-           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN 
+           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN
                CNST=Sign(2.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
                 ELSE
@@ -1520,36 +1520,36 @@
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Second order gradient
-           CNST7 = CNST4 - CNST5 
+           CNST7 = CNST4 - CNST5
            CNST9 = 2.0/( CNST2+CNST3+CNST3+CNST1 )
 
 !    Use 3rd order scheme
            IF( Abs(CNST7) .LT. 0.6*CNST9*Abs(CF(N)-CF(L)) ) THEN
-               CNST= CNST5 + ( CNST2-UFLX(i) )*CNST7*CNST9/1.5 
+               CNST= CNST5 + ( CNST2-UFLX(i) )*CNST7*CNST9/1.5
 
 !    Use doubled UNO2 scheme
-           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN 
+           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN
                CNST=Sign(2.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
                 ELSE
-!    Use minimum gradient UNO2 scheme. 
+!    Use minimum gradient UNO2 scheme.
                CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
-           ENDIF 
+           ENDIF
 
 !    Mid-flux value inside central cell M
            FU(i)=(CF(M) - CNST*(CNST3+UFLX(i)))*CNST8
 
          ENDIF
 
-!    Diffusion flux by face gradient x DT 
+!    Diffusion flux by face gradient x DT
          FX(i)=CNST0*CNST5*CNST8/( CLATS( ij )*CLATS( ij ) )
 
       END DO
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCxUNO3 ended.'
 
@@ -1603,21 +1603,21 @@
            CNST3=FLOAT( IJKCel(4,M) )
            CNST5=(CF(M)-CF(L))/( CNST2 + CNST3 )
 
-!    Courant number in local size-1 cell unit 
+!    Courant number in local size-1 cell unit
 !    Multiply by multi-resolution time step factor  FTS
            CNST6=0.5*( VC(L)+VC(M) )*FTS
            VFLY(j) = CNST6
 
-!    Face size integer and cosine factor.  
+!    Face size integer and cosine factor.
 !    CLATF is defined on V-face for SMC grid.  JGLi28Feb2012
          CNST8=CLATF(j)*FLOAT( IJKVFc(3,j) )
 
 !    For positive velocity case
          IF(CNST6 >= 0.0)  THEN
 
-!    Boundary cell y-size is set equal to central cell y-size 
-!    as y-boundary cell sizes are not proportional to refined 
-!    inner cells but constant of the base cell y-size, and  
+!    Boundary cell y-size is set equal to central cell y-size
+!    as y-boundary cell sizes are not proportional to refined
+!    inner cells but constant of the base cell y-size, and
 !    Use central cell speed for face speed.  JGLi06Apr2011
            IF( M .LE. 0 ) THEN
               VFLY(j) = VC(L)*FTS
@@ -1629,15 +1629,15 @@
            CNST4=(CF(L)-CF(K))/( CNST2 + CNST1 )
 
 !    Second order gradient
-           CNST7 = CNST5 - CNST4 
+           CNST7 = CNST5 - CNST4
            CNST9 = 2.0/( CNST3+CNST2+CNST2+CNST1 )
 
 !    Use 3rd order scheme
            IF( Abs(CNST7) .LT. 0.6*CNST9*Abs(CF(M)-CF(K)) ) THEN
-               CNST= CNST5 - ( CNST3+VFLY(j) )*CNST7*CNST9/1.5 
+               CNST= CNST5 - ( CNST3+VFLY(j) )*CNST7*CNST9/1.5
 
 !    Use doubled UNO2 scheme
-           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN 
+           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN
                CNST=Sign(2.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
                 ELSE
@@ -1645,7 +1645,7 @@
 !    Use minimum gradient outside monotonic region
                CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
-           ENDIF 
+           ENDIF
 
 !    Mid-flux value multiplied by face width and cosine factor
            FV(j)=( CF(L) + CNST*(CNST2 - VFLY(j)) )*CNST8
@@ -1653,7 +1653,7 @@
 !    For negative velocity case
          ELSE
 
-!    Set boundary cell y-size equal to central cell y-size and 
+!    Set boundary cell y-size equal to central cell y-size and
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( L .LE. 0 ) THEN
                VFLY(j) = VC(M)*FTS
@@ -1666,15 +1666,15 @@
            CNST4=(CF(N)-CF(M))/( CNST1 + CNST3 )
 
 !    Second order gradient
-           CNST7 = CNST4 - CNST5 
+           CNST7 = CNST4 - CNST5
            CNST9 = 2.0/( CNST2+CNST3+CNST3+CNST1 )
 
 !    Use 3rd order scheme
            IF( Abs(CNST7) .LT. 0.6*CNST9*Abs(CF(N)-CF(L)) ) THEN
-               CNST= CNST5 + ( CNST2-VFLY(j) )*CNST7*CNST9/1.5 
+               CNST= CNST5 + ( CNST2-VFLY(j) )*CNST7*CNST9/1.5
 
 !    Use doubled UNO2 scheme
-           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN 
+           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN
                CNST=Sign(2.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
 
                 ELSE
@@ -1685,7 +1685,7 @@
            ENDIF
 
 !    Mid-flux value multiplied by face width and cosine factor
-           FV(j)=( CF(M) - CNST*(CNST3 + VFLY(j)) )*CNST8 
+           FV(j)=( CF(M) - CNST*(CNST3 + VFLY(j)) )*CNST8
 
          ENDIF
 
@@ -1697,7 +1697,7 @@
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCyUNO3 ended.'
 
@@ -1705,13 +1705,13 @@
       END SUBROUTINE SMCyUNO3
 
 
-! Subroutine that calculate mid-flux values for x dimension with UNO3 
+! Subroutine that calculate mid-flux values for x dimension with UNO3
        SUBROUTINE SMCxUNO3r(NUA, NUB, CF, UC, UFLX, AKDif, FU, FX)
 !!Li         CALL SMCxUNO3r(1, NUFc, CQ, UCFL, ULCFLX, DNND, FUMD, FUDIFX)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA, NY, NCel, NUFc, IJKCel, IJKUFc, CLATS
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
          INTEGER, INTENT( IN):: NUA, NUB
@@ -1720,7 +1720,7 @@
 !
          INTEGER ::  i, j, k, L, M, N, ij
          REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6, &
-                      CNST7, CNST8, CNST9 
+                      CNST7, CNST8, CNST9
 !    Two layer of boundary cells are added to each boundary cell face
 !    with all boundary cell values CF(-9:0)=0.0.
 
@@ -1746,7 +1746,7 @@
            CNST3=FLOAT( IJKCel(3,M) )
            CNST5=(CF(M)-CF(L))
 
-!    Averaged Courant number for base-level cell face 
+!    Averaged Courant number for base-level cell face
            CNST6= 0.5*( UC(L)+UC(M) )
            UFLX(i) = CNST6
 
@@ -1769,23 +1769,23 @@
            IF( Abs(CNST9) <= 0.6*Abs(CNST8) )  THEN
 !    Use 3rd order scheme in limited zone, note division by 2 grid sizes
              CNST=0.5*CNST5 - (1.0+UFLX(i)/CNST2)*CNST9/6.0
-           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN 
+           ELSE IF( DBLE(CNST4)*DBLE(CNST5) .GT. 0.d0 ) THEN
 !    Use doubled minimum gradient in rest of monotonic region
              CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
-           ELSE 
+           ELSE
 !    Use minimum gradient all region with 0.5 factor
              CNST=Sign(0.5, CNST5)*min( Abs(CNST4), Abs(CNST5) )
            ENDIF
 !    Mid-flux value inside central cell
            FU(i)=(CF(L) + CNST*(1.0-UFLX(i)/CNST2))
-           
+
 !    For negative velocity case
          ELSE
 
 !    Use central cell velocity for boundary flux.  JGLi06Apr2011
            IF( L .LE. 0) UFLX(i) = UC(M)
 
-!    Side gradient for upstream cell, depneding on UFLX sign. 
+!    Side gradient for upstream cell, depneding on UFLX sign.
            CNST4=(CF(N)-CF(M))
            CNST8=(CF(N)-CF(L))
            CNST9=(CNST4-CNST5)
@@ -1806,14 +1806,14 @@
 
          ENDIF
 
-!    Diffusion flux by face gradient x DT 
+!    Diffusion flux by face gradient x DT
          FX(i)=AKDif*CNST0*CNST5/(CNST2 + CNST3)
 
       END DO
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCxUNO3r ended.'
 
@@ -1835,7 +1835,7 @@
          REAL,    INTENT(Out):: VFLY(NVFc), FV(NVFc), FY(NVFc)
          INTEGER ::  i, j, k, L, M, N, ij
          REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6, &
-      &               CNST7, CNST8, CNST9 
+      &               CNST7, CNST8, CNST9
 
 !    Notice an extra side length L is multiplied to mid-flux to give correct
 !    proportion of flux into the cells.  This length will be removed by the
@@ -1871,7 +1871,7 @@
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( M .LE. 0 ) VFLY(j) = VC(L)
 
-!    Upstream face gradient, depending on VFLY sign. 
+!    Upstream face gradient, depending on VFLY sign.
            CNST4=(CF(L)-CF(K))
 
 !    Second gradient for 3rd scheme
@@ -1885,7 +1885,7 @@
 !    Use doubled minimum gradient in rest of monotonic region
              CNST=Sign(1.0, CNST5)*min( Abs(CNST4), Abs(CNST5) )
            ELSE
-!    Use minimum gradient, including 0.5 factor and central sign. 
+!    Use minimum gradient, including 0.5 factor and central sign.
              CNST=Sign(0.5, CNST5)*min( Abs(CNST4), Abs(CNST5) )
            ENDIF
 
@@ -1898,7 +1898,7 @@
 !    Use central cell speed for flux face speed.  JGLi06Apr2011
            IF( L .LE. 0 ) VFLY(j) = VC(M)
 
-!    Side gradients for upstream face, depending on VFLY sign. 
+!    Side gradients for upstream face, depending on VFLY sign.
            CNST4=(CF(N)-CF(M))
 
 !    Second gradient for 3rd scheme
@@ -1916,7 +1916,7 @@
              CNST=Sign(0.5, CNST5)*min( Abs(CNST4), Abs(CNST5) )
            ENDIF
 !    Mid-flux value multiplied by face width and cosine factor
-           FV(j)=( CF(M) - CNST*(1.0+VFLY(j)) )*CNST7 
+           FV(j)=( CF(M) - CNST*(1.0+VFLY(j)) )*CNST7
 
          ENDIF
 
@@ -1927,7 +1927,7 @@
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 ! 999  PRINT*, ' Sub SMCyUNO3r ended.'
 
@@ -1936,37 +1936,37 @@
 
 !
 ! Subroutine that calculate cell centre gradient for any input variable.
-! Nemerical average is applied to size-changing faces and the gradients 
+! Nemerical average is applied to size-changing faces and the gradients
 ! are along the lat-lon local east-north directions.    JGLi18Aug2015
 ! Add optional zero-gradient bounday conditions.    JGLi08Aug2017
 !
-       SUBROUTINE SMCGradn(CVQ, GrdX, GrdY, L0r1) 
+       SUBROUTINE SMCGradn(CVQ, GrdX, GrdY, L0r1)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA,   NUFc,   NVFc,   MRFct,       &
       &                      IJKCel, IJKUFc, IJKVFC, CLATS, SX, SY
 !/ARC         USE W3GDATMD, ONLY:  NGLO
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
 !!   New boundary conditions depending on user defined L0r1.
-!!   L0r1 = 0 will set zero at land points while L0r1 > 0 invokes 
+!!   L0r1 = 0 will set zero at land points while L0r1 > 0 invokes
 !!   the zero-gradient boundary condition.    JGLi08Aug2017
          REAL,    INTENT( IN)::  CVQ(NSEA)
          REAL,    INTENT(Out):: GrdX(NSEA), GrdY(NSEA)
-         INTEGER, INTENT( IN):: L0r1      
+         INTEGER, INTENT( IN):: L0r1
 !
          INTEGER :: I, J, K, L, M, N
-         REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6 
+         REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6
          REAL :: DX0I, DY0I
 
 !    Use a few working arrays
-         REAL,  Dimension(-9:NSEA):: CVF, AUN, AVN  
+         REAL,  Dimension(-9:NSEA):: CVF, AUN, AVN
 
 !    Two layer of boundary cells are added to each boundary cell face
 !    with all boundary cell default values CVF(-9:0)= 0.0.
          CVF(-9:0)  = 0.0
-         CVF(1:NSEA)=CVQ(1:NSEA) 
+         CVF(1:NSEA)=CVQ(1:NSEA)
 
 !!   Initialize arrays
          AUN = 0.
@@ -1985,7 +1985,7 @@
 
 !$OMP DO
 
-!!   Calculate x-gradient by averaging U-face gradients. 
+!!   Calculate x-gradient by averaging U-face gradients.
         DO i=1, NUFc
 
 !    Select Upstream, Central and Downstream cells
@@ -1996,21 +1996,21 @@
         IF( L0r1 .EQ. 0 .OR. (L > 0 .AND. M > 0) ) THEN
 
 !    Multi-resolution SMC grid requires flux multiplied by face factor.
-           CNST1=FLOAT( IJKUFc(3,i) ) 
+           CNST1=FLOAT( IJKUFc(3,i) )
 
 !    Face bounding cell lengths and central gradient
-           CNST2=FLOAT( IJKCel(3,L) ) 
-           CNST3=FLOAT( IJKCel(3,M) ) 
+           CNST2=FLOAT( IJKCel(3,L) )
+           CNST3=FLOAT( IJKCel(3,M) )
 
 !    Side gradients over 2 cell lengths for central cell.
 !    Face size factor is also included for average.
            CNST5=CNST1*(CVF(M)-CVF(L))/(CNST2+CNST3)
 
-!$OMP CRITICAL 
+!$OMP CRITICAL
 !    Store side gradient in two neighbouring cells
            AUN(L) = AUN(L) + CNST5
            AUN(M) = AUN(M) + CNST5
-!$OMP END CRITICAL 
+!$OMP END CRITICAL
 
         ENDIF
         END DO
@@ -2019,13 +2019,13 @@
 
 !  Assign averaged side-gradient to GrdX, plus latitude factor
 !  Note averaging over 2 times of cell y-width factor but AUN
-!  has already been divied by two cell lengths. 
+!  has already been divied by two cell lengths.
 
 !$OMP DO
 
         DO n=1, NSEA
-!  Cell y-size IJKCel(4,i) is used to cancel the face size-factor in AUN. 
-!  Plus the actual physical length scale for size-1 cell. 
+!  Cell y-size IJKCel(4,i) is used to cancel the face size-factor in AUN.
+!  Plus the actual physical length scale for size-1 cell.
 !  Note polar cell (if any) AUN = 0.0 as it has no U-face.
            GrdX(n)=DX0I*AUN(n)/( CLats(n)*IJKCel(4,n) )
 
@@ -2035,7 +2035,7 @@
 
 !$OMP DO
 
-!!   Calculate y-gradient by averaging V-face gradients. 
+!!   Calculate y-gradient by averaging V-face gradients.
         DO j=1, NVFc
 
 !    Select Central and Downstream cells
@@ -2056,11 +2056,11 @@
 !    Face size factor is also included for average.
            CNST6=CNST1*(CVF(M)-CVF(L))/(CNST2+CNST3)
 
-!$OMP CRITICAL 
+!$OMP CRITICAL
 !    Store side gradient in two neighbouring cells
-           AVN(L) = AVN(L) + CNST6 
-           AVN(M) = AVN(M) + CNST6 
-!$OMP END CRITICAL 
+           AVN(L) = AVN(L) + CNST6
+           AVN(M) = AVN(M) + CNST6
+!$OMP END CRITICAL
 
         ENDIF
         END DO
@@ -2070,7 +2070,7 @@
 !$OMP DO
 
 !  Assign averaged side-gradient to GrdY.
-        DO n=1, NSEA 
+        DO n=1, NSEA
 !  AV is divided by the cell x-size IJKCel(3,i) to cancel face
 !  size-factor, and physical y-distance of size-1 cell.
            GrdY(n)=DY0I*AVN(n)/Real( IJKCel(3,n) )
@@ -2079,7 +2079,7 @@
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
 !/ARC  !!Li  Polar cell (if any) y-gradient is set to zero.
 !/ARC        IF( NSEA .GT. NGLO ) GrdY(NSEA) = 0.0
@@ -2091,15 +2091,15 @@
 
 
 !
-! Subroutine that average sea point values with a 1-2-1 scheme. 
+! Subroutine that average sea point values with a 1-2-1 scheme.
 !
-       SUBROUTINE SMCAverg(CVQ) 
+       SUBROUTINE SMCAverg(CVQ)
 
          USE CONSTANTS
          USE W3GDATMD, ONLY: NSEA,   NUFc,   NVFc,    &
-      &                      IJKCel, IJKUFc, IJKVFC 
+      &                      IJKCel, IJKUFc, IJKVFC
 !/ARC         USE W3GDATMD, ONLY:  NGLO
-         USE W3ODATMD, ONLY: NDSE, NDST 
+         USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
          REAL,    INTENT(INOUT)::  CVQ(-9:NSEA)
@@ -2108,17 +2108,17 @@
          REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6
 
 !    Use a few working arrays
-         REAL,  Dimension(-9:NSEA):: CVF, AUN, AVN  
+         REAL,  Dimension(-9:NSEA):: CVF, AUN, AVN
 
 !    Two layer of boundary cells are added to each boundary cell face
 !    with all boundary cell values stored in CVF(-9:0).
-         CVF=CVQ 
+         CVF=CVQ
 
 !!   Initialize arrays
          AUN = 0.
          AVN = 0.
 
-!/ARC !!Li  Save polar cell value 
+!/ARC !!Li  Save polar cell value
 !/ARC       CNST0 = CVQ(NSEA)
 
 !$OMP Parallel Default(Shared), Private(i, j, L, M, n),  &
@@ -2126,7 +2126,7 @@
 
 !$OMP DO
 
-!!   Calculate x-gradient by averaging U-face gradients. 
+!!   Calculate x-gradient by averaging U-face gradients.
         DO i=1, NUFc
 
 !    Select Upstream, Central and Downstream cells
@@ -2136,11 +2136,11 @@
 !    Multi-resolution SMC grid requires flux multiplied by face factor.
            CNST5=Real( IJKUFc(3,i) )*(CVF(M)+CVF(L))
 
-!$OMP CRITICAL 
+!$OMP CRITICAL
 !    Store side gradient in two neighbouring cells
-           AUN(L) = AUN(L) + CNST5 
-           AUN(M) = AUN(M) + CNST5 
-!$OMP END CRITICAL 
+           AUN(L) = AUN(L) + CNST5
+           AUN(M) = AUN(M) + CNST5
+!$OMP END CRITICAL
 
         END DO
 
@@ -2148,7 +2148,7 @@
 
 !$OMP DO
 
-!!   Calculate y-gradient by averaging V-face gradients. 
+!!   Calculate y-gradient by averaging V-face gradients.
         DO j=1, NVFc
 
 !    Select Central and Downstream cells
@@ -2158,11 +2158,11 @@
 !    Face size is required for multi-resolution grid.
            CNST6=Real( IJKVfc(3,j) )*(CVF(M)+CVF(L))
 
-!$OMP CRITICAL 
+!$OMP CRITICAL
 !    Store side gradient in two neighbouring cells
-           AVN(L) = AVN(L) + CNST6 
-           AVN(M) = AVN(M) + CNST6 
-!$OMP END CRITICAL 
+           AVN(L) = AVN(L) + CNST6
+           AVN(M) = AVN(M) + CNST6
+!$OMP END CRITICAL
 
        END DO
 
@@ -2171,21 +2171,21 @@
 !$OMP DO
 
 !  Assign averaged value back to CVQ.
-       DO n=1, NSEA 
+       DO n=1, NSEA
 
             CNST3=0.125/Real( IJKCel(3,n) )
             CNST4=0.125/Real( IJKCel(4,n) )
-!  AUN is divided by the cell y-size IJKCel(4,n) and AVN by 
-!  the cell x-size IJKCel(3,n) to cancel face size factors. 
-            CVQ(n)= AUN(n)*CNST4 + AVN(n)*CNST3 
+!  AUN is divided by the cell y-size IJKCel(4,n) and AVN by
+!  the cell x-size IJKCel(3,n) to cancel face size factors.
+            CVQ(n)= AUN(n)*CNST4 + AVN(n)*CNST3
 
        END DO
 
 !$OMP END DO
 
-!$OMP END Parallel 
+!$OMP END Parallel
 
-!/ARC !!Li  Polar cell (if any) keep original value. 
+!/ARC !!Li  Polar cell (if any) keep original value.
 !/ARC       IF( NSEA .GT. NGLO ) CVQ(NSEA) = CNST0
 
 ! 999  PRINT*, ' Sub SMCAverg ended.'
@@ -2196,10 +2196,10 @@
 
 !Li
 ! Subroutine that calculate great circle turning (GCT) and refraction.
-! The refraction and GCT terms are equivalent to a simgle rotation by each 
+! The refraction and GCT terms are equivalent to a simgle rotation by each
 ! element and does not need to be calculated as advection.  A simple rotation
-! scheme similar to the 1st order upstream scheme but without any restriction 
-! on the rotation angle or the CFL limit by an Eulerian advection scheme. 
+! scheme similar to the 1st order upstream scheme but without any restriction
+! on the rotation angle or the CFL limit by an Eulerian advection scheme.
 !                 Jian-Guo Li  12 Nov 2010
 !Li
 
@@ -2210,7 +2210,7 @@
          IMPLICIT NONE
          REAL, INTENT(IN)   ::  CoRfr(NTH, NK)
          REAL, INTENT(INOUT):: SpeTHK(NTH, NK)
-         INTEGER ::  I, J, K, L, M, N 
+         INTEGER ::  I, J, K, L, M, N
          REAL, Dimension(NTH):: SpeGCT, Spectr
          REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6
 
@@ -2219,7 +2219,7 @@
 
 !!   Asign cell spectrum to temporary variable Spcetr
          Spectr=SpeTHK(1:NTH,n)
-         SpeGCT=0.0 
+         SpeGCT=0.0
 
 !!   Loop through NTH directional bins for each cell spectrum
          DO j=1, NTH
@@ -2230,7 +2230,7 @@
 !    Work out integer number of bins to be skipped.
 !    If K is great than NTH, full circle turning is removed.
            CNST5=ABS( CNST6 )
-           K= MOD( INT(CNST5), NTH ) 
+           K= MOD( INT(CNST5), NTH )
 
 !    Partitioning faraction of the spectral component
            CNST1=CNST5 - FLOAT( INT(CNST5) )
@@ -2238,7 +2238,7 @@
 
 !    For positive turning case
          IF(CNST6 > 0.0)  THEN
- 
+
 !    Select the upstream and downstream bins to rotate in, wrap at end
            L=j+K
            M=j+K+1
@@ -2250,7 +2250,7 @@
            SpeGCT(M)=SpeGCT(M)+Spectr(j)*CNST1
 
 !    For negative or no turning case
-         ELSE 
+         ELSE
 
 !    Select the upstream and downstream bins to rotate in, wrap at end
            L=j-K
@@ -2280,9 +2280,9 @@
 
 
 !Li
-! Subroutine that calculates refraction induced shift in k-space. 
+! Subroutine that calculates refraction induced shift in k-space.
 ! The term is equivalent to advection on an irregular k-space grid.
-! The UNO2 scheme on irregular grid is used for this term. 
+! The UNO2 scheme on irregular grid is used for this term.
 !                 Jian-Guo Li  15 Nov 2010
 ! Fix bug on CFL limiter and add positive filter.  JGLi28Jun2017
 !Li
@@ -2300,11 +2300,11 @@
          REAL, Dimension(-1:NK+2):: SpeRfr, Spectr, SpeFlx
          REAL:: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6
 
-!Li  Cell and side indices for k-dimension are arranged as 
+!Li  Cell and side indices for k-dimension are arranged as
 !    Cell:    | -1 | 0 | 1 | 2 | ... | NK | NK+1 | NK+2 |
 !    Side:        -1   0   1   2 ...     NK     NK+1
-!    The wave action in k-space is extended at the high-wavenumber (frequency) end 
-!    by the (m+2)th negative power of frequency for boundary conditions.  Outside 
+!    The wave action in k-space is extended at the high-wavenumber (frequency) end
+!    by the (m+2)th negative power of frequency for boundary conditions.  Outside
 !    low-wavenumber (frequncy) end, wave action is assumed to be zero.
         CNST=XFR**(-7)
 
@@ -2317,16 +2317,16 @@
          Spectr(NK+1)=Spectr(NK  )*CNST
          Spectr(NK+2)=Spectr(NK+1)*CNST
 
-!!   Calculate k-space gradient for NK+2 faces by UNO2 scheme 
+!!   Calculate k-space gradient for NK+2 faces by UNO2 scheme
             SpeRfr(-1)= 0.0
          DO j=-1, NK+1
             SpeRfr(j)=(Spectr(j+1)-Spectr(j))/DKS(j)
          ENDDO
 
-!!   Calculate k-space fluxes for NK+1 faces by UNO2 scheme 
+!!   Calculate k-space fluxes for NK+1 faces by UNO2 scheme
          DO j=0, NK
 
-!    Final refraction Courant number for this k-space face 
+!    Final refraction Courant number for this k-space face
          CNST6=CoRfr(n,j)
 !!   Note CoRfr is CFL for k but without dividing dk.
 
@@ -2336,9 +2336,9 @@
             CNST0 = MIN( CTMAX*DKC(j), CNST6 )
          SpeFlx(j) = CNST0*( Spectr(j) + SIGN(0.5, SpeRfr(j))*(DKC(j)-CNST0)  &
                       *MIN( ABS(SpeRfr(j-1)), ABS(SpeRfr(j)) ) )
- 
+
 !    For negative or no turning case
-         ELSE 
+         ELSE
 
             CNST0 = MIN( CTMAX*DKC(j+1), -CNST6 )
          SpeFlx(j) = -CNST0*( Spectr(j+1) - SIGN(0.5, SpeRfr(j))*(DKC(j+1)-CNST0) &
@@ -2351,7 +2351,7 @@
 
 !!   Update spectrum for the given direction
          DO j=1, NK
-!    Final refraction Courant number for this k-space face 
+!    Final refraction Courant number for this k-space face
 !           SpeTHK(n, j) = Spectr(j) + (SpeFlx(j-1) - SpeFlx(j))/DKC(j)
 !    Add positive filter in case negative values.  JGLi27Jun2017
             SpeTHK(n, j) = MAX( 0.0, Spectr(j)+(SpeFlx(j-1)-SpeFlx(j))/DKC(j) )
@@ -2380,7 +2380,7 @@
 
          IMPLICIT NONE
 
-         INTEGER :: I, J, K, L, M, N 
+         INTEGER :: I, J, K, L, M, N
          REAL :: CNST, CNST0, CNST1, CNST2, CNST3, CNST4, CNST5, CNST6
          REAL, Dimension(NSEA) :: HCel, GrHx, GrHy
 !        REAL, Dimension(-9:NSEA) :: HCel
@@ -2388,7 +2388,7 @@
 !!   Assign water depth to HCel from DW integer values.
 !!   set half the minimum depth DMIN for negative cells.
 !      HCel(-9:0) = 0.5*DMIN
-       HCel(1:NSEA)= DW(1:NSEA) 
+       HCel(1:NSEA)= DW(1:NSEA)
 
 !!   Reset shallow water depth with minimum depth
 !$OMP Parallel DO Private(k)
@@ -2427,10 +2427,10 @@
            DDDX(j:j+m-1,i:i+k-1)  = DHDX(n)
            DDDY(j:j+m-1,i:i+k-1)  = DHDY(n)
 
-!/ARC  !Li  Depth gradient in the Arctic part has to be rotated into 
-!/ARC  !Li  the map-east system for calculation of refraction. 
+!/ARC  !Li  Depth gradient in the Arctic part has to be rotated into
+!/ARC  !Li  the map-east system for calculation of refraction.
 !/ARC       IF( n .GT. NGLO ) THEN
-!/ARC          CNST0 = ANGARC(n - NGLO)*DERA 
+!/ARC          CNST0 = ANGARC(n - NGLO)*DERA
 !/ARC          CNST1 = DHDX(n)*COS(CNST0) - DHDY(n)*SIN(CNST0)
 !/ARC          CNST2 = DHDX(n)*SIN(CNST0) + DHDY(n)*COS(CNST0)
 !/ARC          DHDX(n) = CNST1
@@ -2440,7 +2440,7 @@
        END DO
 !$OMP END Parallel DO
 
-!! Calculate the depth gradient limiter for refraction.  
+!! Calculate the depth gradient limiter for refraction.
        L = 0
 
 !$OMP Parallel DO Private(i, n, CNST4, CNST6)
@@ -2460,7 +2460,7 @@
 !Li   Refraction is done only when depth gradient is non-zero.
 !Li   Note ACOS returns value between [0, Pi), always positive.
                CNST6 = ACOS(-(DHDX(n)*ECOS(i)+DHDY(n)*ESIN(i))/CNST4 )
-!Li   User-defined refraction limiter added.   JGLi09Jan2012 
+!Li   User-defined refraction limiter added.   JGLi09Jan2012
                DHLMT(i,n)=MIN(Refran, 0.75*MIN(CNST6,ABS(PI-CNST6)))/DTH
              END DO
 !Li   Output some values for inspection.  JGLi22Jul2011
@@ -2474,12 +2474,12 @@
        ENDDO
 !$OMP END Parallel DO
 
-!/T       WRITE(NDST,*) ' No. Refraction points =', L 
+!/T       WRITE(NDST,*) ' No. Refraction points =', L
 
 !/T 999  PRINT*, ' Sub SMCDHXY ended.'
 
        RETURN
-       END SUBROUTINE SMCDHXY 
+       END SUBROUTINE SMCDHXY
 
 
 ! Subroutine that calculates current velocity gradient for refraction.
@@ -2489,9 +2489,9 @@
 !
        SUBROUTINE SMCDCXY
          USE CONSTANTS
-         USE W3GDATMD, ONLY: NX, NY, NSEA, MAPSTA, MAPFS, MRFct, IJKCel 
+         USE W3GDATMD, ONLY: NX, NY, NSEA, MAPSTA, MAPFS, MRFct, IJKCel
 !/ARC         USE W3GDATMD, ONLY: NGLO, ANGARC
-         USE W3ADATMD, ONLY: CX, CY, DCXDX, DCXDY, DCYDX, DCYDY 
+         USE W3ADATMD, ONLY: CX, CY, DCXDX, DCXDY, DCYDX, DCYDY
          USE W3ODATMD, ONLY: NDSE, NDST
 
          IMPLICIT NONE
@@ -2505,7 +2505,7 @@
 !      CXCY(-9:0) = 0.0
 !!   Use zero-gradient boundary condition or L0r1 > 0
        L = 1
-       CXCY(1:NSEA)= CX(1:NSEA) 
+       CXCY(1:NSEA)= CX(1:NSEA)
 
 !!   Initialize full grid gradient arrays
 !/DEBUGDCXDX        WRITE(740+IAPROC,*) 'Before assigning DCXDX to ZERO'
@@ -2523,10 +2523,10 @@
            IF( ABS( GrHx(n) ) .GT.  0.01) GrHx(n)=SIGN( 0.01, GrHx(n) )
            IF( ABS( GrHy(n) ) .GT.  0.01) GrHy(n)=SIGN( 0.01, GrHy(n) )
 
-!/ARC  !Li  Current gradient in the Arctic part has to be rotated into 
-!/ARC  !Li  the map-east system for calculation of refraction. 
+!/ARC  !Li  Current gradient in the Arctic part has to be rotated into
+!/ARC  !Li  the map-east system for calculation of refraction.
 !/ARC       IF( n .GT. NGLO ) THEN
-!/ARC          CNST0 = ANGARC(n - NGLO)*DERA 
+!/ARC          CNST0 = ANGARC(n - NGLO)*DERA
 !/ARC          CNST1 = GrHx(n)*COS(CNST0) - GrHy(n)*SIN(CNST0)
 !/ARC          CNST2 = GrHx(n)*SIN(CNST0) + GrHy(n)*COS(CNST0)
 !/ARC          GrHx(n) = CNST1
@@ -2550,7 +2550,7 @@
 !      CXCY(-9:0) = 0.0
 !!   Use zero-gradient boundary condition or L0r1 > 0
        L = 1
-       CXCY(1:NSEA)= CY(1:NSEA) 
+       CXCY(1:NSEA)= CY(1:NSEA)
 
 !!   Initialize full grid gradient arrays
        DCYDX = 0.0
@@ -2567,10 +2567,10 @@
            IF( ABS( GrHx(n) ) .GT.  0.01) GrHx(n)=SIGN( 0.01, GrHx(n) )
            IF( ABS( GrHy(n) ) .GT.  0.01) GrHy(n)=SIGN( 0.01, GrHy(n) )
 
-!/ARC  !Li  Current gradient in the Arctic part has to be rotated into 
-!/ARC  !Li  the map-east system for calculation of refraction. 
+!/ARC  !Li  Current gradient in the Arctic part has to be rotated into
+!/ARC  !Li  the map-east system for calculation of refraction.
 !/ARC       IF( n .GT. NGLO ) THEN
-!/ARC          CNST0 = ANGARC(n - NGLO)*DERA 
+!/ARC          CNST0 = ANGARC(n - NGLO)*DERA
 !/ARC          CNST1 = GrHx(n)*COS(CNST0) - GrHy(n)*SIN(CNST0)
 !/ARC          CNST2 = GrHx(n)*SIN(CNST0) + GrHy(n)*COS(CNST0)
 !/ARC          GrHx(n) = CNST1
@@ -2591,7 +2591,7 @@
 !/T 999  PRINT*, ' Sub SMCDCXY ended.'
 
        RETURN
-       END SUBROUTINE SMCDCXY 
+       END SUBROUTINE SMCDCXY
 
 
 !/
@@ -2790,9 +2790,9 @@
 !/MPI          END IF
 !/MPI        IF ( NPST .GE. 2 ) EXIT
 !/MPI        END DO
-! 
+!
 !/MPI      RETURN
-! 
+!
 !/ End of W3GATHSMC ----------------------------------------------------- /
 !/
       END SUBROUTINE W3GATHSMC
@@ -2814,7 +2814,7 @@
 !/    07-Sep-2005 : Updated boundary conditions.        ( version 3.08 )
 !/    13-Jun-2006 : Split STORE in G/SSTORE             ( version 3.09 )
 !/     9-Dec-2010 : Adapted for SMC grid propagtion.     JGLi09Dec2010
-!/    16-Jan-2012 : Remove MAPSTA checking for SMC grid. JGLi16Jan2012  
+!/    16-Jan-2012 : Remove MAPSTA checking for SMC grid. JGLi16Jan2012
 !/
 !/
 !  1. Purpose :
@@ -2889,7 +2889,7 @@
       IMPLICIT NONE
 !
 !/MPI      INCLUDE "mpif.h"
-!/ 
+!/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
 !/

--- a/model/ftn/w3ref1md.ftn
+++ b/model/ftn/w3ref1md.ftn
@@ -18,11 +18,11 @@
 !/    11-Nov-2013 : Extends IG energy into main band    ( version 4.13 )
 !/    11-Jun-2014 : Put reflection by subgrids back     ( version 5.01 )
 !/    27-Jun-2014 : Modifies subgrid reflection of IG   ( version 5.01 )
-!/ 
+!/
 !  1. Purpose :
 !
-!     This module computes : 
-!        - shoreline reflection 
+!     This module computes :
+!        - shoreline reflection
 !        - unresolved islands and iceberg reflections
 !
 !  2. Variables and types :
@@ -88,18 +88,18 @@
 !
 !  2. Method :
 !
-!     Adds the reflected components from 2 types of sources: 
-!        shoreline reflection, subgrid obstruction and icebergs 
+!     Adds the reflected components from 2 types of sources:
+!        shoreline reflection, subgrid obstruction and icebergs
 !
 !     In the case where the IG switch is present, there are two passes:
-!        - ICALC = 1, only the wind sea and swell are reflected (no IG added) 
-!        - ICALC = 2, IG energy is added into all frequency bands 
+!        - ICALC = 1, only the wind sea and swell are reflected (no IG added)
+!        - ICALC = 2, IG energy is added into all frequency bands
 !
 !
 !     When IG energy is put in the entire spectrum ( NINT(IGPARS(4)).EQ.2 )
 !        two passes are done: the first for the reflection of windsea and swell
 !                             the second for the addition of IG and IG reflection alone
-!      
+!
 !
 !  3. Parameters :
 !
@@ -173,12 +173,12 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/ 
+!/
       INTEGER         :: ISPECI, ISPEC, IK, ITH, ITH2, ITH3, ITH2X, ITH2Y, &
                          NRS, IK1
       INTEGER         :: ISEA, ICALC
 !/S      INTEGER, SAVE           :: IENT = 0
-      LOGICAL         :: IGBCOVERWRITE, IGSWELLMAX 
+      LOGICAL         :: IGBCOVERWRITE, IGSWELLMAX
       REAL            :: R1, R2, R3, R4, R2X, R2Y, DEPTHIG
       REAL            :: DELA, DELX, DELY, FACX
       REAL            :: FAC1, FAC2, FAC3, FAC4, RAMP0, RAMP, &
@@ -197,7 +197,7 @@
 !
 !/IG1 IGBCOVERWRITE =(MOD( NINT(IGPARS(4)),2).EQ.1)
 !/IG1 IGSWELLMAX =( NINT(IGPARS(4)).GE.2)
-! This following line is a quick fix before the bug is understood .... 
+! This following line is a quick fix before the bug is understood ....
 !/IG1 IF (GTYPE.EQ.UNGTYPE) IGSWELLMAX =.FALSE.
 !/IG1 IGFAC1 = 0.25
 !/IG1 IGFAC2 = 0.25
@@ -205,29 +205,29 @@
       FMEANA  = 0.
       FMEAN2  = 0.
 
-      DELX=1. 
-      DELY=1. 
+      DELX=1.
+      DELY=1.
       ! set FACx for all grid types
       IF (FLAGLL) THEN
-        FACX   =  1./(DERA * RADIUS) 
-      ELSE 
+        FACX   =  1./(DERA * RADIUS)
+      ELSE
         FACX   =  1.
       END IF
 
-      ISEA = MAPFS (IY,IX) 
-      IF (GTYPE.EQ.RLGTYPE) THEN 
+      ISEA = MAPFS (IY,IX)
+      IF (GTYPE.EQ.RLGTYPE) THEN
         DELX=SX*CLATS(ISEA)/FACX
         DELY=SY/FACX
         END IF
-      IF (GTYPE.EQ.CLGTYPE) THEN 
+      IF (GTYPE.EQ.CLGTYPE) THEN
       ! Maybe what follows works also for RLGTYPE ... to be verified
         DELX=HPFAC(IY,IX)/ FACX
-        DELY=HQFAC(IY,IX)/ FACX 
+        DELY=HQFAC(IY,IX)/ FACX
         END IF
 
-      IF (GTYPE.EQ.UNGTYPE) THEN 
-        DELX=5.*SQRT(SI(IX))*(DERA * RADIUS)    ! first approximation ... 
-        DELY=5.*SQRT(SI(IX))*(DERA * RADIUS)    ! first approximation ... 
+      IF (GTYPE.EQ.UNGTYPE) THEN
+        DELX=5.*SQRT(SI(IX))*(DERA * RADIUS)    ! first approximation ...
+        DELY=5.*SQRT(SI(IX))*(DERA * RADIUS)    ! first approximation ...
         END IF
 
       IK1=1
@@ -255,32 +255,32 @@
       HS=4.*SQRT(EMEANA)
 !/IG1      ATMP(:)=A(:)      ! the IG energy will be added to this ATMP
 !/IG1      ATMP2(:)=A(:)     ! this is really to keep in memory the original spectrum
-!/IG1      IF (IGBCOVERWRITE.AND.REFLC(1).GT.0) THEN 
+!/IG1      IF (IGBCOVERWRITE.AND.REFLC(1).GT.0) THEN
 !/IG1        IGFAC1 = 1.
 !/IG1        ATMP2(1:NSPECIGSTART)=0.
 !/IG1        END IF
 !/IG1!
 !/IG1! resets IG band energy to zero
 !/IG1!
-!/IG1      DO ICALC=1,2 
+!/IG1      DO ICALC=1,2
       S = 0.
 !/IG1        IF (IGBCOVERWRITE) A(1:NSPECIGSTART)=0.
 !/IG1        IF (ICALC.EQ.1) A=ATMP2
-!/IG1        IF (ICALC.EQ.2) THEN 
+!/IG1        IF (ICALC.EQ.2) THEN
 !/IG1!
-!/IG1! 1.1 Replaces IG part by forced IG 
+!/IG1! 1.1 Replaces IG part by forced IG
 !/IG1!
 !/IG1! determines highest IG frequency
 !/IG1!
-!/IG1          IF (IGSWELLMAX) THEN 
-!/IG1            NKIG=NK 
-!/IG1          ELSE 
+!/IG1          IF (IGSWELLMAX) THEN
+!/IG1            NKIG=NK
+!/IG1          ELSE
 !/IG1            NKIG=NINT(IGPARS(5))
 !/IG1            ENDIF
 !/IG1          FREQIG=SIG(NINT(IGPARS(5)))*TPIINV
 !/IG1!
 !/IG1          NSPECIG=NKIG*NTH
-!/IG1          ATMP(1:NSPECIGSTART)=0.               ! flat bottom approximation (Hasselmann 1962) 
+!/IG1          ATMP(1:NSPECIGSTART)=0.               ! flat bottom approximation (Hasselmann 1962)
 !/IG1                                                  !                 is not valid for long waves
 !/IG1          IF (NINT(IGPARS(3)).EQ.1) THEN        ! IGPARS(3) = IGSOURCE
 !/IG1            IF (NINT(IGPARS(8)).EQ.1) THEN      ! in this case, uses depth at break point
@@ -310,7 +310,7 @@
 !/IG1!
 !/IG1!/ --- INLINED WAVNU1 (END) ------------------------------------------ /
 !/IG1!
-!/IG1            IF (NINT(IGPARS(1)).EQ.1) THEN         ! IGPARS(1) = IGMETHOD 
+!/IG1            IF (NINT(IGPARS(1)).EQ.1) THEN         ! IGPARS(1) = IGMETHOD
 !/IG1              CALL W3ADDIG(ATMP,DEPTHIG,WNB,CGB,1)
 !/IG1            ELSE
 !/IG1              CALL W3ADD2NDORDER(ATMP,DEPTHIG,WNB,CGB,1)
@@ -320,42 +320,42 @@
 !/IG1              ATMP(1+(IK-1)*NTH:IK*NTH)=ATMP(1+(IK-1)*NTH:IK*NTH)*(CGB(IK)*WN(IK))/(CG(IK)*WNB(IK))
 !/IG1              END DO
 !/IG1            A(1:NSPECIG)=ATMP(1:NSPECIG)
-!/IG1            IF (IGSWELLMAX) THEN 
+!/IG1            IF (IGSWELLMAX) THEN
 !/IG1              DO ISPEC=1,NSPECIG
-!/IG1                A(ISPEC)=MAX(ATMP(ISPEC)-A(ISPEC),0.)   
+!/IG1                A(ISPEC)=MAX(ATMP(ISPEC)-A(ISPEC),0.)
 !/IG1                END DO
-!/IG1            ELSE 
+!/IG1            ELSE
 !/IG1              A(1:NSPECIG)=ATMP(1:NSPECIG)
 !/IG1              ENDIF
 !/IG1!
-!/IG1          ELSEIF (NINT(IGPARS(3)).EQ.2) THEN   ! Empirical source of IG energy 
+!/IG1          ELSEIF (NINT(IGPARS(3)).EQ.2) THEN   ! Empirical source of IG energy
 !/IG1!
-!/IG1! This empirical source was adjusted to Waimea and Duck data 
+!/IG1! This empirical source was adjusted to Waimea and Duck data
 !/IG1! When applied to deep water the 1/Depth must be replaced with k/Cg
 !/IG1! Hence the proper coefficient is WN(IK)/CG(IK)*GRAV**2/SIG(IK)
 !/IG1!
-!/IG1! The empirical form is HIG = IGEMPIRICAL * ... 
-!/IG1! this is not quite yet a wave height: multiplied below by MIN(0.0036, ... 
+!/IG1! The empirical form is HIG = IGEMPIRICAL * ...
+!/IG1! this is not quite yet a wave height: multiplied below by MIN(0.0036, ...
 !/IG1!
 !/IG1            HIG= HS/(MAX(FMEAN2,FREQIG)**2)
-!/IG1            EFIG=(HIG*0.25)**2/0.0279  ! this is (HsIG/4)^2 / df 
+!/IG1            EFIG=(HIG*0.25)**2/0.0279  ! this is (HsIG/4)^2 / df
 !/IG1            HIG2 = 0.
-!/IG1            DO IK=1,NKIG   
+!/IG1            DO IK=1,NKIG
 !/IG1!
 !/IG1! First approximation: constant IG spectrum  with frequency
 !/IG1!
-!/IG1              EFIG1=EFIG*MIN(0.0036,IGPARS(11)*WN(IK)/CG(IK)*GRAV**2/SIG(IK)) 
+!/IG1              EFIG1=EFIG*MIN(0.0036,IGPARS(11)*WN(IK)/CG(IK)*GRAV**2/SIG(IK))
 !/IG1!
-!/IG1! Correction: gives a frequency shape ... 
+!/IG1! Correction: gives a frequency shape ...
 !/IG1!
-!/IG1              IF (IK.LT.IK1) THEN 
+!/IG1              IF (IK.LT.IK1) THEN
 !/IG1 ! The 1.5 exponent of Ardhuin et al. 2014 (see figure 8.a) was probably too high  ... now reduced to 1.0
-!/IG1                EFIG1=EFIG1*IGFAC1*1.2*MIN(1.,0.013/(SIG(IK)*TPIINV))**1.0  
-!/IG1              ELSE 
+!/IG1                EFIG1=EFIG1*IGFAC1*1.2*MIN(1.,0.013/(SIG(IK)*TPIINV))**1.0
+!/IG1              ELSE
 !/IG1                EFIG1=EFIG1*IGFAC2*1.2*MIN(1.,0.013/(SIG(IK)*TPIINV))**1.0
 !/IG1                END IF
 !/IG1!
-!/IG1! Conversion to action spectral density A(k,theta), assuming isotropic dir. 
+!/IG1! Conversion to action spectral density A(k,theta), assuming isotropic dir.
 !/IG1!
 !/IG1              A(1+(IK-1)*NTH:IK*NTH)=EFIG1*CG(IK)/((SIG(IK)*TPI)*TPI)
 !/IG1              HIG2 = HIG2 + EFIG1*DSII(IK)*TPIINV
@@ -369,7 +369,7 @@
       NRS=NINT(REFPARS(8))
       IF (REFPARS(6).GT.0) THEN
 !
-! This is the Miche parameter for a beach slope of REFLC(3) 
+! This is the Miche parameter for a beach slope of REFLC(3)
 !
         IF(REFLC(3)/=REFLC(3)) THEN ! isnan test
           SLOPE=0.001
@@ -387,7 +387,7 @@
 !
 ! 2.  Shoreline reflection =============================================== *
 !
-      IF (REFLC(1).GT.0) THEN 
+      IF (REFLC(1).GT.0) THEN
         FAC1=1/(0.5*REAL(NTH))
         FAC2=1.57/(0.5*REAL(NTH))
 !           FAC3=2.6/(0.5*REAL(NTH))  ! this is for NRS=4
@@ -397,7 +397,7 @@
         DO IK=1, NK
 !
 ! Includes frequency dependence (see Elgar et al. JPO 1994)
-!       
+!
           IF (REFPARS(6).GT.0) THEN
             RAMP=(MAX((0.75*TPI*FMEANA/SIG(IK)),1.)**REFPARS(10))*RAMP0
             RAMP1=MIN(REFPARS(9),REFLC(1)*RAMP)
@@ -407,9 +407,9 @@
             RAMP2=RAMP0*REFLC(2)
             END IF
 !
-! Special treatment for unstructured grids when not using source term 
+! Special treatment for unstructured grids when not using source term
 !
-          IF (GTYPE.EQ.UNGTYPE.AND.REFPARS(3).LT.0.5) THEN 
+          IF (GTYPE.EQ.UNGTYPE.AND.REFPARS(3).LT.0.5) THEN
             DO ITH=1, NTH
               ISPECI=ITH+(IK-1)*NTH
               A(ISPECI)=A(ISPECI)*IOBPD(ITH,IX) !puts to zero the energy not going to coast
@@ -420,10 +420,10 @@
               R1=IOBPD(ITH,IX)
               ISPECI=ITH+(IK-1)*NTH
               R2=RAMP1*A(ISPECI)
-              IF (R1.GT.0.AND.R2.GT.0) THEN 
+              IF (R1.GT.0.AND.R2.GT.0) THEN
 !
-! Determines direction of specular reflection: th3=pi+2*n-th1  
-! 
+! Determines direction of specular reflection: th3=pi+2*n-th1
+!
                 ITH3=1+MOD(NTH/2+NTH+2*REFLD(1)-ITH-1,NTH)
                 DO ITH2=1,NTH
 !
@@ -431,19 +431,19 @@
 !
                   ISPEC=ITH2+(IK-1)*NTH
                   R3=ECOS(1+MOD(ABS(ITH2-REFLD(1)),NTH))
-                  IF (R3.LT.0) THEN 
+                  IF (R3.LT.0) THEN
                     R4=ECOS(1+MOD(ABS(ITH2-ITH3),NTH))*(1-IOBPD(ITH2,IX))
-                    IF (R4.GT.0.) THEN 
+                    IF (R4.GT.0.) THEN
 !
 ! Tests the type of shoreline geometry
-! 
+!
                     SELECT CASE (REFLD(2))
                       CASE (0)
                    ! Sharp corner: broad reflection
                         S(ISPEC)=S(ISPEC)+R2*FAC1/DT
 
-! FA: analog to following lines to be swapped in if reflection method changed 
-                        ! RECT CASE: 
+! FA: analog to following lines to be swapped in if reflection method changed
+                        ! RECT CASE:
                         !  S(ISPEC)=S(ISPEC)+    &
                         !    REAL(REFLD(3))*R2*CG(IK)*ABS(ECOS(ITH2X)/DELX)*FAC1   &
                         !   +REAL(REFLD(4))*R2*CG(IK)*ABS(ESIN(ITH2Y)/DELY)*FAC1
@@ -454,17 +454,17 @@
                         S(ISPEC)=S(ISPEC)+R2*ABS(R4)*FAC2/DT
                       CASE (2)
                    ! straight coast: narrow reflection
-                   !     IF(ITH3.EQ.ITH2) S(ISPEC)=S(ISPEC)+R2/DT  ! THIS IS FOR SPECULAR REF. 
+                   !     IF(ITH3.EQ.ITH2) S(ISPEC)=S(ISPEC)+R2/DT  ! THIS IS FOR SPECULAR REF.
                          S(ISPEC)=S(ISPEC)+R2*(R4**NRS) *FAC3/DT
                       END SELECT
                     END IF  ! (R4.GT.0.)
-                  END IF  ! (R3.LT.0) 
+                  END IF  ! (R3.LT.0)
                 END DO ! ITH2=1,NTH
               END IF  ! (R1.GT.0.AND.R2.GT.0)
-            END DO  ! ITH=1, NTH 
+            END DO  ! ITH=1, NTH
           ELSE ! (GTYPE.NE.UNGTYPE)
 !
-! This is for structured grids .... 
+! This is for structured grids ....
 !
 !
 !  Loop on  incident wave direction (ITH)
@@ -472,7 +472,7 @@
             DO ITH=1, NTH
               R1=ECOS(1+MOD(ABS(ITH-REFLD(1)),NTH))
               R2=RAMP1*A(ITH+(IK-1)*NTH)
-              IF (R1.GT.0.AND.R2.GT.0) THEN 
+              IF (R1.GT.0.AND.R2.GT.0) THEN
                 DO ITH2=1,NTH
 !
 !  Adds energy into reflected directions (ITH2)
@@ -481,13 +481,13 @@
                   ITH2X=1+MOD(NTH+ITH2-REFLD(5)-1,NTH)
                   ITH2Y=1+MOD(NTH+ITH2-REFLD(6)-1,NTH)
                   R3=ECOS(1+MOD(ABS(ITH2-REFLD(1)),NTH))
-                  IF (R3.LT.0) THEN 
+                  IF (R3.LT.0) THEN
 !
-! Determines direction of specular reflection: th3=pi+2*n-th1  
+! Determines direction of specular reflection: th3=pi+2*n-th1
 !
                     ITH3=1+MOD(NTH/2+NTH+2*REFLD(1)-ITH-1,NTH)
                     R4=ECOS(1+MOD(ABS(ITH2-ITH3),NTH))
-                    IF (R4.GT.0.) THEN 
+                    IF (R4.GT.0.) THEN
 !
 ! Tests the type of shoreline geometry
 ! NB: REFLD(3) or REFLD(4) is equal to 1 if the reflection is applied (real land neighbor)
@@ -505,19 +505,19 @@
                           + REAL(REFLD(4))*R2*CG(IK)*ABS(ESIN(ITH2Y)/DELY)*ABS(R4)*FAC2
                       CASE (2)
                    ! straight coast: narrow reflection
-! Specular for tests 
+! Specular for tests
 !                   S(ISPEC)=S(ISPEC)+REAL(REFLD(3))*R2*CG(IK)*ABS(ECOS(ITH2)/DELX)  &
 !                                    +REAL(REFLD(4))*R2*CG(IK)*ABS(ESIN(ITH2)/DELY)
 !
                            S(ISPEC)=S(ISPEC)+REAL(REFLD(3))*R2*CG(IK)*ABS(ECOS(ITH2X)/DELX) &
-                                                *(R4**NRS) *FAC3                          & 
+                                                *(R4**NRS) *FAC3                          &
                                             +REAL(REFLD(4))*R2*CG(IK)*ABS(ESIN(ITH2Y)/DELY) &
                                                 *(R4**NRS) *FAC3
                         END SELECT
                       END IF ! (R4.GT.0.)
-                    END IF  ! (R3.LT.0) 
+                    END IF  ! (R3.LT.0)
                   END DO  ! ITH2=1,NTH
-                END IF  ! (R1.GT.0.AND.R2.GT.0) 
+                END IF  ! (R1.GT.0.AND.R2.GT.0)
               END DO  ! ITH=1,NTH
             END IF  ! UNGTYPE
 
@@ -525,13 +525,13 @@
         END IF   ! end of test on REFLC(1)
 !
 !  Add diffuse reflection due to subgrid islands and icebergs
-!  At present this feature is not supported for unstructured grids. 
+!  At present this feature is not supported for unstructured grids.
 !
       IF (    ((REFPARS(2).GT.0.).AND.((TRNX+TRNY).LT.2))     &
-        .OR.((REFPARS(4).GT.0.).AND.(BERG.GT.0)       )   ) THEN 
+        .OR.((REFPARS(4).GT.0.).AND.(BERG.GT.0)       )   ) THEN
 !
 ! Includes frequency dependence (see Elgar et al. JPO 1994)
-!       
+!
           IF (REFPARS(6).GT.0) THEN
             RAMP=(MAX((0.75*TPI*FMEANA/SIG(IK)),1.)**REFPARS(10))*RAMP0
             RAMP2=MIN(REFPARS(9),REFLC(2)*RAMP)
@@ -558,12 +558,12 @@
         DO IK=1, NK
           DO ITH=1, NTH
             R2=A(ITH+(IK-1)*NTH)
-            IF (R2.GT.0.) THEN 
- 
+            IF (R2.GT.0.) THEN
+
               DO ITH2=1,NTH
                 ISPEC=ITH2+(IK-1)*NTH
                 R3=ECOS(1+MOD(NTH+ITH2-ITH,NTH))
-                IF (R3.LT.0) THEN 
+                IF (R3.LT.0) THEN
                      S(ISPEC)=S(ISPEC)+ &
                                CG(IK)*R2X*R2*ABS(ECOS(ITH2)/DELX)*FAC1 &
                              + CG(IK)*R2Y*R2*ABS(ESIN(ITH2)/DELY)*FAC1
@@ -574,16 +574,16 @@
           END DO
         END IF
 
-!/IG1     IF (ICALC.EQ.1) THEN 
+!/IG1     IF (ICALC.EQ.1) THEN
 !/IG1        STMP1(NSPECIGSTART+1:NSPEC) = S(NSPECIGSTART+1:NSPEC)
 !/IG1     ELSE
 !/IG1        STMP2 = S
-!/IG1        DO ISPEC = 1, NSPEC 
+!/IG1        DO ISPEC = 1, NSPEC
 !/IG1          S(ISPEC) = MAX(STMP2(ISPEC),STMP1(ISPEC))
 !/IG1          END DO
 !/IG1        END IF
 !/IG1     ENDDO ! ICALC = 1,2
-!/IG1     A(1:NSPECIG)=ATMP2(1:NSPECIG)   ! removes bound IG components ... 
+!/IG1     A(1:NSPECIG)=ATMP2(1:NSPECIG)   ! removes bound IG components ...
 !/
 !/ End of W3SREF ----------------------------------------------------- /
 !/

--- a/model/ftn/w3sbs1md.ftn
+++ b/model/ftn/w3sbs1md.ftn
@@ -17,7 +17,7 @@
 !/
 !  1. Purpose :
 !
-!     This module computes a scattering term 
+!     This module computes a scattering term
 !     based on the theory by Ardhuin and Magne (JFM 2007)
 !
 !  2. Variables and types :
@@ -30,7 +30,7 @@
 !
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
-!      W3SBS1    Subr. Public   bottom scattering 
+!      W3SBS1    Subr. Public   bottom scattering
 !      INSBS1    Subr. Public   Corresponding initialization routine.
 !     ----------------------------------------------------------------
 !
@@ -57,15 +57,15 @@
 !/
 !/ Public variables
 !/
-      REAL, DIMENSION(:,:), ALLOCATABLE   :: BOTSPEC 
+      REAL, DIMENSION(:,:), ALLOCATABLE   :: BOTSPEC
       INTEGER, PARAMETER :: NKSCAT = 30                 !number of wavenumbers
       DOUBLE PRECISION  ,DIMENSION(:,:,:) ,  ALLOCATABLE :: SCATMATV !scattering matrices
       DOUBLE PRECISION  ,DIMENSION(:,:,:) ,  ALLOCATABLE :: SCATMATA !original matrix
-      DOUBLE PRECISION  ,DIMENSION(:,:)   ,  ALLOCATABLE :: SCATMATD 
-      CHARACTER(len=10)                   :: botspec_indicator 
+      DOUBLE PRECISION  ,DIMENSION(:,:)   ,  ALLOCATABLE :: SCATMATD
+      CHARACTER(len=10)                   :: botspec_indicator
       INTEGER            :: nkbx, nkby
       REAL               :: dkbx, dkby, kwmin, kwmax
-      REAL, PARAMETER    :: scattcutoff=0. 
+      REAL, PARAMETER    :: scattcutoff=0.
       REAL               :: CURTX, CURTY
 !/
       CONTAINS
@@ -86,13 +86,13 @@
 !/
 !  1. Purpose :
 !
-!     Bottom scattering source term 
+!     Bottom scattering source term
 !
 !  2. Method :
 !
-!     Without current, goes through a diagonalization of the matrix 
+!     Without current, goes through a diagonalization of the matrix
 !     problem  S(f,:) = M(f,:,:)**E(f,:)
-!     With current, integrates the source term along the resonant locus 
+!     With current, integrates the source term along the resonant locus
 !
 !  3. Parameters :
 !
@@ -104,8 +104,8 @@
 !       DEPTH     Real  I   Mean water depth.
 !       S         R.A.  O   Source term (1-D version).
 !       D         R.A.  O   Diagonal term of derivative (1-D version).
-!       CX1-Y1    R.A.  I   Current components at ISEA.   
-!       TAUSCX-Y  R.A.  I   Change of wave momentum due to scattering   
+!       CX1-Y1    R.A.  I   Current components at ISEA.
+!       TAUSCX-Y  R.A.  I   Change of wave momentum due to scattering
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -161,31 +161,31 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/ 
+!/
       INTEGER         :: ISPEC, IK, NSCUT, ITH, ITH2, i, j,iajust,iajust2
 !/S      INTEGER, SAVE           :: IENT = 0
       LOGICAL, SAVE   :: FIRST = .TRUE.
       INTEGER         :: MATRICES = 0
-       
+
       REAL            :: R1, R2, R3
-      
+
       REAL            :: WN2(NSPEC, NTH), Ka(NSPEC),        &
                          Kb(NSPEC, NTH), WNBOT(NSPEC, NTH), &
                          B(NSPEC, NTH)
       REAL            :: kbotxi, kbotyi, xbk,   &
                          ybk,integral, kbotx, kboty, count,count2
-     
+
       INTEGER         :: ibk, jbk, ik2
       REAL            ::  SIGP,KU, KPU, CGK, CGPK, WN2i, xk2, Ap, kcutoff, ECC2, &
                          variance , integral1,integral1b,integral2, SB(NK,NTH), integral3,&
                          ajust,absajust,aa,bb,LNORM,UdotL,KdotKP,MBANDC
-      REAL            :: KD, Kfactor, kscaled, kmod , CHECKSUM, ETOT                 
+      REAL            :: KD, Kfactor, kscaled, kmod , CHECKSUM, ETOT
       REAL            :: SMATRIX(NTH,NTH),SMATRIX2(NTH,NTH)
       DOUBLE PRECISION :: AVECT(NTH)
 
       CURTX=CX1
       CURTY=CY1
-      
+
       count=0
 !/
 !/ ------------------------------------------------------------------- /
@@ -220,27 +220,27 @@
 !
 ! 3.  Bottom scattering ================================================== *
 !
-      IF ( DEPTH*WN(1) .LE. 6 ) THEN 
+      IF ( DEPTH*WN(1) .LE. 6 ) THEN
 !
 ! 3.a Ardhuin and Herbers JFM 2000: no current
 !
-        IF ((ABS(CX1)+ABS(CY1).EQ.0.).AND.(MATRICES.EQ.1)) THEN 
+        IF ((ABS(CX1)+ABS(CY1).EQ.0.).AND.(MATRICES.EQ.1)) THEN
           DO IK=1,NK
             KD=WN(IK)*DEPTH
             IF ( KD .LE. 6 .AND.WN(IK).LT.kwmax ) THEN
-! Test on kwmax means that scattering is not computed if interaction goes beyond the shortest resolved 
-! bottom component. This should probably be replaced by a warning... 
-              Kfactor=(WN(IK)**4)*SIG(IK)*pi*4.             &      
+! Test on kwmax means that scattering is not computed if interaction goes beyond the shortest resolved
+! bottom component. This should probably be replaced by a warning...
+              Kfactor=(WN(IK)**4)*SIG(IK)*pi*4.             &
                    /(SINH(2*KD)*(2*KD+SINH(2*KD)))
               kscaled=(nkscat-2)*(WN(IK)-kwmin)/(kwmax-kwmin)
               AVECT=DBLE(A(:,IK))
-              IF (kscaled.LT.0) THEN 
+              IF (kscaled.LT.0) THEN
                 ibk=0
                 kmod=0.
-              ELSE 
+              ELSE
                 ibk=INT(kscaled)
                 kmod=mod(kscaled,1.0)
-                END IF 
+                END IF
               S((IK-1)*NTH+1:IK*NTH)                              &
                 =REAL(MATMUL(SCATMATV(IBK,:,:),Kfactor*SCATMATD(IBK,:) &
                      *MATMUL(TRANSPOSE(SCATMATV(IBK,:,:)),AVECT))*(1.-kmod))
@@ -260,14 +260,14 @@
 ! 3.b
 !  Case with current (Ardhuin and Magne JFM 2007)
 ! Compute k' (WN2) from k (WN) and U (CX1, CY1)
-! using : k'=(Cg+k.U/k)/(Cg+k'.U/k') 
+! using : k'=(Cg+k.U/k)/(Cg+k'.U/k')
 !
          DO ITH2=1, NTH
-       
+
            DO ISPEC=1, NSPEC
-          
+
              KU=CX1 * ECOS(MAPTH(ISPEC))+CY1 * ESIN(MAPTH(ISPEC))
-             KPU=CX1 * ECOS(ITH2)+  CY1 * ESIN(ITH2) 
+             KPU=CX1 * ECOS(ITH2)+  CY1 * ESIN(ITH2)
              CGK=CG(MAPWN(ISPEC))
              IF ((CGK+KPU).LT.0.1*CGK) KPU=-0.9*CGK
              IF ((CGK+KU).LT.0.1*CGK)  KU=-0.9*CG(MAPWN(ISPEC))
@@ -276,27 +276,27 @@
 
            END DO
 !
-! 3.c Compute the coupling coefficient as a product of two terms 
-!               
-!   K=0.5*pi k'^2 * M(k,k')^2 / [sig*sig' *(k'*Cg'+k'.U)]  
+! 3.c Compute the coupling coefficient as a product of two terms
+!
+!   K=0.5*pi k'^2 * M(k,k')^2 / [sig*sig' *(k'*Cg'+k'.U)]
 !                                      (Magne and Ardhuin JFM 2007)
 !
 !   K=Ka(k)*Kb(k,k',theta')
-! 
+!
 !   Ka = ...
 !   here Mc is neglected
 !
          DO ISPEC=1, NSPEC
            Ka(ISPEC)= 4*PI*SIG2(ISPEC) * WN(MAPWN(ISPEC))  /    &
-                SINH(MIN(2*WN(MAPWN(ISPEC))*DEPTH,20.))    
+                SINH(MIN(2*WN(MAPWN(ISPEC))*DEPTH,20.))
 
            DO ITH2=1, NTH
              KU=CX1 * ECOS(MAPTH(ISPEC))+CY1 * ESIN(MAPTH(ISPEC))
-             KPU=CX1 * ECOS(ITH2)+  CY1 * ESIN(ITH2) 
+             KPU=CX1 * ECOS(ITH2)+  CY1 * ESIN(ITH2)
              SIGP=SQRT(GRAV*WN2(ISPEC,ITH2)*TANH(WN2(ISPEC,ITH2)*DEPTH))
              CGPK=SIGP*(0.5+WN2(ISPEC,ITH2)*DEPTH &
-                 /SINH(MIN(2*WN2(ISPEC,ITH2)*DEPTH,20.)))/WN2(ISPEC, ITH2)   
-             
+                 /SINH(MIN(2*WN2(ISPEC,ITH2)*DEPTH,20.)))/WN2(ISPEC, ITH2)
+
              Kb(ISPEC, ITH2)= WN2(ISPEC, ITH2)**3      &
                *EC2(1+ABS(MAPTH(ISPEC)-ITH2)) /        &
                 (                                      &
@@ -317,35 +317,35 @@
 !           - UdotL**2*(KdotKP-SIGP*SIG2(ISPEC)*(SIGP*SIG2(ISPEC)+UdotL**2)/GRAV**2)) &
 !           /(LNORM*(UdotL**2/(GRAV*LNORM)-TANH(MIN(LNORM*DEPTH,20.)))*COSH(MIN(LNORM*DEPTH,20.)))
 !  Kb(ISPEC,ITH2)= WN2(ISPEC, ITH2)**2
-!                   /((SIG2(ISPEC)*SIGP*WN2(ISPEC, ITH2)*(CGPK+KPU)) & 
+!                   /((SIG2(ISPEC)*SIGP*WN2(ISPEC, ITH2)*(CGPK+KPU)) &
 !                  *MBANDC**2
 !
-             END DO                 
-           END DO  
-!    
-! 3.a Bilinear interpolation of the bottom spectrum BOTSPEC 
+             END DO
+           END DO
+!
+! 3.a Bilinear interpolation of the bottom spectrum BOTSPEC
 !     along the locus -> B(ISPEC,ITH2)
 !
          B(:,:)=0
          DO ISPEC=1, NSPEC
            kcutoff=scattcutoff*WN(MAPWN(ISPEC))
            DO ITH2=1,NTH
-             kbotx=WN(MAPWN(ISPEC))*ECOS(MAPTH(ISPEC)) - &             
-               WN2(ISPEC, ITH2) * ECOS(ITH2)     
-             kboty=WN(MAPWN(ISPEC))*ESIN(MAPTH(ISPEC)) - &             
-               WN2(ISPEC, ITH2) * ESIN(ITH2)           
+             kbotx=WN(MAPWN(ISPEC))*ECOS(MAPTH(ISPEC)) - &
+               WN2(ISPEC, ITH2) * ECOS(ITH2)
+             kboty=WN(MAPWN(ISPEC))*ESIN(MAPTH(ISPEC)) - &
+               WN2(ISPEC, ITH2) * ESIN(ITH2)
 !
 ! 3.a.1 test if the bottom wavenumber is larger than the cutoff
 !        otherwise the interaction is set to zero
-    
-             IF ((kbotx**2+kboty**2)>(kcutoff**2)) THEN    
-  
+
+             IF ((kbotx**2+kboty**2)>(kcutoff**2)) THEN
+
              kbotxi=REAL(nkbx-MOD(nkbx,2))/2.+1.+kbotx/dkbx   ! The MOD(nkbx,2) is either 1 or 0
              kbotyi=REAL(nkby-MOD(nkby,2))/2.+1.+kboty/dkby   ! k=0 is at ik=(nkbx-1)/2+1 if kkbx is odd
 
              ibk=MAX(MIN(INT(kbotxi),nkbx-1),1)
              xbk=mod(kbotxi,1.0)
-             jbk=MAX(MIN(INT(kbotyi),nkby-1),1)        
+             jbk=MAX(MIN(INT(kbotyi),nkby-1),1)
              ybk=mod(kbotyi,1.0)
 
              B(ISPEC,ITH2)=(                &
@@ -354,16 +354,16 @@
                 +               &
                 (BOTSPEC(ibk+1,jbk)*(1-ybk)+    &
                 BOTSPEC(ibk+1,jbk+1)*ybk)*xbk   &
-                )   
+                )
             END IF
             END DO
-         END DO 
+         END DO
 !
 ! 4. compute Sbscat
 ! 4.a linear interpolation of A(k', theta') -> Ap
 !
-      
-!  4.b computation of the source term    
+
+!  4.b computation of the source term
          integral2=0.
          integral3=0.
          SMATRIX(:,:)=0.
@@ -376,21 +376,21 @@
                 END DO
               iajust=MAX(iajust,1)
               iajust2=MIN(iajust+1,NK)
-              IF (iajust.EQ.iajust2) THEN 
+              IF (iajust.EQ.iajust2) THEN
                 Ap=A(ITH2,iajust)
               ELSE
                 bb=(WN2(ISPEC,ITH2)-WN(iajust))/(WN(iajust2)-WN(iajust))
                 aa=(WN(iajust2)-WN2(ISPEC,ITH2))/(WN(iajust2)-WN(iajust))
                 Ap=(A(ITH2,iajust)*aa+A(ITH2,iajust2)*bb)
                 END IF
-        
+
               integral=integral + Ka(ISPEC)*Kb(ISPEC, ITH2)*B(ISPEC,ITH2)*               &
-                     ( Ap*WN(MAPWN(ISPEC))/WN2(ISPEC,ITH2)- A(MAPTH(ISPEC),MAPWN(ISPEC))) *DTH  
-         ! the factor WN/WN2 accounts for the fact that N(K) and N(K') 
+                     ( Ap*WN(MAPWN(ISPEC))/WN2(ISPEC,ITH2)- A(MAPTH(ISPEC),MAPWN(ISPEC))) *DTH
+         ! the factor WN/WN2 accounts for the fact that N(K) and N(K')
                      ! have different Jacobian transforms from kx,ky to k,theta
 
               integral1=integral1+Kb(ISPEC, ITH2)*B(ISPEC,ITH2)*Ap*WN(MAPWN(ISPEC))/WN2(ISPEC,ITH2)*DTH &
-                         *DTH*DSII(MAPWN(ISPEC))/CG(MAPWN(ISPEC))  
+                         *DTH*DSII(MAPWN(ISPEC))/CG(MAPWN(ISPEC))
               integral1b=integral1b+Kb(ISPEC, ITH2)*B(ISPEC,ITH2)*A(MAPTH(ISPEC),MAPWN(ISPEC))*DTH  &
                          *DTH*DSII(MAPWN(ISPEC))/CG(MAPWN(ISPEC))
               END DO
@@ -401,8 +401,8 @@
             END DO
           END IF
 !/T    print*,'BOTTOM SCAT CHECKSUM:',integral2,integral3,integral1,integral1b
-    
-!/T    DO ITH=1,120 
+
+!/T    DO ITH=1,120
 !/T      WRITE(6,'(120G15.7)') SMATRIX(ITH,:)
 !/T      END DO
         END IF
@@ -474,7 +474,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
-!/      
+!/
       INTEGER, INTENT(IN)        :: inistep
 !/
 !/ ------------------------------------------------------------------- /
@@ -491,7 +491,7 @@
 !/
 !/S      CALL STRACE (IENT, 'INSBS1')
 !
-       IF (inistep.EQ.1) THEN 
+       IF (inistep.EQ.1) THEN
 !
 ! 1.  Reads bottom spectrum
 !
@@ -516,39 +516,39 @@
 !
 ! 2.  Precomputed the scatering matrices for zero current
 !
-! The Scattering source term is expressed as a matrix problem for 
+! The Scattering source term is expressed as a matrix problem for
 ! a list of wavenumbers k0
-! in the range of wavenumbers used in the model. 
+! in the range of wavenumbers used in the model.
 ! i.e. S(k0,theta)=Kfactor*SCATMATA ** TRANSPOSE (E(k0,theta))
 !
 ! in which
-! 
-! Kfactor is a scalar computed in CALCSOURCE as 
+!
+! Kfactor is a scalar computed in CALCSOURCE as
 !        Kfactor=tailfactor*(Kp(I,J)**4)*2.*pi*FREQ(J)*pi*4./(SINH(HND)*(HND+SINH(HND)))
 !
 ! SCATMATA is a square matrix of size NTH*NTH
 !
-! S(k0,theta) and E(k0,theta) are the vectors giving the directional source term 
+! S(k0,theta) and E(k0,theta) are the vectors giving the directional source term
 !   and spectrum at a fixed wavenumber
 !
          ALLOCATE(SCATMATA(0:nkscat-1,1:NTH,1:NTH))
          ALLOCATE(AMAT(NTH,NTH))
          DO I=0,nkscat-1
-           ! kcurr is the current surface wavenumber for which 
+           ! kcurr is the current surface wavenumber for which
            ! the scattering matrices are evaluated
            kcurr=kwmin+I*(kwmax-kwmin)/(nkscat-2)
            kcutoff=scattcutoff*kcurr
            DO K1=1,NTH
              DO K2=1,NTH
-               kbotx=-kcurr*(ECOS(K2)-ECOS(K1))  
-               kboty=-kcurr*(ESIN(K2)-ESIN(K1))  
+               kbotx=-kcurr*(ECOS(K2)-ECOS(K1))
+               kboty=-kcurr*(ESIN(K2)-ESIN(K1))
                AMAT(K1,K2)=0.
                ! Tests if the bottom wavenumber is larger than the cutoff
                ! Otherwise the interaction is set to zero
                IF ((kbotx**2+kboty**2) > (kcutoff**2)) THEN
-                 !WARNING : THERE MAY BE A BUG : spectrum not symmetric when 
+                 !WARNING : THERE MAY BE A BUG : spectrum not symmetric when
                  ! nkbx is odd !!
-                 
+
                  kbotxi=REAL(nkbx)/2.+1.+kbotx/dkbx
                  kbotyi=REAL(nkby)/2.+1.+kboty/dkby
                  !WRITE(6,*) 'Bottom wavenumber i:',kbotxi,kbotyi
@@ -570,9 +570,9 @@
                END DO
              AMAT(K1,K1)=AMAT(K1,K1)-SUM(AMAT(K1,:))
              END DO
-           AMAT(:,:)=DTH*(AMAT(:,:)+TRANSPOSE(AMAT(:,:)))*0.5   
+           AMAT(:,:)=DTH*(AMAT(:,:)+TRANSPOSE(AMAT(:,:)))*0.5
            !makes sure the matrix is exactly symmetric
-           !which should already be the case if the bottom 
+           !which should already be the case if the bottom
            ! spectrum is really symmetric
            SCATMATA(I,:,:)=AMAT(:,:)
            END DO
@@ -584,11 +584,11 @@
            AMAT(:,:)=SCATMATA(I,:,:)
 !
 !diagonalizes the matrix A
-!D is a vector with the eigenvalues, V is the matrix made of the 
+!D is a vector with the eigenvalues, V is the matrix made of the
 !eigenvectors so that VD2Vt=A  with D2(i,j)=delta(i,j)D(i)
 !and VVt=Id, so that exp(A)=Vexp(D2)Vt
 !
-           CALL DIAGONALIZE(AMAT,D,V,nrot) 
+           CALL DIAGONALIZE(AMAT,D,V,nrot)
            SCATMATD(I,:)=D(:)    !eigen values
            SCATMATV(I,:,:)=V(:,:) !eigen vectors
            kcurr=kwmin+I*(kwmax-kwmin)/(nkscat-2)

--- a/model/ftn/w3sbsxmd.ftn
+++ b/model/ftn/w3sbsxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3sbt1md.ftn
+++ b/model/ftn/w3sbt1md.ftn
@@ -58,7 +58,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3sbt4md.ftn
+++ b/model/ftn/w3sbt4md.ftn
@@ -17,13 +17,13 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     SHOWEX bottom friction source term (Ardhuin et al. 2003), 
-!     using a subgrid depth parameterization based on Tolman (CE 1995). 
+!     SHOWEX bottom friction source term (Ardhuin et al. 2003),
+!     using a subgrid depth parameterization based on Tolman (CE 1995).
 !
 !  2. Variables and types :
 !
@@ -68,8 +68,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -80,14 +80,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !
@@ -100,15 +100,15 @@
 !/ ------------------------------------------------------------------- /
 !/
 !
-      
+
        PUBLIC
 !
 ! Parameters for ERF function
-!      
-      INTEGER, PARAMETER      :: SIZEERFTABLE=300  
-      REAL                    :: ERFTABLE(0:SIZEERFTABLE)     
+!
+      INTEGER, PARAMETER      :: SIZEERFTABLE=300
+      REAL                    :: ERFTABLE(0:SIZEERFTABLE)
       REAL                    :: DELXERF
-      REAL,    PARAMETER      :: XERFMAX =  4. ! number of stdev     
+      REAL,    PARAMETER      :: XERFMAX =  4. ! number of stdev
 !/
       CONTAINS
 
@@ -253,7 +253,7 @@
        IMPLICIT NONE
        INTEGER :: I
        REAL :: x,y
-    
+
       DELXERF   = (2*XERFMAX)/REAL(SIZEERFTABLE)
       DO I=0,SIZEERFTABLE
         x=-1.*XERFMAX+I*DELXERF
@@ -261,9 +261,9 @@
           y=2**(1/2)*(1-abs(erf(x)))/2
         else
           y=2**(1/2)*(1+erf(x))/2
-          end if      
-        ERFTABLE(I)=y 
-      END DO 
+          end if
+        ERFTABLE(I)=y
+      END DO
       RETURN
 !/ ------------------------------------------------------------------- /
        END SUBROUTINE TABU_ERF
@@ -286,12 +286,12 @@
 !/
 !  1. Purpose :
 !
-!     Computes the SHOWEX bottom friction with movable bed effects 
+!     Computes the SHOWEX bottom friction with movable bed effects
 !
 !  2. Method :
 !     Uses a Gaussian distribution for friction factors, and estimates
-!     the contribution of rippled and non-rippled fractions based on 
-!     the bayesian approach of Tolman (1995). 
+!     the contribution of rippled and non-rippled fractions based on
+!     the bayesian approach of Tolman (1995).
 !
 !  3. Parameters :
 !
@@ -343,13 +343,13 @@
 ! 10. Source code :
 !
 !/ ------------------------------------------------------------------- /
-      
+
       USE CONSTANTS
       USE W3ODATMD, ONLY: NDSE
       USE W3SERVMD, ONLY: EXTCDE
       USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, DDEN,  &
-                          SBTCX, ECOS, ESIN, DTH      
-          
+                          SBTCX, ECOS, ESIN, DTH
+
 !/S      USE W3SERVMD, ONLY: STRACE
       IMPLICIT NONE
 !/
@@ -365,7 +365,7 @@
       LOGICAL, SAVE           :: FIRST = .TRUE.
       REAL, INTENT(IN)        :: CG(NK), WN(NK), DEPTH, A(NSPEC), D50
       REAL, INTENT(IN)        :: PSIC
-      INTEGER, INTENT(IN)     :: IX, IY     
+      INTEGER, INTENT(IN)     :: IX, IY
       REAL, INTENT(OUT)       :: S(NSPEC), D(NSPEC), TAUBBL(2)
       REAL, INTENT(INOUT)     :: BEDFORM(3)
       REAL                    :: CBETA(NK)
@@ -379,10 +379,10 @@
       REAL DSUM(NK)
 ! These are the 3-point Gauss-Hermitte quadrature coefficients
       REAL, PARAMETER :: WSUB(3) = (/ 0.1666667,   0.1666666  , 0.6666667/)
-      REAL, PARAMETER :: XSUB(3) = (/ -0.001,  0.001 , 0. /) 
+      REAL, PARAMETER :: XSUB(3) = (/ -0.001,  0.001 , 0. /)
 
-      REAL :: PROBA1, PROBA2, PSIX, PSIXT, PSIN2, DPSI , FACTOR   
-      REAL :: BACKGROUND 
+      REAL :: PROBA1, PROBA2, PSIX, PSIXT, PSIN2, DPSI , FACTOR
+      REAL :: BACKGROUND
 
 !/
 !/ ------------------------------------------------------------------- /
@@ -405,15 +405,15 @@
 !
      BACKGROUND=MAX(SBTCX(6),SBTCX(7)*DD50)
 !
-! 2. Subgrid loop 
-! 
+! 2. Subgrid loop
+!
       DSUM(:)=0.
       TAUBBL(:)=0.
 !
       DO ISUB=1,3
 !
 ! 2.a  Computes bulk parameters : E, Uorb, Aorb------------------------- *
-!    
+!
         DSUB=DEPTH*(1.+XSUB(ISUB))
         UORB=0.
         AORB=0.
@@ -421,7 +421,7 @@
         AY  =0.
 
         DO IK=1, NK
-          IF ( WN(IK)*DSUB .LT. 6. ) THEN  
+          IF ( WN(IK)*DSUB .LT. 6. ) THEN
             EB  = 0.
             EBX = 0.
             EBY = 0.
@@ -430,14 +430,14 @@
               EB  = EB  + A(IS)
               EBX = EBX +A(IS)*ECOS(ITH)
               EBY = EBY +A(IS)*ESIN(ITH)
-              END DO   
+              END DO
 !
 ! U_bot=sigma * Zeta / sinh(KD)  and CBETA = 0.5*sigma^2 /(g*sinh^(kD))
 ! therefore variance(u_bot)= variance(elevation)*2*CBETA/D
 !
 !            CBETA(IK) = MAX(0., (CG(IK)*WN(IK)/SIG(IK)-0.5) )/DSUB
             CBETA(IK) = 0.5*SIG(IK)**2 /(GRAV*(SINH(WN(IK)*DSUB))**2)
-!  N.B.:  could also include shoaling effect on EB ... 
+!  N.B.:  could also include shoaling effect on EB ...
             FACTOR= (DDEN(IK) / CG(IK))*2*CBETA(IK)*GRAV
             VARU= EB * FACTOR
             UORB = UORB + VARU
@@ -449,15 +449,15 @@
             END IF
           END DO
 !
-! Computes RMS orbital amplitudes 
-!     
+! Computes RMS orbital amplitudes
+!
         UORB2 = 2*UORB
         UORB = SQRT(MAX(1.0E-7,UORB2))
         AORB = SQRT(MAX(1.0E-7,2*AORB))
 !
 ! Computes potential ripple wavelength, 1.7 = 2 * sqrt(2) * 0.6
-! Based on Ardhuin et al. (JGR 2002): lambda = 0.6 * d_1/3 
-!     
+! Based on Ardhuin et al. (JGR 2002): lambda = 0.6 * d_1/3
+!
         LX = AORB*1.7*AX/SQRT(AX**2+AY**2+1E-12)
         LY = AORB*1.7*AY/SQRT(AX**2+AY**2+1E-12)
 !
@@ -468,45 +468,45 @@
         DELI1= MIN (1. ,XI-FLOAT(IND))
         DELI2= 1. - DELI1
         FW =FWTABLE(IND)*DELI2+FWTABLE(IND+1)*DELI1
-        
-        PSI=FW*UORB2/(2.*GRAV*(SED_SG-1)*DD50) 
+
+        PSI=FW*UORB2/(2.*GRAV*(SED_SG-1)*DD50)
 !
 ! Normalized Shields parameter
 !
-        SHIELDS(ISUB)=PSI/PSIC 
+        SHIELDS(ISUB)=PSI/PSIC
 !
         END DO ! end of loop on ISUB
       DPSI=(SHIELDS(2)-SHIELDS(1))/(XSUB(2)-XSUB(1))*SBTCX(5)
 !
 ! Tests if the variation in psi is large enough to use subgrid
 !
-      IF (ABS(DPSI).LT.0.0001*SHIELDS(3).OR.ABS(DPSI).LT.1.E-8) THEN 
+      IF (ABS(DPSI).LT.0.0001*SHIELDS(3).OR.ABS(DPSI).LT.1.E-8) THEN
 !
 ! no subgrid in this case
 !
-        IF(SHIELDS(3).GT.SBTCX(3)) THEN 
+        IF(SHIELDS(3).GT.SBTCX(3)) THEN
 
 !  ripple roughness, see Ardhuin et al. (2003)
           KSUBR=AORB*SBTCX(1)*SHIELDS(3)**SBTCX(2)
 !  Sheet flow roughness, see Wilson (1989)
-          KSUBS=AORB*0.0655*(UORB2/((SED_SG-1)*GRAV*AORB))**1.4  
-          KSUBN = KSUBR + KSUBS     
+          KSUBS=AORB*0.0655*(UORB2/((SED_SG-1)*GRAV*AORB))**1.4
+          KSUBN = KSUBR + KSUBS
           BEDFORM(2)=LX
           BEDFORM(3)=LY
-        ELSE    
+        ELSE
 !  relict roughness, see Ardhuin et al. (2003)
           KSUBN=MAX(BACKGROUND,AORB*SBTCX(4))
           BEDFORM(2)=-LX
           BEDFORM(3)=-LY
-          END IF 
+          END IF
 
         BEDFORM(1)=KSUBN
 
-      ELSE 
+      ELSE
 !
 ! subgrid in this case
 !
-        PSIX=(SBTCX(3)-SHIELDS(3))/DPSI 
+        PSIX=(SBTCX(3)-SHIELDS(3))/DPSI
 
         PSIXT=MAX((PSIX + XERFMAX)/DELXERF,0.)
         INDE  = MAX(MIN (SIZEERFTABLE-1, INT(PSIXT)),0)
@@ -517,11 +517,11 @@
 ! Mean psi with ripples (Tolman 1995, eq. XX)
         PSIN2=MAX(SHIELDS(3)+EXP(-(0.5*PSIX**2))/SQRT(TPI)*DPSI/(PROBA2+0.0001),SBTCX(3))
 ! Sum of relict, ripple and sheet flow roughnesses
-        KSUBN = PROBA1*MAX(BACKGROUND,AORB*SBTCX(4))       & 
+        KSUBN = PROBA1*MAX(BACKGROUND,AORB*SBTCX(4))       &
                +PROBA2*AORB*(SBTCX(1)*PSIN2**SBTCX(2)+                   &
                            0.0655*(UORB2/((SED_SG-1)*GRAV*AORB))**1.4)
 !
-        IF (PROBA2.GT.0.5) THEN 
+        IF (PROBA2.GT.0.5) THEN
           BEDFORM(2)=LX
           BEDFORM(3)=LY
         ELSE
@@ -533,21 +533,21 @@
         BEDFORM(1)=KSUBN
 
 !
-! 2.c second use of FWTABLE to get FW from the full roughness 
+! 2.c second use of FWTABLE to get FW from the full roughness
 !
         XI=MAX((ALOG10(MAX(AORB/KSUBN,0.3))-ABMIN)/DELAB,1.)
         IND  = MIN (SIZEFWTABLE-1, INT(XI))
         DELI1= MIN (1. ,XI-FLOAT(IND))
         DELI2= 1. - DELI1
         FW =FWTABLE(IND)*DELI2+FWTABLE(IND+1)*DELI1
-! 
-! 5. Fills output arrays and estimates the energy and momentum loss 
+!
+! 5. Fills output arrays and estimates the energy and momentum loss
 !
       DO IK=1, NK
         CONST2=DDEN(IK)/CG(IK) &         !Jacobian to get energy in band
                *GRAV/(SIG(IK)/WN(IK))    ! coefficient to get momentum
         DSUM(IK)=-FW*UORB*CBETA(IK)      !*WSUB(ISUB)
-        DO ITH=1,NTH       
+        DO ITH=1,NTH
           IS=ITH+(IK-1)*NTH
           D(IS)=DSUM(IK)
           TEMP2=CONST2*D(IS)*A(IS)
@@ -555,7 +555,7 @@
           TAUBBL(2) = TAUBBL(2) - TEMP2*ESIN(IS)
           S(IS)=D(IS)*A(IS)
           END DO
-        END DO 
+        END DO
 !
     RETURN
 !/

--- a/model/ftn/w3sbt8md.ftn
+++ b/model/ftn/w3sbt8md.ftn
@@ -15,12 +15,12 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Contains routines for computing dissipation by viscous fluid mud using 
+!     Contains routines for computing dissipation by viscous fluid mud using
 !     Dalrymple and Liu (1978) "Thin Model".
 !
 !  2. Variables and types :
@@ -46,15 +46,15 @@
 !     ----------------------------------------------------------------
 !
 !  5. Remarks :
-!     Historical information: 
+!     Historical information:
 !        This started as a matlab script provided to Erick Rogers by Tony
-!        Dalrympyle Sep 2006. Erick Rogers converted to Fortran and put 
+!        Dalrympyle Sep 2006. Erick Rogers converted to Fortran and put
 !        it into the SWAN model May 2007. Mark Orzech adapted the code for
-!        WW3 and added it to NRL code repository July-Dec 2011. 
+!        WW3 and added it to NRL code repository July-Dec 2011.
 !        Erick Rogers brought it over to the NCEP repository May 2013
 !        and has been updating and maintaining it there.
 !
-!     Reference: Dalrymple, R.A., Liu,P.L.-F.,1978: 
+!     Reference: Dalrymple, R.A., Liu,P.L.-F.,1978:
 !                Waves over soft muds :a 2-layer fluid model.
 !                Journal of Physical Oceanography, 8, 1121–1131.
 !
@@ -80,7 +80,7 @@
 !/                  | Last update :         21-Nov-2013 |
 !/                  +-----------------------------------+
 !/
-!/    20-Dec-2004 : Origination.                        ( version 3.06 
+!/    20-Dec-2004 : Origination.                        ( version 3.06
 !/    23-Jun-2006 : Formatted for submitting code for   ( version 3.09 )
 !/                  inclusion in WAVEWATCH III.
 !/
@@ -160,72 +160,72 @@
 !/ Local parameters
 !/
 !/S      INTEGER, SAVE           :: IENT = 0
-     
-      COMPLEX    :: K           
-      COMPLEX    :: SHH         
-      COMPLEX    :: CHH         
-      COMPLEX    :: SHD         
-      COMPLEX    :: CHD         
-      COMPLEX    :: LAM1        
-      COMPLEX    :: LAM2        
-      COMPLEX    :: CHLAM2      
-      COMPLEX    :: SHLAM2      
-      COMPLEX    :: A1          
-      COMPLEX    :: A2          
-      COMPLEX    :: A3          
-      COMPLEX    :: B1          
-      COMPLEX    :: B2          
-      COMPLEX    :: B3          
-      COMPLEX    :: B4          
-      COMPLEX    :: C0          
-      COMPLEX    :: TESTALF1    
-      COMPLEX    :: TESTALF2    
-      COMPLEX    :: ALF1        
-      COMPLEX    :: ALF2        
-      COMPLEX    :: PSI1        
-      COMPLEX    :: PSI2        
-      COMPLEX    :: M1          
-      COMPLEX    :: M0          
-      COMPLEX    :: C(4,3)      
-      COMPLEX    :: C41A        
-      COMPLEX    :: C42A        
-      COMPLEX    :: C43A        
-      COMPLEX    :: B(4)        
-      COMPLEX    :: CD          
-      COMPLEX    :: HH          
-      COMPLEX    :: DD          
-      COMPLEX    :: GG          
-      COMPLEX    :: FM1         
-      COMPLEX    :: KM1         
-      COMPLEX    :: FP          
-      COMPLEX    :: I         
-      COMPLEX    :: F         
+
+      COMPLEX    :: K
+      COMPLEX    :: SHH
+      COMPLEX    :: CHH
+      COMPLEX    :: SHD
+      COMPLEX    :: CHD
+      COMPLEX    :: LAM1
+      COMPLEX    :: LAM2
+      COMPLEX    :: CHLAM2
+      COMPLEX    :: SHLAM2
+      COMPLEX    :: A1
+      COMPLEX    :: A2
+      COMPLEX    :: A3
+      COMPLEX    :: B1
+      COMPLEX    :: B2
+      COMPLEX    :: B3
+      COMPLEX    :: B4
+      COMPLEX    :: C0
+      COMPLEX    :: TESTALF1
+      COMPLEX    :: TESTALF2
+      COMPLEX    :: ALF1
+      COMPLEX    :: ALF2
+      COMPLEX    :: PSI1
+      COMPLEX    :: PSI2
+      COMPLEX    :: M1
+      COMPLEX    :: M0
+      COMPLEX    :: C(4,3)
+      COMPLEX    :: C41A
+      COMPLEX    :: C42A
+      COMPLEX    :: C43A
+      COMPLEX    :: B(4)
+      COMPLEX    :: CD
+      COMPLEX    :: HH
+      COMPLEX    :: DD
+      COMPLEX    :: GG
+      COMPLEX    :: FM1
+      COMPLEX    :: KM1
+      COMPLEX    :: FP
+      COMPLEX    :: I
+      COMPLEX    :: F
       COMPLEX    :: KMUD
 
-      REAL    :: BET0        
-      REAL    :: KINVISW     
-      REAL    :: RHOW        
-      REAL    :: EXPH        
-      REAL    :: A           
-      REAL    :: K_UNMUD     
+      REAL    :: BET0
+      REAL    :: KINVISW
+      REAL    :: RHOW
+      REAL    :: EXPH
+      REAL    :: A
+      REAL    :: K_UNMUD
       REAL    :: SIGMA       ! radian frequency (rad)
       REAL    :: SMUDWD(NK)  ! dissipation due to mud
       REAL    :: KMIMAG(NK)  ! imag part of kmud
-      REAL    :: KD      
-      REAL    :: KDCUTOFF      
-      REAL    :: CWAVE      
-      REAL    :: ZTMP      
-      REAL    :: NWAVE_MUD      
-      REAL    :: CG_MUD      
-      REAL    :: KCHECK      
+      REAL    :: KD
+      REAL    :: KDCUTOFF
+      REAL    :: CWAVE
+      REAL    :: ZTMP
+      REAL    :: NWAVE_MUD
+      REAL    :: CG_MUD
+      REAL    :: KCHECK
       REAL    :: KTHRESHOLD
-      REAL    :: RHOM      
-      REAL    :: KINVISM      
+      REAL    :: RHOM
+      REAL    :: KINVISM
       REAL    :: THICKM
       REAL    :: CG_UNMUD
 
-      INTEGER :: ICOUNT      
-      INTEGER :: IK      
+      INTEGER :: ICOUNT
+      INTEGER :: IK
       INTEGER :: IS
 
       PARAMETER (I=(0.,1.))
@@ -237,7 +237,7 @@
 !
 ! 0.  Initializations ------------------------------------------------ *
 !
-      !     Dalrymple and Liu, Waves over soft muds:  1978. 
+      !     Dalrymple and Liu, Waves over soft muds:  1978.
       !     Thin layer solution.
       !     Matlab code provided by Tony Dalrymple
       !     Converted to Fortran by Erick Rogers
@@ -261,10 +261,10 @@
          WRITE(NDSE,*)'KINVISM NOT SET'
          CALL EXTCDE ( 3 )
       ENDIF
-      
-      RHOW=DWAT        ! Density of seawater 
+
+      RHOW=DWAT        ! Density of seawater
       KINVISW=NU_WATER
-      KDCUTOFF = 10.0 
+      KDCUTOFF = 10.0
       KTHRESHOLD=1.0E-9
 
       A=1.0
@@ -279,10 +279,10 @@
 
 ! *** loop over frequencies
       DO IK = 1,NK
-      
+
         SIGMA = SIG(IK)
 
-        !     un-muddy wave number, to start things off 
+        !     un-muddy wave number, to start things off
         CALL WAVNU1(SIGMA,H_WDEPTH,K_UNMUD,CG_UNMUD)
         K=K_UNMUD
 
@@ -379,7 +379,7 @@
            B(4)=0
            !  coefficients
            CD=-(C(3,3)-C(3,2)*C(4,3)/C(4,2))/C(3,1)
-           HH=B(2)/(C(2,1)*CD -C(2,2)*(C(4,3)/C(4,2))+C(2,3))      
+           HH=B(2)/(C(2,1)*CD -C(2,2)*(C(4,3)/C(4,2))+C(2,3))
            DD=CD*HH
            GG=-C(4,3)*HH/C(4,2)
 
@@ -391,7 +391,7 @@
               KM1=K
               K=K*(.995)+.001*I
               KCHECK=100.0
-           ELSE 
+           ELSE
               KCHECK=ABS(IMAG(K)-IMAG(KM1))
               IF((F.EQ.FM1).OR.(K.EQ.KM1).OR.(KCHECK<KTHRESHOLD))THEN
 ! notes: I have noticed that if iterations are not stopped early enough, NaNs result
@@ -406,7 +406,7 @@
         END DO
 
         KMUD=K
-        
+
 ! KD calc: not that important: just used to determine whether we make the mud calculation
         KD = REAL(KMUD) * H_WDEPTH
 
@@ -422,17 +422,17 @@
           ENDIF
           NWAVE_MUD=0.5*(1.0+2.0*REAL(KMUD)*H_WDEPTH/ZTMP)
           CG_MUD=NWAVE_MUD*CWAVE
-!        --- compute fluid mud-induced wave dissipation 
+!        --- compute fluid mud-induced wave dissipation
           SMUDWD(IK)=2.0*IMAG(KMUD)*CG_MUD
 
-!        --- store imaginary part of KMUD  
+!        --- store imaginary part of KMUD
           KMIMAG(IK)=IMAG(KMUD)
- 
+
         END IF !     IF ( KD .LT. KDCUTOFF ) THEN
-        
+
       END DO ! IK
 
-!     *** store the results in the DIAGONAL array D *** 
+!     *** store the results in the DIAGONAL array D ***
       DO IS = 1,NSPEC
         D(IS) = -SMUDWD(MAPWN(IS))
       END DO
@@ -440,7 +440,7 @@
       END IF !   IF ( THICKM>0.0 & RHOM>0.0 & KINVISM>0.0 ) THEN
 
       S = D * AC
-      
+
       RETURN
 !/
 !/ End of W3SBT8 ----------------------------------------------------- /

--- a/model/ftn/w3sbt9md.ftn
+++ b/model/ftn/w3sbt9md.ftn
@@ -15,12 +15,12 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Contains routines for computing dissipation by viscous fluid mud using 
+!     Contains routines for computing dissipation by viscous fluid mud using
 !     Ng (2000)
 !
 !  2. Variables and types :
@@ -47,22 +47,22 @@
 !     ----------------------------------------------------------------
 !
 !  5. Remarks :
-!     Historical information: 
+!     Historical information:
 !        This started as some equations (the "B" parameter equations
-!        in subroutine "Ng" below) in a standalone Fortran 
-!        code written by Jim Kaihatu, December 2004. These were adapted by  
-!        Erick Rogers for a simple model based on governing equation 
-!        similar to SWAN, and installed in a full version of SWAN in 
-!        March 2005 with an informal report in May 2005. Kaihatu provided 
-!        a "patch" for the B equations May 2006. Mud code in SWAN v40.41A was 
-!        finalized June 2006, and v40.51 August 2007. The code was applied 
+!        in subroutine "Ng" below) in a standalone Fortran
+!        code written by Jim Kaihatu, December 2004. These were adapted by
+!        Erick Rogers for a simple model based on governing equation
+!        similar to SWAN, and installed in a full version of SWAN in
+!        March 2005 with an informal report in May 2005. Kaihatu provided
+!        a "patch" for the B equations May 2006. Mud code in SWAN v40.41A was
+!        finalized June 2006, and v40.51 August 2007. The code was applied
 !        to Cassino Beach ~Sep 2006. This work was presented at a conference
-!        in Brazil Nov 2006, and later published in Rogers and Holland 
-!        (CSR 2009). The code was adapted for WW3 by Mark Orzech in Nov 2012 
+!        in Brazil Nov 2006, and later published in Rogers and Holland
+!        (CSR 2009). The code was adapted for WW3 by Mark Orzech in Nov 2012
 !        (he had installed the D&L routines as BT8 in July 2011).
 !
-!     Reference: Ng, C.O.,2000. Water waves over a muddy bed: 
-!                a two-layer Stokes’ boundary layer model. 
+!     Reference: Ng, C.O.,2000. Water waves over a muddy bed:
+!                a two-layer Stokes’ boundary layer model.
 !                Coastal Engineering 40(3),221–242.
 !
 !  6. Switches :
@@ -146,7 +146,7 @@
 ! 10. Source code :
 !
 !/ ------------------------------------------------------------------- /
-      USE W3GDATMD, ONLY: NK,SIG,NSPEC,MAPWN   
+      USE W3GDATMD, ONLY: NK,SIG,NSPEC,MAPWN
       USE W3IDATMD, ONLY: MUDT, MUDV, MUDD, INFLAGS1
       USE CONSTANTS, ONLY: PI,GRAV,DWAT,NU_WATER
       USE W3SERVMD, ONLY: EXTCDE
@@ -167,31 +167,31 @@
 !/ Local parameters
 !/
 !/S      INTEGER, SAVE           :: IENT = 0
-  
+
    !  LOCAL VARIABLES
       REAL :: DMW(NK)
-      REAL :: ROOTDG     
-      REAL :: SND        
-      REAL :: SND2       
-      REAL :: WGD        
-      REAL :: CWAVE      
-      REAL :: KD_ROCK         
-      REAL :: CG_MUD     
-      REAL :: K_MUD     
-      REAL :: NWAVE_MUD  
-      REAL :: ND_MUD     
+      REAL :: ROOTDG
+      REAL :: SND
+      REAL :: SND2
+      REAL :: WGD
+      REAL :: CWAVE
+      REAL :: KD_ROCK
+      REAL :: CG_MUD
+      REAL :: K_MUD
+      REAL :: NWAVE_MUD
+      REAL :: ND_MUD
       REAL :: SMUDWD(NK) !  DISSIPATION DUE TO MUD
-      REAL :: CG_ROCK     
-      REAL :: K_ROCK      
-      REAL :: NWAVE_ROCK  
-      REAL :: ND_ROCK     
+      REAL :: CG_ROCK
+      REAL :: K_ROCK
+      REAL :: NWAVE_ROCK
+      REAL :: ND_ROCK
       REAL :: KINVISM       ! := THE KINEMATIC VISCOSITY OF THE MUD
       REAL :: KINVISW       ! := KINEMATIC VISCOSITY OF WATER
       REAL :: RHOW          ! := DENSITY OF WATER
       REAL :: RHOM          ! := DENSITY OF MUD
       REAL :: DM            ! := DEPTH OF MUD LAYER
       REAL :: ZETA          ! := THIS IS ZETA AS USED IN NG PG. 238. IT IS THE
-                            !    RATIO OF STOKES' BOUNDARY LAYER THICKNESSES, 
+                            !    RATIO OF STOKES' BOUNDARY LAYER THICKNESSES,
                             !    OR DELTA_M/DELTA_W
       REAL :: GAMMA         ! := THIS IS THE GAMMA USED IN NG PG. 238. THIS IS
                             !  DENSITY(WATER)/DENSITY(MUD)
@@ -199,21 +199,21 @@
       REAL :: SBLTM         ! := A FUNCTION OF VISCOSITY AND FREQ
       REAL :: DTILDE        ! := NORMALIZED MUD DEPTH = MUD DEPTH / DELTA_M,
                             !  DELTA IS THE SBLT= SQRT(2*VISC/SIGMA)
-      REAL :: ZTMP          
-      REAL :: KDCUTOFF      
-      REAL :: KD            
+      REAL :: ZTMP
+      REAL :: KDCUTOFF
+      REAL :: KD
 
-      INTEGER :: IS         
+      INTEGER :: IS
 
       LOGICAL :: INAN
-     
+
 !/ ------------------------------------------------------------------- /
 !/
 !/S      CALL STRACE (IENT, 'W3SBT9')
 !
 ! 0.  Initializations ------------------------------------------------ *
 !
-      !     Ng (2000), Waves over soft muds. 
+      !     Ng (2000), Waves over soft muds.
       !     Based on code for SWAN created by Erick Rogers.
       !     Adapted for WW3 by Mark Orzech, Nov 2012.
 
@@ -236,35 +236,35 @@
          WRITE(NDSE,*)'KINVISM NOT SET'
          CALL EXTCDE ( 3 )
       ENDIF
-      
-      ROOTDG = SQRT(H_WDEPTH/GRAV) 
-      WGD    = ROOTDG*GRAV 
+
+      ROOTDG = SQRT(H_WDEPTH/GRAV)
+      WGD    = ROOTDG*GRAV
       DO IS = 1, NK
        !       SND is dimensionless frequency
        SND = SIG(IS) * ROOTDG
        IF (SND .GE. 2.5) THEN
           !       ******* DEEP WATER *******
-          K_ROCK  = SIG(IS) * SIG(IS) / GRAV 
-          CG_ROCK = 0.5 * GRAV / SIG(IS)   
+          K_ROCK  = SIG(IS) * SIG(IS) / GRAV
+          CG_ROCK = 0.5 * GRAV / SIG(IS)
           NWAVE_ROCK  = 0.5
           ND_ROCK = 0.
        ELSE IF (SND.LT.1.E-6) THEN
-          !       *** VERY SHALLOW WATER ***          
-          K_ROCK  = SND/H_WDEPTH                     
+          !       *** VERY SHALLOW WATER ***
+          K_ROCK  = SND/H_WDEPTH
           CG_ROCK = WGD
           NWAVE_ROCK  = 1.
           ND_ROCK = 0.
        ELSE
 
-          SND2  = SND*SND                        
+          SND2  = SND*SND
           CWAVE     = SQRT(GRAV*H_WDEPTH/(SND2+1./(1.+0.666*SND2 &
                        +0.445*SND2**2 -0.105*SND2**3+0.272*SND2**4)))
-          K_ROCK = SIG(IS)/CWAVE                                  
+          K_ROCK = SIG(IS)/CWAVE
 
           CALL CALC_ND(K_ROCK,H_WDEPTH,SND2,ND_ROCK)
 
           NWAVE_ROCK = 0.5*(1.0+2.0*K_ROCK*H_WDEPTH/SINH(2.0*K_ROCK*H_WDEPTH))
-          CG_ROCK= NWAVE_ROCK*CWAVE             
+          CG_ROCK= NWAVE_ROCK*CWAVE
 
           SND2=0
           CWAVE=0
@@ -273,8 +273,8 @@
 
           KDCUTOFF = 10.0  ! hardwired (same as w3sbt8md)
 
-          ! now that kh is known, we can use a definition of "deep" that is 
-          ! consistent with the definition used in sbot 
+          ! now that kh is known, we can use a definition of "deep" that is
+          ! consistent with the definition used in sbot
           K_MUD=0.0
           DMW(IS)=0.0
           KD_ROCK = K_ROCK * H_WDEPTH
@@ -285,7 +285,7 @@
              ZETA=SQRT(KINVISM/KINVISW)
              GAMMA=RHOW/RHOM
              SBLTW=SQRT(2.0*KINVISW/SIG(IS))
-             SBLTM=SQRT(2.0*KINVISM/SIG(IS)) 
+             SBLTM=SQRT(2.0*KINVISM/SIG(IS))
 
              DTILDE=DM/SBLTM
              CALL NG(SIG(IS),H_WDEPTH,DTILDE,ZETA,SBLTM,GAMMA,K_ROCK,K_MUD, &
@@ -307,14 +307,14 @@
           NWAVE_MUD=0.5*(1.0+2.0*K_MUD*H_WDEPTH/ZTMP)
 
           CG_MUD=NWAVE_MUD*CWAVE
-          SND2  = SND*SND                        
+          SND2  = SND*SND
 
           CALL CALC_ND(K_MUD,H_WDEPTH,SND2,ND_MUD)
 
           SND2=0
           CWAVE=0
 
-       ! If we wanted to include the effects of mud on the real part of the 
+       ! If we wanted to include the effects of mud on the real part of the
        ! wavnumber (as we do in SWAN), this is where we would do it.
        ! Set output variables k_out, cg_out, nwave_out, nd_out, dmw.
 !kinematics       IF(MUD)THEN !
@@ -322,7 +322,7 @@
 !kinematics          CG_OUT(IS)   =CG_MUD
 !kinematics          NWAVE_OUT(IS)=NWAVE_MUD
 !kinematics          ND_OUT(IS)   =ND_MUD
-!kinematics       ELSE ! USE ROCKY WAVENUMBER,ETC. 
+!kinematics       ELSE ! USE ROCKY WAVENUMBER,ETC.
 !kinematics          K_OUT(IS)    =K_ROCK
 !kinematics          CG_OUT(IS)   =CG_ROCK
 !kinematics          NWAVE_OUT(IS)=NWAVE_ROCK
@@ -337,7 +337,7 @@
        END IF
 
 ! NaN check:
-        INAN = .NOT. ( DMW(IS) .GE. -HUGE(DMW(IS)) .AND. DMW(IS) & 
+        INAN = .NOT. ( DMW(IS) .GE. -HUGE(DMW(IS)) .AND. DMW(IS) &
                .LE. HUGE(DMW(IS)) )
         IF (INAN) THEN
            WRITE(*,'(/1A/)') 'W3SBT9 ERROR -- DMW(IS) IS NAN'
@@ -349,7 +349,7 @@
         END IF
 
       END DO !  DO IS = 1, NK
-         
+
 !    *** store the results in the DIAGONAL arrays D and S ***
       DO IS = 1,NSPEC
          ! note that "IS" here is for the directional spectrum (2d)
@@ -359,9 +359,9 @@
       S = D * AC
 
       RETURN
-     
+
       END SUBROUTINE W3SBT9
-     
+
 !/ ------------------------------------------------------------------- /
       SUBROUTINE NG(SIGMA,H_WDEPTH,DTILDE,ZETA,SBLTM,GAMMA,WK,WKDR,DISS)
 !/
@@ -429,7 +429,7 @@
 !/ ------------------------------------------------------------------- /
 !/
 
-  !   
+  !
       IMPLICIT NONE
 
     ! INPUT VARIABLES :
@@ -438,13 +438,13 @@
       REAL, INTENT(IN)  ::  DTILDE  ! normalized mud depth = mud depth / sbltm,
                                     ! delta is the sblt= sqrt(2*visc/sigma)
       REAL, INTENT(IN)  ::  ZETA    ! this is zeta as used in Ng pg. 238. it is
-                                    ! the ratio of stokes' boundary layer 
+                                    ! the ratio of stokes' boundary layer
                                     ! thicknesses, or sbltm/delta_w
-      REAL, INTENT(IN)  ::  GAMMA   ! this is the gamma used in Ng pg. 238. 
+      REAL, INTENT(IN)  ::  GAMMA   ! this is the gamma used in Ng pg. 238.
                                     ! this is density(water)/density(mud)
-      REAL, INTENT(IN)  ::  SBLTM   ! sbltm is what you get if you calculate 
-                                    ! sblt using the viscosity of the mud, 
-                                    ! sbltm=sqrt(2*visc_m/sigma) 
+      REAL, INTENT(IN)  ::  SBLTM   ! sbltm is what you get if you calculate
+                                    ! sblt using the viscosity of the mud,
+                                    ! sbltm=sqrt(2*visc_m/sigma)
                                     ! .....also delta_m
       REAL, INTENT(IN)  :: WK       ! unmuddy wavenumber
 
@@ -467,16 +467,16 @@
   !   NOW CALCULATE Ng's B coefficients : see Ng pg 238
       B1=GAMMA*(-2.0*GAMMA**2+2.0*GAMMA-1.-ZETA**2)*SINH(DTILDE)*   &
          COSH(DTILDE)-GAMMA**2*ZETA*((COSH(DTILDE))**2+             &
-         (SINH(DTILDE))**2)-(GAMMA-1.)**2*ZETA*((COSH(DTILDE))**2   & 
+         (SINH(DTILDE))**2)-(GAMMA-1.)**2*ZETA*((COSH(DTILDE))**2   &
          *(COS(DTILDE))**2+(SINH(DTILDE))**2*(SIN(DTILDE))**2)-2.0  &
-         *GAMMA*(1.-GAMMA)*(ZETA*COSH(DTILDE)+GAMMA*SINH(DTILDE))   & 
+         *GAMMA*(1.-GAMMA)*(ZETA*COSH(DTILDE)+GAMMA*SINH(DTILDE))   &
          *COS(DTILDE)
 
       B2=GAMMA*(-2.0*GAMMA**2+2.0*GAMMA-1.+ZETA**2)*SIN(DTILDE)*    &
          COS(DTILDE) -2.0*GAMMA*(1.-GAMMA)*(ZETA*SINH(DTILDE)+GAMMA &
          *COSH(DTILDE))*SIN(DTILDE)
 
-      B3=(ZETA*COSH(DTILDE)+GAMMA*SINH(DTILDE))**2*(COS(DTILDE))**2 & 
+      B3=(ZETA*COSH(DTILDE)+GAMMA*SINH(DTILDE))**2*(COS(DTILDE))**2 &
         +(ZETA*SINH(DTILDE)+GAMMA*COSH(DTILDE))**2*(SIN(DTILDE))**2
 
       BR=WK*SBLTM*(B1-B2)/(2.0*B3)+GAMMA*WK*DM
@@ -492,7 +492,7 @@
       RETURN
 
       END SUBROUTINE NG
-      
+
 !/ ------------------------------------------------------------------- /
       SUBROUTINE CALC_ND(KWAVE,H_WDEPTH,SND2,ND)
 !/ ------------------------------------------------------------------- /
@@ -507,15 +507,15 @@
       REAL    :: FAC3       ! LOCAL
       REAL    :: KND        ! LOCAL
 
-      KND   = KWAVE*H_WDEPTH              
-      FAC1  = 2.*KND/SINH(2.*KND)   
-      FAC2  = SND2/KND              
-      FAC3  = 2.*FAC2/(1.+FAC2*FAC2) 
+      KND   = KWAVE*H_WDEPTH
+      FAC1  = 2.*KND/SINH(2.*KND)
+      FAC2  = SND2/KND
+      FAC3  = 2.*FAC2/(1.+FAC2*FAC2)
       ND= FAC1*(0.5/H_WDEPTH - KWAVE/FAC3)
 
       END SUBROUTINE CALC_ND
-      
+
 !/ ------------------------------------------------------------------- /
 !/
       END MODULE W3SBT9MD
-      
+

--- a/model/ftn/w3sbtxmd.ftn
+++ b/model/ftn/w3sbtxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !
@@ -120,7 +120,7 @@
 !/                  | Last update :         23-Jun-2006 |
 !/                  +-----------------------------------+
 !/
-!/    20-Dec-2004 : Origination.                        ( version 3.06 
+!/    20-Dec-2004 : Origination.                        ( version 3.06
 !/    23-Jun-2006 : Formatted for submitting code for   ( version 3.09 )
 !/                  inclusion in WAVEWATCH III.
 !/

--- a/model/ftn/w3sdb1md.ftn
+++ b/model/ftn/w3sdb1md.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -57,7 +57,7 @@
 !/                  |                        FORTRAN 90 |
 !/                  |           J. H. Alves             |
 !/                  |           H. L. Tolman            |
-!/                  !           A. Roland               | 
+!/                  !           A. Roland               |
 !/                  | Last update :         08-Jun-2018 |
 !/                  +-----------------------------------+
 !/
@@ -71,25 +71,25 @@
 !     Compute depth-induced breaking using Battjes and Janssen bore
 !     model approach
 !
-!  2. Method : Battjes & Janssen (1978), 
-! 
+!  2. Method : Battjes & Janssen (1978),
+!
 !           Sbr   = Dtot/Etot*WA = D * WA
 !           Dtot  = 0.25*alpha*Qb*fm*Hmax²
 !           fm    = sigma/2Pi
 !           BB    = Hrms²/Hmax² = 8Etot/Hmax²
 !           D     = Dtot/Etot = BJALFA * sigma / pi * Qb/BB = 2 * BJALFA * fm * Qb/BB
 !
-!           AR: only valid for Hrms .le. Hm, Qb .le. 1, otherwise, in the degenrative regime it is 
+!           AR: only valid for Hrms .le. Hm, Qb .le. 1, otherwise, in the degenrative regime it is
 !           due to Qb > 1 that all wave are broken and Hrms .le. Hmax
-!           MLIM can be used to enforce this conditions, source term will smoothly converge to this limit. 
-!           
+!           MLIM can be used to enforce this conditions, source term will smoothly converge to this limit.
+!
 !     Where CDB   = SDBC1 = BJALFA (defaults to BJALFA = 1)
 !                   modified via ww3_grid namelist parameter BJALFA
 !           HM    = GAMMA * DEP
 !           GAMMA = SDBC2 defaults to 0.73 (mean Battjes/Janssen value)
 !                   modified via ww3_grid namelist parameter BJGAM
 !
-!     And QB is estimated by iterations using the nonlinear expression 
+!     And QB is estimated by iterations using the nonlinear expression
 !
 !           1 - QB = HRMS**2
 !           ------   -------
@@ -195,7 +195,7 @@
       DO IK=1, NK
         EB(IK) = 0.
         DO ITH=1, NTH
-          EB(IK) = EB(IK) + A(ITH+(IK-1)*NTH) 
+          EB(IK) = EB(IK) + A(ITH+(IK-1)*NTH)
         END DO
       END DO
       DO IK=1, NK
@@ -203,7 +203,7 @@
         ETOT  = ETOT  + EB(IK)
       END DO
       DO IK=1, NK
-        FMEAN2 = FMEAN2 + EB(IK) * SIG(IK) 
+        FMEAN2 = FMEAN2 + EB(IK) * SIG(IK)
       END DO
       FMEAN2 = FMEAN2 / ETOT * TPIINV
 !
@@ -226,11 +226,11 @@
 !
 !AR: Add Dingemans ...
 ! 1.b. Hrms and ratio Hrms / Hmax
-! 
+!
       HRMS = DSQRT (8.d0 * DBLE(EMEAN))
       IF ( HM .GT. THR) THEN
         BB     = HRMS * HRMS / ( HM * HM )
-        B      = DSQRT(BB) 
+        B      = DSQRT(BB)
       ELSE
         BB     = 0.d0
         B      = 0.d0
@@ -261,20 +261,20 @@
 !
 ! 3. Estimate the breaking coefficient ------------------------------- /
 !
-      CBJ  = 0  
+      CBJ  = 0
       IF (IWB == 1) THEN
         IF ( ( BB .GT. THR) .AND. ( ABS ( BB - QB ) .GT. THR) ) THEN
           IF ( BB .LT. 1.0) THEN
             CBJ = 2 * DBLE(SDBC1) * QB * DBLE(FMEAN) / BB
           ELSE
-            CBJ = 2 * DBLE(SDBC1) * DBLE(FMEAN) * BB ! AR: degenerative regime, all waves must be .le. Hmax, we just smoothly let the excessive energy vanish by * BB. 
+            CBJ = 2 * DBLE(SDBC1) * DBLE(FMEAN) * BB ! AR: degenerative regime, all waves must be .le. Hmax, we just smoothly let the excessive energy vanish by * BB.
           END IF
         ELSE
           CBJ = 0.d0
         ENDIF
         D = - CBJ
         S = D * A
-      ELSE IF (IWB == 2) THEN 
+      ELSE IF (IWB == 2) THEN
         IF (ETOT .GT. THR) THEN
           HRMS = SQRT(8*EMEAN)
           FAK  = (1+4./SQRT(PI)*(B*BB+1.5*B)*exp(-BB)-ERF(B))
@@ -283,13 +283,13 @@
           CBJ  = 0.
         ENDIF
         D = - CBJ
-        S = D * A 
+        S = D * A
       ENDIF
 
       IF (CBJ .GT. 0.) THEN
-        LBREAK = .TRUE. 
+        LBREAK = .TRUE.
       ELSE
-        LBREAK = .FALSE. 
+        LBREAK = .FALSE.
       ENDIF
 
 !/DEBUGRUN      IF (IX == DEBUG_NODE) THEN
@@ -310,12 +310,12 @@
 !
 !/T0      CALL PRT2DS (NDST, NK, NK, NTH, DOUT, SIG, '  ', 1.,    &
 !/T0                         0.0, 0.001, 'Diag Sdb', ' ', 'NONAME')
-!     
+!
 !/T1      CALL OUTMAT (NDST, D, NTH, NTH, NK, 'diag Sdb')
-!  
+!
       RETURN
 !
-! Formats   
+! Formats
 !
 !/T 9000 FORMAT (' TEST W3SDB1 : PARAMETERS :',2F7.3,L4)
 !/

--- a/model/ftn/w3sdbxmd.ftn
+++ b/model/ftn/w3sdbxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3servmd.ftn
+++ b/model/ftn/w3servmd.ftn
@@ -10,9 +10,9 @@
 !/                  +-----------------------------------+
 !/
 !/    For update log see individual subroutines.
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    18-Aug-2016 : Add dist_sphere: angular distance   ( version 5.11 )
 !/    01-Mar-2016 : Added W3THRTN and W3XYRTN for post  ( version 6.02 )
@@ -20,7 +20,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -44,17 +44,17 @@
 !     ----------------------------------------------------------------
 !      ITRACE    Subr. Public   (Re-) Initialization for STRACE.
 !      STRACE    Subr. Public   Enable subroutine tracing, usually
-!                               activated with the !/S switch.   
+!                               activated with the !/S switch.
 !      NEXTLN    Subr. Public   Get to next line in input command file.
 !      W3S2XY    Subr. Public   Grid conversion routine.
 !      EJ5P      R.F.  Public   Five parameter JONSWAP spectrum.
 !      WWDATE    Subr. Public   Get system date.
 !      WWTIME    Subr. Public   Get system time.
 !      EXTCDE    Subr. Public   Abort program with exit code.
-!     Four subs for rotated grid are appended to this module.  As they 
-!     are shared with SMC grid, they are not quoted by option /RTD but 
+!     Four subs for rotated grid are appended to this module.  As they
+!     are shared with SMC grid, they are not quoted by option /RTD but
 !     are available for general use.     JGLi12Jun2012
-!     W3SPECTN       turns wave spectrum anti-clockwise by AnglD 
+!     W3SPECTN       turns wave spectrum anti-clockwise by AnglD
 !     W3ACTURN       turns wave action(k,nth) anti-clockwise by AnglD.
 !     W3LLTOEQ       convert standard into rotated lat/lon, plus AnglD
 !     W3EQTOLL       revers of the LLTOEQ, but AnglD unchanged.
@@ -570,7 +570,7 @@
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
 !/
-      REAL, INTENT(IN)        :: LO1, LA1, LO2, LA2 
+      REAL, INTENT(IN)        :: LO1, LA1, LO2, LA2
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -579,7 +579,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/
-     DIST_SPHERE=acos(sin(la2*DERA)*sin(la1*DERA)+ &   
+     DIST_SPHERE=acos(sin(la2*DERA)*sin(la1*DERA)+ &
                       cos(la2*DERA)*cos(la1*DERA)*cos((lo2-lo1)*DERA))*RADE
 !
       RETURN
@@ -769,10 +769,10 @@
 !
 !     Perform a program stop with an exit code.
 !
-!     If exit code IEXIT=0, then it is not an error, but 
+!     If exit code IEXIT=0, then it is not an error, but
 !     a stop has been requested by the calling routine:
 !     wait for other processes in communicator to catch up.
-!     
+!
 !     If exit code IEXIT.ne.0, then abort program w/out
 !     waiting for other processes to catch up (important for example
 !     when not all processes are used by WW3).
@@ -909,7 +909,7 @@
 ! Subroutine Interface:
 
        Subroutine W3SPECTN( NFreq, NDirc, Alpha, Spectr )
- 
+
 ! Description:
 !   Rotates wave spectrum anticlockwise by angle alpha in degree
 !   This routine is distinct from W3ACTURN since orders spectrum as freq, dirn
@@ -948,7 +948,7 @@
 ! Wave spectral direction bin number is assumed to increase Anti-clockwise from EAST
 ! So shift nsft bins anticlockwise results in local bin number decreasing by nsft
               jj=ii - nsft
- 
+
 ! As nsft may be either positive or negative depends on alpha, wrapping may
 ! happen in either ends of the bin number train
               IF( jj > NDirc )  jj=jj - NDirc
@@ -956,7 +956,7 @@
 
 ! Copy the selected bin to the loop bin number
               Wrkspc(:,ii)=Spectr(:,jj)
- 
+
            ENDDO
 
 ! If nsft=0, no need to shift, simply copy
@@ -978,15 +978,15 @@
 ! Negative or clockwise case, larger bin upstream
            Tmpfrq=Wrkspc(:,1)*frac
            DO kk=NDirc, 1, -1
-              Wrkfrq=Wrkspc(:,kk)*frac 
-              Spectr(:,kk)=Wrkspc(:,kk) + Wrkfrq - Tmpfrq 
+              Wrkfrq=Wrkspc(:,kk)*frac
+              Spectr(:,kk)=Wrkspc(:,kk) + Wrkfrq - Tmpfrq
               Tmpfrq=Wrkfrq
            ENDDO
          ENDIF
 
 ! Spectral turning completed
 
-        RETURN 
+        RETURN
         END SUBROUTINE W3SPECTN
 !
 !  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -998,7 +998,7 @@
 ! Subroutine Interface:
 
        Subroutine W3ACTURN( NDirc, NFreq, Alpha, Spectr )
- 
+
 ! Description:
 !   Rotates wave spectrum anticlockwise by angle alpha
 !   Routine is distinct from W3SPECTN since orders spectrum as dirn, freq
@@ -1037,7 +1037,7 @@
 ! Wave spectral direction bin number is assumed to increase Anti-clockwise from EAST
 ! So shift nsft bins anticlockwise results in local bin number decreasing by nsft
              jj=ii - nsft
- 
+
 ! As nsft may be either positive or negative depends on alpha, wrapping may
 ! happen in either ends of the bin number train
              IF( jj > NDirc )  jj=jj - NDirc
@@ -1045,7 +1045,7 @@
 
 ! Copy the selected bin to the loop bin number
              Wrkspc(ii,:)=Spectr(jj,:)
- 
+
           ENDDO
 
 ! If nsft=0, no need to shift, simply copy
@@ -1067,15 +1067,15 @@
 ! Negative or clockwise case, larger bin upstream
           Tmpfrq=Wrkspc(1,:)*frac
           DO kk=NDirc, 1, -1
-             Wrkfrq=Wrkspc(kk,:)*frac 
-             Spectr(kk,:)=Wrkspc(kk,:) + Wrkfrq - Tmpfrq 
+             Wrkfrq=Wrkspc(kk,:)*frac
+             Spectr(kk,:)=Wrkspc(kk,:) + Wrkfrq - Tmpfrq
              Tmpfrq=Wrkfrq
           ENDDO
         ENDIF
 
 ! Spectral turning completed
 
-       RETURN 
+       RETURN
        END SUBROUTINE W3ACTURN
 !
 !Li  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -1088,32 +1088,32 @@
 !Li         Jian-Guo Li     26 May 2005
 !Li
 !Li  The WCOEFF1A subroutine is merged into LLTOEQ to reduce repetition
-!Li  of the same calculations. Subroutine interface changed to 
+!Li  of the same calculations. Subroutine interface changed to
 !Li  LLTOEQANGLE
 !Li         Jian-GUo Li     23 Aug 2005
 !Li
-!Li  Subroutine W3LLTOEQ   --------------------------------------------    
-!Li                                                                        
-!Li  Purpose:  Calculates latitude and longitude on equatorial             
-!Li            latitude-longitude (eq) grid used in regional               
-!Li            models from input arrays of latitude and                    
-!Li            longitude on standard grid. Both input and output           
-!Li            latitudes and longitudes are in degrees.                    
+!Li  Subroutine W3LLTOEQ   --------------------------------------------
+!Li
+!Li  Purpose:  Calculates latitude and longitude on equatorial
+!Li            latitude-longitude (eq) grid used in regional
+!Li            models from input arrays of latitude and
+!Li            longitude on standard grid. Both input and output
+!Li            latitudes and longitudes are in degrees.
 !Li            Also calculate rotation angle in degree to tranform
 !Li            standard wind velocity into equatorial wind.
 !Li            Valid for 0<PHI_POLE<90 or new pole in N. hemisphere.
-!Li                                                                        
-!* Arguments:--------------------------------------------------------    
-      SUBROUTINE W3LLTOEQ ( PHI, LAMBDA, PHI_EQ, LAMBDA_EQ,     &              
-     &                 ANGLED, PHI_POLE, LAMBDA_POLE, POINTS )             
-                                                                           
-      IMPLICIT NONE                                                        
-                                                                           
-      INTEGER:: POINTS    !IN  Number of points to be processed             
+!Li
+!* Arguments:--------------------------------------------------------
+      SUBROUTINE W3LLTOEQ ( PHI, LAMBDA, PHI_EQ, LAMBDA_EQ,     &
+     &                 ANGLED, PHI_POLE, LAMBDA_POLE, POINTS )
+
+      IMPLICIT NONE
+
+      INTEGER:: POINTS    !IN  Number of points to be processed
 
       REAL :: PHI_POLE,  & !IN  Latitude of equatorial lat-lon pole
      &        LAMBDA_POLE  !INOUT  Longitude of equatorial lat-lon pole
-                                                                           
+
       REAL, DIMENSION(POINTS) ::         &
      &        PHI,       & !IN  Latitude
      &        LAMBDA,    & !IN  Longitude
@@ -1125,16 +1125,16 @@
       REAL(KIND=8) :: A_LAMBDA, A_PHI, E_LAMBDA, E_PHI,                 &
                       SIN_PHI_POLE, COS_PHI_POLE,                       &
                       TERM1, TERM2, ARG, LAMBDA_ZERO, LAMBDA_POLE_KEEP
-      INTEGER      :: I 
+      INTEGER      :: I
 
       REAL(KIND=8), PARAMETER :: SMALL=1.0E-6
 
       ! Double precision versions of values in constants.ftn:
-      REAL(KIND=8), PARAMETER         :: PI = 3.141592653589793 
+      REAL(KIND=8), PARAMETER         :: PI = 3.141592653589793
       REAL(KIND=8), PARAMETER         :: RECIP_PI_OVER_180 = 180. / PI
       REAL(KIND=8), PARAMETER         :: PI_OVER_180   = PI / 180.
 
-!*----------------------------------------------------------------------   
+!*----------------------------------------------------------------------
 
 ! 1. Initialise local constants
 ! Scale lambda pole to range -180 to 180 degs
@@ -1219,8 +1219,8 @@
       LAMBDA_POLE=LAMBDA_POLE_KEEP
 
       RETURN
-      END SUBROUTINE W3LLTOEQ 
-! 
+      END SUBROUTINE W3LLTOEQ
+!
 !Li  +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 !Li
 !Li  Merged UM source code for rotated grid, consiting the following
@@ -1231,7 +1231,7 @@
 !Li         Jian-Guo Li     26 May 2005
 !Li
 !Li  The WCOEFF1A subroutine is merged into EQTOLL to reduce repetition
-!Li  of the same calculations. Subroutine interface changed to 
+!Li  of the same calculations. Subroutine interface changed to
 !Li  EQTOLLANGLE
 !Li  First created:   Jian-GUo Li     23 Aug 2005
 !Li  Last modified:   Jian-GUo Li     25 Feb 2008
@@ -1275,7 +1275,7 @@
       REAL(KIND=8), PARAMETER :: SMALL=1.0E-6
 
       ! Double precision versions of values in constants.ftn:
-      REAL(KIND=8), PARAMETER         :: PI = 3.141592653589793 
+      REAL(KIND=8), PARAMETER         :: PI = 3.141592653589793
       REAL(KIND=8), PARAMETER         :: RECIP_PI_OVER_180 = 180. / PI
       REAL(KIND=8), PARAMETER         :: PI_OVER_180   = PI / 180.
 
@@ -1358,7 +1358,7 @@
       ENDDO
 
       RETURN
-      END SUBROUTINE W3EQTOLL  
+      END SUBROUTINE W3EQTOLL
 
 !Li
 !/ ------------------------------------------------------------------- /
@@ -1413,7 +1413,7 @@
         ENDIF
       END DO
 
-      RETURN 
+      RETURN
       END SUBROUTINE W3THRTN
 !
 !/ ------------------------------------------------------------------- /
@@ -1468,7 +1468,7 @@
         END IF
       END DO
 
-      RETURN 
+      RETURN
       END SUBROUTINE W3XYRTN
 !
 !/ ------------------------------------------------------------------- /
@@ -1542,13 +1542,13 @@
    SUBROUTINE STR_TO_UPPER(STR)
      character(*), intent(inout) :: str
      integer :: i
- 
+
      DO i = 1, len(str)
        select case(str(i:i))
          case("a":"z")
            str(i:i) = achar(iachar(str(i:i))-32)
        end select
-       END DO 
+       END DO
 !/ End of STR_TO_UPPER
 !/ ------------------------------------------------------------------- /
 END SUBROUTINE STR_TO_UPPER
@@ -1890,7 +1890,7 @@ END SUBROUTINE STR_TO_UPPER
    DOUBLE PRECISION    , DIMENSION(size(d)) ::b,z
    DOUBLE PRECISION, DIMENSION(size(d),size(d)) :: a
    LOGICAL, DIMENSION(size(d),size(d)) :: upper_triangle
-   
+
    a=a1
    n=size(d)
    v(:,:)=0.

--- a/model/ftn/w3sic1md.ftn
+++ b/model/ftn/w3sic1md.ftn
@@ -15,10 +15,10 @@
 !  1. Purpose :
 !
 !     Calculate ice source term S_{ice} according to simple methods.
-!          Exponential decay rate is uniform in frequency, and 
-!          specified directly by the user.  This method is, in effect, 
-!          not sustantially different from handling sea ice via the 
-!          "sub-grid" blocking approach, after improvements by 
+!          Exponential decay rate is uniform in frequency, and
+!          specified directly by the user.  This method is, in effect,
+!          not sustantially different from handling sea ice via the
+!          "sub-grid" blocking approach, after improvements by
 !          Fabrice Ardhuin (in v4.00).
 !
 !  2. Variables and types :
@@ -37,10 +37,10 @@
 !  5. Remarks :
 !
 !     Reference:Rogers, W.E. and M.D. Orzech, 2013: Implementation and
-!        Testing of Ice and Mud Source Functions in WAVEWATCH III(R), 
+!        Testing of Ice and Mud Source Functions in WAVEWATCH III(R),
 !        NRL/MR/7320--13-9462, 31pp.
 !        available from http://www7320.nrlssc.navy.mil/pubs.php
-!        Direct link: 
+!        Direct link:
 !        http://www7320.nrlssc.navy.mil/pubs/2013/rogers2-2013.pdf
 !
 !  6. Switches :
@@ -76,7 +76,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -101,23 +101,23 @@
 !     Sea ice affects the wavenumber k of wind-generated ocean waves.
 !     The ice-modified wavenumber can be expressed as a complex number
 !     k = k_r + i*k_i, with the real part k_r representing impact of
-!     the sea ice on the physical wavelength and propagation speeds, 
-!     producing something analogous to shoaling and refraction by 
-!     bathymetry, whereas the imaginary part of the complex 
-!     wavenumber, k_i, is an exponential decay coefficient 
-!     k_i(x,y,t,sigma) (depending on location, time and frequency, 
-!     respectively), representing wave attenuation, and can be 
-!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i, 
-!     where S_ice is one of several dissipation mechanisms, along 
-!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r - 
-!     modified by ice would enter the model via the C calculations 
+!     the sea ice on the physical wavelength and propagation speeds,
+!     producing something analogous to shoaling and refraction by
+!     bathymetry, whereas the imaginary part of the complex
+!     wavenumber, k_i, is an exponential decay coefficient
+!     k_i(x,y,t,sigma) (depending on location, time and frequency,
+!     respectively), representing wave attenuation, and can be
+!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i,
+!     where S_ice is one of several dissipation mechanisms, along
+!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r -
+!     modified by ice would enter the model via the C calculations
 !     on the left-hand side of the governing equation.The fundamentals
-!     are straightforward, e.g. Rogers and Holland (2009 and 
-!     subsequent unpublished work) modified a similar model, SWAN 
-!     (Booij et al. 1999) to include the effects of a viscous mud 
+!     are straightforward, e.g. Rogers and Holland (2009 and
+!     subsequent unpublished work) modified a similar model, SWAN
+!     (Booij et al. 1999) to include the effects of a viscous mud
 !     layer using the same approach (k = k_r + i*k_i) previously.
 !
-!     General approach is analogous to Rogers and Holland (2009) 
+!     General approach is analogous to Rogers and Holland (2009)
 !         approach for mud.
 !     See text near their eq. 1 :
 !       k        = k_r  +  i * k_i
@@ -129,7 +129,7 @@
 !         S = D * E
 !     However, the code of W3SBT1 has
 !         S = D * A
-!     This leads me to believe that the calling routine is 
+!     This leads me to believe that the calling routine is
 !         expecting "S/sigma" not "S"
 !     Thus we will use D = S/E = -2 * Cg * k_i
 !

--- a/model/ftn/w3sic2md.ftn
+++ b/model/ftn/w3sic2md.ftn
@@ -19,21 +19,21 @@
 !  1. Purpose :
 !
 !     Calculate ice dissipation source term S_{ice}.
-!          Exponential decay rate according to Liu et al., which 
+!          Exponential decay rate according to Liu et al., which
 !          uses as input: 1) ice thickness, and 2) an eddy
 !          viscosity parameter. This method is non-uniform in
-!          frequency. This is discussed further below, in 
+!          frequency. This is discussed further below, in
 !          subroutine "LIU_REVERSE_DISPERSION".
 !
-!          Includes generalization by F. Ardhuin with viscous and tubulent 
-!          boundary layers. That part is activating by setting namelist 
-!          parameters that define the under-ice roughness and a friction 
+!          Includes generalization by F. Ardhuin with viscous and tubulent
+!          boundary layers. That part is activating by setting namelist
+!          parameters that define the under-ice roughness and a friction
 !          coefficient. For example: &IC2 IC2TURB = 1. , IC2ROUGH =0.0001
 !
 !        References for Subtype 2:
 !              Liu et al.    1991: JGR 96 (C3), 4605-4621
 !              Liu and Mollo 1988: JPO 18       1720-1712
-!              Stopa et al.  2016: The Cryosphere 
+!              Stopa et al.  2016: The Cryosphere
 !
 !  2. Variables and types :
 !
@@ -51,10 +51,10 @@
 !  5. Remarks :
 !
 !     Reference:Rogers, W.E. and M.D. Orzech, 2013: Implementation and
-!        Testing of Ice and Mud Source Functions in WAVEWATCH III(R), 
+!        Testing of Ice and Mud Source Functions in WAVEWATCH III(R),
 !        NRL/MR/7320--13-9462, 31pp.
 !        available from http://www7320.nrlssc.navy.mil/pubs.php
-!        Direct link: 
+!        Direct link:
 !        http://www7320.nrlssc.navy.mil/pubs/2013/rogers2-2013.pdf
 !
 !  6. Switches :
@@ -95,7 +95,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -120,23 +120,23 @@
 !     Sea ice affects the wavenumber k of wind-generated ocean waves.
 !     The ice-modified wavenumber can be expressed as a complex number
 !     k = k_r + i*k_i, with the real part k_r representing impact of
-!     the sea ice on the physical wavelength and propagation speeds, 
-!     producing something analogous to shoaling and refraction by 
-!     bathymetry, whereas the imaginary part of the complex 
-!     wavenumber, k_i, is an exponential decay coefficient 
-!     k_i(x,y,t,sigma) (depending on location, time and frequency, 
-!     respectively), representing wave attenuation, and can be 
-!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i, 
-!     where S_ice is one of several dissipation mechanisms, along 
-!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r - 
-!     modified by ice would enter the model via the C calculations 
+!     the sea ice on the physical wavelength and propagation speeds,
+!     producing something analogous to shoaling and refraction by
+!     bathymetry, whereas the imaginary part of the complex
+!     wavenumber, k_i, is an exponential decay coefficient
+!     k_i(x,y,t,sigma) (depending on location, time and frequency,
+!     respectively), representing wave attenuation, and can be
+!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i,
+!     where S_ice is one of several dissipation mechanisms, along
+!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r -
+!     modified by ice would enter the model via the C calculations
 !     on the left-hand side of the governing equation.The fundamentals
-!     are straightforward, e.g. Rogers and Holland (2009 and 
-!     subsequent unpublished work) modified a similar model, SWAN 
-!     (Booij et al. 1999) to include the effects of a viscous mud 
+!     are straightforward, e.g. Rogers and Holland (2009 and
+!     subsequent unpublished work) modified a similar model, SWAN
+!     (Booij et al. 1999) to include the effects of a viscous mud
 !     layer using the same approach (k = k_r + i*k_i) previously.
 !
-!     General approach is analogous to Rogers and Holland (2009) 
+!     General approach is analogous to Rogers and Holland (2009)
 !         approach for mud.
 !     See text near their eq. 1 :
 !       k        = k_r  +  i * k_i
@@ -144,10 +144,10 @@
 !       a        = a0 * exp( -k_i * x )
 !       S / E    = -2 * Cg * k_i (see also Komen et al. (1994, pg. 170)
 !
-!     Please note that S is source term for action. 
+!     Please note that S is source term for action.
 !
-!     Notes regarding numerics: 
-!     (Note by F. Ardhuin: these may not apply in version 5 thanks to splitting 
+!     Notes regarding numerics:
+!     (Note by F. Ardhuin: these may not apply in version 5 thanks to splitting
 !                          of ice source terms and implicit integration in W3SRCE)
 !     Experiments with constant k_i values suggest that :
 !       for dx=20.0 km, k_i should not exceed 3.5e-6
@@ -163,8 +163,8 @@
 !
 !     {put more equations here}
 !
-!     The laminar to turbulent transition is described in 
-!         Stopa et al. (The Cryosphere, 2016). 
+!     The laminar to turbulent transition is described in
+!         Stopa et al. (The Cryosphere, 2016).
 !
 !  3. Parameters :
 !
@@ -172,7 +172,7 @@
 !     ----------------------------------------------------------------
 !       A       R.A.   I   Action density spectrum (1-D)
 !       DEPTH   Real   I   Local water depth
-!       ICEH    Real   I   Ice thickness 
+!       ICEH    Real   I   Ice thickness
 !       CG      R.A.   I   Group velocities
 !       WN      R.A.   I   Wavenumbers
 !       IX,IY   I.S.   I   Grid indices
@@ -184,7 +184,7 @@
 !       R       R.A.   I   Ratio of energy to wave energy without ice
 !       ICEF    Real   I   Ice Floe diameter
 !
-!       imported via module: 
+!       imported via module:
 !       ICEP2   R.A.   I   Eddy viscosity
 !     ----------------------------------------------------------------
 !
@@ -233,7 +233,7 @@
       USE W3ODATMD, ONLY: NDSE
       USE W3SERVMD, ONLY: EXTCDE
       USE W3DISPMD
-      USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, MAPWN, IC2PARS, DDEN,  & 
+      USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, MAPWN, IC2PARS, DDEN,  &
                           FLAGLL, YGRD, GTYPE, RLGTYPE
       USE W3IDATMD, ONLY: INFLAGS2,ICEP1,ICEP2,ICEP3,ICEP4,ICEP5,WLEV,&
                           ICEI
@@ -249,7 +249,7 @@
       REAL, INTENT(IN)       :: A(NSPEC), DEPTH, ICEH
       REAL, INTENT(IN)       :: CG(NK),   WN(NK)
       REAL, INTENT(OUT)      :: S(NSPEC), D(NSPEC)
-      REAL, INTENT(IN)       :: ALPHA(NK) ! exponential (spatial) decay rate for energy (1/m)   
+      REAL, INTENT(IN)       :: ALPHA(NK) ! exponential (spatial) decay rate for energy (1/m)
       INTEGER, INTENT(IN)    :: IX, IY
       REAL, INTENT(IN)       :: WN_R(NK), CG_ICE(NK), R(NK)
       REAL, INTENT(IN)       :: ICEF ! Hypothesis: friction does not occur for broken ice
@@ -266,9 +266,9 @@
       REAL                    :: ICECOEF1, ICECOEF2, ICECONC
       REAL, ALLOCATABLE       :: WN_I(:)  ! exponential (spatial) decay rate for amplitude (1/m)
       REAL                    :: VISCM=1.83E-6 ! molecular viscosity of water at freezing
-      REAL                    :: PTURB, PVISC, DTURB, DVISC,   & 
+      REAL                    :: PTURB, PVISC, DTURB, DVISC,   &
                                  SMOOTH, RE, UORB, AORB, EB,   &
-                                 DELI1, DELI2, FW, XI, FTURB,  & 
+                                 DELI1, DELI2, FW, XI, FTURB,  &
                                  CG_EFF(NK), WLG_R(NK), SMOOTH_DMAX(NK)
       INTEGER                 :: IND, ITH, IS
       LOGICAL                 :: NOICE=.FALSE.
@@ -289,7 +289,7 @@
       ICECONC  = 0.0
       CG_EFF = 0.
       SMOOTH_DMAX(:)=1.
-!       
+!
       IF (INFLAGS2(-7))ICECOEF1 = ICEH
       IF (INFLAGS2(-6))ICECOEF2 = ICEP2(IX,IY)
       IF (INFLAGS2(4))  ICECONC = ICEI(IX,IY)
@@ -318,10 +318,10 @@
          !  ICECOEF1 = H_ICE
          !  ICECOEF2 = VISC
 !
-! Branches out depending on choice of dispersion relation... 
+! Branches out depending on choice of dispersion relation...
 ! by default IC2PARS(1)=0, and attenuation computed as described in Stopa et al. 2016
 !
-         IF (IC2PARS(1).GT.0.5) THEN 
+         IF (IC2PARS(1).GT.0.5) THEN
            IF (.NOT.INFLAGS2(-7))THEN
               WRITE (NDSE,1001) 'ICE PARAMETER 1'
               CALL EXTCDE(2)
@@ -343,13 +343,13 @@
 ! Alternative by F.A.: generalization to a turbulent boundary layer
 !                      uses the ice-free dispersion, to be updated later
 !
-         ELSE ! goes here if IC2PARS(1).LE.0.5 (this is the default behavior) 
-           IF (IC2PARS(2).GT.0.) THEN 
+         ELSE ! goes here if IC2PARS(1).LE.0.5 (this is the default behavior)
+           IF (IC2PARS(2).GT.0.) THEN
              UORB=0.
              AORB=0.
              FTURB = IC2PARS(2)
-! Special treatment in the southern ocean ... 
-             IF (IC2PARS(7).GT.0) THEN 
+! Special treatment in the southern ocean ...
+             IF (IC2PARS(7).GT.0) THEN
                IF (YGRD(IY,IX).LT.0.AND.GTYPE.EQ.RLGTYPE.AND.FLAGLL) FTURB = IC2PARS(7)
                END IF
              DO IK=1, NK
@@ -357,14 +357,14 @@
                DO ITH=1, NTH
                  IS=ITH+(IK-1)*NTH
                  EB  = EB  + A(IS)
-                 END DO   
+                 END DO
 !
 !  UORB and AORB are the variances of the orbital velocity and surface elevation
-! of the water relative to the ice ... this is only correct if the ice layer 
-! does not move. This should is changed by taking into account DMAX when IC2DMAX > 0: 
+! of the water relative to the ice ... this is only correct if the ice layer
+! does not move. This should is changed by taking into account DMAX when IC2DMAX > 0:
 !
 !/IS2          IF (IC2PARS(8).GT.0) THEN
-!/IS2            WLG_R(IK)=TPI/WN_R(IK)   
+!/IS2            WLG_R(IK)=TPI/WN_R(IK)
 !/IS2            SMOOTH_DMAX(IK)= (0.5*(1+TANH((ICEF-IC2PARS(8)*WLG_R(IK))/(ICEF*0.5))))**2
 !/IS2            END IF
 !
@@ -380,7 +380,7 @@
 
                END DO
 !
-             AORB = 2*SQRT(AORB)  ! significant amplitude 
+             AORB = 2*SQRT(AORB)  ! significant amplitude
              UORB = 2*SQRT(UORB)  ! significant amplitude
 
              RE = UORB*AORB / VISCM
@@ -398,11 +398,11 @@
              DTURB = 0.
              PTURB = 0.
              PVISC = 1.
-           END IF ! IF (IC2PARS(2).GT.0.)  
+           END IF ! IF (IC2PARS(2).GT.0.)
 !
            DO IK=1, NK
 ! WN_R is used here but warning, this is only OK for unbroken ice
-             DVISC = IC2PARS(6) * WN_R(IK) * SQRT(VISCM* SIG(IK) / 2.) 
+             DVISC = IC2PARS(6) * WN_R(IK) * SQRT(VISCM* SIG(IK) / 2.)
              D1D(IK) = -1.*(PTURB*MAX(DTURB*SIG(IK)**2,DVISC) + PVISC*DVISC) &
                           *SMOOTH_DMAX(IK)
            END DO

--- a/model/ftn/w3sic3md.ftn
+++ b/model/ftn/w3sic3md.ftn
@@ -23,14 +23,14 @@
 !     Calculate ice source term S_{ice} according to a viscoelastic sea
 !     ice model (Wang and Shen 2010).
 !
-!     Reference: Wang, R., and H. H. Shen (2010), Gravity waves 
-!     propagating into an ice‐covered ocean: A viscoelastic model, J. 
+!     Reference: Wang, R., and H. H. Shen (2010), Gravity waves
+!     propagating into an ice‐covered ocean: A viscoelastic model, J.
 !     Geophys. Res., 115, C06024, doi:10.1029/2009JC005591 .
 !
 !  2. Variables and types :
 !      Name              Type  Scope    Description
 !     ------------------------------------------------------------------
-!      IC3TABLE_CHENG    Int.  Public   Table of wave number k_r, 
+!      IC3TABLE_CHENG    Int.  Public   Table of wave number k_r,
 !                                       attenuation k_i and group
 !                                       velocity cg
 !      IC3_DITK          R.A.  Private  Ice thickness increment
@@ -45,12 +45,12 @@
 !      W3SIC3            Subr. Public   Ice source term.
 !      BSDET             Func. Private  Calculate the determinant for
 !                                       the dispersion relation.
-!      WN_CMPLX_V1       Func. Private  Calculate complex wavenumber in 
+!      WN_CMPLX_V1       Func. Private  Calculate complex wavenumber in
 !                                       ice
 !      WN_PRECALC_CHENG  Subr. Private  Calculate complex wavenumber in
 !                                       ice
 !      WN_CMPLX_HF       Func. Private  Like above, but for h-f waves
-!      CMPLX_ROOT_MULLER_CHENG Func. Private  Find root for complex 
+!      CMPLX_ROOT_MULLER_CHENG Func. Private  Find root for complex
 !                                             numbers
 !      FUN_ZHAO          Func. Private  Wrapper function for FUNC0/FUNC1
 !      FUNC0_ZHAO        Func. Private
@@ -114,7 +114,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -122,8 +122,8 @@
 !     Calculate ice source term S_{ice} according to a viscoelastic sea
 !     ice model (Wang and Shen 2010).
 !
-!     Reference: Wang, R., and H. H. Shen (2010), Gravity waves 
-!     propagating into an ice‐covered ocean: A viscoelastic model, J. 
+!     Reference: Wang, R., and H. H. Shen (2010), Gravity waves
+!     propagating into an ice‐covered ocean: A viscoelastic model, J.
 !     Geophys. Res., 115, C06024, doi:10.1029/2009JC005591 .
 !
 !/ ------------------------------------------------------------------- /
@@ -140,23 +140,23 @@
 !     Sea ice affects the wavenumber k of wind-generated ocean waves.
 !     The ice-modified wavenumber can be expressed as a complex number
 !     k = k_r + i*k_i, with the real part k_r representing impact of
-!     the sea ice on the physical wavelength and propagation speeds, 
-!     producing something analogous to shoaling and refraction by 
-!     bathymetry, whereas the imaginary part of the complex 
-!     wavenumber, k_i, is an exponential decay coefficient 
-!     k_i(x,y,t,sigma) (depending on location, time and frequency, 
-!     respectively), representing wave attenuation, and can be 
-!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i, 
-!     where S_ice is one of several dissipation mechanisms, along 
-!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r - 
-!     modified by ice would enter the model via the C calculations 
+!     the sea ice on the physical wavelength and propagation speeds,
+!     producing something analogous to shoaling and refraction by
+!     bathymetry, whereas the imaginary part of the complex
+!     wavenumber, k_i, is an exponential decay coefficient
+!     k_i(x,y,t,sigma) (depending on location, time and frequency,
+!     respectively), representing wave attenuation, and can be
+!     introduced in a wave model such as WW3 as S_ice/E=-2*Cg*k_i,
+!     where S_ice is one of several dissipation mechanisms, along
+!     with whitecapping, for example, S_ds=S_wc+S_ice+⋯. The k_r -
+!     modified by ice would enter the model via the C calculations
 !     on the left-hand side of the governing equation.The fundamentals
-!     are straightforward, e.g. Rogers and Holland (2009 and 
-!     subsequent unpublished work) modified a similar model, SWAN 
-!     (Booij et al. 1999) to include the effects of a viscous mud 
+!     are straightforward, e.g. Rogers and Holland (2009 and
+!     subsequent unpublished work) modified a similar model, SWAN
+!     (Booij et al. 1999) to include the effects of a viscous mud
 !     layer using the same approach (k = k_r + i*k_i) previously.
 !
-!     General approach is analogous to Rogers and Holland (2009) 
+!     General approach is analogous to Rogers and Holland (2009)
 !         approach for mud.
 !     See text near their eq. 1 :
 !       k        = k_r  +  i * k_i
@@ -168,7 +168,7 @@
 !         S = D * E
 !     However, the code of W3SBT1 has
 !         S = D * A
-!     This leads me to believe that the calling routine is 
+!     This leads me to believe that the calling routine is
 !         expecting "S/sigma" not "S"
 !     Thus we will use D = S/E = -2 * Cg * k_i
 !
@@ -184,20 +184,20 @@
 !
 !     Note regarding applicability/validity:
 !
-!     The Wang and Shen model is intended as a generalized model for 
-!     various types of ice cover. It is a "continuum" model for  
-!     which the same model is used from the ice edge to the ice 
-!     interior. Though the ice types are expected to be very different 
+!     The Wang and Shen model is intended as a generalized model for
+!     various types of ice cover. It is a "continuum" model for
+!     which the same model is used from the ice edge to the ice
+!     interior. Though the ice types are expected to be very different
 !     from the edge to the interior, this is accomodated by the relative
-!     importance of the "effective viscosity" and the "modulus of 
+!     importance of the "effective viscosity" and the "modulus of
 !     elasticity". At the ice edge, where one finds frazil ice, pancake
 !     ice, or ice floes much smaller than the wave length, the "viscous"
-!     component of the model is believed to be most appropriate. At the 
-!     interior, where one finds a continuous ice sheet, the "elastic 
-!     model" component of the generalized visco-elastic model is 
+!     component of the model is believed to be most appropriate. At the
+!     interior, where one finds a continuous ice sheet, the "elastic
+!     model" component of the generalized visco-elastic model is
 !     expected to be appropriate. In addition to the case of continuous
 !     ice, Wang and Shen argue that the elastic model is also applicable
-!     to ice floes when the floe sizes are large relative to the 
+!     to ice floes when the floe sizes are large relative to the
 !     wavelength. So to summarize,
 !     * frazil ice, pancake ice, and floes smaller than wavelength :
 !          viscosity dominates
@@ -205,46 +205,46 @@
 !          elasticity dominates
 !     * intermediate conditions: neither dominates
 !     All this is accomodated in WW3 by using non-uniform specification
-!     of viscosity and elasticity. 
+!     of viscosity and elasticity.
 !
-!     In the case where a user wishes to utilize only the "viscous 
+!     In the case where a user wishes to utilize only the "viscous
 !     model" aspect of Wang and Shen, and use an alternative scheme for
-!     continous ice and large ice floes, we allow this through the use 
-!     of a user-defined namelist parameter "IC3MAXTHK". Floe size is 
+!     continous ice and large ice floes, we allow this through the use
+!     of a user-defined namelist parameter "IC3MAXTHK". Floe size is
 !     not (at time of writing) an output available from ice model CICE,
 !     so we use the ice thickness as a way to anticipate the floe size.
-!     When ice thickness exceeds IC3MAXTHK, WW3 will use another model 
+!     When ice thickness exceeds IC3MAXTHK, WW3 will use another model
 !     in place of the Wang and Shen formulation :
 !
-!     S_ice by F.A., an estimation of dissipation by turbulence 
+!     S_ice by F.A., an estimation of dissipation by turbulence
 !     at the ice-water interface. It uses only namelists for input, and
 !     no space/time varying input (though of course ice concentration is
-!     space/time varying). Unlike Liu et al. (IC2), it does not use 
+!     space/time varying). Unlike Liu et al. (IC2), it does not use
 !     ice thickness and does not yield a new C|Cg|k (i.e. it is non-
-!     dispersive), but it has the very nice feature of not requiring  
-!     an eddy viscosity, which is a major drawback of the Liu et al.  
+!     dispersive), but it has the very nice feature of not requiring
+!     an eddy viscosity, which is a major drawback of the Liu et al.
 !     model. That is why we use it here, vs. Liu et al.
-!     (S_ice by Liu et al. and S_ice by F.A. are the two options 
+!     (S_ice by Liu et al. and S_ice by F.A. are the two options
 !     available in IC2, i.e. w3sic2md.ftn)
 !
-!     At time of writing (March 23 2015), there may be some problems 
+!     At time of writing (March 23 2015), there may be some problems
 !     with the root-selection of IC3. For example with these settings:
-!     hice=1   ; rho_ice=917.0 ; emod=4.9e+12 ; visc=5e+7 ; 
-!     h_water=deep (without using the IC3MAXTHK feature) the solution 
+!     hice=1   ; rho_ice=917.0 ; emod=4.9e+12 ; visc=5e+7 ;
+!     h_water=deep (without using the IC3MAXTHK feature) the solution
 !     is rather irregular:
-!     T=11.11    k_i = 215.0e-5    
-!     T=10       k_i = 266.0e-5   
-!     T=9        k_i =   1.4e-5   
-!     T=8.1      k_i =   1.7e-5    
+!     T=11.11    k_i = 215.0e-5
+!     T=10       k_i = 266.0e-5
+!     T=9        k_i =   1.4e-5
+!     T=8.1      k_i =   1.7e-5
 !     With hice=0.1, ki is monotonically increasing in that range:
-!     T=11.11    k_i = 0.97e-5 
-!     T=10       k_i = 2.64e-5 
-!     T=9        k_i = 3.90e-5 
-!     T=8.1      k_i = 4.47e-5 
+!     T=11.11    k_i = 0.97e-5
+!     T=10       k_i = 2.64e-5
+!     T=9        k_i = 3.90e-5
+!     T=8.1      k_i = 4.47e-5
 !     Of course, when using IC3MAXTHK=0.1, the first example (hice=1)
 !     would switch to the "S_ice by F.A." model, and so this problem
 !     is circumvented.
-!     
+!
 !  3. Parameters :
 !
 !     Parameter list
@@ -290,24 +290,24 @@
 !     This feature is not understood by me (ER) and so omitted.
 !
 !/ ------------------------------------------------------------------- /
-!     On array size, S. Cheng says: 
-!     Upon checking the origin of CG, I would say CG = CG_IC3, this is 
-!     the topic ‘call W3IC3WNCG twice’. Recently I find they are not 
-!     exactly the same due to calculation and smoothing of cg using 
-!     several neighbor points. For different input array size, results 
-!     are slightly different. In subr. w3wave, the size of input arrays 
-!     is 0:NK+1, while in w3sic3, the size of all input arrays is 1:NK. 
-!     This array size  difference is reflected in the resulting cg. The 
-!     small difference in cg between calling IC3 twice or just calling 
-!     once produces small difference in SWH. To eliminate this small 
-!     difference, I suggest to keep CG instead of CG_IC3, as well as WN, 
-!     WN_I, because other source terms use CG. I confirmed this change 
-!     would make results of ICE the same whether calling twice or once 
-!     by defining dimension WN_R, WN_I, CG_IC3 as 0:NK+1 instead of 
+!     On array size, S. Cheng says:
+!     Upon checking the origin of CG, I would say CG = CG_IC3, this is
+!     the topic ‘call W3IC3WNCG twice’. Recently I find they are not
+!     exactly the same due to calculation and smoothing of cg using
+!     several neighbor points. For different input array size, results
+!     are slightly different. In subr. w3wave, the size of input arrays
+!     is 0:NK+1, while in w3sic3, the size of all input arrays is 1:NK.
+!     This array size  difference is reflected in the resulting cg. The
+!     small difference in cg between calling IC3 twice or just calling
+!     once produces small difference in SWH. To eliminate this small
+!     difference, I suggest to keep CG instead of CG_IC3, as well as WN,
+!     WN_I, because other source terms use CG. I confirmed this change
+!     would make results of ICE the same whether calling twice or once
+!     by defining dimension WN_R, WN_I, CG_IC3 as 0:NK+1 instead of
 !     1:NK. Then CG_IC3 = CG.
 !/ ------------------------------------------------------------------- /
 !     On optimization, S. Cheng says:
-!     For Wang and Shen’s model, D does not change in the loop 
+!     For Wang and Shen’s model, D does not change in the loop
 !     corresponding to NSTEPS in subr. W3SRCE. I find the most efficient
 !     and easy way to speed up is that Add D and NSTEPS as inputs of
 !     W3SIC3
@@ -315,7 +315,7 @@
 !          Current Wang and Shen’s model code above.
 !     ELSE
 !          S = D*A
-!     Endif 
+!     Endif
 !/ ------------------------------------------------------------------- /
 !
 !  8. Structure :
@@ -337,7 +337,7 @@
       USE W3ODATMD, ONLY: NDSE, IAPROC, NAPROC, NAPERR
 !     USE WMMDATMD, ONLY: IMPROC, NMPERR ! WMMDATMD unavailable to outp
       USE W3SERVMD, ONLY: EXTCDE
-      USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, MAPWN, IC3PARS, DDEN,  & 
+      USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, MAPWN, IC3PARS, DDEN,  &
                           FLAGLL, YGRD, GTYPE, RLGTYPE
       USE W3IDATMD, ONLY: ICEP1, ICEP2, ICEP3, ICEP4, ICEP5, ICEI,    &
                           INFLAGS2
@@ -369,7 +369,7 @@
       REAL                       :: VISCM=1.83E-6
       REAL                       :: FREQ
 !  ............VISCM=1.83E-6 :  molecular viscosity of water at freezing
-      REAL                    :: PTURB, PVISC, DTURB, DVISC,   & 
+      REAL                    :: PTURB, PVISC, DTURB, DVISC,   &
                                  SMOOTH, RE, UORB, AORB, EB,   &
                                  DELI1, DELI2, FW, XI, FTURB,  &
                                  MAXTHK, MAXCNC, USE_CHENG,    &
@@ -409,7 +409,7 @@
       FIXEDVISC=IC3PARS(14)
       FIXEDDENS=IC3PARS(15)
       FIXEDELAS=IC3PARS(16)
-            
+
 !     --- Error checking for input ----------------------------------- /
 !     --- Allow one and only one input option for each variable ------ /
       NUMIN=0
@@ -448,7 +448,7 @@
          CALL EXTCDE(2)
       ENDIF
 
-!     --- Set local value to be used subsequently (ICEPx variables 
+!     --- Set local value to be used subsequently (ICEPx variables
 !         are not used beyond this point). --------------------------- /
       IF (INFLAGS2(-7)) THEN
          ICECOEF1 = ICEP1(IX,IY) ! ice thickness
@@ -544,11 +544,11 @@
          !
       ELSE ! .. e.g. if ice thickness is .gt. 10 cm
          ! Alternative by F.A., see Remarks section.
-         IF (IC3PARS(2).GT.0.) THEN 
+         IF (IC3PARS(2).GT.0.) THEN
             UORB=0.
             AORB=0.
             FTURB = IC3PARS(2)
-            IF (IC3PARS(7).GT.0) THEN 
+            IF (IC3PARS(7).GT.0) THEN
                IF (YGRD(IY,IX).LT.0.AND.GTYPE.EQ.RLGTYPE.AND.FLAGLL) &
                     FTURB = IC3PARS(7)
             END IF
@@ -583,7 +583,7 @@
             DTURB=-1.* FTURB*FW*UORB/GRAV
          ELSE ! so case of IC3PARS(2).LE.0.
             DTURB = 0.
-         END IF ! IF (IC3PARS(2).GT.0.)  
+         END IF ! IF (IC3PARS(2).GT.0.)
 
          DO IK=1, NK
             DVISC = -1. *IC3PARS(6) * WN(IK) * SQRT(VISCM* SIG(IK) / 2.)
@@ -599,7 +599,7 @@
       END DO
 
 !
-! sign convention (example): 
+! sign convention (example):
 !        S is from -10e-3 to 0
 !        A is from 0 to 10
 ! See Remarks section re: optimization
@@ -648,7 +648,7 @@
 !  1. Purpose :
 !
 !     Calculation of complex wavenumber for waves in ice. Outsourced
-!     from W3SIC3 to allow update on wavenumbers and  group 
+!     from W3SIC3 to allow update on wavenumbers and  group
 !     velocities at each time step an ice parameter is updated.
 !
 !  2. Method :
@@ -698,7 +698,7 @@
 !     which makes WW3 slow down quite a bit. This is done via ICEKILIM
 !     in the namelists.
 !
-!     This function does not get used in update by S. Cheng. 
+!     This function does not get used in update by S. Cheng.
 !     It should be removed if/when "V1" routines are removed.
 !
 !  8. Structure :
@@ -738,7 +738,7 @@
       IC3HILIM=IC3PARS(10)
       IC3KILIM=IC3PARS(11)
 !
-!     --- Input to routine (part 1): set 6 double precision variables 
+!     --- Input to routine (part 1): set 6 double precision variables
 !        using single precision variables. -------------------------- /
       HWAT    = DBLE(DPT)     ! water depth
       HICE    = DBLE(ICE1)    ! ice thickness
@@ -765,7 +765,7 @@
       WNCOMPLEX_OLD=CMPLX(0.0D0,0.0D0)
 
       DO IK = KL,KU
-!     --- Input to routine (part 2): set 2 double precision variables 
+!     --- Input to routine (part 2): set 2 double precision variables
 !         using single precision variable. --------------------------- /
          CALL WAVNU1(SIGMA(IK),DPT,K_OCEAN,CG_OCEAN)
          K_NOICE = DBLE(K_OCEAN)
@@ -791,7 +791,7 @@
 
          ENDIF
 
-!     --- Output from function is type of DOUBLE COMPLEX. Set 
+!     --- Output from function is type of DOUBLE COMPLEX. Set
 !         precision of imaginary to single precision array element --- /
          WN_I(IK)  = REAL(AIMAG(WNCOMPLEX))
 
@@ -873,9 +873,9 @@
 !   This code is based on Fortran code provided by Hayley Shen (Clarkson
 !     University) to Erick Rogers (NRL) on April 19 2013.
 !
-!   Hayley Shen says, 
+!   Hayley Shen says,
 !     We have determined that it may not be necessary to use curve
-!     fitting or lookup tables to get the group velocity and the 
+!     fitting or lookup tables to get the group velocity and the
 !     attenuation coefficient. Attached is a short report with some
 !     sample numerical solutions. To implement the viscoelastic model,
 !     there are 4 fortran programs. According to Xin Zhao, the graduate
@@ -883,10 +883,10 @@
 !     try the pure viscous case by setting G=0 to start with. nu can be
 !     set at 0.05*ice concentration (m^2/s) to begin with, because for
 !     grease ice Newyear's data showed nu to be about 0.02-0.03 m^2/s.
-!     By setting G=0 in you get exactly the Keller model for pure 
-!     viscous layer. 
+!     By setting G=0 in you get exactly the Keller model for pure
+!     viscous layer.
 !
-!   This routine provides the initial guess according to the parameters 
+!   This routine provides the initial guess according to the parameters
 !   of the present case. T>10s use open water, T<10s cases, calculate
 !   T=10s first using open water as the initial guess.
 !
@@ -1017,13 +1017,13 @@
 !
 !   Original authors: Zhao and Shen.
 !     See notes in FUNCTION WN_CMPLX, not repeated here.
-!     New in this function, Hayley Shen says (Jan 15 2014) : 
-!     "To speed up the computation, we need to add a new function 
-!     WN_CMPLXA (attached) into the earlier version of the MODULE 
-!     W3SIC3MD. When wave period T>=10s, we call old function WN_CMPLX 
-!     directly. When T<10s, call the new function WN_CMPLXA with last 
-!     calculation step's information: last complex wave number, last 
-!     angular wave frequency. The calculation should be from large T 
+!     New in this function, Hayley Shen says (Jan 15 2014) :
+!     "To speed up the computation, we need to add a new function
+!     WN_CMPLXA (attached) into the earlier version of the MODULE
+!     W3SIC3MD. When wave period T>=10s, we call old function WN_CMPLX
+!     directly. When T<10s, call the new function WN_CMPLXA with last
+!     calculation step's information: last complex wave number, last
+!     angular wave frequency. The calculation should be from large T
 !     to small T."
 !
 !  8. Structure :
@@ -1060,7 +1060,7 @@
 !/
       IF (HICE<0.001) THEN
          WN  = CMPLX(WN_O,0.)
-      ELSE 
+      ELSE
          X0  = 0.90 * WN_LAST
          X1  = WN_LAST
          X2  = 1.1 * WN_LAST
@@ -1102,8 +1102,8 @@
 !
 !  2. Method :
 !
-!     Muller method for complex equations is a recursive approximation 
-!     with initial guess X0, X1, and X2. To the initial guesses a 
+!     Muller method for complex equations is a recursive approximation
+!     with initial guess X0, X1, and X2. To the initial guesses a
 !     quadratic parabola is fitted.
 !
 !  3. Parameters :
@@ -1363,7 +1363,7 @@
 !/
 !  1. Purpose :
 !
-!     Calculate the difference between the left and right side 
+!     Calculate the difference between the left and right side
 !     of the dispersion relation. It is called by the Muller method.
 !
 !  2. Method :
@@ -1398,7 +1398,7 @@
 !   This code is based on Fortran code provided by Hayley Shen (Clarkson
 !     University) to Erick Rogers (NRL) on April 19 2013.
 !
-!   This function does not get used in update by S. Cheng. 
+!   This function does not get used in update by S. Cheng.
 !     It should be removed if/when "V1" routines are removed.
 !
 !  8. Structure :
@@ -1469,7 +1469,7 @@
 !      FUNC1 CMPLX DBL O  Result (double complex)
 !      WN    CMPLX DBL I  Wavenumber (double complex)
 !      W     REAL  DBL I  Wave angular frequency
-!      ES    REAL  DBL I  Effective shear modulus on ice 
+!      ES    REAL  DBL I  Effective shear modulus on ice
 !      NU    REAL  DBL I  Effective viscosity
 !      DICE  REAL  DBL I  Density of ice
 !      HICE  REAL  DBL I  Thickness of ice
@@ -1500,7 +1500,7 @@
 !   This code is based on Fortran code provided by Hayley Shen (Clarkson
 !     University) to Erick Rogers (NRL) on April 19 2013.
 !
-!   This function does not get used in update by S. Cheng. 
+!   This function does not get used in update by S. Cheng.
 !     It should be removed if/when "V1" routines are removed.
 !
 !  8. Structure :
@@ -1633,7 +1633,7 @@
 !   This code is based on Fortran code provided by Hayley Shen (Clarkson
 !     University) to Erick Rogers (NRL) on April 19 2013.
 !
-!   This function does not get used in update by S. Cheng. 
+!   This function does not get used in update by S. Cheng.
 !     It should be removed if/when "V1" routines are removed.
 !
 !  8. Source code :
@@ -1736,7 +1736,7 @@
 !
 !  4. Remarks :
 !
-!     This function does not get used in update by S. Cheng. 
+!     This function does not get used in update by S. Cheng.
 !     It should be removed if/when "V1" routines are removed.
 !
 !  5. Called by :
@@ -1832,11 +1832,11 @@
 !     by IC3WN_R in the look up table. IC3WN_R is related to an ice
 !     thickness in the table, which is closest to HICE and less than
 !     HICE
-!   
+!
 !     Fix submitted by Sukun March 2017:
 !         replace :
 !            I = MIN(INT(HICE/IC3_DITK)+1,ITKNUM)
-!         with :   
+!         with :
 !            I = MIN(NINT(HICE/IC3_DITK),ITKNUM)
 !
 !  8. Structure :
@@ -1928,7 +1928,7 @@
 
 !!!     --- Update group velocitiy ----
       CALL CGinIC3_CHENG(CG,SIGMA,WN_R,KU-KL+1)
-      
+
       DEALLOCATE(SIGMA)
 
 900   FORMAT (/' *** WAVEWATCH III ERROR IN W3SIC3_W3IC3WNCG : '/&
@@ -1951,7 +1951,7 @@
 !
 !     It's a Preprocess part to create a table of wave nubmer,
 !        attenuation and group velocity
-!     for all ice thickness in deep water situation for main 
+!     for all ice thickness in deep water situation for main
 !        computation.
 !
 !  2. Method :
@@ -1982,7 +1982,7 @@
 !     University) to Erick Rogers (NRL) on Aug 25 2015
 !
 !   **UNRESOLVED BUG** This routine should be called again if ice
-!     rheology (visc., elast.) changes (either time or space). 
+!     rheology (visc., elast.) changes (either time or space).
 !     It doesn't. We need to set CALLEDIC3TABLE=0 if either parameter is
 !     changed.
 !
@@ -2035,7 +2035,7 @@ END SUBROUTINE IC3TABLE_CHENG
 !  1. Purpose :
 !
 !     Preprocess part to create a table of wave nubmer, attenuation and
-!     group velocity for all ice thickness in deep water situation for 
+!     group velocity for all ice thickness in deep water situation for
 !     main computation.
 !
 !  2. Method :
@@ -2244,35 +2244,35 @@ END SUBROUTINE IC3TABLE_CHENG
 !/
 !/ ------------------------------------------------------------------- /
 !   compute shear wave and pressure wave modes
-      GV = CMPLX(ES_MOD,-SIGMA*NU*DICE)      
+      GV = CMPLX(ES_MOD,-SIGMA*NU*DICE)
       KP = SIGMA/SQRT(4*GV/DICE)
       KS = 2*KP
 !   RR,R2 are empirical coefficients
       RR  = 0.2
       R2  = 4
       EPS = 1.D-10   ! assuming variable =0, if it is less than this value
-!   compute root 1  
-!   initial guesses from wave number of open water 
+!   compute root 1
+!   initial guesses from wave number of open water
 !
       X1  = WN_O    ! initial guess
       X0  = X1*(1-RR)
       X2  = X1*(1+RR)
 
-      WN1 = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,1,SIGMA, & 
+      WN1 = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,1,SIGMA, &
            ES_MOD,NU,DICE,HICE,DEPTH)
-!   if root finder failed, or found shear wave mode, 
+!   if root finder failed, or found shear wave mode,
 !   redo searching using simplified dispersion relation form, index 2
       IF (REAL(WN1)<0.or.abs(wn1-ks)/abs(ks)<0.03 .or. &
           abs(wn1-kp)/abs(kp)<0.03.and.Es_mod>1.e7*nu)THEN
-         WN1 = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,2,SIGMA, &     
-              ES_MOD,NU,DICE,HICE,DEPTH)   
+         WN1 = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,2,SIGMA, &
+              ES_MOD,NU,DICE,HICE,DEPTH)
       ENDIF
 !   similar as wn1, but search with opposite order of inital guesses
-      WN2 = CMPLX_ROOT_MULLER_CHENG(X2,X1,X0,1,SIGMA, &     
-           ES_MOD,NU,DICE,HICE,DEPTH)     
+      WN2 = CMPLX_ROOT_MULLER_CHENG(X2,X1,X0,1,SIGMA, &
+           ES_MOD,NU,DICE,HICE,DEPTH)
       IF (REAL(WN2)<0.or.abs(wn2-ks)/abs(ks)<0.03)THEN
-         WN2 = CMPLX_ROOT_MULLER_CHENG(X2,X1,X0,2,SIGMA, &     
-              ES_MOD,NU,DICE,HICE,DEPTH) 
+         WN2 = CMPLX_ROOT_MULLER_CHENG(X2,X1,X0,2,SIGMA, &
+              ES_MOD,NU,DICE,HICE,DEPTH)
       ENDIF
       IF(ABS(REAL(WN1)-REAL(WN_O))<ABS(REAL(WN2)-REAL(WN_O)))THEN
          WN0 = WN1
@@ -2283,8 +2283,8 @@ END SUBROUTINE IC3TABLE_CHENG
       IF(SIGMAM1==0.)THEN
          WN = WN0
       ELSE
-         !      compute root 2        
-         !      Calculate the other wave number based on last frequency 
+         !      compute root 2
+         !      Calculate the other wave number based on last frequency
          !      in the frequency array
          R2    = MAX(ABS(WNM1-WNM2)/ABS(WNM2), ABS((SIGMA-SIGMAM1)/SIGMA))
          DO I  = 1,7,2
@@ -2307,18 +2307,18 @@ END SUBROUTINE IC3TABLE_CHENG
                IF(REAL(WN)<0)THEN   ! try another dispersion relation form
                    WN = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,3,SIGMA0, &
                         ES_MOD,NU,DICE,HICE,DEPTH)
-               ENDIF 
+               ENDIF
                KP = SIGMA0/SQRT(4*GV/DICE)
                KS = 2*KP
                !               set 3 means simple dispersion relation form
-               IF(ABS(WN-KS)/ABS(KS)<0.03.OR.REAL(WN)<0)THEN 
-                  WN = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,2,SIGMA0, &  
+               IF(ABS(WN-KS)/ABS(KS)<0.03.OR.REAL(WN)<0)THEN
+                  WN = CMPLX_ROOT_MULLER_CHENG(X0,X1,X2,2,SIGMA0, &
                        ES_MOD,NU,DICE,HICE,DEPTH)
                ENDIF
                X1 = WN
                IF( REAL(WN)<0.99*REAL(WNM1).OR. ABS(WN-WN0)>EPS .AND. &
                     (ABS(X1-WN)/ABS(WN)>0.3 .OR.                  &
-                    IMAG(WN)/(IMAG(X1)+EPS)>10.OR. REAL(WN)<0))THEN  
+                    IMAG(WN)/(IMAG(X1)+EPS)>10.OR. REAL(WN)<0))THEN
                   EXIT  ! redo with smaller intervals
                ENDIF
                X0 = X1
@@ -2328,17 +2328,17 @@ END SUBROUTINE IC3TABLE_CHENG
             IF(IX==NUM+1)THEN
                EXIT
             ENDIF
-            WN = X1  !/ --- if exit of inner loop: give an approximate wn             
+            WN = X1  !/ --- if exit of inner loop: give an approximate wn
          ENDDO !         DO I  = 1,7,2
-        
+
 ! part 2
 ! assume found two roots, choose from the two condidates.
          KP = SIGMA/SQRT(4*GV/DICE)
-         IF(REAL(WN0)>0.AND.IMAG(WN0)>=0.AND.ABS(WN - WN0)>EPS)THEN  
-!do switch at last 3 points is not worth numerically. 
-!For v>5.e-2, it is low chance to be wrong at the last 3 points        
+         IF(REAL(WN0)>0.AND.IMAG(WN0)>=0.AND.ABS(WN - WN0)>EPS)THEN
+!do switch at last 3 points is not worth numerically.
+!For v>5.e-2, it is low chance to be wrong at the last 3 points
 ! we suppose to use two mode in the future
-            IF(NU>0.AND.IK>=KU-1.OR.   &  
+            IF(NU>0.AND.IK>=KU-1.OR.   &
                  NU>0.AND.SWITCHID/=0)THEN
 ! assume one mode switch for general viscoelastic model
             ELSE
@@ -2348,12 +2348,12 @@ END SUBROUTINE IC3TABLE_CHENG
                IF ((DIS >= 1 .AND. KAPPA>=1 .AND.  &
                     IMAG(WN0)>=0.1*IMAG(WNM1).AND. &
                     ABS(WN-KP)<ABS(WN0-KP)) .OR.  &
-! wn0 has larger attenuation and closer to k0                        
+! wn0 has larger attenuation and closer to k0
                     ( DIS>=1 .AND. KAPPA<1 .AND. &
                     ((KAPPA> 0.2 .AND. IMAG(WN0)/REAL(WN0)<0.5).or. &
                     ABS(REAL(WN)-REAL(KP))<ABS(REAL(WN0)-REAL(KP)))).OR.&
-! wn0 has smaller attenuation and farther to k0, 
-! wn0 could be wrong at high G 
+! wn0 has smaller attenuation and farther to k0,
+! wn0 could be wrong at high G
 ! (kappa>1 .and. dis<1 .and. dis>  0.8 ))then
                     ( KAPPA>1 .AND. DIS<1 .AND. &
                     ABS(REAL(WN)-REAL(WNM1))>   &
@@ -2364,9 +2364,9 @@ END SUBROUTINE IC3TABLE_CHENG
                ELSEIF(DIS<1 .AND. KAPPA<1) THEN
 ! keep wn without change
                ENDIF !  IF ((DIS >= 1 .AND. KAPPA>=1 .AND.  &
-            ENDIF !   IF(NU>0.AND.IK>=KU-2.OR.   &  
+            ENDIF !   IF(NU>0.AND.IK>=KU-2.OR.   &
 
-! choose dominant mode is farther than pressure wave. 
+! choose dominant mode is farther than pressure wave.
 !but it doens't work for high viscosity.
             if (abs(wn-kp)/abs(kp)<0.03) then
                 wn = wn0
@@ -2375,7 +2375,7 @@ END SUBROUTINE IC3TABLE_CHENG
             !if (real(wn)<=real(wnm1))then
             !    wn = wn0
             !    switchid = ik
-            !endif  
+            !endif
 
             IF (REAL(WN0)>REAL(WNM1).AND.REAL(WN0)<REAL(WN).and. &
             ABS(IMAG(WN0)-IMAG(WNM1))<ABS(IMAG(WN)-IMAG(WNM1)))THEN
@@ -2386,7 +2386,7 @@ END SUBROUTINE IC3TABLE_CHENG
          ENDIF ! IF(REAL(WN0)>0.AND.IMAG(WN0)>=0.AND.ABS(WN - WN0)....
       ENDIF   !      IF(SIGMAM1==0.)THEN
 
-      IF(REAL(WN)<0)THEN     
+      IF(REAL(WN)<0)THEN
          PRINT*, "MULLER METHOD FAILED, ES_MOD,NU,HICE:",ES_MOD,NU,HICE
       ENDIF
       RETURN
@@ -2438,7 +2438,7 @@ END SUBROUTINE IC3TABLE_CHENG
 !  6. Error messages :
 !
 !  7. Remarks :
-!      Smooth function is used due to jump problem when wave modes 
+!      Smooth function is used due to jump problem when wave modes
 !             switch
 !
 !  8. Structure :
@@ -2463,7 +2463,7 @@ END SUBROUTINE IC3TABLE_CHENG
       DO IK = 2,N-1
         CG1 = (SIGMA(IK)-SIGMA(IK-1))/(WN_R(IK)-WN_R(IK-1))
         CG2 = (SIGMA(IK+1)-SIGMA(IK))/(WN_R(IK+1)-WN_R(IK))
-        CG(IK) = 2.0/(1./CG1 + 1./CG2)        
+        CG(IK) = 2.0/(1./CG1 + 1./CG2)
       END DO
 
       RETURN
@@ -2475,7 +2475,7 @@ END SUBROUTINE IC3TABLE_CHENG
     REAL, INTENT(IN)  :: SIGMA(N)
     REAL              :: WN_R(N), WN_I(N),DIFF(N),REMOVEID(N)
     INTEGER           :: N,I,J,SWITCHID
-!    
+!
     DIFF = 0
 ! remove kr in mode switch zone,
 ! if it is a local extremum or suddenly increasing
@@ -2484,7 +2484,7 @@ END SUBROUTINE IC3TABLE_CHENG
         DO I = 2,N
       DIFF(I) = WN_R(I) - WN_R(I-1)
     ENDDO
-    DO I = 3,N            
+    DO I = 3,N
             IF(DIFF(I)<=0.OR.DIFF(I)>3*DIFF(I-1).OR.SWITCHID==I)THEN
                 REMOVEID(I) = 1
                 REMOVEID(I-1) = 1
@@ -2492,18 +2492,18 @@ END SUBROUTINE IC3TABLE_CHENG
         ENDDO
 ! fill removed location with kr,ki by interpolation
          DO I = 2,N-1
-             IF (REMOVEID(I) ==1) THEN             
+             IF (REMOVEID(I) ==1) THEN
                  WN_R(I) = WN_R(I-1) + (WN_R(I+1)-WN_R(I-1))/    &
          (SIGMA(I+1)-SIGMA(I-1))*(SIGMA(I)-SIGMA(I-1))
                  WN_I(I) = WN_I(I-1) + (WN_I(I+1)-WN_I(I-1))/    &
          (SIGMA(I+1)-SIGMA(I-1))*(SIGMA(I)-SIGMA(I-1))
              ENDIF
-         ENDDO         
-    ENDDO 
+         ENDDO
+    ENDDO
 ! mode switch upward at the last frequencies
     IF (DIFF(N)>3*DIFF(N-1))THEN
         I = N
-        WN_R(I) = WN_R(I-1) + (WN_R(I-1)-WN_R(I-2))/   & 
+        WN_R(I) = WN_R(I-1) + (WN_R(I-1)-WN_R(I-2))/   &
         (SIGMA(I-1)-SIGMA(I-2))*(SIGMA(I)-SIGMA(I-1))
         WN_I(I) = WN_I(I-1) + (WN_I(I-1)-WN_I(I-2))/   &
         (SIGMA(I-1)-SIGMA(I-2))*(SIGMA(I)-SIGMA(I-1))
@@ -2731,7 +2731,7 @@ END SUBROUTINE IC3TABLE_CHENG
 !
 !      Name        Type  Module   Description
 !     ----------------------------------------------------------------
-!      DRFUN_dble  Func. W3SIC3MD Function to find root with double 
+!      DRFUN_dble  Func. W3SIC3MD Function to find root with double
 !      precision.
 !      DRFUN_quad  Func. W3SIC3MD Function to find root with quadruple
 !      precision.
@@ -2809,7 +2809,7 @@ END SUBROUTINE IC3TABLE_CHENG
 !
 !  2. Method :
 !
-!     function based on dispersion relation derived by Wang and Shen 
+!     function based on dispersion relation derived by Wang and Shen
 !     2010
 !
 !  3. Parameters :
@@ -2870,7 +2870,7 @@ END SUBROUTINE IC3TABLE_CHENG
       COMPLEX(8), INTENT(IN)   :: WN
       REAL(8), INTENT(IN)      :: SIGMA, ES, NU, DICE, HICE, DEPTH
       COMPLEX(8)               :: FUNC1,AA(4,4)                   ! RESULT
-      INTEGER                  :: JUDGE  
+      INTEGER                  :: JUDGE
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -2897,11 +2897,11 @@ END SUBROUTINE IC3TABLE_CHENG
       ELSE
           TH = 1.D0
       ENDIF
-!      JUDGE==3 is not used yet   
+!      JUDGE==3 is not used yet
       IF ((ES>=1.E5.AND.JUDGE/=2).or.JUDGE==3) THEN
           L     = 2 * WN * ALPHA * SIGMA * VE
           M     = (DBLE(DWAT)/DICE - 1) * DBLE(GRAV) * WN             &
-                - DBLE(DWAT) / DICE * SIGMA**2 / TH          
+                - DBLE(DWAT) / DICE * SIGMA**2 / TH
          AA(1,1) = 0.
          AA(1,2) = 2 * CMPLX(0.,1.) * WN**2.
          AA(1,3) = ALPHA**2. + WN**2.
@@ -2928,7 +2928,7 @@ END SUBROUTINE IC3TABLE_CHENG
                   + 16.* VE**4.*WN**6.*ALPHA**2.)*SK*SA - 8. &
                   *WN**3.*ALPHA*VE**2.*N**2.*(CK*CA-1.))
           J2    = (4.*WN**3.*ALPHA*VE**2.*SK*CA+N**2.*SA*CK &
-                  -DBLE(GRAV)*WN*SK*SA)          
+                  -DBLE(GRAV)*WN*SK*SA)
           IF (JUDGE==2)THEN
             FUNC1 = (SIGMA**2. - TH*WN*DBLE(GRAV)) - TH*J1/(J2+1.e-20)
           ELSEIF (JUDGE==1)THEN
@@ -3005,7 +3005,7 @@ END SUBROUTINE IC3TABLE_CHENG
 !   Original authors: Zhao and Shen.
 !   This code is based on Fortran code provided by Hayley Shen (Clarkson
 !     University) to Erick Rogers (NRL) on April 19 2013.
-!   ER: S. Cheng had "COMPLEX(16)" for the local parameters. This is not 
+!   ER: S. Cheng had "COMPLEX(16)" for the local parameters. This is not
 !     supported by my compiler (gfortran on linux machine), so I changed
 !     it to "COMPLEX(8)"
 !

--- a/model/ftn/w3sic4md.ftn
+++ b/model/ftn/w3sic4md.ftn
@@ -15,9 +15,9 @@
 !  1. Purpose :
 !
 !     Calculate ice source term S_{ice} according to simple methods.
-!          Attenuation is a function of frequency and specified directly 
+!          Attenuation is a function of frequency and specified directly
 !          by the user. Example: a function is based on an exponential fit to
-!          the empirical data of Wadhams et al. (1988). 
+!          the empirical data of Wadhams et al. (1988).
 !
 !  2. Variables and types :
 !
@@ -38,24 +38,24 @@
 !         1) Wadhams et al. JGR 1988
 !         2) Meylan et al. GRL 2014
 !         3) Kohout & Meylan JGR 2008 in Horvat & Tziperman Cryo. 2015
-!         4) Kohout et al. Nature 2014 
+!         4) Kohout et al. Nature 2014
 !         5) Doble et al. GRL 2015
 !         6) Rogers et al. JGR 2016
 !     Documentation of IC4:
 !         1) Collins and Rogers, NRL Memorandum report 2017
-!         ---> "A Source Term for Wave Attenuation by Sea 
+!         ---> "A Source Term for Wave Attenuation by Sea
 !               Ice in WAVEWATCH III® : IC4"
 !         ---> describes original IC4 methods, 1 to 6
 !         2) Rogers et al., NRL Memorandum report 2018a
 !         ---> "Forecasting and hindcasting waves in and near the
-!              marginal ice zone: wave modeling and the ONR “Sea 
+!              marginal ice zone: wave modeling and the ONR “Sea
 !              State” Field Experiment"
 !         ---> IC4 method 7 added
 !         2) Rogers et al., NRL Memorandum report 2018b
-!         ---> "Frequency Distribution of Dissipation of Energy of 
+!         ---> "Frequency Distribution of Dissipation of Energy of
 !               Ocean Waves by Sea Ice Using Data from Wave Array 3 of
 !               the ONR “Sea State” Field Experiment"
-!         ---> New recommendations for IC4 Method 2 (polynomial fit) 
+!         ---> New recommendations for IC4 Method 2 (polynomial fit)
 !              and IC4 Method 6 (step function via namelist)
 !
 !  6. Switches :
@@ -96,7 +96,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -117,11 +117,11 @@
 !     3) Quadratic fit to Kohout & Meylan'08 in Horvat & Tziperman'15
 !        Here, note that their eqn is given as ln(alpha)=blah, so we
 !        have alpha=exp(blah)
-!     4) Eq. 1 from Kohout et al. 2014 
+!     4) Eq. 1 from Kohout et al. 2014
 !
 !     5) Simple step function for ki as a function of frequency
 !          with up to 4 "steps". Controlling parameters KIx and FCx are
-!          read in as input fields, so they may be nonstationary and 
+!          read in as input fields, so they may be nonstationary and
 !          non-uniform in the same manner that ice concentration and
 !          water levels may be nonstationary and non-uniform.
 !                                          444444444444
@@ -157,7 +157,7 @@
 !             ICEP5=FC5=0.10
 !             MUDD=FC6=0.12
 !             MUDT=FC7=0.16
-!             In terms of the 3-character IDs for "Homogeneous field 
+!             In terms of the 3-character IDs for "Homogeneous field
 !             data" in ww3_shel.inp, these are, respectively, IC1, IC2,
 !             IC3, IC4, IC5, MDN, MTH, and so this might look like:
 !                'IC1' 19680606 000000   5.0e-6
@@ -183,17 +183,17 @@
 !          ic4_fc(1)   ic4_fc(2)   ic4_fc(3) ic4_fc(4)=large number
 !       Example: Beaufort Sea, AWAC mooring, 2012, Oct 27 to 30
 !           &SIC4  IC4METHOD = 6,
-!                  IC4KI =    0.50E-05,   0.70E-05,   0.15E-04,  
-!                             0.10E+00,   0.00E+00,   0.00E+00,   
+!                  IC4KI =    0.50E-05,   0.70E-05,   0.15E-04,
+!                             0.10E+00,   0.00E+00,   0.00E+00,
 !                             0.00E+00,   0.00E+00,   0.00E+00,
 !                             0.00E+00,
-!                  IC4FC =    0.100,      0.120,      0.160, 
+!                  IC4FC =    0.100,      0.120,      0.160,
 !                             99.00,      0.000,      0.000,
 !                             0.000,      0.000,      0.000,
 !                             0.000
 !                             /
 !
-!     7) Doble et al. (GRL 2015), eq. 3. This is a function of ice 
+!     7) Doble et al. (GRL 2015), eq. 3. This is a function of ice
 !        thickness and wave period.
 !        ALPHA  = 0.2*(T^(-2.13)*HICE or
 !        ALPHA  = 0.2*(FREQ^2.13)*HICE
@@ -250,11 +250,11 @@
 !        Method 5 : E. Rogers
 !        Method 6 : E. Rogers
 !        Method 7 : E. Rogers
-!     
+!
 !     ALPHA = 2 * WN_I
 !     Though it may seem redundant/unnecessary to have *both* in the
-!       code, we do it this way to make the code easier to read and 
-!       relate to other codes and source material, and hopefully avoid 
+!       code, we do it this way to make the code easier to read and
+!       relate to other codes and source material, and hopefully avoid
 !       mistakes.
 !/ ------------------------------------------------------------------- /
 !
@@ -344,7 +344,7 @@
       ICECOEF8 = 0.0
       HS       = 0.0
       HICE     = 0.0
-      EMEAN    = 0.0      
+      EMEAN    = 0.0
 !
 !     IF (.NOT.INFLAGS2(-7))THEN
 !        WRITE (NDSE,1001) 'ICE PARAMETER 1'
@@ -352,7 +352,7 @@
 !     ENDIF
 
 !
-!   We cannot remove the other use of INFLAGS below, 
+!   We cannot remove the other use of INFLAGS below,
 !   because we would get 'array not allocated' error for the methods
 !   that don't use MUDV, etc. and don't have MUDV allocated.
 
@@ -389,33 +389,33 @@
 !/T38        WRITE (NDST,9000) DEPTH,ICECOEF1,ICECOEF2,ICECOEF3,ICECOEF4
 !
 ! 1.  Make calculations ---------------------------------------------- /
-!                
+!
 ! 1.a Calculate WN_I
 
       SELECT CASE (IC4METHOD)
-    
+
         CASE (1) ! IC4M1 : Exponential fit to Wadhams et al. 1988
           ALPHA = EXP(-ICECOEF1 * TPI / SIG - ICECOEF2)
           WN_I = 0.5 * ALPHA
-        
+
         CASE (2) ! IC4M2 : Polynomial fit, Eq. 3 from Meylan et al. 2014
-                 !NB: Eq. 3 only includes T^2 and T^4 terms, 
+                 !NB: Eq. 3 only includes T^2 and T^4 terms,
                  !  which correspond to ICECOEF3, ICECOEF5, so in
                  !  regtest: ICECOEF1=ICECOEF2=ICECOEF4=0
           MARG1 = ICECOEF1 + ICECOEF2*(SIG/TPI) + ICECOEF3*(SIG/TPI)**2
           MARG2 = ICECOEF4*(SIG/TPI)**3 + ICECOEF5*(SIG/TPI)**4
           ALPHA = MARG1 + MARG2
           WN_I = 0.5 * ALPHA
-        
+
         CASE (3) ! IC4M3 : Quadratic fit to Kohout & Meylan'08 in Horvat & Tziperman'15
           HICE=ICECOEF1 ! For this method, ICECOEF1=ice thickness
           KARG1 = -0.3203 + 2.058*HICE - 0.9375*(TPI/SIG)
-          KARG2 = -0.4269*HICE**2 + 0.1566*HICE*(TPI/SIG) 
-          KARG3 =  0.0006 * (TPI/SIG)**2 
+          KARG2 = -0.4269*HICE**2 + 0.1566*HICE*(TPI/SIG)
+          KARG3 =  0.0006 * (TPI/SIG)**2
           ALPHA  = EXP(KARG1 + KARG2 + KARG3)
           WN_I = 0.5 * ALPHA
-        
-        CASE (4) !Eq. 1 from Kohout et al. 2014 
+
+        CASE (4) !Eq. 1 from Kohout et al. 2014
           !Calculate HS
           DO IK=1, NK
             EB(IK) = 0.
@@ -486,7 +486,7 @@
            END DO
 
         CASE (7) ! Doble et al. (GRL 2015)
-           
+
            HICE=ICECOEF1 ! For this method, ICECOEF1=ice thickness
            DO IK=1,NK
               FREQ=SIG(IK)/TPI
@@ -496,12 +496,12 @@
 
         CASE DEFAULT
           WN_I = ICECOEF1 !Default to IC1: Uniform in k
-      
+
       END SELECT
 
 !
 ! 1.b Calculate DID
-!        
+!
          DO IK=1, NK
 !   SBT1 has: D1D(IK) = FACTOR *  MAX(0., (CG(IK)*WN(IK)/SIG(IK)-0.5) )
 !             recall that D=S/E=-2*Cg*k_i

--- a/model/ftn/w3sis2md.ftn
+++ b/model/ftn/w3sis2md.ftn
@@ -16,9 +16,9 @@
 !/
 !  1. Purpose :
 !
-!     Floe-size dependant scattering of waves in the marginal ice zone based on tabulated 
+!     Floe-size dependant scattering of waves in the marginal ice zone based on tabulated
 !     scattering coefficients for a semi-infinite ice sheet. See papers
-!     by Dumont et al. (JGR 2011) and Williams et al. (OM 2013) 
+!     by Dumont et al. (JGR 2011) and Williams et al. (OM 2013)
 !     combined with flexural dissipation and ice break-up.
 !
 !  2. Variables and types :
@@ -46,7 +46,7 @@
 !/ ------------------------------------------------------------------- /
 !/
       INTEGER ,    PARAMETER             :: NTHICK = 20, NICED = 500
-      REAL, PARAMETER                    :: FRAGILITY = 0.9   
+      REAL, PARAMETER                    :: FRAGILITY = 0.9
       REAL                               :: THICK1 = 0.1, DTHICK = 0.25
       REAL                               :: ICEDMIN      ! minimum floe diameter
       REAL                               :: ICEDAVETAB(NICED)
@@ -92,7 +92,7 @@
 !
 !  5. Called by :
 !
-!     - W3IOGR (initialization after reading mod_def.ww3) 
+!     - W3IOGR (initialization after reading mod_def.ww3)
 !
 !  6. Subroutines used :
 !
@@ -133,7 +133,7 @@
 !/S      CALL STRACE (IENT, 'SIS2ALPHATAB')
 !
 ! -------------------------------------------------------------------- /
-! 1.  Fills array of reflection as a function of frequency and ice thickness 
+! 1.  Fills array of reflection as a function of frequency and ice thickness
 !
       ALLOCATE(SIS2ALPHAS(NTHICK,NK))
       ALLOCATE(SIS2ALPHA2(NTHICK,NK))
@@ -141,7 +141,7 @@
 ! Table of ice thickness for which the reflection was computed
 !
       SIS1HTABLE = (/ 0.1, 0.35, 0.6, 0.85, 1.1, 1.35, 1.6, 1.85, 2.1,  2.35, &
-                      2.6, 2.85, 3.1, 3.35, 3.6, 3.85, 4.1, 4.35, 4.6, 4.85 /) 
+                      2.6, 2.85, 3.1, 3.35, 3.6, 3.85, 4.1, 4.35, 4.6, 4.85 /)
       NFTAB = 25
 
 !
@@ -155,13 +155,13 @@ IF (IS2PARS(18).LT.0.5) THEN
       SIS1ALPHATABLE = reshape((/  &
         1.78E-007, 2.21E-006, 6.57E-006, 1.31E-005, 2.28E-005, 3.60E-005, 5.23E-005, 7.19E-005, 9.60E-005, 0.0001260665, &
         0.0001621645, 0.0002032202, 0.0002483457, 0.0002987263, 0.0003571903, &
-        0.0004247358, 0.00049714, 0.0005689017, 0.0006469729, 0.0007470985, & 
+        0.0004247358, 0.00049714, 0.0005689017, 0.0006469729, 0.0007470985, &
         2.74E-007, 3.40E-006, 1.04E-005, 2.10E-005, 3.67E-005, 5.82E-005, &
         8.52E-005, 0.0001179843, 0.0001581719, 0.0002075378,    &
         0.0002663323, 0.0003330095, 0.0004063158, 0.000487845, 0.0005815828, &
         0.0006893214, 0.0008061048, 0.0009252626, 0.0010565619, 0.0012218782, &
         4.16E-007, 5.21E-006, 1.62E-005, 3.32E-005, 5.91E-005, 9.56E-005, 0.0001423817, &
-        0.0002001783, 0.0002716622, 0.0003599526, 0.0004656353, & 
+        0.0002001783, 0.0002716622, 0.0003599526, 0.0004656353, &
         0.0005861828, 0.0007194785, 0.0008683691, 0.0010401368, 0.0012386623, 0.0014562639, &
         0.0016819935, 0.0019335276, 0.0022507523, &
         6.25E-007, 7.95E-006, 2.50E-005, 5.28E-005, 9.71E-005, 0.0001615969, 0.0002467311, &
@@ -229,7 +229,7 @@ IF (IS2PARS(18).LT.0.5) THEN
         2.9057350396, 3.2594397982, 3.5553142762, 3.8420910788, 4.1929464318,&
          4.6097641365, 4.975238806, 5.1850270882, 5.4153321104, 5.9516719058, &
         0.009037082, 0.1761561171, 0.4486599083, 0.747307698, 1.1406376531, &
-        1.5966776005, 2.0299434584, 2.4186982894, 2.8096987013, 3.2399866752, & 
+        1.5966776005, 2.0299434584, 2.4186982894, 2.8096987013, 3.2399866752, &
         3.6899433755, 4.105747098, 4.4658248514, 4.8172532951, 5.2300901821, &
         5.7046450426, 6.1270633187, 6.3975380116, 6.6851833028, 7.2647998139, &
         0.0191118494, 0.2660897811, 0.6359174284, 1.0316197503, 1.5313672569, &
@@ -245,7 +245,7 @@ IF (IS2PARS(18).LT.0.5) THEN
         7.0521552001, 7.6857035561, 8.2469182713, 8.7926955021, 9.4042992778, &
         10.0780089999, 10.6798375161, 11.0993158393, 11.5359791079, 12.3054058274, &
         0.0912925253, 0.7587053794, 1.5933132286, 2.4467380656, 3.4467575836, &
-        4.4845019618, 5.3910117536, 6.1520041613, 6.8749329856, 7.6395860278, & 
+        4.4845019618, 5.3910117536, 6.1520041613, 6.8749329856, 7.6395860278, &
         8.4275368684, 9.1660844666, 9.8268448897, 10.4746437466, 11.2031746957, &
         12.0078539018, 12.7326579385, 13.2484048884, 13.7868789237, 14.7164075718, &
         0.1320035456, 1.258347597, 2.2697363962, 2.8626691529, 3.4800285532, &
@@ -257,142 +257,142 @@ IF (IS2PARS(18).LT.0.5) THEN
 ELSE
 ! May be changed, but according to T. Williams, wim1 is okay from 0.25 only
        SIS1HTABLE = (/ 0.25, 0.35, 0.6, 0.85, 1.1, 1.35, 1.6, 1.85, 2.1,  2.35, &
-                      2.6, 2.85, 3.1, 3.35, 3.6, 3.85, 4.1, 4.35, 4.6, 4.85 /) 
+                      2.6, 2.85, 3.1, 3.35, 3.6, 3.85, 4.1, 4.35, 4.6, 4.85 /)
        SIS1ALPHATABLE = reshape((/  &
-       3.80373e-06 ,  6.02822e-06 , 1.12121e-05 , 2.24588e-05 , & 
-3.05165e-05 ,  3.85142e-05 , 5.29712e-05 , 7.55453e-05 , & 
-1.05531e-04 ,  1.38952e-04 , 1.73378e-04 , 2.09421e-04 , & 
-2.47299e-04 ,  2.87669e-04 , 3.34304e-04 , 3.91094e-04 , & 
-4.57710e-04 ,  5.31901e-04 , 6.14490e-04 , 7.08299e-04 , & 
-4.76980e-06 ,  6.95433e-06 , 1.54179e-05 , 2.46138e-05 , & 
-3.79955e-05 ,  5.96725e-05 , 8.81668e-05 , 1.20881e-04 , & 
-1.57364e-04 ,  1.99666e-04 , 2.50723e-04 , 3.13346e-04 , & 
-3.89907e-04 ,  4.81606e-04 , 5.88164e-04 , 7.08707e-04 , & 
-8.42536e-04 ,  9.88622e-04 , 1.14498e-03 , 1.30931e-03 , & 
-5.84556e-06 ,  8.58738e-06 , 2.00947e-05 , 3.18410e-05 , & 
-5.67385e-05 ,  9.37456e-05 , 1.37304e-04 , 1.87832e-04 , & 
-2.49218e-04 ,  3.28900e-04 , 4.31988e-04 , 5.59364e-04 , & 
-7.11302e-04 ,  8.86736e-04 , 1.08074e-03 , 1.28808e-03 , & 
-1.50809e-03 ,  1.74230e-03 , 1.98930e-03 , 2.24607e-03 , & 
-6.90305e-06 ,  1.12155e-05 , 2.59514e-05 , 5.15063e-05 , & 
-9.18902e-05 ,  1.45703e-04 , 2.18304e-04 , 3.18476e-04 , & 
-4.51992e-04 ,  6.21037e-04 , 8.24428e-04 , 1.05881e-03 , & 
-1.32112e-03 ,  1.60970e-03 , 1.92396e-03 , 2.26484e-03 , & 
-2.63577e-03 ,  3.04238e-03 , 3.49116e-03 , 3.98911e-03 , & 
-8.46004e-06 ,  1.46791e-05 , 3.69837e-05 , 8.32870e-05 , & 
-1.49151e-04 ,  2.46175e-04 , 3.92165e-04 , 5.95871e-04 , & 
-8.57938e-04 ,  1.17280e-03 , 1.53668e-03 , 1.95109e-03 , & 
-2.42048e-03 ,  2.95341e-03 , 3.56468e-03 , 4.27150e-03 , & 
-5.08843e-03 ,  6.02927e-03 , 7.11153e-03 , 8.35459e-03 , & 
-1.11513e-05 ,  1.95090e-05 , 5.78215e-05 , 1.32267e-04 , & 
-2.57932e-04 ,  4.61051e-04 , 7.55044e-04 , 1.14193e-03 , & 
-1.62478e-03 ,  2.21208e-03 , 2.92101e-03 , 3.77684e-03 , & 
-4.80845e-03 ,  6.04635e-03 , 7.52256e-03 , 9.26818e-03 , & 
-1.13101e-02 ,  1.36712e-02 , 1.63732e-02 , 1.94360e-02 , & 
-1.52571e-05 ,  2.78128e-05 , 9.43665e-05 , 2.30636e-04 , & 
-4.90057e-04 ,  9.02105e-04 , 1.48012e-03 , 2.24822e-03 , & 
-3.24754e-03 ,  4.53444e-03 , 6.16979e-03 , 8.21171e-03 , & 
-1.07145e-02 ,  1.37253e-02 , 1.72805e-02 , 2.14091e-02 , & 
-2.61367e-02 ,  3.14840e-02 , 3.74632e-02 , 4.40798e-02 , & 
-2.13731e-05 ,  4.29771e-05 , 1.64050e-04 , 4.49510e-04 , & 
-9.84576e-04 ,  1.82921e-03 , 3.06425e-03 , 4.79802e-03 , & 
-7.14520e-03 ,  1.02139e-02 , 1.40940e-02 , 1.88529e-02 , & 
-2.45396e-02 ,  3.11875e-02 , 3.88141e-02 , 4.74255e-02 , & 
-5.70233e-02 ,  6.76049e-02 , 7.91611e-02 , 9.16776e-02 , & 
-3.17688e-05 ,  7.05749e-05 , 3.13449e-04 , 9.26652e-04 , & 
-2.08059e-03 ,  3.98338e-03 , 6.87070e-03 , 1.09528e-02 , & 
-1.63868e-02 ,  2.32726e-02 , 3.16649e-02 , 4.15851e-02 , & 
-5.30293e-02 ,  6.59789e-02 , 8.04085e-02 , 9.62863e-02 , & 
-1.13575e-01 ,  1.32236e-01 , 1.52233e-01 , 1.73533e-01 , & 
-5.14019e-05 ,  1.24975e-04 , 6.49063e-04 , 2.01553e-03 , & 
-4.70028e-03 ,  9.17913e-03 , 1.58010e-02 , 2.47576e-02 , & 
-3.61186e-02 ,  4.98708e-02 , 6.59568e-02 , 8.42994e-02 , & 
-1.04811e-01 ,  1.27404e-01 , 1.51996e-01 , 1.78511e-01 , & 
-2.06873e-01 ,  2.37011e-01 , 2.68862e-01 , 3.02365e-01 , & 
-9.05394e-05 ,  2.44433e-04 , 1.43884e-03 , 4.66981e-03 , & 
-1.09558e-02 ,  2.08947e-02 , 3.46681e-02 , 5.22109e-02 , & 
-7.33489e-02 ,  9.78738e-02 , 1.25579e-01 , 1.56274e-01 , & 
-1.89790e-01 ,  2.25973e-01 , 2.64687e-01 , 3.05808e-01 , & 
-3.49223e-01 ,  3.94830e-01 , 4.42530e-01 , 4.92227e-01 , & 
-1.75074e-04 ,  5.25080e-04 , 3.39573e-03 , 1.10036e-02 , & 
-2.46312e-02 ,  4.44096e-02 , 6.99511e-02 , 1.00742e-01 , & 
-1.36302e-01 ,  1.76219e-01 , 2.20147e-01 , 2.67802e-01 , & 
-3.18937e-01 ,  3.73339e-01 , 4.30813e-01 , 4.91183e-01 , & 
-5.54282e-01 ,  6.19954e-01 , 6.88048e-01 , 7.58418e-01 , & 
-3.74908e-04 ,  1.22443e-03 , 8.17252e-03 , 2.46994e-02 , & 
-5.11207e-02 ,  8.63422e-02 , 1.29173e-01 , 1.78641e-01 , & 
-2.34006e-01 ,  2.94691e-01 , 3.60235e-01 , 4.30258e-01 , & 
-5.04426e-01 ,  5.82438e-01 , 6.64019e-01 , 7.48914e-01 , & 
-8.36872e-01 ,  9.27649e-01 , 1.02102e+00 , 1.11676e+00 , & 
-8.82800e-04 ,  3.03043e-03 , 1.88248e-02 , 5.09125e-02 , & 
-9.68861e-02 ,  1.54064e-01 , 2.20524e-01 , 2.94949e-01 , & 
-3.76394e-01 ,  4.64138e-01 , 5.57588e-01 , 6.56231e-01 , & 
-7.59605e-01 ,  8.67281e-01 , 9.78849e-01 , 1.09393e+00 , & 
-1.21214e+00 ,  1.33315e+00 , 1.45662e+00 , 1.58224e+00 , & 
-2.22521e-03 ,  7.51676e-03 , 3.98357e-02 , 9.57376e-02 , & 
-1.68983e-01 ,  2.55527e-01 , 3.52939e-01 , 4.59644e-01 , & 
-5.74490e-01 ,  6.96566e-01 , 8.25086e-01 , 9.59331e-01 , & 
-1.09864e+00 ,  1.24238e+00 , 1.38997e+00 , 1.54085e+00 , & 
-1.69451e+00 ,  1.85049e+00 , 2.00833e+00 , 2.16765e+00 , & 
-5.66833e-03 ,  1.75464e-02 , 7.66453e-02 , 1.65727e-01 , & 
-2.74951e-01 ,  3.99380e-01 , 5.36249e-01 , 6.83721e-01 , & 
-8.40370e-01 ,  1.00497e+00 , 1.17642e+00 , 1.35368e+00 , & 
-1.53580e+00 ,  1.72190e+00 , 1.91118e+00 , 2.10291e+00 , & 
-2.29645e+00 ,  2.49123e+00 , 2.68675e+00 , 2.88259e+00 , & 
-1.36539e-02 ,  3.72456e-02 , 1.35140e-01 , 2.67780e-01 , & 
-4.22901e-01 ,  5.95111e-01 , 7.81333e-01 , 9.79307e-01 , & 
-1.18712e+00 ,  1.40304e+00 , 1.62548e+00 , 1.85300e+00 , & 
-2.08433e+00 ,  2.31832e+00 , 2.55400e+00 , 2.79055e+00 , & 
-3.02727e+00 ,  3.26361e+00 , 3.49910e+00 , 3.73337e+00 , & 
-2.98722e-02 ,  7.15314e-02 , 2.21423e-01 , 4.09271e-01 , & 
-6.21810e-01 ,  8.53369e-01 , 1.10028e+00 , 1.35949e+00 , & 
-1.62829e+00 ,  1.90425e+00 , 2.18522e+00 , 2.46937e+00 , & 
-2.75516e+00 ,  3.04136e+00 , 3.32695e+00 , 3.61118e+00 , & 
-3.89345e+00 ,  4.17331e+00 , 4.45047e+00 , 4.72471e+00 , & 
-5.88578e-02 ,  1.25612e-01 , 3.41821e-01 , 5.98292e-01 , & 
-8.81793e-01 ,  1.18598e+00 , 1.50596e+00 , 1.83748e+00 , & 
-2.17675e+00 ,  2.52062e+00 , 2.86649e+00 , 3.21233e+00 , & 
-3.55662e+00 ,  3.89823e+00 , 4.23636e+00 , 4.57049e+00 , & 
-4.90029e+00 ,  5.22559e+00 , 5.54632e+00 , 5.86250e+00 , & 
-1.05468e-01 ,  2.04724e-01 , 5.03158e-01 , 8.44026e-01 , & 
-1.21416e+00 ,  1.60557e+00 , 2.01139e+00 , 2.42573e+00 , & 
-2.84383e+00 ,  3.26205e+00 , 3.67776e+00 , 4.08914e+00 , & 
-4.49503e+00 ,  4.89472e+00 , 5.28788e+00 , 5.67440e+00 , & 
-6.05432e+00 ,  6.42782e+00 , 6.79514e+00 , 7.15656e+00 , & 
-1.74545e-01 ,  3.14137e-01 , 7.13063e-01 , 1.15691e+00 , & 
-1.63126e+00 ,  2.12499e+00 , 2.62866e+00 , 3.13493e+00 , & 
-3.63860e+00 ,  4.13623e+00 , 4.62576e+00 , 5.10610e+00 , & 
-5.57680e+00 ,  6.03787e+00 , 6.48955e+00 , 6.93227e+00 , & 
-7.36652e+00 ,  7.79283e+00 , 8.21174e+00 , 8.62378e+00 , & 
-2.70834e-01 ,  4.59350e-01 , 9.80330e-01 , 1.54856e+00 , & 
-2.14570e+00 ,  2.75617e+00 , 3.36813e+00 , 3.97376e+00 , & 
-4.56847e+00 ,  5.14997e+00 , 5.71743e+00 , 6.27093e+00 , & 
-6.81101e+00 ,  7.33850e+00 , 7.85432e+00 , 8.35942e+00 , & 
-8.85471e+00 ,  9.34106e+00 , 9.81925e+00 , 1.02900e+01 , & 
-3.99120e-01 ,  6.46435e-01 , 1.31507e+00 , 2.03136e+00 , & 
-2.76957e+00 ,  3.50946e+00 , 4.23832e+00 , 4.94958e+00 , & 
-5.64069e+00 ,  6.31137e+00 , 6.96253e+00 , 7.59564e+00 , & 
-8.21234e+00 ,  8.81426e+00 , 9.40295e+00 , 9.97983e+00 , & 
-1.05461e+01 ,  1.11030e+01 , 1.16515e+01 , 1.21924e+01 , & 
-5.64538e-01 ,  8.82405e-01 , 1.72870e+00 , 2.61770e+00 , & 
-3.51364e+00 ,  4.39362e+00 , 5.24695e+00 , 6.07052e+00 , & 
-6.86499e+00 ,  7.63269e+00 , 8.37647e+00 , 9.09919e+00 , & 
-9.80351e+00 ,  1.04918e+01 , 1.11660e+01 , 1.18280e+01 , & 
-1.24792e+01 ,  1.31209e+01 , 1.37543e+01 , 1.43803e+01 , & 
-7.72889e-01 ,  1.17552e+00 , 2.23335e+00 , 3.31894e+00 , & 
-4.38704e+00 ,  5.41672e+00 , 6.40295e+00 , 7.34788e+00 , & 
-8.25618e+00 ,  9.13289e+00 , 9.98272e+00 , 1.08097e+01 , & 
-1.16174e+01 ,  1.24086e+01 , 1.31857e+01 , 1.39506e+01 , & 
-1.47049e+01 ,  1.54501e+01 , 1.61872e+01 , 1.69173e+01   & 
+       3.80373e-06 ,  6.02822e-06 , 1.12121e-05 , 2.24588e-05 , &
+3.05165e-05 ,  3.85142e-05 , 5.29712e-05 , 7.55453e-05 , &
+1.05531e-04 ,  1.38952e-04 , 1.73378e-04 , 2.09421e-04 , &
+2.47299e-04 ,  2.87669e-04 , 3.34304e-04 , 3.91094e-04 , &
+4.57710e-04 ,  5.31901e-04 , 6.14490e-04 , 7.08299e-04 , &
+4.76980e-06 ,  6.95433e-06 , 1.54179e-05 , 2.46138e-05 , &
+3.79955e-05 ,  5.96725e-05 , 8.81668e-05 , 1.20881e-04 , &
+1.57364e-04 ,  1.99666e-04 , 2.50723e-04 , 3.13346e-04 , &
+3.89907e-04 ,  4.81606e-04 , 5.88164e-04 , 7.08707e-04 , &
+8.42536e-04 ,  9.88622e-04 , 1.14498e-03 , 1.30931e-03 , &
+5.84556e-06 ,  8.58738e-06 , 2.00947e-05 , 3.18410e-05 , &
+5.67385e-05 ,  9.37456e-05 , 1.37304e-04 , 1.87832e-04 , &
+2.49218e-04 ,  3.28900e-04 , 4.31988e-04 , 5.59364e-04 , &
+7.11302e-04 ,  8.86736e-04 , 1.08074e-03 , 1.28808e-03 , &
+1.50809e-03 ,  1.74230e-03 , 1.98930e-03 , 2.24607e-03 , &
+6.90305e-06 ,  1.12155e-05 , 2.59514e-05 , 5.15063e-05 , &
+9.18902e-05 ,  1.45703e-04 , 2.18304e-04 , 3.18476e-04 , &
+4.51992e-04 ,  6.21037e-04 , 8.24428e-04 , 1.05881e-03 , &
+1.32112e-03 ,  1.60970e-03 , 1.92396e-03 , 2.26484e-03 , &
+2.63577e-03 ,  3.04238e-03 , 3.49116e-03 , 3.98911e-03 , &
+8.46004e-06 ,  1.46791e-05 , 3.69837e-05 , 8.32870e-05 , &
+1.49151e-04 ,  2.46175e-04 , 3.92165e-04 , 5.95871e-04 , &
+8.57938e-04 ,  1.17280e-03 , 1.53668e-03 , 1.95109e-03 , &
+2.42048e-03 ,  2.95341e-03 , 3.56468e-03 , 4.27150e-03 , &
+5.08843e-03 ,  6.02927e-03 , 7.11153e-03 , 8.35459e-03 , &
+1.11513e-05 ,  1.95090e-05 , 5.78215e-05 , 1.32267e-04 , &
+2.57932e-04 ,  4.61051e-04 , 7.55044e-04 , 1.14193e-03 , &
+1.62478e-03 ,  2.21208e-03 , 2.92101e-03 , 3.77684e-03 , &
+4.80845e-03 ,  6.04635e-03 , 7.52256e-03 , 9.26818e-03 , &
+1.13101e-02 ,  1.36712e-02 , 1.63732e-02 , 1.94360e-02 , &
+1.52571e-05 ,  2.78128e-05 , 9.43665e-05 , 2.30636e-04 , &
+4.90057e-04 ,  9.02105e-04 , 1.48012e-03 , 2.24822e-03 , &
+3.24754e-03 ,  4.53444e-03 , 6.16979e-03 , 8.21171e-03 , &
+1.07145e-02 ,  1.37253e-02 , 1.72805e-02 , 2.14091e-02 , &
+2.61367e-02 ,  3.14840e-02 , 3.74632e-02 , 4.40798e-02 , &
+2.13731e-05 ,  4.29771e-05 , 1.64050e-04 , 4.49510e-04 , &
+9.84576e-04 ,  1.82921e-03 , 3.06425e-03 , 4.79802e-03 , &
+7.14520e-03 ,  1.02139e-02 , 1.40940e-02 , 1.88529e-02 , &
+2.45396e-02 ,  3.11875e-02 , 3.88141e-02 , 4.74255e-02 , &
+5.70233e-02 ,  6.76049e-02 , 7.91611e-02 , 9.16776e-02 , &
+3.17688e-05 ,  7.05749e-05 , 3.13449e-04 , 9.26652e-04 , &
+2.08059e-03 ,  3.98338e-03 , 6.87070e-03 , 1.09528e-02 , &
+1.63868e-02 ,  2.32726e-02 , 3.16649e-02 , 4.15851e-02 , &
+5.30293e-02 ,  6.59789e-02 , 8.04085e-02 , 9.62863e-02 , &
+1.13575e-01 ,  1.32236e-01 , 1.52233e-01 , 1.73533e-01 , &
+5.14019e-05 ,  1.24975e-04 , 6.49063e-04 , 2.01553e-03 , &
+4.70028e-03 ,  9.17913e-03 , 1.58010e-02 , 2.47576e-02 , &
+3.61186e-02 ,  4.98708e-02 , 6.59568e-02 , 8.42994e-02 , &
+1.04811e-01 ,  1.27404e-01 , 1.51996e-01 , 1.78511e-01 , &
+2.06873e-01 ,  2.37011e-01 , 2.68862e-01 , 3.02365e-01 , &
+9.05394e-05 ,  2.44433e-04 , 1.43884e-03 , 4.66981e-03 , &
+1.09558e-02 ,  2.08947e-02 , 3.46681e-02 , 5.22109e-02 , &
+7.33489e-02 ,  9.78738e-02 , 1.25579e-01 , 1.56274e-01 , &
+1.89790e-01 ,  2.25973e-01 , 2.64687e-01 , 3.05808e-01 , &
+3.49223e-01 ,  3.94830e-01 , 4.42530e-01 , 4.92227e-01 , &
+1.75074e-04 ,  5.25080e-04 , 3.39573e-03 , 1.10036e-02 , &
+2.46312e-02 ,  4.44096e-02 , 6.99511e-02 , 1.00742e-01 , &
+1.36302e-01 ,  1.76219e-01 , 2.20147e-01 , 2.67802e-01 , &
+3.18937e-01 ,  3.73339e-01 , 4.30813e-01 , 4.91183e-01 , &
+5.54282e-01 ,  6.19954e-01 , 6.88048e-01 , 7.58418e-01 , &
+3.74908e-04 ,  1.22443e-03 , 8.17252e-03 , 2.46994e-02 , &
+5.11207e-02 ,  8.63422e-02 , 1.29173e-01 , 1.78641e-01 , &
+2.34006e-01 ,  2.94691e-01 , 3.60235e-01 , 4.30258e-01 , &
+5.04426e-01 ,  5.82438e-01 , 6.64019e-01 , 7.48914e-01 , &
+8.36872e-01 ,  9.27649e-01 , 1.02102e+00 , 1.11676e+00 , &
+8.82800e-04 ,  3.03043e-03 , 1.88248e-02 , 5.09125e-02 , &
+9.68861e-02 ,  1.54064e-01 , 2.20524e-01 , 2.94949e-01 , &
+3.76394e-01 ,  4.64138e-01 , 5.57588e-01 , 6.56231e-01 , &
+7.59605e-01 ,  8.67281e-01 , 9.78849e-01 , 1.09393e+00 , &
+1.21214e+00 ,  1.33315e+00 , 1.45662e+00 , 1.58224e+00 , &
+2.22521e-03 ,  7.51676e-03 , 3.98357e-02 , 9.57376e-02 , &
+1.68983e-01 ,  2.55527e-01 , 3.52939e-01 , 4.59644e-01 , &
+5.74490e-01 ,  6.96566e-01 , 8.25086e-01 , 9.59331e-01 , &
+1.09864e+00 ,  1.24238e+00 , 1.38997e+00 , 1.54085e+00 , &
+1.69451e+00 ,  1.85049e+00 , 2.00833e+00 , 2.16765e+00 , &
+5.66833e-03 ,  1.75464e-02 , 7.66453e-02 , 1.65727e-01 , &
+2.74951e-01 ,  3.99380e-01 , 5.36249e-01 , 6.83721e-01 , &
+8.40370e-01 ,  1.00497e+00 , 1.17642e+00 , 1.35368e+00 , &
+1.53580e+00 ,  1.72190e+00 , 1.91118e+00 , 2.10291e+00 , &
+2.29645e+00 ,  2.49123e+00 , 2.68675e+00 , 2.88259e+00 , &
+1.36539e-02 ,  3.72456e-02 , 1.35140e-01 , 2.67780e-01 , &
+4.22901e-01 ,  5.95111e-01 , 7.81333e-01 , 9.79307e-01 , &
+1.18712e+00 ,  1.40304e+00 , 1.62548e+00 , 1.85300e+00 , &
+2.08433e+00 ,  2.31832e+00 , 2.55400e+00 , 2.79055e+00 , &
+3.02727e+00 ,  3.26361e+00 , 3.49910e+00 , 3.73337e+00 , &
+2.98722e-02 ,  7.15314e-02 , 2.21423e-01 , 4.09271e-01 , &
+6.21810e-01 ,  8.53369e-01 , 1.10028e+00 , 1.35949e+00 , &
+1.62829e+00 ,  1.90425e+00 , 2.18522e+00 , 2.46937e+00 , &
+2.75516e+00 ,  3.04136e+00 , 3.32695e+00 , 3.61118e+00 , &
+3.89345e+00 ,  4.17331e+00 , 4.45047e+00 , 4.72471e+00 , &
+5.88578e-02 ,  1.25612e-01 , 3.41821e-01 , 5.98292e-01 , &
+8.81793e-01 ,  1.18598e+00 , 1.50596e+00 , 1.83748e+00 , &
+2.17675e+00 ,  2.52062e+00 , 2.86649e+00 , 3.21233e+00 , &
+3.55662e+00 ,  3.89823e+00 , 4.23636e+00 , 4.57049e+00 , &
+4.90029e+00 ,  5.22559e+00 , 5.54632e+00 , 5.86250e+00 , &
+1.05468e-01 ,  2.04724e-01 , 5.03158e-01 , 8.44026e-01 , &
+1.21416e+00 ,  1.60557e+00 , 2.01139e+00 , 2.42573e+00 , &
+2.84383e+00 ,  3.26205e+00 , 3.67776e+00 , 4.08914e+00 , &
+4.49503e+00 ,  4.89472e+00 , 5.28788e+00 , 5.67440e+00 , &
+6.05432e+00 ,  6.42782e+00 , 6.79514e+00 , 7.15656e+00 , &
+1.74545e-01 ,  3.14137e-01 , 7.13063e-01 , 1.15691e+00 , &
+1.63126e+00 ,  2.12499e+00 , 2.62866e+00 , 3.13493e+00 , &
+3.63860e+00 ,  4.13623e+00 , 4.62576e+00 , 5.10610e+00 , &
+5.57680e+00 ,  6.03787e+00 , 6.48955e+00 , 6.93227e+00 , &
+7.36652e+00 ,  7.79283e+00 , 8.21174e+00 , 8.62378e+00 , &
+2.70834e-01 ,  4.59350e-01 , 9.80330e-01 , 1.54856e+00 , &
+2.14570e+00 ,  2.75617e+00 , 3.36813e+00 , 3.97376e+00 , &
+4.56847e+00 ,  5.14997e+00 , 5.71743e+00 , 6.27093e+00 , &
+6.81101e+00 ,  7.33850e+00 , 7.85432e+00 , 8.35942e+00 , &
+8.85471e+00 ,  9.34106e+00 , 9.81925e+00 , 1.02900e+01 , &
+3.99120e-01 ,  6.46435e-01 , 1.31507e+00 , 2.03136e+00 , &
+2.76957e+00 ,  3.50946e+00 , 4.23832e+00 , 4.94958e+00 , &
+5.64069e+00 ,  6.31137e+00 , 6.96253e+00 , 7.59564e+00 , &
+8.21234e+00 ,  8.81426e+00 , 9.40295e+00 , 9.97983e+00 , &
+1.05461e+01 ,  1.11030e+01 , 1.16515e+01 , 1.21924e+01 , &
+5.64538e-01 ,  8.82405e-01 , 1.72870e+00 , 2.61770e+00 , &
+3.51364e+00 ,  4.39362e+00 , 5.24695e+00 , 6.07052e+00 , &
+6.86499e+00 ,  7.63269e+00 , 8.37647e+00 , 9.09919e+00 , &
+9.80351e+00 ,  1.04918e+01 , 1.11660e+01 , 1.18280e+01 , &
+1.24792e+01 ,  1.31209e+01 , 1.37543e+01 , 1.43803e+01 , &
+7.72889e-01 ,  1.17552e+00 , 2.23335e+00 , 3.31894e+00 , &
+4.38704e+00 ,  5.41672e+00 , 6.40295e+00 , 7.34788e+00 , &
+8.25618e+00 ,  9.13289e+00 , 9.98272e+00 , 1.08097e+01 , &
+1.16174e+01 ,  1.24086e+01 , 1.31857e+01 , 1.39506e+01 , &
+1.47049e+01 ,  1.54501e+01 , 1.61872e+01 , 1.69173e+01   &
         /) ,(/NTHICK,NFTAB/))
         END IF
       DO I=1,NK
         DO J=1,NTHICK
-          IF (SIG(I)*TPIINV.LT.SIS1FTABLE(1)) THEN 
+          IF (SIG(I)*TPIINV.LT.SIS1FTABLE(1)) THEN
             SIS2ALPHAS(J,I) = SIS1ALPHATABLE(J,1)
-          ELSE IF (SIG(I)*TPIINV.GT. SIS1FTABLE(NFTAB)) THEN 
+          ELSE IF (SIG(I)*TPIINV.GT. SIS1FTABLE(NFTAB)) THEN
             SIS2ALPHAS(J,I) = SIS1ALPHATABLE(J,NFTAB)
-          ELSE 
+          ELSE
             IND = 1
             DO K = 1, NFTAB-1
               IF (SIS1FTABLE(K).LT.SIG(I)*TPIINV) IND = K
@@ -515,11 +515,11 @@ ELSE
 
       DO I=1,NK
         DO J=1,NTHICK
-          IF (SIG(I)*TPIINV.LT. SIS1FTABLE(1)) THEN 
+          IF (SIG(I)*TPIINV.LT. SIS1FTABLE(1)) THEN
             SIS2ALPHA2(J,I) = SIS1ALPHATABLE2(J,1)
-          ELSE IF (SIG(I)*TPIINV.GT. SIS1FTABLE(NFTAB)) THEN 
+          ELSE IF (SIG(I)*TPIINV.GT. SIS1FTABLE(NFTAB)) THEN
             SIS2ALPHA2(J,I) = SIS1ALPHATABLE2(J,NFTAB)
-          ELSE 
+          ELSE
             IND = 1
             DO K = 1, NFTAB-1
               IF (SIS1FTABLE(K).LT.SIG(I)*TPIINV) IND = K
@@ -531,37 +531,37 @@ ELSE
         END DO
 !
 ! -------------------------------------------------------------------- /
-! 2.  Fills array of ICEDMAX to ICEDAVE 
+! 2.  Fills array of ICEDMAX to ICEDAVE
 !
       DO I=1,NICED
         ICEDAVETAB(I) = W3FSD_DAVE(IS2PARS(9),REAL(I),IS2PARS(8))
         ENDDO
 !
 ! -------------------------------------------------------------------- /
-! 2.  Defines and diagonalizes the scattering matrix 
+! 2.  Defines and diagonalizes the scattering matrix
 !
       ALLOCATE(IS2SCATMAT(NTH,NTH))
       ALLOCATE(IS2EIGVEC(NTH,NTH))
       ALLOCATE(IS2EIGVAL(NTH))
 !
-      DO I=1,NTH 
+      DO I=1,NTH
         DO J=1,NTH
-! This is for isotropic back-scatter 
+! This is for isotropic back-scatter
 !         IS2SCATMAT(I,J)=-1./DBLE(NTH)
 ! Other example that looks like figure 12 in Masson & LeBlond
           IS2SCATMAT(I,J)=-1./DBLE(NTH)*(2.*EC2(ABS(I-J)+1)**2+0.8*ECOS(ABS(I-J)+1)**3)
           IF (ECOS(ABS(I-J)+1).LT.0.001) IS2SCATMAT(I,J)=IS2SCATMAT(I,J)-1./DBLE(NTH)*0.8*ES2(ABS(I-J)+1)
           END DO
-!WRITE(997,'(36G16.8)') IS2SCATMAT(I,:) 
-! Now removes sum from diagonal to enforce energy conservation ... 
+!WRITE(997,'(36G16.8)') IS2SCATMAT(I,:)
+! Now removes sum from diagonal to enforce energy conservation ...
           IS2SCATMAT(I,I)=IS2SCATMAT(I,I)-SUM(IS2SCATMAT(I,1:NTH))
         END DO
-      CALL DIAGONALIZE(IS2SCATMAT,IS2EIGVAL,IS2EIGVEC,nrot) 
-      DO I=1,NTH 
+      CALL DIAGONALIZE(IS2SCATMAT,IS2EIGVAL,IS2EIGVEC,nrot)
+      DO I=1,NTH
         IS2EIGVAL(I)=MAX(0.d0,IS2EIGVAL(I))
-!WRITE(994,'(36G16.8)') I,IS2EIGVAL(I) 
-!WRITE(995,'(36G16.8)') IS2EIGVEC(I,:) 
-!WRITE(996,'(36G16.8)') IS2SCATMAT(I,:) 
+!WRITE(994,'(36G16.8)') I,IS2EIGVAL(I)
+!WRITE(995,'(36G16.8)') IS2EIGVEC(I,:)
+!WRITE(996,'(36G16.8)') IS2SCATMAT(I,:)
         END DO
 !CLOSE(994)
 !CLOSE(995)
@@ -590,21 +590,21 @@ ELSE
 !/    27-Aug-2015 : Add breaking criterion, WIM1d       ( version 5.05 )
 !/                  (ref. Williams, 2012)
 !/    02-Nov-2015 : Integration of strain over bandwidth( version 5.05 )
-!/    13-Jan-2016 : Changed initialization of ICEDMAX   ( version 5.10 ) 
-!/    06-Feb-2016 : Added IICEHMIN and creep dissipation( version 5.10 ) 
+!/    13-Jan-2016 : Changed initialization of ICEDMAX   ( version 5.10 )
+!/    06-Feb-2016 : Added IICEHMIN and creep dissipation( version 5.10 )
 !/    10-Mar-2016 : Added depth and call to Liu disp.   ( version 5.10 )
 !/    02-May-2016 : Call to Liu disp moved to w3srce    ( version 5.10 )
 !
 !  1. Purpose :
-!     Wave scattering in the MIZ, adapted from Dumont et al.  
+!     Wave scattering in the MIZ, adapted from Dumont et al.
 !
 !/ ------------------------------------------------------------------- /
 !
 !  2. Method :
-!     This scattering routine allows the estimation of the maximum floe 
-!     size and an estimate of the creep-induced dissipation. 
-!     For the scattering, it is based on the normal incidence results of 
-!     Kohout and Meylan which are provided in a table. 
+!     This scattering routine allows the estimation of the maximum floe
+!     size and an estimate of the creep-induced dissipation.
+!     For the scattering, it is based on the normal incidence results of
+!     Kohout and Meylan which are provided in a table.
 !
 !  3. Parameters :
 !
@@ -672,7 +672,7 @@ ELSE
 !/T      USE W3ODATMD, ONLY: NDST
 !/S      USE W3SERVMD, ONLY: STRACE
 !/T      USE W3ARRYMD, ONLY: PRT2DS
-      USE W3DISPMD 
+      USE W3DISPMD
 !
       IMPLICIT NONE
 !/
@@ -698,13 +698,13 @@ ELSE
                                  DMAX, S_ATT, FACTOR, BETA
       REAL                    :: ICEDAVE(NK), CURVTOSTRAIN, CREEPFAC, MP2, B, ICEF_CREEP
       REAL                    :: SUMALLDIR, SUMA, SUME, CURVSPEC(NK), ESPEC(NK),STRAIN
-      REAL, PARAMETER         :: YOUNG = 5.49E+9   ! Young modulus 
-      REAL, PARAMETER         :: POISSON = 0.3     ! Poisson Ratio 
+      REAL, PARAMETER         :: YOUNG = 5.49E+9   ! Young modulus
+      REAL, PARAMETER         :: POISSON = 0.3     ! Poisson Ratio
       REAL                    :: SIGMA_C
 !      REAL, PARAMETER         :: SIGMA_C =  2.7414E+05  ! Flexural strenght in Pa
-                                                         ! this is now a parametrer IS2PARS(19) 
-      REAL, PARAMETER         :: DENS = 1025.0     ! ice density 
-      REAL                    :: GAMMA_TOY 
+                                                         ! this is now a parametrer IS2PARS(19)
+      REAL, PARAMETER         :: DENS = 1025.0     ! ice density
+      REAL                    :: GAMMA_TOY
       REAL, DIMENSION(NK)        :: WN_I, WN_RP, WSQ, WLG, WLG_I, CG_I,   &
                                     CURV, CGRATIO, CG_EFF, DUMMY, ALPHA_DISP
 !/T      REAL                    :: SOUT(NK,NTH)
@@ -733,18 +733,18 @@ ELSE
       TAU_D=B_COLE/0.07
       S_D=LOG(SIG(:)*TAU_D)
       !IF ((IX.EQ.50).AND.(IY.EQ.20)) WRITE(*,*) 'B', B_COLE, 'SD1' ,S_D(1), 'SD5', S_D(5), 'TAU_D', TAU_D
-      DELTA_D=IS2PARS(21) 
+      DELTA_D=IS2PARS(21)
       !SIGMA_RATIO =1.
       !
       IF (IS2PARS(9).GT.0) ICEDMIN = IS2PARS(9)
-      IF (IS2PARS(12).GT.0) THEN 
+      IF (IS2PARS(12).GT.0) THEN
         B=IS2PARS(12)
-! 2 is the ratio of <H/2^4> to (Hrms/2)^4 for a Rayleigh distribution 
-! 0.375 is the average of cos^4 
-! 0.4 is 2/5 
+! 2 is the ratio of <H/2^4> to (Hrms/2)^4 for a Rayleigh distribution
+! 0.375 is the average of cos^4
+! 0.4 is 2/5
         CREEPFAC = -2*(0.25/(IS2PARS(15)+2))*0.375*B*ICEH**(IS2PARS(15)+2)  &
                         *(YOUNG/(2*B*MP2))**(IS2PARS(15)+1)/(DWAT*GRAV)
-      ELSE 
+      ELSE
         CREEPFAC=1.
         ENDIF
 
@@ -753,24 +753,24 @@ ELSE
       DMAX = ICEF
       BRK_CRIT = .FALSE.
       NSUM = NINT(0.3/(XFR-1.))
-!    
+!
       STRAIN_C = SIGMA_C*MP2/YOUNG
 
-! Minimum floe size that can break 
-      D_FLEX_FAIL =  0.5* ( (PI**4*YOUNG*ICEH**3)/( 48*DENS*GRAV*MP2 ) )**.25 
-! Estimates mean floe diameter from max floe diameter 
+! Minimum floe size that can break
+      D_FLEX_FAIL =  0.5* ( (PI**4*YOUNG*ICEH**3)/( 48*DENS*GRAV*MP2 ) )**.25
+! Estimates mean floe diameter from max floe diameter
       IF (DMAX.GT.NICED) THEN
         ICEDAVE=DMAX
       ELSE
         IF (IS2PARS(9).GT.0) THEN
           ICEDAVE= ICEDAVETAB(MAX(1,NINT(DMAX)))
-        ELSE 
+        ELSE
           DO IK=1,NK
             IF (IS2PARS(14)*(TPI/WN_R(IK)).LT.DMAX) THEN
               ICEDAVE(IK)=W3FSD_DAVE( (TPI/WN_R(IK))*IS2PARS(14),DMAX,IS2PARS(8))
-            ELSE 
+            ELSE
               ICEDAVE(IK)=DMAX
-              ENDIF 
+              ENDIF
             END DO
           ENDIF
         ENDIF
@@ -779,20 +779,20 @@ ELSE
 !
       IF (CICE .GT. 0) THEN
 !
-!  1. Calculate wavelength, Robinson-Palmer dispersion relation 
+!  1. Calculate wavelength, Robinson-Palmer dispersion relation
 !     (should be tabulated )
-!     Warning: it only applies to unbroken ice. 
+!     Warning: it only applies to unbroken ice.
 !
-        IF (IS2PARS(6).GT.0.5) THEN 
+        IF (IS2PARS(6).GT.0.5) THEN
           CALL W3RPWNICE(ICEH,WN_I,WN_RP,CG_I)
-        ELSE 
+        ELSE
           WN_I  = WN_R
           CG_I  = CG_ICE
           WN_RP=WN*0.
-          END IF          
+          END IF
 !
-        WLG_I = TPI/WN_I  ! Ice wavelength 
-        WSQ = (WLG/WLG_I)  
+        WLG_I = TPI/WN_I  ! Ice wavelength
+        WSQ = (WLG/WLG_I)
 !
         IF (IS2PARS(16).GT.0.5) THEN
           CGRATIO(:)=CG_I(:)/CG(:)
@@ -800,29 +800,29 @@ ELSE
           CGRATIO(:)=1
           END IF
 !
-!  2. gets reflection coefficient from table 
+!  2. gets reflection coefficient from table
 !
         IND1 = 1+FLOOR((ICEH-THICK1)/DTHICK)
         IND2 = IND1+1
-! defines weight for interpolation of ice thickness 
-        W = (ICEH-THICK1)/DTHICK - (IND1-1) 
-        IF (IND1.LT.1) THEN 
+! defines weight for interpolation of ice thickness
+        W = (ICEH-THICK1)/DTHICK - (IND1-1)
+        IF (IND1.LT.1) THEN
           IND1 = 1
           W = 0
-        ELSE IF (IND2.GT.NTHICK) THEN 
+        ELSE IF (IND2.GT.NTHICK) THEN
           IND2 = NTHICK
-          IND1 = NTHICK 
-          W = 0 
+          IND1 = NTHICK
+          W = 0
           END IF
 !
         DO IK = 1,NK
 !
-! Spatial decay scale taken from table. This corresponds the the values shown 
-! in Dumont et al. (JGR 2011, fig 3). 
+! Spatial decay scale taken from table. This corresponds the the values shown
+! in Dumont et al. (JGR 2011, fig 3).
 !
           CG_EFF(IK) = CICE*CG_I(IK) + (1-CICE)*CG(IK)
 
-! Note by FA: dissipation should be done by ICx not by ISx 
+! Note by FA: dissipation should be done by ICx not by ISx
 ! the RP damping is thus defined by an optional IS2PARS(7), which is 0 by default
           ALPHA = -1.*(  (SIS2ALPHAS(IND1,IK)*(1-W)+SIS2ALPHAS(IND2,IK)*W)/ICEDAVE(IK) &
                         +2.*IS2PARS(7)*WN_RP(IK) )*CICE
@@ -830,15 +830,15 @@ ELSE
 ! Additional scattering for pack ice defined by IS2PARS(4:5)  (see Squire et al. GRL 2009)
 !
           ALPHA = IS2PARS(1) * ALPHA -2.*IS2PARS(4)*EXP(-1.*IS2PARS(5)/SIG(IK))
-          IF (IS2PARS(11).GT.0) THEN 
+          IF (IS2PARS(11).GT.0) THEN
             IF (CICE.LT.0.2) ALPHA = 0.
             IF (CICE.GT.0.8) ALPHA = 0.
             IF (CICE.GE.0.2.AND.CICE.LE.0.8) ALPHA = ALPHA*(CICE-0.2)*(0.8-CICE)
-            END IF 
+            END IF
 !
 ! time decay
 !
-          BETA = ALPHA * CICE * CG_EFF(IK) 
+          BETA = ALPHA * CICE * CG_EFF(IK)
 !
 !  3. attenuation due to scattering for all spectral components
 !     with added backscattering for energy conservation ( if IS2PARS(2).EQ.1)
@@ -849,22 +849,22 @@ ELSE
           DO ITH = 1,NTH
             IS  = ITH+(IK-1)*NTH
             D(IS) = BETA
-            S(IS) = BETA * A(IS) 
-            SUMALLDIR = SUMALLDIR + S(IS) 
+            S(IS) = BETA * A(IS)
+            SUMALLDIR = SUMALLDIR + S(IS)
             SUMA = SUMA + A(IS)
             END DO ! loop over directions
 !
 ! R is the ratio of energy (including bending of ice) to wave energy without ice
-! Wadhams 1973 eq. 34, warning, his ice thickness is 2*h 
-! Warning : R uses DMAX=ICEF, even if IS2DUPDATE=F   
+! Wadhams 1973 eq. 34, warning, his ice thickness is 2*h
+! Warning : R uses DMAX=ICEF, even if IS2DUPDATE=F
 !
           IF (IICESMOOTH) THEN
-            IF (IS2PARS(14)*WLG_I(IK).LT.DMAX) THEN 
-              SMOOTHD=TANH((DMAX-IS2PARS(14)*WLG_I(IK))/(DMAX*IS2PARS(13))) 
+            IF (IS2PARS(14)*WLG_I(IK).LT.DMAX) THEN
+              SMOOTHD=TANH((DMAX-IS2PARS(14)*WLG_I(IK))/(DMAX*IS2PARS(13)))
             ELSE
               SMOOTHD=0.
-              END IF    
-          ELSE 
+              END IF
+          ELSE
             SMOOTHD=1.
             END IF
 !
@@ -873,40 +873,40 @@ ELSE
 ! Converting action to surface elevation variance SUME with units m^2
 !
           SUME = SUMA*DDEN(IK) / CG(IK)  / (R(IK)*CGRATIO(IK))
-! 
-! CURVSPEC is the curvature variance = elevation variance * k^4 
+!
+! CURVSPEC is the curvature variance = elevation variance * k^4
 !
           CURVSPEC (IK) = SUME * (2*PI/ WLG_I(IK))**4
-          ESPEC (IK) = SUME 
+          ESPEC (IK) = SUME
           SUMALLDIR = SUMALLDIR / REAL(NTH)
 !
-! Adds the scattered energy isotropically to conserve the energy 
-! This may not be a very good scheme numerically. Another possible 
-! approach is the matrix inversion used for bottom scattering (w3sbs1md.ftn) 
+! Adds the scattered energy isotropically to conserve the energy
+! This may not be a very good scheme numerically. Another possible
+! approach is the matrix inversion used for bottom scattering (w3sbs1md.ftn)
 !
           S(1+(IK-1)*NTH:IK*NTH)=S(1+(IK-1)*NTH:IK*NTH)-SUMALLDIR*IS2PARS(2)
           END DO ! loop over wavenumbers IK
 !
-!  4. update of floe size 
-!      
+!  4. update of floe size
+!
         IF (IS2PARS(10).LT.0.5) THEN ! resets max floe size to the last forcing or initial value
           DMAX = ICEDMAX
           ICEF = ICEDMAX
           END IF
 !
-        DO IK = 1, NK 
-! CURV is the variance of the curvature integrated over a finite bandwidth 
-          CURV(IK) = SUM(CURVSPEC(MAX(1,IK-NSUM):MIN(NK,IK+NSUM)))  
-! Now converts curvature variance to strain variance 
+        DO IK = 1, NK
+! CURV is the variance of the curvature integrated over a finite bandwidth
+          CURV(IK) = SUM(CURVSPEC(MAX(1,IK-NSUM):MIN(NK,IK+NSUM)))
+! Now converts curvature variance to strain variance
           END DO ! end of loop on IK
 !
 ! If IS2PARS(3)=IS2BREAK is set to true in ww3_grid, then activates ice break-up
 !
         IF (IS2PARS(3).GT.0.5) THEN
           IKBREAK=0
-          DO IK = 1, NK 
-            STRAIN = CURV(IK)*CURVTOSTRAIN                            
-            IF (D_FLEX_FAIL .LT. DMAX) THEN 
+          DO IK = 1, NK
+            STRAIN = CURV(IK)*CURVTOSTRAIN
+            IF (D_FLEX_FAIL .LT. DMAX) THEN
 ! Note that Williams et al. used IS2PARS(17)=SQRT(2), Here our default is 3.6
               WAMP(IK)= IS2PARS(17)*SQRT(STRAIN)
 !
@@ -928,14 +928,14 @@ ELSE
 !
           IF (BRK_CRIT) THEN
             DO IK=MAX(IKBREAK-NSUM,1),IKBREAK,1
-! Modified by F.A. on Jan. 31, 2017: uses the maximum of CURVSPEC instead of CURV. 
-! this is better for very narrow spectra. 
-            IF (CURVSPEC(IK).GE.CURVSPEC(IKBREAK).AND.DMAX.GE.(WLG_I(IK)/2)) THEN 
+! Modified by F.A. on Jan. 31, 2017: uses the maximum of CURVSPEC instead of CURV.
+! this is better for very narrow spectra.
+            IF (CURVSPEC(IK).GE.CURVSPEC(IKBREAK).AND.DMAX.GE.(WLG_I(IK)/2)) THEN
               IKBREAK = IK
               END IF
             END DO
 !
-            DMAX = WLG_I(IKBREAK)/2  
+            DMAX = WLG_I(IKBREAK)/2
 !
 !  Uses  a weighting by CURVSPEC to have a continuous shift of DMAX ..
 !
@@ -946,43 +946,43 @@ ELSE
                     +WLG_I(IKP1)*CURVSPEC(IKP1)+WLG_I(IKM1)*CURVSPEC(IKM1)) &
                     /(2.*(CURVSPEC(IKBREAK)+CURVSPEC(IKM1)+CURVSPEC(IKP1)))
               END IF
-!	
+!
             ICEF = DMAX
             END IF
           END IF  !end of test  (IS2PARS(3).GT.0.5)
 !
-!  5. creep dissipation 
-!      
-        IF (IS2PARS(12).GT.0) THEN
-          DO IK = 1, NK 
-!        
-! The TANH((DMAX-D*WLG_I(IK))/DMAX*C) 
-! is an ad hoc factor that goes to zero for WLG << DMAX and 1 for WLG >> DMAX 
-! this should probably be adjusted... 
+!  5. creep dissipation
 !
-            IF (IS2PARS(14)*WLG_I(IK).LT.DMAX) THEN 
+        IF (IS2PARS(12).GT.0) THEN
+          DO IK = 1, NK
+!
+! The TANH((DMAX-D*WLG_I(IK))/DMAX*C)
+! is an ad hoc factor that goes to zero for WLG << DMAX and 1 for WLG >> DMAX
+! this should probably be adjusted...
+!
+            IF (IS2PARS(14)*WLG_I(IK).LT.DMAX) THEN
               SMOOTHD=TANH((DMAX-IS2PARS(14)*WLG_I(IK))/(DMAX*IS2PARS(13)))
               IF (IS2PARS(23).LE.0.5) THEN
-                DCREEP(1+(IK-1)*NTH:IK*NTH)=CREEPFAC*4*CURV(IK)                & 
+                DCREEP(1+(IK-1)*NTH:IK*NTH)=CREEPFAC*4*CURV(IK)                &
                                             *((2*PI)/WLG_I(IK))**(IS2PARS(15)+1) &
                                             /(CGRATIO(IK)**1*R(IK)**2)           &
                                             *SMOOTHD
               ELSE
                 DCREEP(1+(IK-1)*NTH:IK*NTH) =-4*4/3*SIG(IK)* DELTA_D*ALPHA_D *WN_I(IK)**4 * (YOUNG/MP2)**2         &
                                              * (ICEH/2)**3/3 * 1/( EXP(ALPHA_D*S_D(IK)) + EXP(-ALPHA_D*S_D(IK))) &
-                                             * SMOOTHD /(R(IK)**2*CGRATIO(IK)) / (DWAT*GRAV) *TPIINV 
+                                             * SMOOTHD /(R(IK)**2*CGRATIO(IK)) / (DWAT*GRAV) *TPIINV
               END IF
             END IF
             S=S+DCREEP*CICE*A
             END DO ! end of loop on IK
           ENDIF ! end of test (IS2PARS(12).GT.0)
 !
-!  6. Case of no scattering nor dissipation 
-!      
-      ELSE 
+!  6. Case of no scattering nor dissipation
+!
+      ELSE
         DMAX = 0.
-        ICEF = 0. 
-        END IF   ! end of test  (CICE .GT. 0 .AND. ICEDAVE .GT. 0)  
+        ICEF = 0.
+        END IF   ! end of test  (CICE .GT. 0 .AND. ICEDAVE .GT. 0)
 !
 !/T         DO IK = 1, NK
 !/T           DO ITH = 1, NTH
@@ -1001,8 +1001,8 @@ ELSE
 !/ End of W3SIS2 ----------------------------------------------------- /
 !/
       END SUBROUTINE W3SIS2
-      
-      
+
+
 !/ ------------------------------------------------------------------- /
       SUBROUTINE W3RPWNICE(ICEH,WN_I,DAMPING,CG_I)
 !/
@@ -1013,7 +1013,7 @@ ELSE
 !/                  | Last update :         27-Aug-2015 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Origination.                        ( version 5.10 )      
+!/    27-Aug-2015 : Origination.                        ( version 5.10 )
 !
 !  1. Purpose :
 !
@@ -1060,28 +1060,28 @@ ELSE
       IMPLICIT NONE
 !/
 !/ ------------------------------------------------------------------- /
-!/ Parameter list            
+!/ Parameter list
       REAL, INTENT(IN)        :: ICEH
-      REAL, INTENT(INOUT)  :: WN_I(:), DAMPING(:), CG_I(:) 
+      REAL, INTENT(INOUT)  :: WN_I(:), DAMPING(:), CG_I(:)
 
-!/	
+!/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
       DOUBLE COMPLEX :: WN_ROOT, GS1
       INTEGER :: IK
       REAL :: FLEX_RIGID
-      REAL, PARAMETER :: VISC_RP = 10  
+      REAL, PARAMETER :: VISC_RP = 10
       REAL, PARAMETER :: DENS = 1025.0
       REAL, PARAMETER :: DENS_ICE = 922.5
-      REAL, PARAMETER :: POISSON = 0.3            
-      REAL, PARAMETER :: YOUNG = 5.49E+9       
+      REAL, PARAMETER :: POISSON = 0.3
+      REAL, PARAMETER :: YOUNG = 5.49E+9
 
 
-      FLEX_RIGID =  YOUNG * ICEH**3 /(12 *(1-POISSON**2) )  
+      FLEX_RIGID =  YOUNG * ICEH**3 /(12 *(1-POISSON**2) )
       ! Guess value for roots
-      GS1 = CMPLX(SIG(1)**2/GRAV,0.)      
-        
+      GS1 = CMPLX(SIG(1)**2/GRAV,0.)
+
       DO IK=1,NK
         CALL FINDROOTS_NR(GS1,0.,WN_ROOT,ICEH,SIG(IK))
         WN_I(IK) = REAL(WN_ROOT)
@@ -1092,10 +1092,10 @@ ELSE
               /(2*SIG(IK)*(DENS+DENS_ICE*WN_I(IK)*ICEH))
         END DO
 
-!/      
+!/
       END SUBROUTINE W3RPWNICE
-      
-      
+
+
 !/ ------------------------------------------------------------------- /
 !     SUBROUTINE FINDROOTS_NR(FUNCD,X0,VISC_RP,WN_ROOT)
       SUBROUTINE FINDROOTS_NR(GUESS,VISC_RP,X,ICEH,SIGMA)
@@ -1107,7 +1107,7 @@ ELSE
 !/                  | Last update :         27-Aug-2015 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Origination.                        ( version 5.10 )      
+!/    27-Aug-2015 : Origination.                        ( version 5.10 )
 !
 !  1. Purpose :
 !
@@ -1149,7 +1149,7 @@ ELSE
 !
 !/ ------------------------------------------------------------------- /
       USE W3ODATMD, ONLY: NDSE
-      USE W3SERVMD, ONLY: EXTCDE      
+      USE W3SERVMD, ONLY: EXTCDE
 !/
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
@@ -1158,7 +1158,7 @@ ELSE
 !/ Parameter list
       REAL, INTENT(IN) :: VISC_RP, ICEH, SIGMA
       double COMPLEX, INTENT(IN) :: GUESS
-      double COMPLEX, intent(INOUT) :: X      
+      double COMPLEX, intent(INOUT) :: X
 
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
@@ -1167,37 +1167,37 @@ ELSE
       INTEGER, PARAMETER :: MAXIT = 300
       REAL, PARAMETER :: TOL = 1E-9
       INTEGER :: J
-      LOGICAL ::  UNFINISHED_ROOTS            
-      
+      LOGICAL ::  UNFINISHED_ROOTS
+
       X0 = GUESS
       UNFINISHED_ROOTS = .TRUE.
       J = 1
-      DO WHILE (J .LT. MAXIT .AND. UNFINISHED_ROOTS)                    
+      DO WHILE (J .LT. MAXIT .AND. UNFINISHED_ROOTS)
         FVAL = FUNCD_FVAL(X0,VISC_RP,ICEH,SIGMA)
         FDERIV = FUNCD_FDERIV(X0,VISC_RP,ICEH,SIGMA)
         DX = FVAL/FDERIV
         X = X0-DX
-        X0 = X 
+        X0 = X
         IF (ABS(DX) .GT. TOL .OR. ABS(FVAL) .GT. 1) THEN
           J = J+1
         ELSE
             UNFINISHED_ROOTS = .FALSE.
           END IF
-  
-        IF (J .GT. MAXIT) THEN 
+
+        IF (J .GT. MAXIT) THEN
             WRITE (NDSE,1000)
-            CALL EXTCDE ( 1 ) 
+            CALL EXTCDE ( 1 )
             END IF
-        END DO 
-            
+        END DO
+
 !
-! Formats            
+! Formats
       1000 FORMAT (/' *** ERROR FINDROOTS_NR *** '/                              &
-               '     ROOT NOT CONVERGED'/)      
-      
+               '     ROOT NOT CONVERGED'/)
+
       END SUBROUTINE FINDROOTS_NR
-      
-      
+
+
 !/ ------------------------------------------------------------------- /
       FUNCTION W3FSD_DAVE(ICEDMIN,ICEDMAX,FRAGILITY)
 !/
@@ -1208,10 +1208,10 @@ ELSE
 !/                  | Last update :         6-Nov-2015  |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Origination.                        ( version 5.10 )      
-!/     6-Nov-2015 : Uses a continuous DMAX->DAVE function(version 5.10 )      
+!/    27-Aug-2015 : Origination.                        ( version 5.10 )
+!/     6-Nov-2015 : Uses a continuous DMAX->DAVE function(version 5.10 )
 !
-!  1. Purpose : Computes the mean flow size from the max floe size 
+!  1. Purpose : Computes the mean flow size from the max floe size
 !
 !/ ------------------------------------------------------------------- /
 !
@@ -1254,18 +1254,18 @@ ELSE
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /      
+!/ ------------------------------------------------------------------- /
 !
-      IMPLICIT NONE 
+      IMPLICIT NONE
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
       REAL, INTENT(IN) :: ICEDMIN, ICEDMAX, FRAGILITY
       REAL             :: W3FSD_DAVE,  W3FSD_DAVE2
-            
+
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/   
+!/
 !
 ! analytic solution, if the FSD is given by P(x) = x^(-1-gam) for icedmin <= x <= icedmax and 0 elsewhere
 !
@@ -1299,7 +1299,7 @@ ELSE
 !/                  | Last update :         27-Aug-2015 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Origination.                        ( version 5.10 )      
+!/    27-Aug-2015 : Origination.                        ( version 5.10 )
 !
 !  1. Purpose :
 !
@@ -1339,46 +1339,46 @@ ELSE
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /    
-      USE CONSTANTS, ONLY: GRAV      
-    
+!/ ------------------------------------------------------------------- /
+      USE CONSTANTS, ONLY: GRAV
+
       IMPLICIT NONE
-    
+
       REAL, INTENT(IN) :: VISC_RP, ICEH, SIGMA
       DOUBLE COMPLEX, INTENT(IN) :: WN_GUESS
-        
+
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/      
+!/
       REAL :: ALP, FLEX_RIGID, GAMMA, C5, DRAFT, DENS_GRAV
       double complex :: C1, FVAL
-      
+
       REAL, PARAMETER :: DENS = 1025.0
       REAL, PARAMETER :: DENS_ICE = 922.5
-      REAL, PARAMETER :: POISSON = 0.3            
-      ! Effective modulus or strain modulus [Pa], YOUNG 
-      REAL, PARAMETER :: YOUNG = 5.49E+9 
+      REAL, PARAMETER :: POISSON = 0.3
+      ! Effective modulus or strain modulus [Pa], YOUNG
+      REAL, PARAMETER :: YOUNG = 5.49E+9
 
 !/
 !/ ------------------------------------------------------------------- /
 
       ! Length below which flexural felure cannot occur, flexural rigidity
-      FLEX_RIGID =  YOUNG * ICEH**3 /(12 *(1-POISSON**2) )   
+      FLEX_RIGID =  YOUNG * ICEH**3 /(12 *(1-POISSON**2) )
       DRAFT = (DENS_ICE/DENS)*ICEH
       DENS_GRAV = DENS*GRAV
-      
+
       ALP = SIGMA**2/GRAV
-      ! Artificial viscosity (Robinson & Palmer, 1990) 
+      ! Artificial viscosity (Robinson & Palmer, 1990)
       GAMMA = SIGMA * VISC_RP/DENS_GRAV
       C1 = CMPLX(1 - ALP*DRAFT, - 1.*GAMMA)
       C5 = FLEX_RIGID/DENS_GRAV
-      
+
       FVAL = C5*WN_GUESS**5 + C1*WN_GUESS - ALP
-    
+
       END FUNCTION FUNCD_FVAL
-      
-      
+
+
 !/ ------------------------------------------------------------------- /
 !     FUNCTION FUNCD(WN_GUESS, VISC_RP,ICEH)
       FUNCTION FUNCD_FDERIV(WN_GUESS, VISC_RP,ICEH,SIGMA)  RESULT(FDERIV)
@@ -1390,7 +1390,7 @@ ELSE
 !/                  | Last update :         27-Aug-2015 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Origination.                        ( version 5.10 )      
+!/    27-Aug-2015 : Origination.                        ( version 5.10 )
 !
 !  1. Purpose :
 !
@@ -1430,46 +1430,46 @@ ELSE
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /    
-      USE CONSTANTS, ONLY: GRAV      
-    
+!/ ------------------------------------------------------------------- /
+      USE CONSTANTS, ONLY: GRAV
+
       IMPLICIT NONE
-    
+
       REAL, INTENT(IN) :: VISC_RP, ICEH, SIGMA
       DOUBLE COMPLEX, INTENT(IN) :: WN_GUESS
-        
+
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
-!/      
+!/
       REAL :: ALP, FLEX_RIGID, GAMMA, C5, DRAFT, DENS_GRAV
       double complex :: C1, FDERIV
-      
+
       REAL, PARAMETER :: DENS = 1025.0
       REAL, PARAMETER :: DENS_ICE = 922.5
-      REAL, PARAMETER :: POISSON = 0.3            
-      REAL, PARAMETER :: YOUNG = 5.49E+9 
+      REAL, PARAMETER :: POISSON = 0.3
+      REAL, PARAMETER :: YOUNG = 5.49E+9
 
 !/
 !/ ------------------------------------------------------------------- /
 !
 ! Length below which flexural felure cannot occur, flexural rigidity
 !
-      FLEX_RIGID =  YOUNG * ICEH**3 /(12 * (1-POISSON**2))    
+      FLEX_RIGID =  YOUNG * ICEH**3 /(12 * (1-POISSON**2))
       DRAFT = (DENS_ICE/DENS)*ICEH
       DENS_GRAV = DENS*GRAV
-      
-      ALP = SIGMA**2/GRAV     
-!      
-! Artificial viscosity (Robinson & Palmer, 1990) 
+
+      ALP = SIGMA**2/GRAV
+!
+! Artificial viscosity (Robinson & Palmer, 1990)
 !
       GAMMA = SIGMA * VISC_RP/DENS_GRAV
       C1 = CMPLX(1 - ALP*DRAFT, -1.*GAMMA)
       C5 = FLEX_RIGID/DENS_GRAV
-!      
-      FDERIV = 5*C5*WN_GUESS**4 +C1  
 !
-      END FUNCTION FUNCD_FDERIV      
+      FDERIV = 5*C5*WN_GUESS**4 +C1
+!
+      END FUNCTION FUNCD_FDERIV
 !/
 !/ End of module W3SIS1MD -------------------------------------------- /
 !/

--- a/model/ftn/w3sln1md.ftn
+++ b/model/ftn/w3sln1md.ftn
@@ -14,7 +14,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -79,7 +79,7 @@
 !       Sln  = SLNC1 * k   * max | 0., | U* cos(Dtheta) | |        (1)
 !                                \     \                / /
 !
-!                             2     -2 
+!                             2     -2
 !              SLNC1 = 80 RHOr  GRAV   FILT                        (2)
 !
 !     Where :

--- a/model/ftn/w3slnxmd.ftn
+++ b/model/ftn/w3slnxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3smcomd.ftn
+++ b/model/ftn/w3smcomd.ftn
@@ -19,18 +19,18 @@
 !/                  user selected areas.
 !/                  (A. Saulter, UK Met Office)
 !/    18-Apr-2018 : Added Type 3 and 4 SMC output:      ( version 4.18 )
-!/                  re-gridding to an arbitrary regular 
+!/                  re-gridding to an arbitrary regular
 !/                  grid using pre-calculated indices and
 !/                  weights (see WW3_SMCINT). Chris Bunney, UKMO
 !/    20-Jun-2018   Updated routines to ensure that     ( version 4.18 )
-!/                  directional fields are converted to 
+!/                  directional fields are converted to
 !/                  degrees (nautical convention) on output.
 !/                  (Chris Bunney, UK Met Office)
-!/    27-Jun-2018   Ported to V6 (Chris Bunney)         ( version 6.05) 
+!/    27-Jun-2018   Ported to V6 (Chris Bunney)         ( version 6.05)
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -46,7 +46,7 @@
 !
 !       2 - Regular, uniformly gridded output to a specified output grid.
 !           This is achieved by area averaging of the SMC cells. The output
-!           grid will be aligned with the SMC grid cell edges which may 
+!           grid will be aligned with the SMC grid cell edges which may
 !           result in the actual output grid being slightly different to
 !           the original user request. A land/sea mask is created by
 !           keeping track of the cell coverage and setting cells with
@@ -66,7 +66,7 @@
       USE W3GDATMD
       USE CONSTANTS
       USE W3ODATMD, ONLY: UNDEF
-        
+
       PUBLIC
 
       ! Output grid definition
@@ -83,7 +83,7 @@
       INTEGER, ALLOCATABLE    :: MAPSMC(:,:)             ! Regridded MAPSTA
       LOGICAL, ALLOCATABLE    :: SMCMASK(:)              ! Mask for type 1 output (flat array)
       INTEGER, ALLOCATABLE    :: SMCIDX(:)               ! Indices of SMC cells witin output grid domain
-      
+
       INTEGER, ALLOCATABLE    :: smccx(:), smccy(:)      ! Cell size factors
       REAL                    :: dlat, dlon              ! Base lat/lon sizes
       INTEGER                 :: cfac                    ! SMC scaling factor
@@ -114,9 +114,9 @@
       !           uniformly spaced lat/lon grid.
       !
       ! Chris Bunney, UK Met Office. 22-Oct-2015
-      
+
       IMPLICIT NONE
-      
+
       ! Locals
       REAL    :: CX0, CY0   ! SW corner of origin of grid
       REAL    :: S0CHK
@@ -153,7 +153,7 @@
       ENDIF
       IF(ABS(SYO + 999.9) .LT. 1E-4) THEN
           SYO = CY0
-      ELSE 
+      ELSE
           S0CHK = CY0 + FLOOR((SYO - CY0) / SY) * SY
           ! Ensure first grid value falls within specified range
           ! NB the step is made at coarsest cell resolution
@@ -294,7 +294,7 @@
       SYO = SYO + 0.5 * DYO
 
       END SUBROUTINE SMC_INTERP
-      
+
 !--------------------------------------------------------------------------
 
 !--------------------------------------------------------------------------
@@ -302,7 +302,7 @@
       ! Regrid SMC data onto a regular grid using pre-calculated grid
       ! indices and weights.
       ! Chris Bunney, 02-Jul-2013
- 
+
       IMPLICIT NONE
 
       ! Input parameters:
@@ -331,14 +331,14 @@
                IF(IX .GT. NXO .OR. IY .GT. NYO) CYCLE
 
                ! Interpolate:
-               XY(IX, IY) = XY(IX, IY) + S(ISEA) * WTS(ISEA) 
- 
+               XY(IX, IY) = XY(IX, IY) + S(ISEA) * WTS(ISEA)
+
                ! Keep track of how much of cell is (wet) covered:
                COV(IX, IY) = COV(IX, IY) + WTS(ISEA)
             ENDDO
          ENDDO
 
-      ENDDO 
+      ENDDO
 
       ! Create coastline by masking out areas with < 50% coverage:
       DO IX=1,NXO
@@ -348,7 +348,7 @@
                XY(IX,IY) = UNDEF
             ELSE IF(COV(IX,IY) .LT. 0.5) THEN
                ! More than half of cell has UNDEF values - set to NOVAL:
-               XY(IX,IY) = NOVAL 
+               XY(IX,IY) = NOVAL
             ELSE IF(COV(IX,IY) .LT. 1.0) THEN
                ! If coverage < 1.0, scale values back to full cell coverage.
                ! Without this step, points around coast could end up with lower
@@ -371,7 +371,7 @@
       ! area averaging of directional data.
 
       ! Chris Bunney, 02-Jul-2013
- 
+
       IMPLICIT NONE
 
       ! Input parameters:
@@ -407,16 +407,16 @@
                IF(IX .GT. NXO .OR. IY .GT. NYO) CYCLE
 
                ! Interpolate:
-               !XY(IX, IY) = XY(IX, IY) + S(ISEA) * WTS(ISEA) 
-               AUX1(IX, IY) = AUX1(IX, IY) + COSS * WTS(ISEA) 
-               AUX2(IX, IY) = AUX2(IX, IY) + SINS * WTS(ISEA) 
- 
+               !XY(IX, IY) = XY(IX, IY) + S(ISEA) * WTS(ISEA)
+               AUX1(IX, IY) = AUX1(IX, IY) + COSS * WTS(ISEA)
+               AUX2(IX, IY) = AUX2(IX, IY) + SINS * WTS(ISEA)
+
                ! Keep track of how much of cell is (wet) covered:
                COV(IX, IY) = COV(IX, IY) + WTS(ISEA)
             ENDDO
          ENDDO
 
-      ENDDO 
+      ENDDO
 
       ! Create coastline by masking out areas with < 50% coverage:
       DO IX=1,NXO
@@ -483,7 +483,7 @@
             ENDDO
          ENDDO
 
-      ENDDO 
+      ENDDO
 
       ! Create coastline by masking out areas with < 50% coverage:
       DO IX=1,NXO
@@ -511,7 +511,7 @@
 
       ! Locals
       INTEGER :: IERR, I, J
-      REAL :: PLATO, PLONO ! Not used yet....future version might allow 
+      REAL :: PLATO, PLONO ! Not used yet....future version might allow
                            ! output to a rotated pole grid...
 
       NDSMC = 50
@@ -536,7 +536,7 @@
 !--------------------------------------------------------------------------
       SUBROUTINE CALC_INTERP()
 !     Calculates the interpolation indices and weights for regirdding
-!     and SMC grid to an arbitrary regular grid. Index is that of 
+!     and SMC grid to an arbitrary regular grid. Index is that of
 !     SMC cell that contains output cell centre. Weights are the distance
 !     in metres between the output and SMC cell centres.
 !     A future version ~may~ allow for output grids to be on a rotated pole.
@@ -578,8 +578,8 @@
 !/RTD          tmplat = olat
 !/RTD          tmplon = olon
 !/RTD          PRINT*,'Rotating coordinates'
-!/RTD          CALL W3LLTOEQ ( tmplat, tmplon, olat, olon,     &              
-!/RTD                            ang, POLAT, POLON, NXO*NYO )             
+!/RTD          CALL W3LLTOEQ ( tmplat, tmplon, olat, olon,     &
+!/RTD                            ang, POLAT, POLON, NXO*NYO )
 !/RTD          PRINT*,'Rotating coordinates complete'
 
       ! Cycle over output grid points and find containing SMC cell:
@@ -616,7 +616,7 @@
 !     Directional fields (DIRN=True) will be assumed to be in radians
 !     and will be converted to degrees in nautical convention.
 !--------------------------------------------------------------------------
-      IMPLICIT NONE 
+      IMPLICIT NONE
 
       ! Input parameters:
       REAL, INTENT(IN)    :: S(:)        ! Inupt array
@@ -629,7 +629,7 @@
         DO IY = 1,NYO
            ISEA = NNIDX(IX,IY) ! Nearest neighbour SMC point
            IF(ISEA .EQ. -1) THEN
-              ! Land 
+              ! Land
               XY(IX,IY) = UNDEF
            ELSE
               IF(S(ISEA) .EQ. UNDEF) THEN
@@ -657,7 +657,7 @@
 !     and will be converted to degrees in nautical convention.
 !--------------------------------------------------------------------------
       USE W3PSMCMD, ONLY: SMCGradn
-      IMPLICIT NONE 
+      IMPLICIT NONE
 
       ! Input parameters:
       REAL, INTENT(IN)    :: S(:)        ! Input array

--- a/model/ftn/w3snl1md.ftn
+++ b/model/ftn/w3snl1md.ftn
@@ -17,7 +17,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3snl2md.ftn
+++ b/model/ftn/w3snl2md.ftn
@@ -20,7 +20,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -48,7 +48,7 @@
 !       !/S   Enable subroutine tracing.
 !       !/T   Enable general test output.
 !       !/T0  2-D print plot of source term.
-!       !/T1  Print arrays. 
+!       !/T1  Print arrays.
 !
 !  7. Source code :
 !/
@@ -134,7 +134,7 @@
 !       !/S   Enable subroutine tracing.
 !       !/T   Enable general test output.
 !       !/T0  2-D print plot of source term.
-!       !/T1  Print arrays. 
+!       !/T1  Print arrays.
 !
 ! 10. Source code :
 !
@@ -333,12 +333,12 @@
 !
   800 CONTINUE
       IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,1000) IERR
-      CALL EXTCDE ( 1 ) 
+      CALL EXTCDE ( 1 )
 !
 !     Format statements
 !
  1000 FORMAT (/' *** WAVEWATCH III ERROR IN INSNL2 :'/                &
-               '     xnl_init RETURN CODE NON ZERO : ',I8/) 
+               '     xnl_init RETURN CODE NON ZERO : ',I8/)
 !
 !/T 9000 FORMAT (' TEST INSNL2 : NLTAIL :',F6.1/                      &
 !/T              '               XGRAV  :',F8.3/                      &

--- a/model/ftn/w3snl3md.ftn
+++ b/model/ftn/w3snl3md.ftn
@@ -20,7 +20,7 @@
 !/
 !/    Copyright 2008-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !
@@ -39,7 +39,7 @@
 !      KDMAX     R.P.  Private  Maximum relative depth in table.
 !      LAMMAX    R.P.  Public   Maximum value for lambda or mu.
 !      DELTHM    R.P.  Public   Maximum angle gap (degree).
-!      SITMIN    Real  Private  Minimum nondimensional radian 
+!      SITMIN    Real  Private  Minimum nondimensional radian
 !                               frequency in table.
 !      XSIT      Real  Private  Corresponding increment factor.
 !     ----------------------------------------------------------------
@@ -74,13 +74,13 @@
 !     - Filtering techniques for computation of quadruplet spectral
 !       values and distribution in spectral space have been tested
 !       but were not found worth the large coding effort involved.
-!     - WAVNU1 is used in W3SNL3  for consistency with spectral grid 
+!     - WAVNU1 is used in W3SNL3  for consistency with spectral grid
 !       description.
 !     - WAVNU2 is used in INSNL3  for accuracy in the computation of
 !       the layout of the quadruplets (higher computational cost is
 !       not an issue with initialization routine).
-!     - For large lambda or mu the original maximum kd = 10. still 
-!       leads to significantly different quadruplet layout in 
+!     - For large lambda or mu the original maximum kd = 10. still
+!       leads to significantly different quadruplet layout in
 !       secion 3. To remedy this, the orriginal settings of the
 !       lookup tables
 !
@@ -92,8 +92,8 @@
 !     INTEGER, PRIVATE, PARAMETER :: NKD = 275
 !     REAL, PRIVATE, PARAMETER    :: KDMIN = 0.025 ,  KDMAX = 20.
 !
-!       for the bug fix of 03-Jan-2009. Note that with this, the 
-!       estimate of NTHMAX in INSNL3 also is needed to guarantee 
+!       for the bug fix of 03-Jan-2009. Note that with this, the
+!       estimate of NTHMAX in INSNL3 also is needed to guarantee
 !       consistent NTHMAX and NTHM2 for any lambda and mu.
 !
 !  6. Switches :
@@ -140,12 +140,12 @@
 !     Paramterization (DIA) with multiple representative quadruplets
 !     (MDIA) for arbitrary water depths.
 !
-!     The outer loop of the code is over quadruplet realizations, 
+!     The outer loop of the code is over quadruplet realizations,
 !     which implies two realizations for a conventional quadruplet
-!     definitions and four for extended definitions (with rescaling 
+!     definitions and four for extended definitions (with rescaling
 !     of the contants for consistency). Within this loop the compu-
 !     tations are performed in two stages. First, interactions
-!     contributions are computed for the entire spectral space, 
+!     contributions are computed for the entire spectral space,
 !     second all contributions are combined into the actual inter-
 !     actions and diagonal contributions.
 !
@@ -173,14 +173,14 @@
 !       D       R.A.  O   Diagonal term of derivative.
 !     ----------------------------------------------------------------
 !
-!     Variables describing the expanded frequency space from the 
+!     Variables describing the expanded frequency space from the
 !     dynamic storage in w3gdatmd.
 !
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
 !      NFR       Int.  Public   Number of frequencies or wavenumbers
 !                               in discrete spectral space (NFR=>NK).
-!      NFRMIN    Int.  Public   Minimum discrete frequency in the 
+!      NFRMIN    Int.  Public   Minimum discrete frequency in the
 !                               expanded frequency space.
 !      NFRMAX    Int.  Public   Idem maximum for first part.
 !      NFRCUT    Int.  Public   Idem maximum for second part.
@@ -202,7 +202,7 @@
 !      QST2      R.A.  Public   Idem weights.
 !      QST3      R.A.  Public   Norm. factors in product term and
 !                               in diagonal strength.
-!      QST4      I.A.  Public   Spectral offsets for combining of 
+!      QST4      I.A.  Public   Spectral offsets for combining of
 !                               interactions and diagonal.
 !      QST5      R.A.  Public   Idem weights for interactions.
 !      QST6      R.A.  Public   Idem weights for diagonal.
@@ -245,8 +245,8 @@
 !     - Normalization with respect to the number of quadruplets is
 !       included in the proportionality constant.
 !     - Note that the outer loop in the routine considers one actual
-!       quadruplet realization per loop cycle. For the traditional 
-!       quadruplet layout two realizations occure, for the expanded 
+!       quadruplet realization per loop cycle. For the traditional
+!       quadruplet layout two realizations occure, for the expanded
 !       four realizations occur. For consistency, strength of a
 !       traditional layout is therefore doubled.
 !     - 1D representation is used of 2D spectral space for optimization
@@ -454,12 +454,12 @@
             DSB(ISP) = FPROP * ( AUX1 - AUX2 )
 !
             AUX1   = FQ3 + FQ4
-            AUX2   = FQ3 * FQ4     
+            AUX2   = FQ3 * FQ4
             DD1(ISP) = FPROP * FACT(1) * ( FQ2 * AUX1 - AUX2 )
             DD2(ISP) = FPROP * FACT(2) * ( FQ1 * AUX1 - AUX2 )
 !
             AUX1   = FQ1 + FQ2
-            AUX2   = FQ1 * FQ2     
+            AUX2   = FQ1 * FQ2
             DD3(ISP) = FPROP * FACT(3) * ( AUX2 - FQ4*AUX1 )
             DD4(ISP) = FPROP * FACT(4) * ( AUX2 - FQ3*AUX1 )
 !
@@ -517,7 +517,7 @@
                                     + DSB(ISPX+LQST4(13)) * LQST5(13) &
                                     + DSB(ISPX+LQST4(14)) * LQST5(14) &
                                     + DSB(ISPX+LQST4(15)) * LQST5(15) &
-                                    + DSB(ISPX+LQST4(16)) * LQST5(16) 
+                                    + DSB(ISPX+LQST4(16)) * LQST5(16)
 !
             D(ITH,IFR) = D(ITH,IFR) + DD1(ISPX+LQST4( 1)) * LQST6( 1) &
                                     + DD1(ISPX+LQST4( 2)) * LQST6( 2) &
@@ -703,7 +703,7 @@
 !
 !  2. Method :
 !
-!     Fill storage aryays as described in the main subroutine with 
+!     Fill storage aryays as described in the main subroutine with
 !     interpolation, model and distribution data.
 !
 !  3. Parameters :
@@ -746,7 +746,7 @@
 !       IGRID and resetting pointer of aliaases.
 !     - In the 03-Jan-2009 bug fix !/T3 error output was fixed, and
 !       NTHMAX is increased by 1 to assure that NTHMX2 .LE. NTHMAX
-!       for any lambda and mu. With this, the label 810 test is 
+!       for any lambda and mu. With this, the label 810 test is
 !       changed from equality testing to .LE. testing.
 !
 !  8. Structure :
@@ -915,7 +915,7 @@
 !/T1          WRITE (NDST,9022) DELTH(:) * RADE
 !
 ! 2.d Frequency indices
-! 
+!
           DO J=1, 4
             JFR (J) = INT( LOG(AUXFR(J)) / XFRLN )
             JFR1(J) = JFR(J) + 1 * SIGN(1.,AUXFR(J)-1.)
@@ -1036,7 +1036,7 @@
         END DO
       FRQ    = XSI * TPIINV
 !
-! 2.h Final storage 
+! 2.h Final storage
 !
       ALLOCATE ( MPARS(IGRID)%SNLPS%QST1(16,NQA,NKD),                 &
                  MPARS(IGRID)%SNLPS%QST3(6,NQA,NKD),                  &
@@ -1143,7 +1143,7 @@
 !
 ! 3.d Loop over quadruplet components
 !
-          DO JIQ=1, 4  
+          DO JIQ=1, 4
 !
             IF ( JIQ .LE. 2 ) THEN
                 WF     = -1.
@@ -1153,7 +1153,7 @@
 !
 ! 3.e Loop over frequency offsets, get directional offsets
 !
-            DO JOF=1, 2  
+            DO JOF=1, 2
 !
               IF ( JOF .EQ. 1 ) THEN
                   IFR    = -JFR(JIQ)
@@ -1286,7 +1286,7 @@
 !
         END DO
 !
-! 3.g Finalize storage 
+! 3.g Finalize storage
 !
       QST4 = AST1*NTHEXP + AST2
 !
@@ -1367,7 +1367,7 @@
 !/T3 9038 FORMAT (23X,3I4,3F8.3)
 !/
 !/ Embedded subroutines
-!/ 
+!/
       CONTAINS
 !/ ------------------------------------------------------------------- /
       REAL FUNCTION MINLAM ( MU, THETA )
@@ -1382,40 +1382,40 @@
 !/    28-Jan-2009 : Origination.
 !/
 !  1. Purpose :
-!  
+!
 !     Calculate minimum allowed lambda for quadruplet configuration.
-!     
+!
 !  3. Parameters :
-!  
+!
 !     Parameter list
 !     ----------------------------------------------------------------
 !       MU, THETA  Real   Quadruplet parameters, theta in degree.
 !     ----------------------------------------------------------------
-!     
+!
 ! 10. Source code :
-! 
+!
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
 !/
 !/ Parameter list
-!/ 
+!/
       REAL, INTENT(IN)        :: MU, THETA
 !/
 !/ Local parameters
-!/ 
+!/
       REAL                    :: MULOC, THETAR, BB, AUX
 !/
 !/ ------------------------------------------------------------------- /
-!/ 
+!/
       IF ( THETA .LT. 0. ) THEN
-          MINLAM = 0. 
+          MINLAM = 0.
         ELSE
           MULOC  = MAX ( 0. , MIN ( 1., MU ) )
           THETAR = THETA * ATAN(1.) / 45.
           BB     = (1.+MULOC)**4 + (1.-MULOC)**4 +                    &
                       2. * (1.+MULOC)**2 * (1.-MULOC)**2 * COS(THETAR)
           BB     = SQRT ( MAX ( BB , 0. ) )
-          AUX    = MAX ( 0. , 0.5*BB-1. ) 
+          AUX    = MAX ( 0. , 0.5*BB-1. )
           MINLAM = SQRT ( AUX )
         END IF
 !

--- a/model/ftn/w3snl4md.ftn
+++ b/model/ftn/w3snl4md.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !!
@@ -323,7 +323,7 @@
       character            :: grdfname*80
       integer              :: io_unit
 !!
-!!     
+!!
 !!    Dimension wv# array and
 !!    declare local var. dep2, cvel & cgnrng at nrng & depth 'nd'
       real                 :: wka2(nrng)  !* wv# array at depth nd (local)
@@ -585,7 +585,7 @@
 !!    nang      int.  Public    O   # of angles
 !!    npts      int.  Public    I   # of points on the locus
 !!    ndep      int.  Public    I   # of depths in look-up tables
-!!    nzz       int.  Public    O   linear irngxkrng = (NK*(NK+1))/2  
+!!    nzz       int.  Public    O   linear irngxkrng = (NK*(NK+1))/2
 !!    kzone     int.  Public    O   zone of influence = INT(alog(4.0)/alog(dfrq))
 !!    nb2fp     int.  Public    O   # of bins over fp => dfrq**nb2fp)*fp ~ 2.*fp
 !!                                                    = INT(alog(2.0)/alog(dfrq))
@@ -619,7 +619,7 @@
 !!    grad_tbl  R.A.  Public    I   Coupling and gradient term in integral
 !!                                  grad = C * H * g**2 * ds / |dW/dn|
 !!    ------------------------------------------------------------------
-!!    
+!!
 !!    *** The 11 grid integration geometry arrays at one given depth
 !!    *** from gridsetr.            dim=(npts,nang,nzz,ndep)
 !!    kref2     I.A.  Public    O   Index of reference wavenumber for k2
@@ -652,7 +652,7 @@
 !!    tsa       R.A.  Public    O   Snl-tsa = sumint + sumintsa
 !!    diag      R.A.  Public    O   Snl-tsa diagonal term = [dN/dn1]
 !!    ------------------------------------------------------------------
-!!    
+!!
 !!    for -fbi; The 2 returned arrays fbi & diag2 dim=(nrng,nang)
 !!    fbi       R.A.  Public    O   Snl-fbi = sumint + sumintp  + sumintx
 !!    diag2     R.A.  Public    O   Snl-fbi diagonal term = [dN/dn1]
@@ -729,7 +729,7 @@
 !!    -----------------------------
 !/S      INTEGER, SAVE           :: IENT = 0
       integer              :: irng, iang
-      integer              :: nd3         !* bin # corresp. to ww3 dep  
+      integer              :: nd3         !* bin # corresp. to ww3 dep
       real                 :: dep         !* depth (m), get it from WW3 DEPTH
       real                 :: wka(NK)     !* from WW3 WN(1:NK) corresp. to "DEPTH"
       real                 :: cga(NK)     !* from WW3 CG(1:NK) corresp. to "DEPTH"
@@ -1151,7 +1151,7 @@
 !!    have found the 1st good peak (= overall peak) with e1max > eps
 !!
 !!    Now we look for a new 2nd peak that is at least 'nsep' bins away from
-!!    the 1st peak (nsep=2) (i.e. iabs(irng-npk).gt.nsep) before 
+!!    the 1st peak (nsep=2) (i.e. iabs(irng-npk).gt.nsep) before
 !!    calling new "optsa2" (the 2nd peak will have e1max2 < e1max)
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       nsep   = 2
@@ -1423,9 +1423,9 @@
 !!
 !! 2. Method :
 !!
-!! 3. Parameters : 
+!! 3. Parameters :
 !!
-!!    Parameter list 
+!!    Parameter list
 !!    ------------------------------------------------------------------
 !!    Name     Type   Scope    I/O  Description
 !!    ------------------------------------------------------------------
@@ -1478,30 +1478,30 @@
 !!     cplshr    Subr. W3SERVMD Calculates Boltzmann coupling coefficient
 !!                              in shallow water
 !!    ------------------------------------------------------------------
-!! 
-!! 5. Called by : 
-!! 
-!!     Name      Type  Module   Description 
+!!
+!! 5. Called by :
+!!
+!!     Name      Type  Module   Description
 !!    ------------------------------------------------------------------
 !!     insnl4    Subr. W3SNL4MD initialize the grid geometry
 !!    ------------------------------------------------------------------
-!! 
-!! 6. Error messages : 
-!! 
-!!      None. 
-!! 
-!! 7. Remarks : 
-!! 
-!! 8. Structure : 
-!! 
-!!    See source code. 
-!! 
-!! 9. Switches : 
-!! 
-!!    !/S  Enable subroutine tracing. 
-!! 
-!!10. Source code : 
-!! 
+!!
+!! 6. Error messages :
+!!
+!!      None.
+!!
+!! 7. Remarks :
+!!
+!! 8. Structure :
+!!
+!!    See source code.
+!!
+!! 9. Switches :
+!!
+!!    !/S  Enable subroutine tracing.
+!!
+!!10. Source code :
+!!
 !!    --------------------------------------------------------------- &
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!    ----------------------------------------------------------------72
@@ -2164,7 +2164,7 @@
 !!    wk2y      R.A.  Public    O   y_cmp of vector k2 solution on the locus
 !!    wk4x      R.A.  Public    O   x_cmp of vector k4 solution on the locus
 !!    wk4y      R.A.  Public    O   y_cmp of vector k4 solution on the locus
-!!    ds        R.A.  Public    O   element length along the locus 
+!!    ds        R.A.  Public    O   element length along the locus
 !!                                  (npts*ds circles the whole locus)
 !!    ----------------------------------------------------------------
 !!
@@ -2208,7 +2208,7 @@
 !!
 !!
       IMPLICIT NONE
-!!    
+!!
 !!    Parameter list
 !!    --------------
       real,    intent(in)  :: dep
@@ -2216,7 +2216,7 @@
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!    ------------------------------------------------------------------
 !!
-!!    
+!!
 !!    Local Parameters & variables
 !!    -----------------------------
       integer              :: n, np, nnp, nplace
@@ -2418,7 +2418,7 @@
 !!    search in the 10's place out to some reasonably big number to    !
 !!    try to find the place where [12] crosses the rnew = rold line    !
 !!    (if this fails, we set an error flag); in refining the estimate, !
-!!    it appears that [12] can get a little squirrely, so we do a      ! 
+!!    it appears that [12] can get a little squirrely, so we do a      !
 !!    brute force successive decimation search to nplace decimal places!
 !!    to home in on the answer; note that if p is big enough for the   !
 !!    tanh()'s to reach unity, [12] becomes exact and                  !
@@ -2479,7 +2479,7 @@
 !!    -----------------------------------------------------------------#
 !!                                                                     !
 !!    search for cos(dth) for off-p-vector solutions; use a circle     !
-!!    centered on the p-vector axis at a distance                      ! 
+!!    centered on the p-vector axis at a distance                      !
 !!    rcenter = 0.5*(rmax+rmin)  from the  origin with a               !
 !!    radius  = 0.5*(rmax-rmin); radii from the center of the circle   !
 !!    at successive angle increments np*dphi intersect the circle at   !
@@ -2575,7 +2575,7 @@
 !!
       if ( ierr_gr .ne. 0 ) then
         write ( ndse,1000 ) ierr_gr
-        CALL EXTCDE ( 60 ) 
+        CALL EXTCDE ( 60 )
       endif
 !!    ------------------------------------------------------------------
 !!
@@ -2737,7 +2737,7 @@
 !!
 !!eps Bash; added +eps to avoid dividing by 0.0. Dividing by 0.0 causes NaN
 !eps  double precision     :: eps
-!!    
+!!
 !!    Bash; Added domsq23 = denominator of  t1      in cplshr
 !!          and   sumom   = denominator of  csqhatd in cplshr
       double precision     :: domsq23, sumom
@@ -3047,36 +3047,36 @@
 !!    dens2     R.A.  Public    O   Small-scale Action Density (k,theta)
 !!                                                     dim=(nrng,nang)
 !!    ------------------------------------------------------------------
-!! 
+!!
 !! 4. Subroutines used :
-!!     
+!!
 !!     Name      Type  Module   Description
 !!    ------------------------------------------------------------------
 !!    ------------------------------------------------------------------
-!! 
+!!
 !! 5. Called by :
-!!     
+!!
 !!     Name      Type  Module   Description
 !!    ------------------------------------------------------------------
 !!     gridsetr  Subr. W3SNL4MD Setup geometric integration grid
 !!    ------------------------------------------------------------------
-!! 
+!!
 !! 6. Error messages :
-!!      
+!!
 !!      None.
-!! 
+!!
 !! 7. Remarks :
-!! 
+!!
 !! 8. Structure :
-!!    
+!!
 !!    See source code.
-!! 
+!!
 !! 9. Switches :
-!!    
+!!
 !!    !/S  Enable subroutine tracing.
 !!
 !!10. Source code :
-!!    
+!!
 !!    --------------------------------------------------------------- &
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!    ----------------------------------------------------------------72
@@ -3313,7 +3313,7 @@
       maxang       = MAXLOC(ef2maxrow,1)
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!
-!!    Shift the row so that the max is at location of 90 degress 
+!!    Shift the row so that the max is at location of 90 degress
 !!          Negative shift is to the right, Postive to the left
 !!          halfangl - lower angular limit of the half maximum
 !!          halfangu - upper angular limit of the half maximum
@@ -3606,9 +3606,9 @@
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!    ------------------------------------------------------------------
 !!
-!!    
+!!
 !!    Local Parameters & variables
-!!    ----------------------------- 
+!!    -----------------------------
 !!    for both -tsa and -fbi
       integer              :: irng,krng, iang,kang
       integer              :: ipt, iizz, izz
@@ -4221,9 +4221,9 @@
 !!    -- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 !!    ------------------------------------------------------------------
 !!
-!!    
+!!
 !!    Local Parameters & variables
-!!    ----------------------------- 
+!!    -----------------------------
 !!    for both -tsa and -fbi
       integer              :: irng,krng, iang,kang
       integer              :: ipt, iizz, izz
@@ -4701,15 +4701,15 @@
 !!    after alternating the irng, iang, krng & kang loops in snlr's
 !!
 !! 2. Method :
-!! 
+!!
 !! 3. Parameters :
-!!    
+!!
 !!    Parameter list
 !!    ------------------------------------------------------------------
 !!    Name     Type   Scope    I/O  Description
 !!    ------------------------------------------------------------------
 !!    nrng      int.  Public    I   # of freq. or rings
-!!    nang      int.  Public    I   # of angles 
+!!    nang      int.  Public    I   # of angles
 !!    ismo      int.  Local     I   switch;  ismo=0 skip smoothing
 !!                                           ismo.ne.0 do smoothing
 !!    X         R.A.  Local    I/O  Array to be ineterp. & smoothing
@@ -4775,8 +4775,8 @@
 !!    ##################################################################
 !!------------------------------------------------------------------------------
 !!==============================================================================
-!!     
-!!     
+!!
+!!
 !!-0  Initial Y(:,:) array before it's computed
 !!ini
       Y(:,:) = 0.0

--- a/model/ftn/w3snlsmd.ftn
+++ b/model/ftn/w3snlsmd.ftn
@@ -99,7 +99,7 @@
 !/
 !  1. Purpose :
 !
-!     High-frequeny filter based on the nonlinear interactions for 
+!     High-frequeny filter based on the nonlinear interactions for
 !     an uresolved quadruplet.
 !
 !  2. Method :
@@ -239,12 +239,12 @@
 ! 1.c.2 Compute 1D spectrum
 !
           E1(NFR+2) = SUM(A(:,NFR)) * FACHFA**2 * XSI(NFR+2)          &
-                                           / XCG(NFR+2) * TPI * DTH 
+                                           / XCG(NFR+2) * TPI * DTH
           E1(NFR+1) = SUM(A(:,NFR)) * FACHFA    * XSI(NFR+1)          &
-                                           / XCG(NFR+1) * TPI * DTH 
+                                           / XCG(NFR+1) * TPI * DTH
 !
           DO IFR=NFR, 1, -1
-            E1(IFR) = SUM(A(:,IFR)) * XSI(IFR) / XCG(IFR) * TPI * DTH 
+            E1(IFR) = SUM(A(:,IFR)) * XSI(IFR) / XCG(IFR) * TPI * DTH
 !
 ! 1.c.3 Reached PM frequency
 !
@@ -361,7 +361,7 @@
           AUX11  = DT * DS1(ISPX)
           AUX21  = DT * DS2(ISPX)
           AUXB   = CNLSFM * FILTFP(IFR) * MAX(1.E-10,UN(ISPX)) /   &
-                      MAX ( 1.E-10 , ABS(AUX11)+ABS(AUX21) ) / MC 
+                      MAX ( 1.E-10 , ABS(AUX11)+ABS(AUX21) ) / MC
           AUX12  = AUXB * ABS(AUX11)
           AUX22  = AUXB * ABS(AUX21)
 !
@@ -540,17 +540,17 @@
       IMPLICIT NONE
 !/
 !/ Parameter list
-!/    
+!/
       REAL, INTENT(OUT)       :: PSPC(0:NTH+1,0:NFR+2),               &
                                  SPEC(0:NTH+1,0:NFR+2)
 !/
 !/ Local parameters
-!/ 
+!/
       INTEGER                 :: IFR, ITH
 !/
 !/ ------------------------------------------------------------------- /
 !
-      SPEC(:,0) = 0. 
+      SPEC(:,0) = 0.
 !
       SPEC(1:NTH,1:NFR) = A
       SPEC(1:NTH,NFR+1) = SPEC(1:NTH,NFR) * FACHFA
@@ -561,7 +561,7 @@
 !
       DO IFR=1, NFR+2
         PSPC(:,IFR) = SPEC(:,IFR) / XWN(IFR)
-        END DO 
+        END DO
 !
       RETURN
 !/
@@ -586,7 +586,7 @@
 !/
 !  1. Purpose :
 !
-!     Initializations for the Snl / filter source term for high 
+!     Initializations for the Snl / filter source term for high
 !     frequencies.
 !
 !  2. Method :

--- a/model/ftn/w3snlxmd.ftn
+++ b/model/ftn/w3snlxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3src0md.ftn
+++ b/model/ftn/w3src0md.ftn
@@ -14,7 +14,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3src1md.ftn
+++ b/model/ftn/w3src1md.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3src2md.ftn
+++ b/model/ftn/w3src2md.ftn
@@ -17,7 +17,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/w3src3md.ftn
+++ b/model/ftn/w3src3md.ftn
@@ -16,7 +16,7 @@
 !/
 !  1. Purpose :
 !
-!     The 'WAM4+' source terms based on P.A.E.M. Janssen's work, with 
+!     The 'WAM4+' source terms based on P.A.E.M. Janssen's work, with
 !     extensions by him and by J.-R. Bidlot. Converted from the original
 !     WAM codes by F. Ardhuin, with further extensions to adapt to a
 !     saturation-based breaking and observation-based swell dissipation
@@ -58,7 +58,7 @@
 !/
       USE CONSTANTS, ONLY: KAPPA, nu_air
 
-      IMPLICIT NONE 
+      IMPLICIT NONE
 
       PUBLIC
 !/
@@ -92,7 +92,7 @@
 !  1. Purpose :
 !
 !     Calculate mean wave parameters for the use in the source term
-!     routines. 
+!     routines.
 !
 !  2. Method :
 !
@@ -118,7 +118,7 @@
 !       CD      Real  O   Drag coefficient at wind level ZWND.
 !       Z0      Real  O   Corresponding z0.
 !       LLWS    L.A.  I   Wind sea true/false array for each component
-!       FMEANWS Real  O   Mean frequency of wind sea, used for tail 
+!       FMEANWS Real  O   Mean frequency of wind sea, used for tail
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -163,7 +163,7 @@
       REAL, INTENT(IN)        :: TAUWX, TAUWY
       LOGICAL, INTENT(IN)     :: LLWS(NSPEC)
       REAL, INTENT(INOUT)     :: USTAR ,USDIR
-      REAL, INTENT(OUT)       :: EMEAN, FMEAN, FMEANS, WNMEAN, AMAX,  & 
+      REAL, INTENT(OUT)       :: EMEAN, FMEAN, FMEANS, WNMEAN, AMAX,  &
                                  CD, Z0, CHARN, FMEANWS
 !/
 !/ ------------------------------------------------------------------- /
@@ -232,13 +232,13 @@
 ! 4.  Final processing
 !
 
-      IF (FMEAN.LT.1.E-7) THEN 
+      IF (FMEAN.LT.1.E-7) THEN
         FMEAN=TPIINV * SIG(NK)
       ELSE
       FMEAN  = TPIINV *( MAX ( 1.E-7 , FMEAN )                       &
                      / MAX ( 1.E-7 , EMEAN ))**(1/(2.*WWNMEANPTAIL))
         END IF
-      IF (FMEANS.LT.1.E-7) THEN 
+      IF (FMEANS.LT.1.E-7) THEN
         FMEANS=TPIINV * SIG(NK)
       ELSE
         FMEANS = TPIINV *( MAX ( 1.E-7 , FMEANS )                      &
@@ -246,7 +246,7 @@
         END IF
       WNMEAN = ( MAX ( 1.E-7 , WNMEAN )                              &
                 / MAX ( 1.E-7 , EMEAN ) )**(1/WWNMEANP)
-      IF (FMEANWS.LT.1.E-7.OR.EMEANWS.LT.1.E-7) THEN 
+      IF (FMEANWS.LT.1.E-7.OR.EMEANWS.LT.1.E-7) THEN
         FMEANWS=TPIINV * SIG(NK)
       ELSE
         FMEANWS  = TPIINV *( MAX ( 1.E-7 , FMEANWS )                       &
@@ -256,11 +256,11 @@
 ! 5.  Cd and z0 ----------------------------------------------- *
 !
       TAUW = SQRT(TAUWX**2+TAUWY**2)
-     
+
       Z0=0.
-      CALL CALC_USTAR(U,TAUW,USTAR,Z0,CHARN) 
+      CALL CALC_USTAR(U,TAUW,USTAR,Z0,CHARN)
       UNZ    = MAX ( 0.01 , U )
-      CD     = (USTAR/UNZ)**2 
+      CD     = (USTAR/UNZ)**2
       USDIR = UDIR
 !
 ! 6.  Final test output ---------------------------------------------- *
@@ -290,7 +290,7 @@
 !/                  +-----------------------------------+
 !/
 !/    09-Oct-2007 : Origination.                        ( version 3.13 )
-!/    16-May-2010 : Adding sea ice                      ( version 3.14_Ifremer ) 
+!/    16-May-2010 : Adding sea ice                      ( version 3.14_Ifremer )
 !/    02-Sep-2012 : Clean up test output T, T0, T1      ( version 4.07 )
 !/
 !  1. Purpose :
@@ -299,9 +299,9 @@
 !
 !  2. Method :
 !
-!       WAM-4 : Janssen et al. 
+!       WAM-4 : Janssen et al.
 !       WAM-"4.5" : gustiness effect (Cavaleri et al. )
-!       SWELLF: damping coefficient (=1) for Janssen (2004) theory 
+!       SWELLF: damping coefficient (=1) for Janssen (2004) theory
 !
 !  3. Parameters :
 !
@@ -414,7 +414,7 @@
 !
 ! 1.  Preparations
 !
-!      JDM: initializing arrays (shouldn't change answers) 
+!      JDM: initializing arrays (shouldn't change answers)
       DSTAB=0.; STRESSSTAB=0. ;STRESSSTABN=0.
 !
 ! 1.a  estimation of surface roughness parameters
@@ -423,9 +423,9 @@
 !
 ! 2.  Diagonal
 !
-! Here AS is the air-sea temperature difference in degrees. Expression given by 
-! Abdalla & Cavaleri, JGR 2002 for Usigma. For USTARsigma ... I do not see where 
-! I got it from, maybe just made up from drag law ... 
+! Here AS is the air-sea temperature difference in degrees. Expression given by
+! Abdalla & Cavaleri, JGR 2002 for Usigma. For USTARsigma ... I do not see where
+! I got it from, maybe just made up from drag law ...
 !
 !/STAB3      Usigma=MAX(0.,-0.025*AS)
 !/STAB3      USTARsigma=(1.0+U/(10.+U))*Usigma
@@ -437,7 +437,7 @@
       TAUX = UST**2* COS(USDIR)
       TAUY = UST**2* SIN(USDIR)
 !
-! Loop over the resolved part of the spectrum 
+! Loop over the resolved part of the spectrum
 !
       STRESSSTAB(ISTAB,:)=0.
       STRESSSTABN(ISTAB,:)=0.
@@ -452,30 +452,30 @@
         CM=K(IS)/SIG2(IS) !inverse of phase speed
         UCN=UST*CM+ZZALP  !this is the inverse wave age
 !
-! the stress is the real stress (N/m^2) divided by 
+! the stress is the real stress (N/m^2) divided by
 ! rho_a, and thus comparable to USTAR**2
-! it is the integral of rho_w g Sin/C /rho_a 
+! it is the integral of rho_w g Sin/C /rho_a
 ! (air-> waves momentum flux)
 !
         CONST2=DDEN2(IS)/CG(IK) &        !Jacobian to get energy in band
               *GRAV/(SIG(IK)/K(IS)*DRAT) ! coefficient to get momentum
-        CONST=SIG2(IS)*CONST0                    
+        CONST=SIG2(IS)*CONST0
 ! this CM parameter is 1 / C_phi
 ! this is the "correct" shallow-water expression
 ! here Z0 corresponds to Z0+Z1 of the Janssen eq. 14
         ZCN=ALOG(K(IS)*Z0)
-! commented below is the original WAM version (OK for deep water) 
+! commented below is the original WAM version (OK for deep water)
 !       ZCN=ALOG(G*Z0b(I)*CM(I)**2)
         DO ITH=1,NTH
           IS=ITH+(IK-1)*NTH
           COSWIND=(ECOS(IS)*COSU+ESIN(IS)*SINU)
           IF (COSWIND.GT.0.01) THEN
-            X=COSWIND*UCN 
+            X=COSWIND*UCN
 ! this ZARG term is the argument of the exponential
-! in Janssen 1991 eq. 16. 
+! in Janssen 1991 eq. 16.
             ZARG=KAPPA/X
 ! ZLOG is ALOG(MU) where MU is defined by Janssen 1991 eq. 15
-            ZLOG=ZCN+ZARG 
+            ZLOG=ZCN+ZARG
             ZBETA = CONST3*(COSWIND+KAPPA/(ZCN*UST*CM))*UCN**2
             IF (ZLOG.LT.0.) THEN
 ! The source term Sp is beta * omega * X**2
@@ -493,7 +493,7 @@
             END IF
 !
           TEMP2=CONST2*DSTAB(ISTAB,IS)*A(IS)
-          IF (DSTAB(ISTAB,IS).LT.0) THEN 
+          IF (DSTAB(ISTAB,IS).LT.0) THEN
             STRESSSTABN(ISTAB,1)=STRESSSTABN(ISTAB,1)+TEMP2*ECOS(IS)
             STRESSSTABN(ISTAB,2)=STRESSSTABN(ISTAB,2)+TEMP2*ESIN(IS)
             END IF
@@ -508,7 +508,7 @@
         TAUWNX =STRESSSTABN(3,1)
         TAUWNY =STRESSSTABN(3,2)
 !             WRITE(995,'(A,11G14.5)') 'NEGSTRESS:    ',TAUWNX,TAUWNY,FW*UORB**3
-!/STAB3      END DO 
+!/STAB3      END DO
 !/STAB3      D(:)=0.5*(DSTAB(1,:)+DSTAB(2,:))
 !/STAB3      XSTRESS=0.5*(STRESSSTAB(1,1)+STRESSSTAB(2,1))
 !/STAB3      YSTRESS=0.5*(STRESSSTAB(1,2)+STRESSSTAB(2,2))
@@ -556,18 +556,18 @@
       TAUHF = CONST0*TEMP*UST**2*TAU1
       TAUWX = XSTRESS+TAUHF*COS(USDIR)
       TAUWY = YSTRESS+TAUHF*SIN(USDIR)
-!      
-! Reduces tail effect to make sure that wave-supported stress 
-! is less than total stress, this is borrowed from ECWAM Stresso.F      
+!
+! Reduces tail effect to make sure that wave-supported stress
+! is less than total stress, this is borrowed from ECWAM Stresso.F
 !
       TAUW = SQRT(TAUWX**2+TAUWY**2)
-      UST2   = MAX(USTAR,EPS2)**2  
+      UST2   = MAX(USTAR,EPS2)**2
       TAUWB = MIN(TAUW,MAX(UST2-EPS1,EPS2**2))
-      IF (TAUWB.LT.TAUW) THEN 
+      IF (TAUWB.LT.TAUW) THEN
         TAUWX=TAUWX*TAUWB/TAUW
         TAUWY=TAUWY*TAUWB/TAUW
         END IF
-         
+
       RETURN
 !
 ! Formats
@@ -673,7 +673,7 @@
 !/    23-Jun-2006 : Origination.                        ( version 3.13 )
 !/     adapted from WAM, original:P.A.E.M. JANSSEN    KNMI AUGUST 1990
 !/     adapted version (subr. STRESS): J. BIDLOT    ECMWF OCTOBER 2004
-!/     Table values were checkes against the original f90 result and found to 
+!/     Table values were checkes against the original f90 result and found to
 !/     be identical (at least at 0.001 m/s accuracy)
 !/
 !  1. Purpose :
@@ -766,16 +766,16 @@
           !ZZ0 = MAX(ZNU,ZZ0)
                F   = UST-KAPPA*UTOP/(ALOG(ZZWND/ZZ0))
                DELF= 1.-KAPPA*UTOP/(ALOG(ZZWND/ZZ0))**2*2./UST &
-                        *(1.-(XM+1)*X)/(1.-X)  
+                        *(1.-(XM+1)*X)/(1.-X)
                UST = UST-F/DELF
                TAUOLD= MAX(UST**2., ZTAUW+EPS1)
                END DO
             TAUT(I,J)  = SQRT(TAUOLD)
-            END DO   
+            END DO
          END DO
          I=ITAUMAX
          J=JUMAX
-!         
+!
 !  Force zero wind to have zero stress (Bidlot 1996)
 !
       DO I=0,ITAUMAX
@@ -796,7 +796,7 @@
 !/    27-Feb-2004 : Origination in WW3                  ( version 2.22.SHOM )
 !/     the resulting table was checked to be identical to the original f77 result
 !/    14-Aug-2006 : Modified following Bidlot           ( version 2.22.SHOM )
-!/    18-Aug-2006 : Ported to version 3.09      
+!/    18-Aug-2006 : Ported to version 3.09
 !
 !  1. Purpose :
 !
@@ -865,7 +865,7 @@
 !
 !/ ------------------------------------------------------------------- /
       REAL                    :: USTARM, ALPHAM
-      REAL                    :: CONST1, OMEGA, OMEGAC 
+      REAL                    :: CONST1, OMEGA, OMEGAC
       REAL                    :: UST, ZZ0,OMEGACC, CM
       INTEGER, PARAMETER      :: JTOT=250
       REAL, ALLOCATABLE       :: W(:)
@@ -883,7 +883,7 @@
       DELALP = ALPHAM/REAL(IALPHA)
       CONST1 = BBETA/KAPPA**2
       OMEGAC = TPI*FRMAX
-!   
+!
       TAUHFT(0:IUSTAR,0:IALPHA)=0. !table initialization
 !
       ALLOCATE(W(JTOT))
@@ -901,14 +901,14 @@
             OMEGACC  = MAX(OMEGAC,X0*GRAV/UST)
             YC       = OMEGACC*SQRT(ZZ0/GRAV)
             DELY     = MAX((1.-YC)/REAL(JTOT),0.)
-            ! For a given value of UST and ALPHA, 
+            ! For a given value of UST and ALPHA,
             ! the wave-supported stress is integrated all the way
             ! to 0.05*g/UST
             DO J=1,JTOT
                Y        = YC+REAL(J-1)*DELY
                OMEGA    = Y*SQRT(GRAV/ZZ0)
                ! This is the deep water phase speed
-               CM       = GRAV/OMEGA   
+               CM       = GRAV/OMEGA
                !this is the inverse wave age, shifted by ZZALP (tuning)
                ZX       = UST/CM +ZZALP
                ZARG     = MIN(KAPPA/ZX,20.)
@@ -932,7 +932,7 @@
 !WRITE(101,*) 'TAUHFT:',FRMAX,BBETA,AALPHA,CONST1,OMEGAC,TPI
 !WRITE(101,'(20G16.8)') TAUHFT
       RETURN
-!/T 9000 FORMAT (' TABU_HF, L, K :',(2I4,3F8.3)/)    
+!/T 9000 FORMAT (' TABU_HF, L, K :',(2I4,3F8.3)/)
       END SUBROUTINE TABU_TAUHF
 !/ ------------------------------------------------------------------- /
 
@@ -949,7 +949,7 @@
 !/    27-Feb-2004 : Origination in WW3                  ( version 2.22-SHOM )
 !/     the resulting table was checked to be identical to the original f77 result
 !/    14-Aug-2006 : Modified following Bidlot           ( version 2.22-SHOM )
-!/    18-Aug-2006 : Ported to version 3.09      
+!/    18-Aug-2006 : Ported to version 3.09
 !/    03-Apr-2010 : Adding output of Charnock parameter ( version 3.14-IFREMER )
 !
 !  1. Purpose :
@@ -966,7 +966,7 @@
 !     ----------------------------------------------------------------
 !       U10,TAUW,USTAR,Z0
 !     ----------------------------------------------------------------
-!       WINDSPEED Real  I   10-m wind speed ... should be NEUTRAL 
+!       WINDSPEED Real  I   10-m wind speed ... should be NEUTRAL
 !       TAUW      Real  I   Wave-supported stress
 !       USTAR     Real  O   Friction velocity.
 !       Z0        Real  O   air-side roughness length
@@ -1022,9 +1022,9 @@
       !
       SQRTCDM1  = MIN(WINDSPEED/USTAR,100.0)
       Z0  = ZZWND*EXP(-KAPPA*SQRTCDM1)
-                IF (USTAR.GT.0.001) THEN 
+                IF (USTAR.GT.0.001) THEN
                   CHARN = GRAV*Z0/USTAR**2
-                ELSE 
+                ELSE
                   CHARN = AALPHA
                   END IF
 !
@@ -1052,9 +1052,9 @@
 !
 !  2. Method :
 !
-!       WAM-Cycle 4 and following. 
+!       WAM-Cycle 4 and following.
 !       The last update (09-May-2005) follows the redefinition of
-!       the mean wavenumber as in Bidlot et al. (2005). 
+!       the mean wavenumber as in Bidlot et al. (2005).
 !
 !  3. Parameters :
 !
@@ -1119,16 +1119,16 @@
 !/ Parameter list
 !/
       REAL, INTENT(IN)        :: A(NSPEC), K(NK), CG(NK),                     &
-                                 DEPTH, USTAR, USDIR, EMEAN, FMEAN, WNMEAN 
+                                 DEPTH, USTAR, USDIR, EMEAN, FMEAN, WNMEAN
       INTEGER, INTENT(IN)     :: IX, IY
       REAL, INTENT(OUT)       :: S(NSPEC), D(NSPEC)
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      INTEGER                 :: IS, IK, ITH 
+      INTEGER                 :: IS, IK, ITH
 !/S      INTEGER, SAVE           :: IENT = 0
-      REAL                    :: FACTOR, FACTOR2          
+      REAL                    :: FACTOR, FACTOR2
       REAL                    :: ALFAMEAN, WNMEAN2
 !/T0      REAL                    :: DOUT(NK,NTH)
 !/
@@ -1136,8 +1136,8 @@
 !/
 !/S      CALL STRACE (IENT, 'W3SDS3')
 !
-! 0.  Pre-initialization of arrays, should be set before being used 
-!     but this is helping with bit reproducibility 
+! 0.  Pre-initialization of arrays, should be set before being used
+!     but this is helping with bit reproducibility
       D=0.
 
 ! 1.  Common factor
@@ -1148,7 +1148,7 @@
 !
 !/T      WRITE (NDST,9000) SSDSC1, FMEAN, WNMEAN, EMEAN, FACTOR
 !
-!---------------------------------------------------------------------- 
+!----------------------------------------------------------------------
 !
 ! 2.  Source term
 !
@@ -1162,7 +1162,7 @@
           D(IS)=  FACTOR2
           END DO
         END DO
-!            
+!
       S = D * A
 !
 ! ... Test output of arrays
@@ -1187,5 +1187,5 @@
 !/ End of W3SDS3 ----------------------------------------------------- /
 !/
       END SUBROUTINE W3SDS3
-      
+
       END MODULE W3SRC3MD

--- a/model/ftn/w3src4md.ftn
+++ b/model/ftn/w3src4md.ftn
@@ -18,10 +18,10 @@
 !  1. Purpose :
 !
 !     The 'SHOM/Ifremer' source terms based on P.A.E.M. Janssen's wind input
-!     and dissipation functions by Ardhuin et al. (2009,2010) 
+!     and dissipation functions by Ardhuin et al. (2009,2010)
 !     and Filipot & Ardhuin (2010)
 !     The wind input is converted from the original
-!     WAM codes, courtesy of P.A.E.M. Janssen and J. Bidlot 
+!     WAM codes, courtesy of P.A.E.M. Janssen and J. Bidlot
 !
 !
 !  2. Variables and types :
@@ -70,7 +70,7 @@
       REAL                    :: TAUHFT(0:IUSTAR,0:IALPHA), DELUST, DELALP
       ! Table for H.F. stress as a function of 3 variables
       REAL                    :: TAUHFT2(0:IUSTAR,0:IALPHA,0:ILEVTAIL)
-      ! Table for swell damping 
+      ! Table for swell damping
       REAL                    :: DELTAIL
       REAL,    PARAMETER      :: UMAX    = 50.
       REAL,    PARAMETER      :: TAUWMAX = 2.2361 !SQRT(5.)
@@ -101,7 +101,7 @@
 !  1. Purpose :
 !
 !     Calculate mean wave parameters for the use in the source term
-!     routines. 
+!     routines.
 !
 !  2. Method :
 !
@@ -127,8 +127,8 @@
 !       CD      Real  O   Drag coefficient at wind level ZWND.
 !       Z0      Real  O   Corresponding z0.
 !       CHARN   Real  O   Corresponding Charnock coefficient
-!       LLWS    L.A.  I   Wind sea true/false array for each component            
-!       FMEANWS Real  O   Mean frequency of wind sea, used for tail 
+!       LLWS    L.A.  I   Wind sea true/false array for each component
+!       FMEANWS Real  O   Mean frequency of wind sea, used for tail
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines used :
@@ -161,7 +161,7 @@
       USE CONSTANTS, ONLY: TPIINV
       USE W3GDATMD, ONLY: NK, NTH, NSPEC, SIG, DTH, DDEN, WWNMEANP, &
                           WWNMEANPTAIL, FTE, FTF, SSTXFTF, SSTXFTWN,&
-                          SSTXFTFTAIL, SSWELLF 
+                          SSTXFTFTAIL, SSWELLF
 !/S      USE W3SERVMD, ONLY: STRACE
 !/T      USE W3ODATMD, ONLY: NDST
 !/T      USE W3ODATMD, ONLY: NDST
@@ -175,7 +175,7 @@
       REAL, INTENT(IN)        :: TAUWX, TAUWY
       LOGICAL, INTENT(IN)     :: LLWS(NSPEC)
       REAL, INTENT(INOUT)     :: USTAR ,USDIR
-      REAL, INTENT(OUT)       :: EMEAN, FMEAN, FMEAN1, WNMEAN, AMAX,  & 
+      REAL, INTENT(OUT)       :: EMEAN, FMEAN, FMEAN1, WNMEAN, AMAX,  &
                                  CD, Z0, CHARN, FMEANWS
 !/
 !/ ------------------------------------------------------------------- /
@@ -185,7 +185,7 @@
 !/S      INTEGER, SAVE           :: IENT = 0
 
       REAL                    :: TAUW, EBAND, EMEANWS,UNZ,            &
-                                 EB(NK),EB2(NK),ALFA(NK) 
+                                 EB(NK),EB2(NK),ALFA(NK)
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -243,8 +243,8 @@
 !
 ! 4.  Final processing
 !
-      FMEAN  = TPIINV * EMEAN / MAX ( 1.E-7 , FMEAN ) 
-      IF (FMEAN1.LT.1.E-7) THEN 
+      FMEAN  = TPIINV * EMEAN / MAX ( 1.E-7 , FMEAN )
+      IF (FMEAN1.LT.1.E-7) THEN
         FMEAN1=TPIINV * SIG(NK)
       ELSE
         FMEAN1  = TPIINV *( MAX ( 1.E-7 , FMEAN1 )                       &
@@ -252,7 +252,7 @@
         ENDIF
       WNMEAN = ( MAX ( 1.E-7 , WNMEAN )                              &
                 / MAX ( 1.E-7 , EMEAN ) )**(1/WWNMEANP)
-      IF (FMEANWS.LT.1.E-7.OR.EMEANWS.LT.1.E-7) THEN 
+      IF (FMEANWS.LT.1.E-7.OR.EMEANWS.LT.1.E-7) THEN
         FMEANWS=TPIINV * SIG(NK)
       ELSE
         FMEANWS  = TPIINV *( MAX ( 1.E-7 , FMEANWS )                       &
@@ -263,11 +263,11 @@
 ! 5.  Cd and z0 ----------------------------------------------- *
 !
       TAUW = SQRT(TAUWX**2+TAUWY**2)
-     
+
       Z0=0.
-      CALL CALC_USTAR(U,TAUW,USTAR,Z0,CHARN) 
+      CALL CALC_USTAR(U,TAUW,USTAR,Z0,CHARN)
       UNZ    = MAX ( 0.01 , U )
-      CD     = (USTAR/UNZ)**2 
+      CD     = (USTAR/UNZ)**2
       USDIR = UDIR
 !
 ! 6.  Final test output ---------------------------------------------- *
@@ -307,9 +307,9 @@
 !
 !  2. Method :
 !
-!       WAM-4     : Janssen et al. 
+!       WAM-4     : Janssen et al.
 !       WAM-"4.5" : gustiness effect (Cavaleri et al. )
-!       SAT       : high-frequency input reduction for balance with 
+!       SAT       : high-frequency input reduction for balance with
 !                   saturation dissipation (Ardhuin et al., 2008)
 !       SWELL     : negative wind input (Ardhuin et al. 2008)
 !
@@ -366,8 +366,8 @@
 ! 10. Source code :
 !
 !/ ------------------------------------------------------------------- /
-      USE CONSTANTS, ONLY: GRAV,nu_air,KAPPA,TPI,FWTABLE,SIZEFWTABLE, & 
-!/T                        RADE,                                      & 
+      USE CONSTANTS, ONLY: GRAV,nu_air,KAPPA,TPI,FWTABLE,SIZEFWTABLE, &
+!/T                        RADE,                                      &
                            DELAB,ABMIN
       USE W3GDATMD, ONLY: NK, NTH, NSPEC, XFR, DDEN, SIG, SIG2, TH,   &
                           ESIN, ECOS, EC2, ZZWND, AALPHA, BBETA, ZZALP,&
@@ -430,9 +430,9 @@
 !
       !JDM: Initializing values to zero, they shouldn't be used unless
       !set in another place, but seems to solve some bugs with certain
-      !compilers. 
+      !compilers.
       DSTAB =0.
-      STRESSSTAB =0. 
+      STRESSSTAB =0.
       STRESSSTABN =0.
 !
 ! 1.a  estimation of surface roughness parameters
@@ -454,7 +454,7 @@
         DO ITH=1, NTH
            IS=ITH+(IK-1)*NTH
            EB  = EB  + A(IS)
-           END DO   
+           END DO
 !
 !  At this point UORB and AORB are the variances of the orbital velocity and surface elevation
 !
@@ -466,16 +466,16 @@
       AORB1 = 2*AORB**(1-0.5*SSWELLF(6))    ! half the significant wave height ... if SWELLF(6)=1
       !WRITE(740+IAPROC,*) EB, EBX, EBY, UORB, AORB1, NU_AIR, 4*UORB*AORB1/NU_AIR
       !CALL FLUSH(740+IAPROC)
-      RE = 4*UORB*AORB1 / NU_AIR           ! Reynolds number 
+      RE = 4*UORB*AORB1 / NU_AIR           ! Reynolds number
 !
 ! Defines the swell dissipation based on the "Reynolds number"
 !
-      IF (SSWELLF(4).GT.0) THEN           
+      IF (SSWELLF(4).GT.0) THEN
         IF (SSWELLF(7).GT.0.) THEN
           SMOOTH = 0.5*TANH((RE-SSWELLF(4))/SSWELLF(7))
           PTURB=(0.5+SMOOTH)
           PVISC=(0.5-SMOOTH)
-        ELSE 
+        ELSE
           IF (RE.LE.SSWELLF(4)) THEN
             PTURB =  0.
             PVISC =  1.
@@ -488,9 +488,9 @@
         PTURB=1.
         PVISC=1.
         END IF
-        
+
 !
-      IF (SSWELLF(2).EQ.0) THEN 
+      IF (SSWELLF(2).EQ.0) THEN
         FW=MAX(ABS(SSWELLF(3)),0.)
         FU=0.
         FUD=0.
@@ -507,9 +507,9 @@
 !
 ! 2.  Diagonal
 !
-! Here AS is the air-sea temperature difference in degrees. Expression given by 
-! Abdalla & Cavaleri, JGR 2002 for Usigma. For USTARsigma ... I do not see where 
-! I got it from, maybe just made up from drag law ... 
+! Here AS is the air-sea temperature difference in degrees. Expression given by
+! Abdalla & Cavaleri, JGR 2002 for Usigma. For USTARsigma ... I do not see where
+! I got it from, maybe just made up from drag law ...
 !
 !/STAB3      Usigma=MAX(0.,-0.025*AS)
 !/STAB3      USTARsigma=(1.0+U/(10.+U))*Usigma
@@ -521,7 +521,7 @@
       TAUX = UST**2* COS(USDIR)
       TAUY = UST**2* SIN(USDIR)
 !
-! Loop over the resolved part of the spectrum 
+! Loop over the resolved part of the spectrum
 !
       STRESSSTAB(ISTAB,:)=0.
       STRESSSTABN(ISTAB,:)=0.
@@ -541,63 +541,63 @@
         IS=1+(IK-1)*NTH
         CM=K(IS)/SIG2(IS) !inverse of phase speed
         UCN=USTP*CM+ZZALP  !this is the inverse wave age
-           ! the stress is the real stress (N/m^2) divided by 
+           ! the stress is the real stress (N/m^2) divided by
            ! rho_a, and thus comparable to USTAR**2
-           ! it is the integral of rho_w g Sin/C /rho_a 
+           ! it is the integral of rho_w g Sin/C /rho_a
            ! (air-> waves momentum flux)
         CONST2=DDEN2(IS)/CG(IK) &        !Jacobian to get energy in band
               *GRAV/(SIG(IK)/K(IS)*DRAT) ! coefficient to get momentum
-        CONST=SIG2(IS)*CONST0                    
+        CONST=SIG2(IS)*CONST0
            ! CM parameter is 1 / C_phi
            ! Z0 corresponds to Z0+Z1 of the Janssen eq. 14
         ZCN=ALOG(K(IS)*Z0)
 !
 ! precomputes swell factors
 !
-        SWELLCOEFV=-SSWELLF(5)*DRAT*2*K(IS)*SQRT(2*NU_AIR*SIG2(IS)) 
+        SWELLCOEFV=-SSWELLF(5)*DRAT*2*K(IS)*SQRT(2*NU_AIR*SIG2(IS))
         SWELLCOEFT=-DRAT*SSWELLF(1)*16*SIG2(IS)**2/GRAV
 !
         DO ITH=1,NTH
           IS=ITH+(IK-1)*NTH
           COSWIND=(ECOS(IS)*COSU+ESIN(IS)*SINU)
-          IF (COSWIND.GT.0.01) THEN 
-            X=COSWIND*UCN 
+          IF (COSWIND.GT.0.01) THEN
+            X=COSWIND*UCN
             ! this ZARG term is the argument of the exponential
-            ! in Janssen 1991 eq. 16. 
+            ! in Janssen 1991 eq. 16.
             ZARG=KAPPA/X
             ! ZLOG is ALOG(MU) where MU is defined by Janssen 1991 eq. 15
             ! MU=
-            ZLOG=ZCN+ZARG 
-            
+            ZLOG=ZCN+ZARG
+
             IF (ZLOG.LT.0.) THEN
               ! The source term Sp is beta * omega * X**2
               ! as given by Janssen 1991 eq. 19
               ! Note that this is slightly diffent from ECWAM code CY45R2 where ZLOG is replaced by ??
-              DSTAB(ISTAB,IS) = CONST*EXP(ZLOG)*ZLOG**4*UCN*UCN*COSWIND**SSINTHP 
+              DSTAB(ISTAB,IS) = CONST*EXP(ZLOG)*ZLOG**4*UCN*UCN*COSWIND**SSINTHP
 
               ! Below is an example with breaking probability feeding back to the input...
               !DSTAB(ISTAB,IS) = CONST*EXP(ZLOG)*ZLOG**4  &
-              !                  *UCN*UCN*COSWIND**SSINTHP *(1+BRLAMBDA(IS)*20*SSINBR) 
+              !                  *UCN*UCN*COSWIND**SSINTHP *(1+BRLAMBDA(IS)*20*SSINBR)
               LLWS(IS)=.TRUE.
             ELSE
               DSTAB(ISTAB,IS) = 0.
               LLWS(IS)=.FALSE.
               END IF
 !
-!  Added for consistency with ECWAM implsch.F 
+!  Added for consistency with ECWAM implsch.F
 !
             IF (28.*CM*USTAR*COSWIND.GE.1) THEN
               LLWS(IS)=.TRUE.
               END IF
-          ELSE  ! (COSWIND.LE.0.01) 
+          ELSE  ! (COSWIND.LE.0.01)
             DSTAB(ISTAB,IS) = 0.
             LLWS(IS)=.FALSE.
-            END IF 
+            END IF
 !
           IF ((SSWELLF(1).NE.0.AND.DSTAB(ISTAB,IS).LT.1E-7*SIG2(IS)) &
-              .OR.SSWELLF(3).GT.0) THEN  
+              .OR.SSWELLF(3).GT.0) THEN
 !
-              DVISC=SWELLCOEFV        
+              DVISC=SWELLCOEFV
               DTURB=SWELLCOEFT*(FW*UORB+(FU+FUD*COSWIND)*USTP)
 !
               DSTAB(ISTAB,IS) = DSTAB(ISTAB,IS) + PTURB*DTURB +  PVISC*DVISC
@@ -608,7 +608,7 @@
           ! Wave direction is "direction to"
           ! therefore there is a PLUS sign for the stress
           TEMP2=CONST2*DSTAB(ISTAB,IS)*A(IS)
-          IF (DSTAB(ISTAB,IS).LT.0) THEN 
+          IF (DSTAB(ISTAB,IS).LT.0) THEN
             STRESSSTABN(ISTAB,1)=STRESSSTABN(ISTAB,1)+TEMP2*ECOS(IS)
             STRESSSTABN(ISTAB,2)=STRESSSTABN(ISTAB,2)+TEMP2*ESIN(IS)
           ELSE
@@ -623,7 +623,7 @@
         YSTRESS=STRESSSTAB (3,2)
         TAUWNX =STRESSSTABN(3,1)
         TAUWNY =STRESSSTABN(3,2)
-!/STAB3        END DO 
+!/STAB3        END DO
 !/STAB3      D(:)=0.5*(DSTAB(1,:)+DSTAB(2,:))
 !/STAB3      XSTRESS=0.5*(STRESSSTAB(1,1)+STRESSSTAB(2,1))
 !/STAB3      YSTRESS=0.5*(STRESSSTAB(1,2)+STRESSSTAB(2,2))
@@ -671,7 +671,7 @@
       J    = MAX(1 ,MIN (IALPHA-1, INT(XJ)))
       DELJ1= MAX(0.,MIN (1.      , XJ-FLOAT(J)))
       DELJ2=1. - DELJ1
-      IF (TTAUWSHELTER.GT.0) THEN 
+      IF (TTAUWSHELTER.GT.0) THEN
         XK = CONST0*TEMP / DELTAIL
          I = MIN (ILEVTAIL-1, INT(XK))
          DELK1= MIN (1. ,XK-FLOAT(I))
@@ -679,7 +679,7 @@
          TAU1 =((TAUHFT2(IND,J,I)*DELI2+TAUHFT2(IND+1,J,I)*DELI1 )*DELJ2 &
                +(TAUHFT2(IND,J+1,I)*DELI2+TAUHFT2(IND+1,J+1,I)*DELI1)*DELJ1)*DELK2 &
               +((TAUHFT2(IND,J,I+1)*DELI2+TAUHFT2(IND+1,J,I+1)*DELI1 )*DELJ2 &
-               +(TAUHFT2(IND,J+1,I+1)*DELI2+TAUHFT2(IND+1,J+1,I+1)*DELI1)*DELJ1)*DELK1 
+               +(TAUHFT2(IND,J+1,I+1)*DELI2+TAUHFT2(IND+1,J+1,I+1)*DELI1)*DELJ1)*DELK1
       ELSE
         TAU1 =(TAUHFT(IND,J)*DELI2+TAUHFT(IND+1,J)*DELI1 )*DELJ2 &
          +(TAUHFT(IND,J+1)*DELI2+TAUHFT(IND+1,J+1)*DELI1)*DELJ1
@@ -687,18 +687,18 @@
       TAUHF = CONST0*TEMP*UST**2*TAU1
       TAUWX = XSTRESS+TAUHF*COS(USDIRP)
       TAUWY = YSTRESS+TAUHF*SIN(USDIRP)
-!      
-! Reduces tail effect to make sure that wave-supported stress 
-! is less than total stress, this is borrowed from ECWAM Stresso.F      
+!
+! Reduces tail effect to make sure that wave-supported stress
+! is less than total stress, this is borrowed from ECWAM Stresso.F
 !
       TAUW = SQRT(TAUWX**2+TAUWY**2)
-      UST2   = MAX(USTAR,EPS2)**2  
+      UST2   = MAX(USTAR,EPS2)**2
       TAUWB = MIN(TAUW,MAX(UST2-EPS1,EPS2**2))
-      IF (TAUWB.LT.TAUW) THEN 
+      IF (TAUWB.LT.TAUW) THEN
         TAUWX=TAUWX*TAUWB/TAUW
         TAUWY=TAUWY*TAUWB/TAUW
         END IF
-! 
+!
       RETURN
 !
 ! Formats
@@ -728,11 +728,11 @@
 !  2. Method :
 !
 !  3. Parameters :
-!       
+!
 !     ----------------------------------------------------------------
-!      FLTABS    Logical   
+!      FLTABS    Logical
 !     ----------------------------------------------------------------
-! 
+!
 !  4. Subroutines used :
 !
 !      Name      Type  Module   Description
@@ -805,9 +805,9 @@
 ! 1.  Initializations ------------------------------------------------ *
 !
 !
-! These precomputed tables are written in mod_def.ww3 
+! These precomputed tables are written in mod_def.ww3
 !
-      IF (FLTABS) THEN   
+      IF (FLTABS) THEN
         CALL TABU_STRESS
         CALL TABU_TAUHF(SIG(NK) )      !tabulate high-frequency stress: 2D table
         IF (TTAUWSHELTER.GT.0) THEN
@@ -823,7 +823,7 @@
         SATINDICES(:,:)=1
         SATWEIGHTS(:,:)=0.
         DO ITH=1,NTH
-          DO I_INT=ITH-SDSNTH, ITH+SDSNTH       
+          DO I_INT=ITH-SDSNTH, ITH+SDSNTH
             J_INT=I_INT
             IF (I_INT.LT.1)  J_INT=I_INT+NTH
             IF (I_INT.GT.NTH) J_INT=I_INT-NTH
@@ -840,15 +840,15 @@
 !
 ! Precomputes QBI and DCKI (TEST 500)
 !
-      IF (SSDSBCK.GT.0) THEN 
+      IF (SSDSBCK.GT.0) THEN
 !
 ! Precomputes the indices for integrating the spectrum over frequency bandwidth
 !
         BINF=(1-SSDSBINT) ! Banner et al 2002: Hp=4*sqrt(int_0.7^1.3fp E df), SSDSBINT=0.3
         BSUP=(1+SSDSBINT)
         KIK=0.
-! 
-! High frequency tail for convolution calculation 
+!
+! High frequency tail for convolution calculation
 !
         ALLOCATE(K1(NK,NDTAB))
         ALLOCATE(K2(NK,NDTAB))
@@ -856,11 +856,11 @@
 
         SIGTAB=0. !contains frequency for upper windows boundaries
         IKTAB=0  ! contains indices for upper windows boundaries
-    
+
         DO ID=1,NDTAB
-          TOTO=0 
+          TOTO=0
           PROF=REAL(ID)
-          DO IKL=1,NK ! last window starts at IK=NK 
+          DO IKL=1,NK ! last window starts at IK=NK
             CALL WAVNU2(SIG(IKL), PROF, KIK, CGG, 1E-7, 15, ICON)
             K1(IKL,ID)=KIK  ! wavenumber lower boundary (is directly related to the frequency indices, IK)
             K2(IKL,ID)=((BSUP/BINF)**2.)*K1(IKL,ID)! wavenumber upper boundary
@@ -868,10 +868,10 @@
             IF(SIGTAB(IKL,ID) .LE. SIG(1)) THEN
               IKTAB(IKL,ID)=1
               END IF
-            IF(SIGTAB(IKL,ID) .GT. SIG(NK)) THEN 
+            IF(SIGTAB(IKL,ID) .GT. SIG(NK)) THEN
               IKTAB(IKL,ID)=NK+TOTO       ! in w3sds4 only windows with IKSUP<=NK will be kept
-              TOTO=1 
-              END IF  
+              TOTO=1
+              END IF
             DO IK=1,NK-1
               DIFF1=0.
               DIFF2=0.
@@ -879,19 +879,19 @@
                 DIFF1=SIGTAB(IKL,ID)-SIG(IK)   ! seeks the indices of the upper boundary
                 DIFF2=SIG(IK+1)-SIGTAB(IKL,ID)! the indices of lower boudary = IK
                 IF (DIFF1<DIFF2) THEN
-                  IKTAB(IKL,ID)=IK 
+                  IKTAB(IKL,ID)=IK
                 ELSE
-                  IKTAB(IKL,ID)=IK+1 
+                  IKTAB(IKL,ID)=IK+1
                   END IF
-                END IF  
+                END IF
               END DO
             END DO
           END DO
-!      
+!
 ! Tabulates DCKI and QBI
-!   
+!
         DHS=KHSMAX/NKHS ! max value of KHS=KHSMAX
-        DKH=KHMAX/NKHI  ! max value of KH=KHMAX 
+        DKH=KHMAX/NKHI  ! max value of KH=KHMAX
         DKD=KDMAX/NKD
         ALLOCATE(DCKI(NKHS,NKD))
         ALLOCATE(QBI(NKHS,NKD))
@@ -901,7 +901,7 @@
           KHS=0.
           KD=(FAC_KD1**(IKD-FAC_KD2))
           XT=TANH(KD)
-          GAM=1.0314*(XT**3)-1.9958*(XT**2)+1.5522*XT+0.1885 
+          GAM=1.0314*(XT**3)-1.9958*(XT**2)+1.5522*XT+0.1885
           GAM=GAM/2.15
           DO IKHS=1,NKHS  ! max value of KHS=1.
             KH=0.
@@ -910,7 +910,7 @@
               KH=KH+DKH
               PR=(4.*KH/(KHS**2.))*exp(-(2*((KH/KHS)**2.)))
 !              W=1.5*(((KHS)/(SQRT(2.)*GAM*XT))**2.)*(1-exp(-(((KH)/(GAM*XT))**4.))) !CK2002 parameterization
-              W=SSDSABK*(((KHS)/(SQRT(2.)*GAM*XT))**2.)*(1-exp(-(((KH)/(GAM*XT))**SSDSPBK))) 
+              W=SSDSABK*(((KHS)/(SQRT(2.)*GAM*XT))**2.)*(1-exp(-(((KH)/(GAM*XT))**SSDSPBK)))
               EPS=-((((SSDSBCK/(XT**SSDSHCK))*KH)**3.)/4)*SQRT(GRAV/XT)
               DCKI(IKHS, IKD)= DCKI(IKHS, IKD)+PR*W*EPS*DKH
               QBI(IKHS, IKD) = QBI(IKHS, IKD) +PR*W*    DKH
@@ -924,7 +924,7 @@
 
         DEALLOCATE(K1,K2)
         DEALLOCATE(SIGTAB)
-      ELSE 
+      ELSE
         IKTAB(:,:)=1
         DCKI(:,:) =0.
         QBI(:,:)  =0.
@@ -941,9 +941,9 @@
 !       DIKCUMUL is the integer difference in frequency bands
 !       between the "large breakers" and short "wiped-out waves"
         DIKCUMUL = NINT(SSDSBRF1/(XFR-1.))
-!        WRITE(6,*) 'INSIN4b:',DIKCUMUL                               
+!        WRITE(6,*) 'INSIN4b:',DIKCUMUL
         CUMULW(:,:)=0.
-        DO IK=1,NK  
+        DO IK=1,NK
           C = GRAV/SIG(IK)   ! Valid in deep water only
           !C = SIG(IK)/K(IK) ! Valid in all water depth ???
           DO ITH=1,NTH
@@ -956,10 +956,10 @@
                 CUMULW(IS2,IS)=SQRT(C**2+C2**2-2*C*C2*ECOS(1+ABS(ITH2-ITH))) & ! = deltaC
                                    *DSIP(IK2)/(0.5*C2) * DTH                   ! = dk*dtheta (Valid in deep water only)
                 END DO
-              END DO 
+              END DO
             END DO
           END DO
-        ELSE 
+        ELSE
           CUMULW(:,:)=0.
           END IF
 !/
@@ -979,7 +979,7 @@
 !/    23-Jun-2006 : Origination.                        ( version 3.13 )
 !/     adapted from WAM, original:P.A.E.M. JANSSEN    KNMI AUGUST 1990
 !/     adapted version (subr. STRESS): J. BIDLOT    ECMWF OCTOBER 2004
-!/     Table values were checkes against the original f90 result and found to 
+!/     Table values were checkes against the original f90 result and found to
 !/     be identical (at least at 0.001 m/s accuracy)
 !/
 !  1. Purpose :
@@ -1072,16 +1072,16 @@
                !ZZ0 = MAX(ZNU,ZZ0)
                F   = UST-KAPPA*UTOP/(ALOG(ZZWND/ZZ0))
                DELF= 1.-KAPPA*UTOP/(ALOG(ZZWND/ZZ0))**2*2./UST &
-                        *(1.-(XM+1)*X)/(1.-X)  
+                        *(1.-(XM+1)*X)/(1.-X)
                UST = UST-F/DELF
                TAUOLD= MAX(UST**2., ZTAUW+EPS1)
                END DO
             TAUT(I,J)  = SQRT(TAUOLD)
-            END DO   
+            END DO
          END DO
        I=ITAUMAX
        J=JUMAX
-!         
+!
 !  Force zero wind to have zero stress (Bidlot 1996)
 !
       DO I=0,ITAUMAX
@@ -1102,7 +1102,7 @@
 !/    27-Feb-2004 : Origination in WW3                  ( version 2.22.SHOM )
 !/     the resulting table was checked to be identical to the original f77 result
 !/    14-Aug-2006 : Modified following Bidlot           ( version 2.22.SHOM )
-!/    18-Aug-2006 : Ported to version 3.09      
+!/    18-Aug-2006 : Ported to version 3.09
 !
 !  1. Purpose :
 !
@@ -1172,7 +1172,7 @@
 !/ ------------------------------------------------------------------- /
 !/S      INTEGER, SAVE           :: IENT = 0
       REAL                    :: USTARM, ALPHAM
-      REAL                    :: CONST1, OMEGA, OMEGAC 
+      REAL                    :: CONST1, OMEGA, OMEGAC
       REAL                    :: UST, ZZ0,OMEGACC, CM
       INTEGER, PARAMETER      :: JTOT=250
       REAL, ALLOCATABLE       :: W(:)
@@ -1189,7 +1189,7 @@
       DELALP = ALPHAM/REAL(IALPHA)
       CONST1 = BBETA/KAPPA**2
       OMEGAC = SIGMAX
-!   
+!
       TAUHFT(0:IUSTAR,0:IALPHA)=0. !table initialization
 !
       ALLOCATE(W(JTOT))
@@ -1207,14 +1207,14 @@
             OMEGACC  = MAX(OMEGAC,X0*GRAV/UST)
             YC       = OMEGACC*SQRT(ZZ0/GRAV)
             DELY     = MAX((1.-YC)/REAL(JTOT),0.)
-            ! For a given value of UST and ALPHA, 
+            ! For a given value of UST and ALPHA,
             ! the wave-supported stress is integrated all the way
             ! to 0.05*g/UST
             DO J=1,JTOT
                Y        = YC+REAL(J-1)*DELY
                OMEGA    = Y*SQRT(GRAV/ZZ0)
                ! This is the deep water phase speed
-               CM       = GRAV/OMEGA   
+               CM       = GRAV/OMEGA
                !this is the inverse wave age, shifted by ZZALP (tuning)
                ZX       = UST/CM +ZZALP
                ZARG     = MIN(KAPPA/ZX,20.)
@@ -1229,7 +1229,7 @@
       END DO
       DEALLOCATE(W)
       RETURN
-!/T 9000 FORMAT ('TABU_HF, L, K, ALPHA, UST, TAUHFT(K,L) :',(2I4,3F8.3))    
+!/T 9000 FORMAT ('TABU_HF, L, K, ALPHA, UST, TAUHFT(K,L) :',(2I4,3F8.3))
       END SUBROUTINE TABU_TAUHF
 
 !/ ------------------------------------------------------------------- /
@@ -1317,7 +1317,7 @@
 !/ ------------------------------------------------------------------- /
 !/S      INTEGER, SAVE           :: IENT = 0
       REAL                    :: USTARM, ALPHAM, LEVTAILM
-      REAL                    :: CONST1, OMEGA, OMEGAC, LEVTAIL 
+      REAL                    :: CONST1, OMEGA, OMEGAC, LEVTAIL
       REAL                    :: UST, UST0, ZZ0,OMEGACC, CM
       REAL                    :: TAUW, TAUW0
       INTEGER, PARAMETER      :: JTOT=250
@@ -1339,19 +1339,19 @@
       FNAMETAB='ST4TABUHF2.bin'
       NOFILE=.TRUE.
       OPEN (993,FILE=FNAMETAB,FORM='UNFORMATTED',IOSTAT=IERR,STATUS='OLD')
-      IF (IERR.EQ.0) THEN 
+      IF (IERR.EQ.0) THEN
         READ(993,IOSTAT=IERR) IDTST, VERTST, INSIGMAX, INAALPHA, INBBETA, INIUSTAR,  &
                               INIALPHA, INILEVTAIL, INZZALP, INKAPPA, INGRAV
         IF (VERTST.EQ.VERGRD.AND.IDTST.EQ.IDSTR.AND.IERR.EQ.0             &
-            .AND.INSIGMAX.EQ.SIGMAX.AND.INAALPHA.EQ.AALPHA.AND.INBBETA.EQ.BBETA) THEN 
+            .AND.INSIGMAX.EQ.SIGMAX.AND.INAALPHA.EQ.AALPHA.AND.INBBETA.EQ.BBETA) THEN
           IF (INIUSTAR.EQ.IUSTAR.AND.INIALPHA.EQ.IALPHA.AND.INILEVTAIL.EQ.ILEVTAIL.AND. &
-              INZZALP.EQ.ZZALP.AND.INGRAV.EQ.GRAV.AND.INKAPPA.EQ.KAPPA) THEN 
+              INZZALP.EQ.ZZALP.AND.INGRAV.EQ.GRAV.AND.INKAPPA.EQ.KAPPA) THEN
             NOFILE=.FALSE.
-          ELSE 
+          ELSE
             CLOSE(993)
             END IF
           END IF
-        END IF 
+        END IF
 !
       USTARM = 5.
       ALPHAM = 20.*AALPHA
@@ -1362,11 +1362,11 @@
       CONST1  = BBETA/KAPPA**2
       OMEGAC  = SIGMAX
 800   CONTINUE
-      IF ( NOFILE ) THEN      
+      IF ( NOFILE ) THEN
         WRITE(NDSE,*) 'Filling 3D look-up table for SIN4. please wait'
         WRITE(NDSE,*)  IDSTR, VERGRD, SIGMAX, AALPHA, BBETA, IUSTAR, IALPHA,  &
                        ILEVTAIL, ZZALP, KAPPA, GRAV
-!   
+!
         TAUHFT(0:IUSTAR,0:IALPHA)=0.  !table initialization
 !
         ALLOCATE(W(JTOT))
@@ -1383,20 +1383,20 @@
             OMEGACC  = MAX(OMEGAC,X0*GRAV/UST)
             YC       = OMEGACC*SQRT(ZZ0/GRAV)
             DELY     = MAX((1.-YC)/REAL(JTOT),0.)
-          ! For a given value of UST and ALPHA, 
+          ! For a given value of UST and ALPHA,
           ! the wave-supported stress is integrated all the way
           ! to 0.05*g/UST
             DO I=0,ILEVTAIL
               LEVTAIL=REAL(I)*DELTAIL
-              TAUHFT(K,L)=0.  
-              TAUHFT2(K,L,I)=0. 
+              TAUHFT(K,L)=0.
+              TAUHFT2(K,L,I)=0.
               TAUW0=UST0**2
               TAUW=TAUW0
               DO J=1,JTOT
                 Y        = YC+REAL(J-1)*DELY
                 OMEGA    = Y*SQRT(GRAV/ZZ0)
                 ! This is the deep water phase speed
-                CM       = GRAV/OMEGA   
+                CM       = GRAV/OMEGA
                 !this is the inverse wave age, shifted by ZZALP (tuning)
                 ZX       = UST0/CM +ZZALP
                 ZARG     = MIN(KAPPA/ZX,20.)
@@ -1431,9 +1431,9 @@
         !      WRITE(995,*) K,L,I,MAX(REAL(K)*DELUST,0.000001),AALPHA+FLOAT(L)*DELALP,REAL(I)*DELTAIL,TAUHFT(K,L),TAUHFT2(K,L,I)
         !      END DO
         !    END DO
-        !  END DO 
+        !  END DO
 !
-      ELSE 
+      ELSE
         WRITE(NDSE,*) 'Reading 3D look-up table for SIN4 from file.'
         READ(993,ERR=2000,IOSTAT=IERR ) TAUHFT(0:IUSTAR,0:IALPHA)
         READ(993,ERR=2000,IOSTAT=IERR ) TAUHFT2
@@ -1443,9 +1443,9 @@
       GOTO 2001
 2000  NOFILE=.TRUE.
       GOTO 800
-2001  CONTINUE 
+2001  CONTINUE
       RETURN
-!/T 9000 FORMAT (' TEST TABU_HFT2, K, L, I, UST, ALPHA, LEVTAIL, TAUHFT2(K,L,I) :',(3I4,4F10.5))    
+!/T 9000 FORMAT (' TEST TABU_HFT2, K, L, I, UST, ALPHA, LEVTAIL, TAUHFT2(K,L,I) :',(3I4,4F10.5))
       END SUBROUTINE TABU_TAUHF2
 
 !/ ------------------------------------------------------------------- /
@@ -1461,7 +1461,7 @@
 !/    27-Feb-2004 : Origination in WW3                  ( version 2.22-SHOM )
 !/     the resulting table was checked to be identical to the original f77 result
 !/    14-Aug-2006 : Modified following Bidlot           ( version 2.22-SHOM )
-!/    18-Aug-2006 : Ported to version 3.09      
+!/    18-Aug-2006 : Ported to version 3.09
 !/    03-Apr-2010 : Adding output of Charnock parameter ( version 3.14-IFREMER )
 !
 !  1. Purpose :
@@ -1478,7 +1478,7 @@
 !     ----------------------------------------------------------------
 !       U10,TAUW,USTAR,Z0
 !     ----------------------------------------------------------------
-!       WINDSPEED Real  I   10-m wind speed ... should be NEUTRAL 
+!       WINDSPEED Real  I   10-m wind speed ... should be NEUTRAL
 !       TAUW      Real  I   Wave-supported stress
 !       USTAR     Real  O   Friction velocity.
 !       Z0        Real  O   air-side roughness length
@@ -1535,9 +1535,9 @@
 !
       SQRTCDM1  = MIN(WINDSPEED/USTAR,100.0)
       Z0  = ZZWND*EXP(-KAPPA*SQRTCDM1)
-      IF (USTAR.GT.0.001) THEN 
+      IF (USTAR.GT.0.001) THEN
         CHARN = GRAV*Z0/USTAR**2
-      ELSE 
+      ELSE
         CHARN = AALPHA
         END IF
 !
@@ -1556,7 +1556,7 @@
 !/
 !/    30-Aug-2010 : Clean up from common ST3-ST4 routine( version 3.14-Ifremer )
 !/    23-Jan-2012 : Add output of lambdas to be used in SIN
-!/    13-Nov-2013 : Reduced frequency range with IG1 switch 
+!/    13-Nov-2013 : Reduced frequency range with IG1 switch
 !/    06-Jun-2018 : Add optional DEBUGSRC              ( version 6.04 )
 !/
 !  1. Purpose :
@@ -1564,17 +1564,17 @@
 !     Calculate whitecapping source term and diagonal term of derivative.
 !
 !  2. Method :
-!       
-!       This codes does either one or the other of 
-!       Ardhuin et al. (JPO 2010)   
+!
+!       This codes does either one or the other of
+!       Ardhuin et al. (JPO 2010)
 !       Filipot & Ardhuin (JGR 2012)
-!       the choice depends on SDSBCK 
+!       the choice depends on SDSBCK
 !
 !  3. Parameters :
 !
 !     Parameter list
 !     ----------------------------------------------------------------
-!       IX, IY    Int   I   Grid Index 
+!       IX, IY    Int   I   Grid Index
 !       A         R.A.  I   Action density spectrum (1-D).
 !       K         R.A.  I   Wavenumber for entire spectrum.          *)
 !       USTAR     Real  I   Friction velocity.
@@ -1639,7 +1639,7 @@
 !/
       INTEGER, OPTIONAL, INTENT(IN) :: IX, IY
       REAL, INTENT(IN)        :: A(NSPEC), K(NK), CG(NK),            &
-                                 DEPTH, USTAR, USDIR 
+                                 DEPTH, USTAR, USDIR
       REAL, INTENT(OUT)       :: SRHS(NSPEC), DDIAG(NSPEC), BRLAMBDA(NSPEC)
       REAL, INTENT(OUT)       :: WHITECAP(1:4)
 !/
@@ -1648,7 +1648,7 @@
 !/
       INTEGER                 :: IS, IS2, IS0, IKL, IKC, ID, NKL
 !/S      INTEGER, SAVE           :: IENT = 0
-      INTEGER                 :: IK, IK1, ITH, IK2, JTH, ITH2,             & 
+      INTEGER                 :: IK, IK1, ITH, IK2, JTH, ITH2,             &
                                  IKHS, IKD, SDSNTH, IT, IKM, NKM
       INTEGER                 :: NSMOOTH(NK)
       REAL                    :: COSWIND, ASUM, SDIAGISO
@@ -1661,13 +1661,13 @@
       REAL                    :: DK(NK), HS(NK), KBAR(NK), DCK(NK)
       REAL                    :: EFDF(NK)     ! Energy integrated over a spectral band
       INTEGER                 :: IKSUP(NK)
-      REAL                    :: FACSAT, DKHS, FACSTRAIN 
-      REAL                    :: BTH0(NK)     !saturation spectrum 
-      REAL                    :: BTH(NSPEC)   !saturation spectrum 
-      REAL                    :: BTH0S(NK)    !smoothed saturation spectrum 
-      REAL                    :: BTHS(NSPEC)  !smoothed saturation spectrum  
-      REAL                    :: SBK(NSPEC)  
-      INTEGER                 :: IMSSMAX(NK), NTHSUM   
+      REAL                    :: FACSAT, DKHS, FACSTRAIN
+      REAL                    :: BTH0(NK)     !saturation spectrum
+      REAL                    :: BTH(NSPEC)   !saturation spectrum
+      REAL                    :: BTH0S(NK)    !smoothed saturation spectrum
+      REAL                    :: BTHS(NSPEC)  !smoothed saturation spectrum
+      REAL                    :: SBK(NSPEC)
+      INTEGER                 :: IMSSMAX(NK), NTHSUM
       REAL                    :: SBKT(NK), MSSSUM(NK,5), WTHSUM(NTH), FACHF
       REAL                    :: MSSSUM2(NK,NTH)
       REAL                    :: MSSLONG(NK,NTH)
@@ -1683,7 +1683,7 @@
 !/S      CALL STRACE (IENT, 'W3SDS4')
 !
 !
-!---------------------------------------------------------------------- 
+!----------------------------------------------------------------------
 !
 ! 0.  Pre-Initialization to zero out arrays. All arrays should be reset
 !     within the computation, but these are helping with some bugs
@@ -1707,18 +1707,18 @@
       !IF (IX == DEBUG_NODE) WRITE(*,'(A20,4F20.10)') 'ST4 DISSIP ANFANG', SUM(SRHS), SUM(DDIAG)
 !/IG1  IK1=NINT(IGPARS(5))+1
       NTHSUM=MIN(FLOOR(SSDSC(10)+0.5),NTH-1)  ! number of angular bins for enhanced modulation
-      IF (NTHSUM.GT.0) THEN 
+      IF (NTHSUM.GT.0) THEN
         WTHSUM(1:NTHSUM)=1
         WTHSUM(NTHSUM+1)=SSDSC(10)+0.5-NTHSUM
-      ELSE 
+      ELSE
         WTHSUM(1)=2*SSDSC(10)
         END IF
 !
-! 2.   Estimation of spontaneous breaking 
+! 2.   Estimation of spontaneous breaking
 !
-      IF ( (SSDSBCK-SSDSC(1)).LE.0 ) THEN 
+      IF ( (SSDSBCK-SSDSC(1)).LE.0 ) THEN
 !
-! 2.a  Case of a direction-dependent breaking term (TEST441) 
+! 2.a  Case of a direction-dependent breaking term (TEST441)
 !
         EPSR = SQRT(SSDSBR)
 !
@@ -1745,7 +1745,7 @@
           ELSE
 
 !/DEBUGSRC          IF(IX == DEBUG_NODE) THEN
-!/DEBUGSRC            WRITE(*,'(A10,I10,5F20.10)') 'ST4 D1', IK, K(IK), BTH0(IK), SUM(BTH(IS0+1:IS0+NTH)), FACSAT, ASUM 
+!/DEBUGSRC            WRITE(*,'(A10,I10,5F20.10)') 'ST4 D1', IK, K(IK), BTH0(IK), SUM(BTH(IS0+1:IS0+NTH)), FACSAT, ASUM
 !/DEBUGSRC            WRITE(*,'(A10,10F20.10)') 'SSDSC', SSDSC
 !/DEBUGSRC          ENDIF
 
@@ -1753,7 +1753,7 @@
 ! straining effect: first finds the mean direction of mss, then applies cos^2
 !                   straining
 !
-            IF (SSDSC(8).GT.0.OR.SSDSC(11).GT.0) THEN 
+            IF (SSDSC(8).GT.0.OR.SSDSC(11).GT.0) THEN
               IKC = MAX(1,IK-DIKCUMUL)
               IMSSMAX (IK) = 1
               MSSP   = 0.
@@ -1761,12 +1761,12 @@
               MSSPS2 = 0.
               MSSPCS = 0.
 !
-! Sums the contributions to the directional MSS for all ITH   
+! Sums the contributions to the directional MSS for all ITH
 !
-              DO ITH=1,NTH         
+              DO ITH=1,NTH
                 IS=ITH+(IK-1)*NTH
                 MSSLONG(IK,ITH) = K(IK)**2 * A(IS) * DDEN(IK) / CG(IK) ! contribution to MSS
-                DO JTH=-NTHSUM,NTHSUM 
+                DO JTH=-NTHSUM,NTHSUM
                    ITH2 = 1+MOD(ITH-1+JTH+NTH,NTH)
                    MSSSUM2(IK:NK,ITH2) = MSSSUM2(IK:NK,ITH2)+MSSLONG(IK,ITH)*WTHSUM(ABS(JTH)+1)
                    END DO
@@ -1777,19 +1777,19 @@
                 END DO
 !
 ! Now sums over IK
-! 
+!
               MSSSUM  (IK:NK,1) = MSSSUM (IK:NK,1) +MSSP
               MSSSUM  (IK:NK,3) = MSSSUM (IK:NK,3) +MSSPC2
               MSSSUM  (IK:NK,4) = MSSSUM (IK:NK,4) +MSSPS2
               MSSSUM  (IK:NK,5) = MSSSUM (IK:NK,5) +MSSPCS
 !
-! Direction of long wave mss summed up to IK       
+! Direction of long wave mss summed up to IK
 !
               MSSD=0.5*(ATAN2(2*MSSSUM(IK,5),MSSSUM(IK,3)-MSSSUM(IK,4)))
               IF (MSSD.LT.0) MSSD = MSSD + PI
               IMSSMAX (IK)=1+NINT(MSSD *NTH/TPI)
 !
-! mss along perpendicular direction        
+! mss along perpendicular direction
 !
               MSSSUM  (IK,2)  = MAX(0.,MSSSUM(IK,4)*COS(MSSD)**2   &
                        -2*MSSSUM(IK,5)*SIN(MSSD)*COS(MSSD)+MSSSUM(IK,3)*SIN(MSSD)**2)
@@ -1800,16 +1800,16 @@
               DO ITH=1,NTH            ! partial integration
 
                 IS=ITH+(IK-1)*NTH
-! 
+!
 ! Testing straining effect of long waves on short waves
-! extended from Longuet-Higgins and Stewart (JFM 1960, eq. 2.27) the amplitude modulation 
+! extended from Longuet-Higgins and Stewart (JFM 1960, eq. 2.27) the amplitude modulation
 ! in deep water is equal to the long wave slope k*a cos(theta1-theta2)
 ! Here we assume that the saturation is modulated as (1 + 2*SSDSC(8) *  sqrt(mss_theta) )
-! where mss_theta is the mss in direction ITH. 
-! 
+! where mss_theta is the mss in direction ITH.
+!
 ! Note: SSDSC(8) is 2 times the MTF: close to 4x2=8 for very small ka but can be 20 or larger for ak~0.1
 !
-                IF (SSDSC(8).GT.0) THEN 
+                IF (SSDSC(8).GT.0) THEN
 !
                 MSSTH=(MSSSUM(IKC,1)-MSSSUM(IKC,2))*EC2(1+ABS(ITH-IMSSMAX (IKC))) &
                         +MSSSUM(IKC,2)*ES2(1+ABS(ITH-IMSSMAX (IKC)))
@@ -1836,17 +1836,17 @@
 !/DEBUGSRC            ENDIF
 
           END DO !NK END
-! 
+!
 !   Optional smoothing of B and B0 over frequencies
-! 
-        IF (SSDSBRFDF.GT.0.AND.SSDSBRFDF.LT.NK/2) THEN 
+!
+        IF (SSDSBRFDF.GT.0.AND.SSDSBRFDF.LT.NK/2) THEN
           BTH0S(:)=BTH0(:)
           BTHS(:)=BTH(:)
           NSMOOTH(:)=1
           DO IK=1, SSDSBRFDF
             BTH0S(1+SSDSBRFDF)=BTH0S(1+SSDSBRFDF)+BTH0(IK)
             NSMOOTH(1+SSDSBRFDF)=NSMOOTH(1+SSDSBRFDF)+1
-            DO ITH=1,NTH       
+            DO ITH=1,NTH
               IS=ITH+(IK-1)*NTH
               BTHS(ITH+SSDSBRFDF*NTH)=BTHS(ITH+SSDSBRFDF*NTH)+BTH(IS)
               END DO
@@ -1854,7 +1854,7 @@
           DO IK=IK1+1+SSDSBRFDF,1+2*SSDSBRFDF
             BTH0S(1+SSDSBRFDF)=BTH0S(1+SSDSBRFDF)+BTH0(IK)
             NSMOOTH(1+SSDSBRFDF)=NSMOOTH(1+SSDSBRFDF)+1
-            DO ITH=1,NTH       
+            DO ITH=1,NTH
               IS=ITH+(IK-1)*NTH
               BTHS(ITH+SSDSBRFDF*NTH)=BTHS(ITH+SSDSBRFDF*NTH)+BTH(IS)
               END DO
@@ -1862,41 +1862,41 @@
           DO IK=SSDSBRFDF,IK1,-1
             BTH0S(IK)=BTH0S(IK+1)-BTH0(IK+SSDSBRFDF+1)
             NSMOOTH(IK)=NSMOOTH(IK+1)-1
-            DO ITH=1,NTH       
+            DO ITH=1,NTH
               IS=ITH+(IK-1)*NTH
               BTHS(IS)=BTHS(IS+NTH)-BTH(IS+(SSDSBRFDF+1)*NTH)
               END DO
             END DO
-! 
+!
           DO IK=IK1+1+SSDSBRFDF,NK-SSDSBRFDF
             BTH0S(IK)=BTH0S(IK-1)-BTH0(IK-SSDSBRFDF-1)+BTH0(IK+SSDSBRFDF)
             NSMOOTH(IK)=NSMOOTH(IK-1)
-            DO ITH=1,NTH       
+            DO ITH=1,NTH
               IS=ITH+(IK-1)*NTH
               BTHS(IS)=BTHS(IS-NTH)-BTH(IS-(SSDSBRFDF+1)*NTH)+BTH(IS+(SSDSBRFDF)*NTH)
               END DO
             END DO
-! 
+!
           DO IK=NK-SSDSBRFDF+1,NK
             BTH0S(IK)=BTH0S(IK-1)-BTH0(IK-SSDSBRFDF)
             NSMOOTH(IK)=NSMOOTH(IK-1)-1
-            DO ITH=1,NTH       
+            DO ITH=1,NTH
               IS=ITH+(IK-1)*NTH
               BTHS(IS)=BTHS(IS-NTH)-BTH(IS-(SSDSBRFDF+1)*NTH)
               END DO
             END DO
-! 
+!
 !    final division by NSMOOTH
-! 
+!
          BTH0(:)=MAX(0.,BTH0S(:)/NSMOOTH(:))
           DO IK=IK1,NK
             IS0=(IK-1)*NTH
             BTH(IS0+1:IS0+NTH)=MAX(0.,BTHS(IS0+1:IS0+NTH)/NSMOOTH(IK))
-            END DO 
+            END DO
           END IF
-! 
+!
 !  2.a.2  Computes spontaneous breaking dissipation rate
-! 
+!
         DO  IK=IK1, NK
 !
 !  Correction of saturation level for shallow-water kinematics
@@ -1918,7 +1918,7 @@
           COEF2=SSDSC(2) * SIG(IK)*(1-SSDSC(6))/(COEF1*COEF1)
           COEF3=-2.*SIG(IK)*K(IK)*FACTURB
           DDIAG((IK-1)*NTH+1:IK*NTH) = SDIAGISO + &
-                                   COEF2*((MAX(0.,BTH((IK-1)*NTH+1:IK*NTH)-COEF1))**SSDSP) 
+                                   COEF2*((MAX(0.,BTH((IK-1)*NTH+1:IK*NTH)-COEF1))**SSDSP)
 !            IF (IX == DEBUG_NODE) THEN
 !              WRITE(*,'(A10,I10,10F15.6)') 'ST4 D3',IK,BTH0(IK),SUM(BTH((IK-1)*NTH+1:IK*NTH)),COEF1,COEF2,COEF3,SSDSP,SDIAGISO
 !            ENDIF
@@ -1929,13 +1929,13 @@
 !
 ! Computes Breaking probability
 !
-        PB = (MAX(SQRT(BTH)-EPSR,0.))**2     
-! 
-! Multiplies by 28.16 = 22.0 * 1.6² * 1/2 with  
-!  22.0 (Banner & al. 2000, figure 6) 
+        PB = (MAX(SQRT(BTH)-EPSR,0.))**2
+!
+! Multiplies by 28.16 = 22.0 * 1.6² * 1/2 with
+!  22.0 (Banner & al. 2000, figure 6)
 !  1.6  the coefficient that transforms  SQRT(B) to Banner et al. (2000)'s epsilon
 !  1/2  factor to correct overestimation of Banner et al. (2000)'s breaking probability due to zero-crossing analysis
-! 
+!
         PB = PB * 28.16
 !/
         END IF ! End of test for (Ardhuin et al. 2010)'s spontaneous dissipation source term
@@ -1944,7 +1944,7 @@
 !
       IF (SSDSBCK.GT.0) THEN ! test for (Filipot et al. 2010)'s disspation source term
         E1 = 0.
-        HS = 0.  
+        HS = 0.
         SRHS  = 0.
         DDIAG = 0.
         PB2  = 0.
@@ -1962,43 +1962,43 @@
 !
 ! Gets windows indices of IKTAB
 !
-        ID=MIN(NINT(DEPTH),NDTAB) 
+        ID=MIN(NINT(DEPTH),NDTAB)
         IF (ID < 1) THEN
           ID = 1
         ELSE IF(ID > NDTAB) THEN
-          ID = NDTAB 
+          ID = NDTAB
           END IF
 !
 ! loop over wave scales
 !
-        HS=0.  
+        HS=0.
         EFDF=0.
         KBAR=0.
-        EFDF=0. 
+        EFDF=0.
         NKL=0. !number of windows
-        DO IKL=1,NK 
+        DO IKL=1,NK
           IKSUP(IKL)=IKTAB(IKL,ID)
           IF (IKSUP(IKL) .LE. NK) THEN
             EFDF(IKL) = DOT_PRODUCT(E1(IKL:IKSUP(IKL)-1),DK(IKL:IKSUP(IKL)-1))
             IF (EFDF(IKL) .NE. 0) THEN
               KBAR(IKL) = DOT_PRODUCT(K(IKL:IKSUP(IKL)-1)*E1(IKL:IKSUP(IKL)-1), &
-                                      DK(IKL:IKSUP(IKL)-1)) / EFDF(IKL) 
-            ELSE 
-              KBAR(IKL)=0. 
+                                      DK(IKL:IKSUP(IKL)-1)) / EFDF(IKL)
+            ELSE
+              KBAR(IKL)=0.
               END IF
 ! estimation of Significant wave height of a given scale
-            HS(IKL) = 4*SQRT(EFDF(IKL)) 
+            HS(IKL) = 4*SQRT(EFDF(IKL))
             NKL = NKL+1
             END IF
           END DO
-!   
-! Computes Dissipation and breaking probability in each scale  
+!
+! Computes Dissipation and breaking probability in each scale
 !
         DCK=0.
         QB =0.
-        DKHS = KHSMAX/NKHS 
+        DKHS = KHSMAX/NKHS
         DO IKL=1, NKL
-          IF (HS(IKL) .NE. 0. .AND. KBAR(IKL) .NE. 0.)  THEN 
+          IF (HS(IKL) .NE. 0. .AND. KBAR(IKL) .NE. 0.)  THEN
 !
 ! gets indices for tabulated dissipation DCKI and breaking probability QBI
 !
@@ -2013,12 +2013,12 @@
               IKHS = NKHS
             ELSE IF (IKHS < 1) THEN
               IKHS = 1
-              END IF  
+              END IF
             XT = TANH(KBAR(IKL)*DEPTH)
 !
 !  Gamma corrected for water depth
 !
-            GAM=1.0314*(XT**3)-1.9958*(XT**2)+1.5522*XT+0.1885 
+            GAM=1.0314*(XT**3)-1.9958*(XT**2)+1.5522*XT+0.1885
 !
 ! Computes the energy dissipated for the scale IKL
 ! using DCKI which is tabulated in INSIN4
@@ -2028,10 +2028,10 @@
 ! Get the breaking probability for the scale IKL
 !
             QB(IKL) = QBI(IKHS,IKD) ! QBI is tabulated in INSIN4
-          ELSE   
+          ELSE
             DCK(IKL)=0.
             QB(IKL) =0.
-            END IF  
+            END IF
           END DO
 !
 ! Distributes scale dissipation over the frequency spectrum
@@ -2040,7 +2040,7 @@
         S2 = 0.
         NTIMES = 0
         DO IKL=1, NKL
-          IF (EFDF(IKL) .GT. 0.) THEN 
+          IF (EFDF(IKL) .GT. 0.) THEN
             S1(IKL:IKSUP(IKL))    = S1(IKL:IKSUP(IKL)) + &
                                      DCK(IKL)*E1(IKL:IKSUP(IKL)) / EFDF(IKL)
             S2(IKL:IKSUP(IKL))    = S2(IKL:IKSUP(IKL)) + &
@@ -2050,7 +2050,7 @@
           END DO
 !
 ! Finish the average
-! 
+!
         WHERE (NTIMES .GT. 0)
           S1 = S1 / NTIMES
           S2 = S2 / NTIMES
@@ -2058,13 +2058,13 @@
           S1 = 0.
           S2 = 0.
           END WHERE
-! goes back to action for dissipation source term 
+! goes back to action for dissipation source term
         S1(1:NK) = S1(1:NK) / SIG(1:NK)
 !
 ! Makes Isotropic distribution
 !
         ASUM = 0.
-        DO IK = 1, NK 
+        DO IK = 1, NK
           ASUM = (SUM(A(((IK-1)*NTH+1):(IK*NTH)))*DTH)
           IF (ASUM.GT.1.E-8) THEN
             FORALL (IS=1+(IK-1)*NTH:IK*NTH) DDIAG(IS)  = S1(IK)/ASUM
@@ -2072,13 +2072,13 @@
           ELSE
             FORALL (IS=1+(IK-1)*NTH:IK*NTH) DDIAG(IS)  = 0.
             FORALL (IS=1+(IK-1)*NTH:IK*NTH) PB2(IS) = 0.
-            END IF  
-          IF (PB2(1+(IK-1)*NTH).GT.0.001) THEN 
+            END IF
+          IF (PB2(1+(IK-1)*NTH).GT.0.001) THEN
             BTH0(IK) = 2.*SSDSBR
           ELSE
-            BTH0(IK) = 0. 
+            BTH0(IK) = 0.
             END IF
-          END DO   
+          END DO
 !
         PB = (1-SSDSC(1))*PB2*A + SSDSC(1)*PB
 !
@@ -2088,7 +2088,7 @@
 !
 ! 3.   Computes Lambda from breaking probability
 !
-! Compute Lambda = PB* l(k,th) 
+! Compute Lambda = PB* l(k,th)
 ! with l(k,th)=1/(2*pi²)= the breaking crest density
 !
       BRLAMBDA = PB / (2.*PI**2.)
@@ -2102,7 +2102,7 @@
 !
       SBKT(:)=0.
       DO  IK=IK1, NK
-        DO ITH=1,NTH       
+        DO ITH=1,NTH
           IS=ITH+(IK-1)*NTH
 !
 ! Computes cumulative effect from Breaking probability
@@ -2130,7 +2130,7 @@
 !
           SBK(IS)   = DDIAG(IS)*A(IS)
           SBKT(IK)  = SBKT(IK) + SBK(IS)
-          DDIAG(IS) = DDIAG(IS) + (SSDSC(3)*RENEWALFREQ+DTURB) 
+          DDIAG(IS) = DDIAG(IS) + (SSDSC(3)*RENEWALFREQ+DTURB)
           END DO
         END DO
 !
@@ -2139,12 +2139,12 @@
       SRHS = DDIAG * A
       !IF(IX == DEBUG_NODE) WRITE(*,'(A10,4F20.10)') 'ST4 DISSIP 2', SUM(SRHS), SUM(DDIAG), SSDSC(3)*RENEWALFREQ, DTURB
 !
-! Adds non-diagonal part: high and low frequency generation 
+! Adds non-diagonal part: high and low frequency generation
 !
-      IF (SSDSC(1).GT.0) THEN 
+      IF (SSDSC(1).GT.0) THEN
         DO IK2 = IK1+DIKCUMUL, NK
           DO IK = IK2-DIKCUMUL, IK2-1
-            DO ITH=1,NTH 
+            DO ITH=1,NTH
               IS2=ITH+(IK2-1)*NTH
               IS=ITH+(IK-1)*NTH
               SRHS(IS) = SRHS(IS) + SSDSC(1)*ABS(SBK(IS2))/DIKCUMUL
@@ -2153,7 +2153,7 @@
           END DO
         END IF
 !
-      IF (SSDSC(9).GT.0) THEN 
+      IF (SSDSC(9).GT.0) THEN
         DO IK2 = IK1, NK-DIKCUMUL
           IKM= MIN(NK,IK2+2*DIKCUMUL)
           NKM=IKM-(IK2+DIKCUMUL)+1
@@ -2174,7 +2174,7 @@
 !
       WHITECAP(1:2) = 0.
 !
-! precomputes integration of Lambda over direction 
+! precomputes integration of Lambda over direction
 ! times wavelength times a (a=5 in Reul&Chapron JGR 2003) times dk
 !
       DO IK=1,NK
@@ -2194,23 +2194,23 @@
 !/
       IF ( FLOGRD(5,8) ) THEN
 !
-! Calculates the Mean Foam Thickness for component K(IK) => Fig.3, Reul and Chapron, 2003 
+! Calculates the Mean Foam Thickness for component K(IK) => Fig.3, Reul and Chapron, 2003
 !
         DO IK=IK1,NK
 !    Duration of active breaking (TAU*)
-          TSTR = 0.8 * 2*PI/SIG(IK)                                
+          TSTR = 0.8 * 2*PI/SIG(IK)
 !    Time persistence of foam (a=5.)
-          TMAX = 5.  * 2*PI/SIG(IK)                                
+          TMAX = 5.  * 2*PI/SIG(IK)
           DT   = TMAX / 50
-          MFT  = 0. 
-          DO IT = 1, 50                                            
+          MFT  = 0.
+          DO IT = 1, 50
 ! integration over time of foam persistance
             T = FLOAT(IT) * DT
 ! Eq. 5 and 6 of Reul and Chapron, 2003
             IF ( T .LT. TSTR ) THEN
-              MFT = MFT + 0.4 / (K(IK)*TSTR) * T * DT              
-            ELSE                                                   
-              MFT = MFT + 0.4 / K(IK) * EXP(-1*(T-TSTR)/3.8) * DT  
+              MFT = MFT + 0.4 / (K(IK)*TSTR) * T * DT
+            ELSE
+              MFT = MFT + 0.4 / K(IK) * EXP(-1*(T-TSTR)/3.8) * DT
               END IF
             END DO
           MFT = MFT / TMAX

--- a/model/ftn/w3srcemd.ftn
+++ b/model/ftn/w3srcemd.ftn
@@ -59,14 +59,14 @@
                           TAUWY, TAUOX, TAUOY, TAUWIX, TAUWIY, TAUWNX,&
                           TAUWNY, PHIAW, CHARN, TWS, PHIOC, WHITECAP, &
                           D50, PSIC, BEDFORM , PHIBBL, TAUBBL, TAUICE,&
-                          PHICE, COEF) 
+                          PHICE, COEF)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           H. L. Tolman            |
 !/                  |            F. Ardhuin             |
-!/                  |            A. Roland              | 
-!/                  |            M. Dutour Sikiric      | 
+!/                  |            A. Roland              |
+!/                  |            M. Dutour Sikiric      |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :         07-Jan-2018 |
 !/                  +-----------------------------------+
@@ -94,14 +94,14 @@
 !/    19-Aug-2010 : Making treatment of 0 water depth   ( version 3.14.6 )
 !/                  consistent with the rest of the model.
 !/    31-Mar-2010 : Adding ice conc. and reflections    ( version 3.14.4 )
-!/    15-May-2010 : Adding transparencies               ( version 3.14.4 ) 
-!/    01-Jun-2011 : Movable bed bottom friction in BT4  ( version 4.01 ) 
-!/    01-Jul-2011 : Energy and momentum flux, friction  ( version 4.01 ) 
+!/    15-May-2010 : Adding transparencies               ( version 3.14.4 )
+!/    01-Jun-2011 : Movable bed bottom friction in BT4  ( version 4.01 )
+!/    01-Jul-2011 : Energy and momentum flux, friction  ( version 4.01 )
 !/    24-Aug-2011 : Uses true depth for depth-induced   ( version 4.04 )
 !/    16-Sep-2011 : Initialization of TAUWAX, TAUWAY    ( version 4.04 )
 !/     1-Dec-2011 : Adding BYDRZ source term package    ( version 4.04 )
 !/                  ST6 and optional Hwang (2011)
-!/                  stresses FLX4. 
+!/                  stresses FLX4.
 !/    14-Mar-2012 : Update of BT4, passing PSIC         ( version 4.04 )
 !/    13-Jul-2012 : Move GMD (SNL3) and nonlinear filter (SNLS)
 !/                  from 3.15 (HLT).                    ( version 4.08 )
@@ -117,13 +117,13 @@
 !/    30-Jul-2017 : Adds TWS in interface               ( version 6.04 )
 !/    07-Jan-2018 : Allows variable ice scaling (F.A.)  ( version 6.04 )
 !/    01-Jan-2018 : Add implicit source term integration ( version 6.04)
-!/    01-Jan-2018 : within PDLIB (A. Roland, M. Dutour    
+!/    01-Jan-2018 : within PDLIB (A. Roland, M. Dutour
 !/    18-Aug-2018 : S_{ice} IC5 (Q. Liu)                ( version  6.06)
 !/    26-Aug-2018 : UOST (Mentaschi et al. 2015, 2018)  ( version 6.06 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -189,10 +189,10 @@
 !       USTAR   Real. !/O  Friction velocity.
 !       USTDIR  Real  !/O  Idem, direction.
 !       CX-Y    Real.  I   Current velocity components.   ( !/BS1 )
-!       ICE     Real   I   Sea ice concentration          
-!       ICEH    Real   I   Sea ice thickness 
-!       ICEF    Real  I/O  Sea ice maximum floe diameter  (updated)        
-!       ICEDMAX Real  I/O  Sea ice maximum floe diameter          
+!       ICE     Real   I   Sea ice concentration
+!       ICEH    Real   I   Sea ice thickness
+!       ICEF    Real  I/O  Sea ice maximum floe diameter  (updated)
+!       ICEDMAX Real  I/O  Sea ice maximum floe diameter
 !       BERG    Real   I   Iceberg damping coefficient    ( !/BS1 )
 !       REFLEC  R.A.   I   reflection coefficients        ( !/BS1 )
 !       REFLED  I.A.   I   reflection direction           ( !/BS1 )
@@ -209,9 +209,9 @@
 !       BEDFORM R.A.  I/O  Bedform parameters             ( !/BT4 )
 !       PSIC    Real   I   Critical Shields               ( !/BT4 )
 !       PHIBBL  Real   O   Energy flux to BBL             ( !/BTx )
-!       TAUBBL  R.A.   O   Momentum flux to BBL           ( !/BTx ) 
+!       TAUBBL  R.A.   O   Momentum flux to BBL           ( !/BTx )
 !       TAUICE  R.A.   O   Momentum flux to sea ice       ( !/ICx )
-!       PHICE   Real   O   Energy flux to sea ice         ( !/ICx ) 
+!       PHICE   Real   O   Energy flux to sea ice         ( !/ICx )
 !     ----------------------------------------------------------------
 !       Note: several pars are set to I/O to avoid compiler warnings.
 !
@@ -309,14 +309,14 @@
 !
 !     !/BT0   No bottom friction.                        ( Choose one )
 !     !/BT1   JONSWAP bottom friction.
-!     !/BT4   Bottom friction using movable bed roughness 
+!     !/BT4   Bottom friction using movable bed roughness
 !                  (Tolman 1994, Ardhuin & al. 2003)
 !     !/BT8   Muddy bed (Dalrymple & Liu).
 !     !/BT9   Muddy bed (Ng).
 !     !/BTX   User-defined bottom friction.
 !
 !     !/IC1   Dissipation via interaction with ice according to simple
-!             methods: 1) uniform in frequency or 
+!             methods: 1) uniform in frequency or
 !     !/IC2            2) Liu et al. model
 !     !/IC3   Dissipation via interaction with ice according to a
 !             viscoelastic sea ice model (Wang and Shen 2010).
@@ -364,7 +364,7 @@
       USE W3WDATMD, ONLY: TIME
       USE W3ODATMD, ONLY: NDSE, NDST, IAPROC
       USE W3IDATMD, ONLY: INFLAGS1, INFLAGS2, ICEP2
-      USE W3DISPMD      
+      USE W3DISPMD
 !/NNT      USE W3ODATMD, ONLY: IAPROC, SCREEN, FNMPRE
 !/FLD1      USE W3FLD1MD, ONLY: W3FLD1
 !/FLD1      USE W3GDATMD, ONLY: AALPHA
@@ -423,7 +423,7 @@
 !/PDLIB    USE yowNodepool,    ONLY: PDLIB_CCON, NPA, PDLIB_I_DIAG, PDLIB_JA, PDLIB_IA_P
 !/PDLIB    USE W3GDATMD, ONLY: CLATS
 !/PDLIB    USE W3WDATMD, ONLY: VA
-!/PDLIB    USE W3PARALL, ONLY: ONESIXTH, ZERO, THR, IMEM 
+!/PDLIB    USE W3PARALL, ONLY: ONESIXTH, ZERO, THR, IMEM
 !/
       IMPLICIT NONE
 !/
@@ -459,9 +459,9 @@
 !/S      INTEGER, SAVE           :: IENT = 0
 !/NNT      INTEGER, SAVE           :: NDSD = 89, NDSD2 = 88, J
       REAL                    :: DTTOT, FHIGH, DT, AFILT, DAMAX, AFAC,&
-                                 HDT, ZWND, FP, DEPTH, TAUSCX, TAUSCY, FHIGI 
+                                 HDT, ZWND, FP, DEPTH, TAUSCX, TAUSCY, FHIGI
 ! Scaling factor for SIN, SDS, SNL
-      REAL                    :: ICESCALELN, ICESCALEIN, ICESCALENL, ICESCALEDS  
+      REAL                    :: ICESCALELN, ICESCALEIN, ICESCALENL, ICESCALEDS
       REAL                    :: EMEAN, FMEAN, WNMEAN, AMAX, CD, Z0, SCAT,    &
                                  SMOOTH_ICEDISP
       REAL                    :: WN_R(NK), CG_ICE(NK),ALPHA_LIU(NK), ICECOEF2,&
@@ -506,10 +506,10 @@
 !/XXX                                 VSXX(NSPEC), VDXX(NSPEC),            &
 !/UOST                                 VSUO(NSPEC), VDUO(NSPEC),            &
                                  VS  (NSPEC), VD  (NSPEC), EB(NK)
-!/ST3      LOGICAL                 :: LLWS(NSPEC) 
+!/ST3      LOGICAL                 :: LLWS(NSPEC)
 !/ST4      LOGICAL                 :: LLWS(NSPEC)
 !/ST4      REAL                    :: BRLAMBDA(NSPEC)
-!/IS2      DOUBLE PRECISION        :: SCATSPEC(NTH) 
+!/IS2      DOUBLE PRECISION        :: SCATSPEC(NTH)
       REAL                    :: FOUT(NK,NTH), SOUT(NK,NTH), DOUT(NK,NTH)
 !/FLD1     REAL, SAVE              :: TAUNUX, TAUNUY
 !/FLD2     REAL, SAVE              :: TAUNUX, TAUNUY
@@ -533,14 +533,14 @@
 !
       DEPTH  = MAX ( DMIN , D_INP )
       IKS1 = 1
-      ICESCALELN = MAX(0.,MIN(1.,1.-ICE*ICESCALES(1))) 
-      ICESCALEIN = MAX(0.,MIN(1.,1.-ICE*ICESCALES(2))) 
-      ICESCALENL = MAX(0.,MIN(1.,1.-ICE*ICESCALES(3))) 
-      ICESCALEDS = MAX(0.,MIN(1.,1.-ICE*ICESCALES(4))) 
-!/IG1! 
-!/IG1! Does not integrate source terms for IG band if IGPARS(12) = 0. 
-!/IG1! 
-!/IG1      IF (NINT(IGPARS(12)).EQ.0) IKS1 = NINT(IGPARS(5)) 
+      ICESCALELN = MAX(0.,MIN(1.,1.-ICE*ICESCALES(1)))
+      ICESCALEIN = MAX(0.,MIN(1.,1.-ICE*ICESCALES(2)))
+      ICESCALENL = MAX(0.,MIN(1.,1.-ICE*ICESCALES(3)))
+      ICESCALEDS = MAX(0.,MIN(1.,1.-ICE*ICESCALES(4)))
+!/IG1!
+!/IG1! Does not integrate source terms for IG band if IGPARS(12) = 0.
+!/IG1!
+!/IG1      IF (NINT(IGPARS(12)).EQ.0) IKS1 = NINT(IGPARS(5))
       IS1=(IKS1-1)*NTH+1
 !
 !/LN0      VSLN = 0.
@@ -712,7 +712,7 @@
 !/ST4                   AMAX, U10ABS, U10DIR, USTAR, USTDIR,          &
 !/ST4                   TAUWX, TAUWY, CD, Z0, CHARN, LLWS, FMEANWS)
 !/ST4      TWS = 1./FMEANWS
-!/ST6      CALL W3SPR6 (SPEC, CG1, WN1, EMEAN, FMEAN, WNMEAN, AMAX, FP)  
+!/ST6      CALL W3SPR6 (SPEC, CG1, WN1, EMEAN, FMEAN, WNMEAN, AMAX, FP)
 !
 ! 1.c2 Stores the initial data
 !
@@ -736,7 +736,7 @@
 !/ST1      IF (FLTEST) WRITE (NDST,9004) FH1*TPIINV, FH2*TPIINV, FHIGH*TPIINV
 !/ST2      FHIGH  = XFC * FPI
 !/ST3      FHIGH  = MAX(FFXFM * MAX(FMEAN,FMEANWS),FFXPM / USTAR)
-!/ST4! Introduces a Long & Resio (JGR2007) type dependance on wave age  
+!/ST4! Introduces a Long & Resio (JGR2007) type dependance on wave age
 ! !/ST4      FAGE   = FFXFA*TANH(0.3*U10ABS*FMEANWS*TPI/GRAV)
 !/ST4      FAGE   = 0.
 !/ST4      FHIGH  = MAX( (FFXFM + FAGE ) * MAX(FMEAN1,FMEANWS), FFXPM / USTAR)
@@ -800,7 +800,7 @@
 !/NL2        CALL W3SNL2 ( SPEC, CG1, DEPTH,               VSNL, VDNL )
 !/NL3        CALL W3SNL3 ( SPEC, CG1, WN1, DEPTH,          VSNL, VDNL )
 !/NL4        CALL W3SNL4 ( SPEC, CG1, WN1, DEPTH,          VSNL, VDNL )
-!/NLX        CALL W3SNLX 
+!/NLX        CALL W3SNLX
 !
 !/PDLIB    IF (.NOT. B_JGS_SOURCE_NONLINEAR) THEN
 !/TR1        CALL W3STR1 ( SPEC, CG1, WN1, DEPTH, IX,        VSTR, VDTR )
@@ -901,12 +901,12 @@
         DT     = MIN ( DTG-DTTOT , DTMAX )
         AFILT  = MAX ( DAM(NSPEC) , XFLT*AMAX )
 !
-!     For input and dissipation calculate the fraction of the ice-free 
+!     For input and dissipation calculate the fraction of the ice-free
 !     surface. In the presence of ice, the effective water surface
 !     is reduce to a fraction of the cell size free from ice, and so is
 !     input :
 !             SIN = (1-ICE)**ISCALEIN*SIN and SDS=(1-ICE)**ISCALEDS*SDS ------------------ *
-!     INFLAGS2(4) is true if ice concentration was ever read during  
+!     INFLAGS2(4) is true if ice concentration was ever read during
 !             this simulation
         IF ( INFLAGS2(4) ) THEN
           VSNL(1:NSPECH) = ICESCALENL * VSNL(1:NSPECH)
@@ -925,7 +925,7 @@
         VD = 0
         DO IS=IS1, NSPECH
           VS(IS) = VSLN(IS) + VSIN(IS) + VSNL(IS)  &
-                 + VSDS(IS) + VSBT(IS) 
+                 + VSDS(IS) + VSBT(IS)
 !/ST6          VS(IS) = VS(IS) + VSWL(IS)
 !/TR1          VS(IS) = VS(IS) + VSTR(IS)
 !/TRX          VS(IS) = VS(IS) + VSTR(IS)
@@ -934,7 +934,7 @@
 !/XXX          VS(IS) = VS(IS) + VSXX(IS)
 !/UOST         VS(IS) = VS(IS) + VSUO(IS)
           VD(IS) =  VDIN(IS) + VDNL(IS)  &
-                 + VDDS(IS) + VDBT(IS) 
+                 + VDDS(IS) + VDBT(IS)
 !/ST6          VD(IS) = VD(IS) + VDWL(IS)
 !/TR1          VD(IS) = VD(IS) + VDTR(IS)
 !/TRX          VD(IS) = VD(IS) + VDTR(IS)
@@ -949,17 +949,17 @@
 !          IF (IX == DEBUG_NODE) THEN
 !            WRITE(*,'(A20,I10,10F30.10)') 'TIME STEP COMP', IS, DAMAX, DAM(IS), XREL*SPECINIT(IS), AFILT, AFAC, DT
 !          ENDIF
-        END DO  ! end of loop on IS 
+        END DO  ! end of loop on IS
 !
 !        WRITE(*,*) 'NODE_NUMBER', IX
-!        IF (IX == DEBUG_NODE) WRITE(*,*) 'TIMINGS 1', DT 
+!        IF (IX == DEBUG_NODE) WRITE(*,*) 'TIMINGS 1', DT
         DT     = MAX ( 0.5, DT )                   ! Here we have a hardlimit, which is not too usefull, at least not as a fixed constant
 !
         DTDYN  = DTDYN + DT
 !/T        DTRAW  = DT
-        IDT    = 1 + INT ( 0.99*(DTG-DTTOT)/DT ) ! number of iterations 
+        IDT    = 1 + INT ( 0.99*(DTG-DTTOT)/DT ) ! number of iterations
         DT     = (DTG-DTTOT)/REAL(IDT)           ! actualy time step
-        SHAVE  = DT.LT.DTMIN .AND. DT.LT.DTG-DTTOT   ! limiter check ... 
+        SHAVE  = DT.LT.DTMIN .AND. DT.LT.DTG-DTTOT   ! limiter check ...
         SHAVEIO = SHAVE
         DT     = MAX ( DT , MIN (DTMIN,DTG-DTTOT) ) ! override dt with input time step or last time step if it is bigger ... anyway the limiter is on!
         IF (srce_call .eq. srce_imp_post) DT = DTG  ! for implicit part
@@ -1024,7 +1024,7 @@
 !            END DO
             WRITE(740+IAPROC,*) 'min/max/sum(DeltaDS)=', minval(DeltaSRC), maxval(DeltaSRC), sum(DeltaSRC)
           END IF
-     
+
             IF (optionCall .eq. 1) THEN
               CALL SIGN_VSD_PATANKAR_WW3(SPEC,VS,VD)
             ELSE IF (optionCall .eq. 2) THEN
@@ -1060,7 +1060,7 @@
 ! 5.  Increment spectrum --------------------------------------------- *
 !
         IF (srce_call .eq. srce_direct) THEN
-!          SHAVE = .FALSE. 
+!          SHAVE = .FALSE.
 !         IF (IX == DEBUG_NODE) THEN
 !            WRITE(*,'(A20,I20,F20.10,L20,4F20.10)') 'BEFORE', IX, DEPTH, SHAVE, SUM(VS), SUM(VD), SUM(SPEC)
 !          ENDIF
@@ -1084,7 +1084,7 @@
 !          IF (IX == DEBUG_NODE) THEN
 !            WRITE(*,'(A20,I20,F20.10,L20,4F20.10)') 'AFTER', IX, DEPTH, SHAVE, SUM(VS), SUM(VD), SUM(SPEC)
 !          ENDIF
-!!/DEBUGSRC          IF (IX == DEBUG_NODE) WRITE(44,'(10EN15.4)') SUM(VS), SUM(VD), SUM(VSIN), SUM(VDIN), SUM(VSDS), SUM(VDDS), SUM(VSNL), SUM(VDNL) 
+!!/DEBUGSRC          IF (IX == DEBUG_NODE) WRITE(44,'(10EN15.4)') SUM(VS), SUM(VD), SUM(VSIN), SUM(VDIN), SUM(VSDS), SUM(VDDS), SUM(VSNL), SUM(VDNL)
 !/DEBUGSRC          IF (IX == DEBUG_NODE) WRITE(44,'(1EN15.4)') SUM(VSIN)
 !/DEBUGSRC          IF (IX == DEBUG_NODE) WRITE(44,'(1EN15.4)') SUM(VDIN)
 !/DEBUGSRC          IF (IX == DEBUG_NODE) WRITE(44,'(1EN15.4)') SUM(VSDS)
@@ -1106,11 +1106,11 @@
 
 
 !
-! 5.b  Computes 
+! 5.b  Computes
 !              atmos->wave flux PHIAW-------------------------------- *
 !              wave ->BBL  flux PHIBBL------------------------------- *
 !              wave ->ice  flux PHICE ------------------------------- *
-! 
+!
        WHITECAP(3)=0.
        HSTOT=0.
        DO IK=IKS1, NK
@@ -1125,7 +1125,7 @@
            COSI(2)=ESIN(IS)
            PHIAW = PHIAW + (VSIN(IS))* DT * FACTOR                    &
              / MAX ( 1. , (1.-HDT*VDIN(IS))) ! semi-implict integration scheme
-           
+
            PHIBBL= PHIBBL- (VSBT(IS))* DT * FACTOR                    &
              / MAX ( 1. , (1.-HDT*VDBT(IS))) ! semi-implict integration scheme
            PHINL = PHINL + VSNL(IS)* DT * FACTOR                      &
@@ -1140,7 +1140,7 @@
        TAUWIY= TAUWIY+ TAUWY * DRAT *DT
        TAUWNX= TAUWNX+ TAUWAX * DRAT *DT
        TAUWNY= TAUWNY+ TAUWAY * DRAT *DT
-       ! MISSING: TAIL TO BE ADDED ?      
+       ! MISSING: TAIL TO BE ADDED ?
 !
 !/NLS      CALL W3SNLS ( SPEC, CG1, WN1, DEPTH, U10ABS, DT, AA=SPEC )
 !
@@ -1190,7 +1190,7 @@
 !/ST3        IF ( FLTEST ) WRITE (NDST,9062)                           &
 !/ST3                      FH1*TPIINV, FH2*TPIINV, FHIGH*TPIINV, NKH
 !
-!/ST4! Introduces a Long & Resio (JGR2007) type dependance on wave age  
+!/ST4! Introduces a Long & Resio (JGR2007) type dependance on wave age
 !/ST4        FAGE   = FFXFA*TANH(0.3*U10ABS*FMEANWS*TPI/GRAV)
 !/ST4        FH1    = (FFXFM+FAGE) * FMEAN1
 
@@ -1211,7 +1211,7 @@
 !
 ! 6.b Limiter for shallow water or Miche style criterion
 !     Last time step ONLY !
-!     uses true depth (D_INP) instead of limited depth 
+!     uses true depth (D_INP) instead of limited depth
 !
 !/MLIM        IF ( DTTOT .GE. 0.9999*DTG ) THEN
 !/MLIM            HM     = FHMAX *TANH(WNMEAN*MAX(0.,D_INP)) / MAX(1.E-4,WNMEAN )
@@ -1296,9 +1296,9 @@
   888 CONTINUE
 !
 ! 9.a  Computes PHIOC------------------------------------------ *
-!     The wave to ocean flux is the difference between initial energy 
-!     and final energy, plus wind input plus the SNL flux to high freq., 
-!     minus the energy lost to the bottom boundary layer (BBL) 
+!     The wave to ocean flux is the difference between initial energy
+!     and final energy, plus wind input plus the SNL flux to high freq.,
+!     minus the energy lost to the bottom boundary layer (BBL)
 !
 !/DEBUGSRC     IF (IX .eq. DEBUG_NODE) THEN
 !/DEBUGSRC       WRITE(740+IAPROC,*) '2 : sum(SPEC)=', sum(SPEC)
@@ -1318,12 +1318,12 @@
           END DO
         EFINISH  = EFINISH  + EBAND * DDEN(IK) / CG1(IK)
         MWXFINISH  = MWXFINISH  + A1BAND * DDEN(IK) / CG1(IK)        &
-                  * WN1(IK)/SIG(IK) 
+                  * WN1(IK)/SIG(IK)
         MWYFINISH  = MWYFINISH  + B1BAND * DDEN(IK) / CG1(IK)        &
                   * WN1(IK)/SIG(IK)
         END DO
 !
-! Transformation in momentum flux in m^2 / s^2 
+! Transformation in momentum flux in m^2 / s^2
 !
       TAUOX=(GRAV*MWXFINISH+TAUWIX-TAUBBL(1))/DTG
       TAUOY=(GRAV*MWYFINISH+TAUWIY-TAUBBL(2))/DTG
@@ -1333,33 +1333,33 @@
       TAUWNY=TAUWNY/DTG
       TAUBBL(:)=TAUBBL(:)/DTG
 !
-! Transformation in wave energy flux in W/m^2=kg / s^3 
+! Transformation in wave energy flux in W/m^2=kg / s^3
 !
-      PHIOC =DWAT*GRAV*(EFINISH+PHIAW-PHIBBL)/DTG 
-      PHIAW =DWAT*GRAV*PHIAW /DTG        
-      PHINL =DWAT*GRAV*PHINL /DTG  
-      PHIBBL=DWAT*GRAV*PHIBBL/DTG        
-! 
+      PHIOC =DWAT*GRAV*(EFINISH+PHIAW-PHIBBL)/DTG
+      PHIAW =DWAT*GRAV*PHIAW /DTG
+      PHINL =DWAT*GRAV*PHINL /DTG
+      PHIBBL=DWAT*GRAV*PHIBBL/DTG
+!
 ! 10.1  Adds ice scattering and dissipation: implicit integration---------------- *
-!     INFLAGS2(4) is true if ice concentration was ever read during  
+!     INFLAGS2(4) is true if ice concentration was ever read during
 !             this simulation
 !
 !/DEBUGSRC     IF (IX .eq. DEBUG_NODE) THEN
 !/DEBUGSRC       WRITE(740+IAPROC,*) '3 : sum(SPEC)=', sum(SPEC)
 !/DEBUGSRC     END IF
 
-      IF ( INFLAGS2(4).AND.ICE.GT.0 ) THEN 
+      IF ( INFLAGS2(4).AND.ICE.GT.0 ) THEN
 
-         IF (IICEDISP) THEN 
+         IF (IICEDISP) THEN
            ICECOEF2 = 1E-6
            CALL LIU_FORWARD_DISPERSION (ICEH,ICECOEF2,DEPTH, &
                                         SIG,WN_R,CG_ICE,ALPHA_LIU)
 !
       IF (IICESMOOTH) THEN
 !/IS2   DO IK=1,NK
-!/IS2     SMOOTH_ICEDISP=0. 
+!/IS2     SMOOTH_ICEDISP=0.
 !/IS2     IF (IS2PARS(14)*(TPI/WN_R(IK)).LT.ICEF) THEN ! IF ICE IS NOT TOO MUCH BROKEN
-!/IS2       SMOOTH_ICEDISP=TANH((ICEF-IS2PARS(14)*(TPI/WN_R(IK)))/(ICEF*IS2PARS(13))) 
+!/IS2       SMOOTH_ICEDISP=TANH((ICEF-IS2PARS(14)*(TPI/WN_R(IK)))/(ICEF*IS2PARS(13)))
 !/IS2       END IF
 !/IS2     WN_R(IK)=WN1(IK)*(1-SMOOTH_ICEDISP)+WN_R(IK)*(SMOOTH_ICEDISP)
 !/IS2     END DO
@@ -1372,7 +1372,7 @@
      R(:)=1 ! In case IC2 is defined but not IS2
 !
 !/IC1      CALL W3SIC1 ( SPEC,DEPTH, CG1,       IX, IY, VSIC, VDIC )
-!/IS2      CALL W3SIS2 ( SPEC, DEPTH, ICE, ICEH, ICEF, ICEDMAX, IX, IY, & 
+!/IS2      CALL W3SIS2 ( SPEC, DEPTH, ICE, ICEH, ICEF, ICEDMAX, IX, IY, &
 !/IS2                              VSIR, VDIR, VDIR2, WN1, CG1, WN_R, CG_ICE, R )
 
 !/IC2                CALL W3SIC2 ( SPEC, DEPTH, ICEH, ICEF, CG1, WN1,&
@@ -1387,9 +1387,9 @@
    TAUICE(:) = 0.
    PHICE = 0.
    DO IK=1,NK
-     IS = 1+(IK-1)*NTH 
+     IS = 1+(IK-1)*NTH
 !
-! First part of ice term integration: dissipation part 
+! First part of ice term integration: dissipation part
 !
      ATT=1.
 !/IC1             ATT=EXP(ICE*VDIC(IS)*DTG)
@@ -1401,57 +1401,57 @@
 !/IS2             ATT=ATT*EXP(ICE*VDIR2(IS)*DTG)
 !/IS2             IF (IS2PARS(2).EQ.0) THEN ! Reminder : IS2PARS(2) = IS2BACKSCAT
 !/IS2!
-!/IS2! If there is not re-distribution in directions the scattering is just an attenuation 
+!/IS2! If there is not re-distribution in directions the scattering is just an attenuation
 !/IS2!
-!/IS2               ATT=ATT*EXP((ICE*VDIR(IS))*DTG) 
-!/IS2               END IF   
+!/IS2               ATT=ATT*EXP((ICE*VDIR(IS))*DTG)
+!/IS2               END IF
              SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) = ATT*SPEC2(1+(IK-1)*NTH:NTH+(IK-1)*NTH)
 !
 ! Second part of ice term integration: scattering including re-distribution in directions
 !
-!/IS2             IF (IS2PARS(2).GE.0) THEN 
-!/IS2               IF (IS2PARS(20).GT.0.5) THEN 
+!/IS2             IF (IS2PARS(2).GE.0) THEN
+!/IS2               IF (IS2PARS(20).GT.0.5) THEN
 !/IS2!
-!/IS2! Case of isotropic back-scatter: the directional spectrum is decomposed into 
+!/IS2! Case of isotropic back-scatter: the directional spectrum is decomposed into
 !/IS2!               - an isotropic part (ISO): eigenvalue of scattering is 0
 !/IS2!               - the rest     (SPEC-ISO): eigenvalue of scattering is VDIR(IS)
 !/IS2!
 !/IS2                 SCAT = EXP(VDIR(IS)*IS2PARS(2)*DTG)
-!/IS2                 ISO = SUM(SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH))/NTH 
+!/IS2                 ISO = SUM(SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH))/NTH
 !/IS2                 SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) = ISO &
 !/IS2                      +(SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH)-ISO)*SCAT
-!/IS2               ELSE 
+!/IS2               ELSE
 !/IS2!
-!/IS2! General solution with matrix exponentials: same as bottom scattering, see Ardhuin & Herbers (JFM 2002) 
-!/IS2!              
+!/IS2! General solution with matrix exponentials: same as bottom scattering, see Ardhuin & Herbers (JFM 2002)
+!/IS2!
 !/IS2                 SCATSPEC(1:NTH)=DBLE(SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH))
 !/IS2                 SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) =  &
 !/IS2                 REAL(MATMUL(IS2EIGVEC(:,:), EXP(IS2EIGVAL(:)*VDIR(IS)*DTG*IS2PARS(2)) &
 !/IS2                                       *MATMUL(TRANSPOSE(IS2EIGVEC(:,:)),SCATSPEC)))
 !/IS2                 END IF
 !/IS2               END IF
-! 
+!
 ! 10.2  Fluxes of energy and momentum due to ice effects
 !
              FACTOR = DDEN(IK)/CG1(IK)                    !Jacobian to get energy in band
              FACTOR2= FACTOR*GRAV*WN1(IK)/SIG(IK)         ! coefficient to get momentum
              DO ITH = 1,NTH
-               IS = ITH+(IK-1)*NTH 
-               PHICE = PHICE + (SPEC(IS)-SPEC2(IS)) * FACTOR      
+               IS = ITH+(IK-1)*NTH
+               PHICE = PHICE + (SPEC(IS)-SPEC2(IS)) * FACTOR
                COSI(1)=ECOS(IS)
                COSI(2)=ESIN(IS)
                TAUICE(:) = TAUICE(:) - (SPEC(IS)-SPEC2(IS))*FACTOR2*COSI(:)
                END DO
              END DO
-           PHICE =-1.*DWAT*GRAV*PHICE /DTG        
+           PHICE =-1.*DWAT*GRAV*PHICE /DTG
            TAUICE(:)=TAUICE(:)/DTG
-           ELSE 
-!/IS2             IF (IS2PARS(10).LT.0.5) THEN 
-!/IS2               ICEF = 0. 
-!/IS2             ENDIF 
+           ELSE
+!/IS2             IF (IS2PARS(10).LT.0.5) THEN
+!/IS2               ICEF = 0.
+!/IS2             ENDIF
            END IF
 !
-! 
+!
 ! - - - - - - - - - - - - - - - - - - - - - -
 ! 11. Sea state dependent stress routine calls
 ! - - - - - - - - - - - - - - - - - - - - - -
@@ -1463,7 +1463,7 @@
 !/DEBUGSRC       WRITE(740+IAPROC,*) '4 : sum(SPEC)=', sum(SPEC)
 !/DEBUGSRC     END IF
 
-! FLD1/2 requires the calculation of FPI: 
+! FLD1/2 requires the calculation of FPI:
 !/FLD1      CALL CALC_FPI(SPEC, CG1, FPI, VSIN )
 !/FLD2      CALL CALC_FPI(SPEC, CG1, FPI, VSIN )
 !
@@ -1471,15 +1471,15 @@
 !/FLD1          CALL W3FLD1 ( SPEC,min(FPI/TPI,2.0),COEF*U10ABS*COS(U10DIR),        &
 !/FLD1                    COEF*U10ABS*Sin(U10DIR), ZWND, DEPTH, 0.0, &
 !/FLD1                    USTAR, USTDIR, Z0,TAUNUX,TAUNUY,CHARN)
-!/FLD1      ELSE 
-!/FLD1          CHARN = AALPHA 
+!/FLD1      ELSE
+!/FLD1          CHARN = AALPHA
 !/FLD1      ENDIF
 !/FLD2      IF (U10ABS.GT.10. .and. HSTOT.gt.0.5) then
 !/FLD2          CALL W3FLD2 ( SPEC,min(FPI/TPI,2.0),COEF*U10ABS*COS(U10DIR),        &
 !/FLD2                    COEF*U10ABS*Sin(U10DIR), ZWND, DEPTH, 0.0, &
 !/FLD2                    USTAR, USTDIR, Z0,TAUNUX,TAUNUY,CHARN)
-!/FLD2      ELSE 
-!/FLD2          CHARN = AALPHA 
+!/FLD2      ELSE
+!/FLD2          CHARN = AALPHA
 !/FLD2      ENDIF
 !
 ! 12. includes shoreline reflection --------------------------------------------- *
@@ -1487,25 +1487,25 @@
 !/DEBUGSRC     IF (IX .eq. DEBUG_NODE) THEN
 !/DEBUGSRC       WRITE(740+IAPROC,*) '5 : sum(SPEC)=', sum(SPEC)
 !/DEBUGSRC     END IF
-!/REF1        IF (REFLEC(1).GT.0.OR.REFLEC(2).GT.0.OR.(REFLEC(4).GT.0.AND.BERG.GT.0)) THEN 
+!/REF1        IF (REFLEC(1).GT.0.OR.REFLEC(2).GT.0.OR.(REFLEC(4).GT.0.AND.BERG.GT.0)) THEN
 !/REF1          CALL W3SREF ( SPEC, CG1, WN1, EMEAN, FMEAN, DEPTH, CX, CY,   &
 !/REF1                        REFLEC, REFLED, TRNX, TRNY,  &
 !/REF1                        BERG, DTG, IX, IY,  VREF )
-!/REF1          IF (GTYPE.EQ.UNGTYPE.AND.REFPARS(3).LT.0.5) THEN 
+!/REF1          IF (GTYPE.EQ.UNGTYPE.AND.REFPARS(3).LT.0.5) THEN
 !AR: this can be further simplified let's do some simple tests 1st ...
-!/REF1            IF (IOBP(IX).EQ.0) THEN 
-!/REF1              DO IK=1, NK 
+!/REF1            IF (IOBP(IX).EQ.0) THEN
+!/REF1              DO IK=1, NK
 !/REF1                DO ITH=1, NTH
 !/REF1                  IF (IOBPD(ITH,IX).EQ.0) SPEC(ITH+(IK-1)*NTH) = DTG*VREF(ITH+(IK-1)*NTH)
 !/REF1                END DO
-!/REF1              END DO 
-!/REF1            ELSE 
+!/REF1              END DO
+!/REF1            ELSE
 !/REF1              IF (IOBDP(IX) .EQ. -1) THEN
 !/REF1                SPEC(:) = SPEC(:) + DTG * VREF(:)
 !/REF1              ENDIF
 !/REF1            ENDIF
 !/REF1          ELSE
-!/REF1            SPEC(:) = SPEC(:) + DTG * VREF(:) 
+!/REF1            SPEC(:) = SPEC(:) + DTG * VREF(:)
 !/REF1            END IF
 !/REF1          END IF
 !
@@ -1517,7 +1517,7 @@
 
       IF (IT.EQ.0) SPEC = SPECINIT
 
-      SPEC = MAX(0., SPEC)      
+      SPEC = MAX(0., SPEC)
 !
       RETURN
 !
@@ -1576,7 +1576,7 @@
 !/                  +-----------------------------------+
 !/
 !/    06-Jul-2016 : Origination                         ( version 5.12 )
-!/    06-Jul-2016 : Add SUBROUTINE SIGN_VSD_SEMI_IMPLICIT_WW3         
+!/    06-Jul-2016 : Add SUBROUTINE SIGN_VSD_SEMI_IMPLICIT_WW3
 !/                  Add optional DEBUGSRC/PDLIB           ( version 6.04 )
 !/
 !  1. Purpose :
@@ -1608,7 +1608,7 @@
 !
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
-!      W3SRCE Subr.            
+!      W3SRCE Subr.
 !     ----------------------------------------------------------------
 !
 !  6. Error messages :
@@ -1682,7 +1682,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1752,7 +1752,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |

--- a/model/ftn/w3srcxmd.ftn
+++ b/model/ftn/w3srcxmd.ftn
@@ -17,7 +17,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -99,7 +99,7 @@
 !     See notes in the file below where to add these elements.
 !
 !  6. Switches :
-!  
+!
 !     !/S  Enable subroutine tracing.
 !
 !  7. Source code :
@@ -466,7 +466,7 @@
 !     ***    The initialization routine should include all   ***
 !     *** initialization, including reading data from files. ***
 !     **********************************************************
-!      
+!
       IF ( FIRST ) THEN
           CALL INSDSX
           FIRST  = .FALSE.

--- a/model/ftn/w3str1md.ftn
+++ b/model/ftn/w3str1md.ftn
@@ -13,12 +13,12 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Module for inclusion of triad nonlinear interaction according to 
+!     Module for inclusion of triad nonlinear interaction according to
 !     Eldeberky's (1996) Lumped Triad Interaction (LTA) source term.
 !
 !  2. Variables and types :
@@ -63,8 +63,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -75,14 +75,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !
@@ -293,7 +293,7 @@
       INTEGER I1, I2, ID, IDDUM, II, IS, ISM, ISM1, ISMAX, &
               ISP, ISP1, ITH, IK
       REAL    AUX1, AUX2, BIPH, C0, CM, DEP, DEP_2, DEP_3, E0, EM, HS, &
-              FT, RINT, SIGPICG, SINBPH, STRI, WISM, WISM1, WISP, & 
+              FT, RINT, SIGPICG, SINBPH, STRI, WISM, WISM1, WISP, &
               WISP1, W0, WM, WN0, WNM, XIS, XISLN
       REAL, ALLOCATABLE :: E(:), SA(:,:)
       REAL              :: EB(NK), EBAND, EMEAN, SIGM01
@@ -421,8 +421,8 @@
 !
            DO IK = 1, NK
               E(IK) = A(ITH+(IK-1)*NTH) * TPI * SIG(IK) / CG(IK)
-!------------ Test ------------------------------------------ 
-              EF(IK) = EF(IK) + E(IK)        
+!------------ Test ------------------------------------------
+              EF(IK) = EF(IK) + E(IK)
 !------------------------------------------------------------
            END DO
 !

--- a/model/ftn/w3str2md.ftn
+++ b/model/ftn/w3str2md.ftn
@@ -15,13 +15,13 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     This peace of code computes the triad interaction term in the same way  
-!     as done in the SWAN model. 
+!     This peace of code computes the triad interaction term in the same way
+!     as done in the SWAN model.
 !
 !  2. Variables and types :
 !
@@ -45,15 +45,15 @@
 !     ----------------------------------------------------------------
 !
 !  5. Remarks : The approach is truncated version of the work of Elderberky.
-!               In SWAN the wave spectra is treated as one-dimensional and 
+!               In SWAN the wave spectra is treated as one-dimensional and
 !               only the transfer to the higher harmoics is taken into account
 !               for this no justification is given and it has to be further investigated.
 !               The approximation of Elderberky is for a flat bottom (actually bragg-0 resonance)
 !               The biggest problem is that it is not conservative, which is the biggest limitation factor.
-!               Moreover it is questionable if it was taken into account the in spectral wave models the 
+!               Moreover it is questionable if it was taken into account the in spectral wave models the
 !               freq. bandwidths are exponentially distributed in freq. space, which leads to the problem that
-!               it is possible that some jacobian transformation is missing the derivation of hte discrete form, 
-!               I am now looking into this and I hope that I can give some closure soon.  
+!               it is possible that some jacobian transformation is missing the derivation of hte discrete form,
+!               I am now looking into this and I hope that I can give some closure soon.
 !
 !
 !     See notes in the file below where to add these elements.
@@ -208,7 +208,7 @@
       INTEGER I1, I2, ID, IDDUM, IENT, II, IS, ISM, ISM1, ISMAX, &
               ISP, ISP1, ITH, IK
       REAL    AUX1, AUX2, BIPH, C0, CM, DEP, DEP_2, DEP_3, E0, EM, HS, &
-              FT, RINT, SIGPICG, SINBPH, STRI, WISM, WISM1, WISP, & 
+              FT, RINT, SIGPICG, SINBPH, STRI, WISM, WISM1, WISP, &
               WISP1, W0, WM, WN0, WNM, XIS, XISLN
       REAL, ALLOCATABLE :: E(:), SA(:,:)
       REAL              :: EB(NK), EBAND, EMEAN, SIGM01
@@ -245,7 +245,7 @@
         END DO
       END DO
 !
-! 2.  Integrate over wave numbers  
+! 2.  Integrate over wave numbers
 !
       DO IK=1, NK
         EB(IK) = EB(IK) * DDEN(IK) / CG(IK)
@@ -329,7 +329,7 @@
 !
            DO IK = 1, NK
               E(IK) = A(ITH+(IK-1)*NTH) * TPI * SIG(IK) / CG(IK)
-              EF(IK) = EF(IK) + E(IK)        
+              EF(IK) = EF(IK) + E(IK)
            END DO
 !
            DO IK = 1, ISMAX
@@ -378,7 +378,7 @@
                                     2.*(WISP  * SA(ITH,IK+ISP1) + &
                                         WISP1 * SA(ITH,IK+ISP )) ) / &
                                     SIGPICG
-!             --- Functional derivative 
+!             --- Functional derivative
               SF(IK) = 2.*( SA(ITH,IK) - &
                          2.*(WISP  * SA(ITH,IK+ISP1) + &
                          WISP1 * SA(ITH,IK+ISP )) ) + SF(IK)

--- a/model/ftn/w3strkmd.ftn
+++ b/model/ftn/w3strkmd.ftn
@@ -24,14 +24,14 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Module containing data structures and subroutines for spatial and 
+!     Module containing data structures and subroutines for spatial and
 !     temporal tracking (part of wave partitioning).
 !
 !  2. Method :
@@ -43,7 +43,7 @@
 !  3. Variables and types :
 !
 !     NOTE: In Fortran 90/95 derived types cannot contain allocatable arrays.
-!           The same functionality is achieved here using pointers (pointing 
+!           The same functionality is achieved here using pointers (pointing
 !           to unnamed allocatable arrays). Can be replaced by allocatable arrays
 !           when transitioning to the Fortran 2003 standard.
 !
@@ -113,10 +113,10 @@
          INTEGER     :: j
       END TYPE neighbr
 !
-!     mtchsys  Der. type    structure for storing data of matched systems 
+!     mtchsys  Der. type    structure for storing data of matched systems
 !     sysVal   Int arr      array of indices of matched systems
-!     tpVal    Real arr     array of peak period values of matched systems 
-!     wfVal    Real arr     array of wind fraction values of matched systems 
+!     tpVal    Real arr     array of peak period values of matched systems
+!     wfVal    Real arr     array of wind fraction values of matched systems
 !
       TYPE mtchsys
          INTEGER     :: sysVal(50)
@@ -167,14 +167,14 @@
       END TYPE system
 !
 !     timsys   Der. type     structure for storing time-tracked systems (all time levels)
-!     sys  type(system) arr  array of all spatially+temporally tracked systems at given 
-!                            time level   
+!     sys  type(system) arr  array of all spatially+temporally tracked systems at given
+!                            time level
 !
       TYPE timsys
          TYPE(system), POINTER :: sys(:)
       END TYPE timsys
 !
-!     sysmemory  Der. type   Structure to store key characteristics of systems over multiple 
+!     sysmemory  Der. type   Structure to store key characteristics of systems over multiple
 !                            time levels. Used during the time tracking routine.
 !
       TYPE sysmemory
@@ -216,7 +216,7 @@
 !     SETDIFF              returns elements in vector1 that are not in vector2
 !     INTERSECT            returns elements that are mutual in vector1 and vector2
 !     UNION                returns the union of vector1 and vector2
-!     func. LENGTH         finds no. of indices in vector not filled with blank entries. 
+!     func. LENGTH         finds no. of indices in vector not filled with blank entries.
 !     func. FINDFIRST      returns index of first instance of a search value in vector
 !     func. STD            computes standard deviation
 !
@@ -253,7 +253,7 @@
 !     |       |      CALL combineSys             See below
 !     |       |
 !     |       +----- SUBROUTINE printFinalSys    output the final output systems for this time step
-!     |       |         (CALL UNIQUE)      
+!     |       |         (CALL UNIQUE)
 !     |       |         (CALL SETDIFF)           returns elements in vector1 that are not in vector2
 !     |       |         (CALL SORT)              sorts the vector in ascending or descending order
 !     |       |
@@ -310,7 +310,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -324,9 +324,9 @@
 !  2. Method
 !
 !     (1) Read the raw partitioning output from one of two file formats:
-!         (a) "partRes" format of IFP-SWAN (intype=1), or 
+!         (a) "partRes" format of IFP-SWAN (intype=1), or
 !         (b) WW3 spectral bulletin format (intype=2).
-!         If intype=0, the partition data is read from memory (not activated yet). 
+!         If intype=0, the partition data is read from memory (not activated yet).
 !
 !     (2) Perform tracking in space by calling subroutine spiralTrackV3
 !     (3) Perform tracking in time by calling subroutine timeTrackingV2
@@ -348,9 +348,9 @@
 !     dirKnob        Real      input  Parameter in direction for combining fields in space
 !     perKnob        Real      input  Parameter in period for combining fields in space
 !     hsKnob         Real      input  Parameter in wave height for purging fields
-!     wetPts         Real      input  Percentage of wet points for purging fields (fraction) 
+!     wetPts         Real      input  Percentage of wet points for purging fields (fraction)
 !     seedLat        Real      input  Start Lat for tracking spiral (if =0 centre of field is used)
-!     seedLon        Real      input  Start Lon for tracking spiral (if =0 centre of field is used) 
+!     seedLon        Real      input  Start Lon for tracking spiral (if =0 centre of field is used)
 !     dirTimeKnob    Real      input  Parameter in direction for combining fields in time
 !     tpTimeKnob     Real      input  Parameter in period for combining fields in time
 !     paramFile      Char      input  File name of partitioning parameters                           Is this used???
@@ -368,14 +368,14 @@
       TYPE(timsys), POINTER :: sysA(:), sysAA(:)
       INTEGER      :: NumConsSys, iConsSys
       REAL         :: dt
-      REAL         :: minlon, maxlon, minlat, maxlat 
+      REAL         :: minlon, maxlon, minlat, maxlat
       INTEGER      :: mxcwt, mycwt
 
-!     Note: Variables wsdat, sysA and maxSys have IN/OUT intent so that they 
-!     can be manipulated outside of this subroutine, e.g. re-indexing of 
-!     systems and groups during the simulation. 
+!     Note: Variables wsdat, sysA and maxSys have IN/OUT intent so that they
+!     can be manipulated outside of this subroutine, e.g. re-indexing of
+!     systems and groups during the simulation.
       INTENT (IN)  intype, tmax, tcur, filename, paramFile, &
-                   minlon, maxlon, minlat, maxlat, & 
+                   minlon, maxlon, minlat, maxlat, &
                    hsKnob, wetPts, seedLat, seedLon, &
                    dirKnob, perKnob, dirTimeKnob, tpTimeKnob
       INTENT (OUT) maxGroup
@@ -383,7 +383,7 @@
 !
 !     Local variables
 !     ----------------------------------------------------------------
-!     llat     Real    Latitude of partition point, from input file 
+!     llat     Real    Latitude of partition point, from input file
 !     llon     Real    Longitude of partition point, from input file
 !     ts       Real    Time step of partition, from input file
 !     hs0      Real    Wave height of partition, from input file
@@ -429,7 +429,7 @@
       REAL       :: lonext, latext
 
 !/MPI      INTEGER    :: rank, irank, nproc, EXTENT, DOMSIZE, tag1, tag2
-!/MPI/!      INTEGER    :: MPI_INT_DOMARR, MPI_REAL_DOMARR 
+!/MPI/!      INTEGER    :: MPI_INT_DOMARR, MPI_REAL_DOMARR
 !/MPI      INTEGER    :: MPI_STATUS(MPI_STATUS_SIZE)
 !/MPI      INTEGER    :: REQ(16)
 !/MPI/!    INTEGER    :: ISTAT(MPI_STATUS_SIZE,16)
@@ -858,7 +858,7 @@
          ALLOCATE(uniqueLatraw(mycwt+1))
          ALLOCATE(uniqueLonraw(mxcwt+1))
          DO i = 1,(mycwt+1)
-            uniqueLatraw(i) =  minlat + & 
+            uniqueLatraw(i) =  minlat + &
                                (REAL(i)-1)/REAL(mycwt)*(maxlat-minlat)
          END DO
          DO i = 1,(mxcwt+1)
@@ -901,7 +901,7 @@
          WRITE(20,*) '                        Latitude range  =', &
                      uniqueLat(1), uniqueLat(SIZE(uniqueLat))
 
-!        Map is transposed (rotated by 90 deg), so that: 
+!        Map is transposed (rotated by 90 deg), so that:
 !          I (matrix row) represents Longitute
 !          J (matrix column) represents Latitude
 !          i.e. from this point onwards the indices (i,j) represents Cart. coordinates
@@ -952,7 +952,7 @@
                   wsdat(tsA)%par(i,j)%dspr(1:10)=9999.
 !                  wsdat(tsA)%par(i,j)%wf(1:10)=9999.
                   wsdat(tsA)%par(i,j)%ipart(1:10)=0
-                  wsdat(tsA)%par(i,j)%sys(1:10)=9999                      ! 40.PAR Increase this array, or make allocatable  
+                  wsdat(tsA)%par(i,j)%sys(1:10)=9999                      ! 40.PAR Increase this array, or make allocatable
                   wsdat(tsA)%par(i,j)%ngbrSys(1:50)=9999
                   wsdat(tsA)%wnd(i,j)%wdir=9999.
                   wsdat(tsA)%wnd(i,j)%wspd=9999.
@@ -1114,7 +1114,7 @@
 !/MPI                         wsdat(tsA)%par(i,j)%dir(1:10)=9999.
 !/MPI                         wsdat(tsA)%par(i,j)%dspr(1:10)=9999.
 !/MPI                         wsdat(tsA)%par(i,j)%ipart(1:10)=0
-!/MPI                         wsdat(tsA)%par(i,j)%sys(1:10)=9999                      ! 40.PAR Increase this array, or make allocatable  
+!/MPI                         wsdat(tsA)%par(i,j)%sys(1:10)=9999                      ! 40.PAR Increase this array, or make allocatable
 !/MPI                         wsdat(tsA)%par(i,j)%ngbrSys(1:50)=9999
 !/MPI                         wsdat(tsA)%wnd(i,j)%wdir=9999.
 !/MPI                         wsdat(tsA)%wnd(i,j)%wspd=9999.
@@ -1226,7 +1226,7 @@
          WRITE(32,'(I4,71x,A)') tsA,'Time step'
          WRITE(32,'(I4,71x,A)') maxpartout,'Tot number of raw partitions'
          DO k = 1,maxpartout
-            WRITE(32,'(I4,71x,A)') k,'System number'  
+            WRITE(32,'(I4,71x,A)') k,'System number'
             WRITE(32,'(I4,71x,A)') 9999,'Number of points in system'
             DO j = maxJ,1,-1
                DO i = 1,maxI
@@ -1249,7 +1249,7 @@
          WRITE(33,'(I4,71x,A)') tsA,'Time step'
          WRITE(33,'(I4,71x,A)') maxpartout,'Tot number of raw partitions'
          DO k = 1,maxpartout
-            WRITE(33,'(I4,71x,A)') k,'System number'  
+            WRITE(33,'(I4,71x,A)') k,'System number'
             WRITE(33,'(I4,71x,A)') 9999,'Number of points in system'
             DO j = maxJ,1,-1
                DO i = 1,maxI
@@ -1263,14 +1263,14 @@
       CLOSE(33)
 
 !-----RAW PARTITION output: dir
-      OPEN(unit=34, file='PART_DIR.OUT', & 
+      OPEN(unit=34, file='PART_DIR.OUT', &
            status='unknown')
 
       DO tsA = 1,SIZE(wsdat)
          WRITE(34,'(I4,71x,A)') tsA,'Time step'
          WRITE(34,'(I4,71x,A)') maxpartout,'Tot number of raw partitions'
          DO k = 1,maxpartout
-            WRITE(34,'(I4,71x,A)') k,'System number'  
+            WRITE(34,'(I4,71x,A)') k,'System number'
             WRITE(34,'(I4,71x,A)') 9999,'Number of points in system'
             DO j = maxJ,1,-1
                DO i = 1,maxI
@@ -1291,11 +1291,11 @@
          WRITE(35,'(I4,71x,A)') tsA,'Time step'
          WRITE(35,'(I4,71x,A)') maxpartout,'Tot number of raw partitions'
          DO k = 1,maxpartout
-            WRITE(35,'(I4,71x,A)') k,'System number'  
+            WRITE(35,'(I4,71x,A)') k,'System number'
             WRITE(35,'(I4,71x,A)') 9999,'Number of points in system'
             DO j = maxJ,1,-1
                DO i = 1,maxI
-                  WRITE(35,'(F8.2)',ADVANCE='NO') & 
+                  WRITE(35,'(F8.2)',ADVANCE='NO') &
                      wsdat(tsA)%par(i,j)%dspr(k)
                END DO
                WRITE(35,'(A)',ADVANCE='YES') ''
@@ -1410,12 +1410,12 @@
 !/MPI                  ALLOCATE( sysA(tsA)%sys(ic)%tp(maxI*maxJ) )
 !/MPI                  ALLOCATE( sysA(tsA)%sys(ic)%dir(maxI*maxJ) )
 !/MPI                  ALLOCATE( sysA(tsA)%sys(ic)%dspr(maxI*maxJ) )
-!/MPI                  sysA(tsA)%sys(ic)%i(:) = 9999  
+!/MPI                  sysA(tsA)%sys(ic)%i(:) = 9999
 !/MPI                  sysA(tsA)%sys(ic)%j(:) = 9999
 !/MPI                  sysA(tsA)%sys(ic)%lon(:) = 9999.
-!/MPI                  sysA(tsA)%sys(ic)%lat(:) = 9999. 
+!/MPI                  sysA(tsA)%sys(ic)%lat(:) = 9999.
 !/MPI                  sysA(tsA)%sys(ic)%hs(:) = 9999.
-!/MPI                  sysA(tsA)%sys(ic)%tp(:) = 9999. 
+!/MPI                  sysA(tsA)%sys(ic)%tp(:) = 9999.
 !/MPI                  sysA(tsA)%sys(ic)%dir(:) = 9999.
 !/MPI                  sysA(tsA)%sys(ic)%dspr(:) = 9999.
 !/MPI                  sysA(tsA)%sys(ic)%hsMean = 9999.
@@ -1694,7 +1694,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -1708,7 +1708,7 @@
 !     Index convention on grid:
 !
 !      j
-!      ^                      
+!      ^
 !      |+(1,maxJ)          +(maxI,maxJ)
 !      |
 !      |
@@ -1740,7 +1740,7 @@
 
       INTENT (IN) wetPts,dirKnob,perKnob,hsKnob,seedLat,seedLon
       INTENT (IN OUT) wsdat
-!      INTENT (OUT) maxSys,sys   
+!      INTENT (OUT) maxSys,sys
 !
 !     Local variables
 !     ----------------------------------------------------------------
@@ -1752,7 +1752,7 @@
       LOGICAL   :: first
       CHARACTER :: way *1
       INTEGER   :: ngbrExt, combine, maxI, maxJ, i, j, oldJ
-      INTEGER   :: horizStepCount, vertStepCount, checkCount, sc, & 
+      INTEGER   :: horizStepCount, vertStepCount, checkCount, sc, &
                    maxPts, landPts, horizBorder, vertBorder, m, k, &
                    stepCount
       REAL      :: deltaLat, minLat, maxLat, minLon, maxLon
@@ -1845,7 +1845,7 @@
       vertBorder=0
       DO WHILE (checkCount.LE.(maxI*maxJ-3) )
 !        From the direction (way) we were going before, find which direction we
-!        are going now and how many 'step' we need to take            
+!        are going now and how many 'step' we need to take
          CALL findWay(way, horizStepCount, vertStepCount, &
                       vertBorder, horizBorder, stepCount)
          IF (first) THEN
@@ -1913,14 +1913,14 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Performs the time tracking of the systems identified within 
+!     Performs the time tracking of the systems identified within
 !     the subroutine spiralTrackV3.
 !
 !  2. Method
@@ -1964,8 +1964,8 @@
       CHARACTER :: dummy*23
       TYPE(sysmemory) :: sysMem(50)                                             !!! 50 memory spaces should be enough Check!!!
       INTEGER :: leng, l, i, ii, j, k, kk, idir, numSys, &
-                 counter, new, DIFSIZE, tpMinInd, dirMinInd, used, ok 
-      REAL    :: Tb,  deltaPer, deltaDir, tpMinVal, dirMinVal, & 
+                 counter, new, DIFSIZE, tpMinInd, dirMinInd, used, ok
+      REAL    :: Tb,  deltaPer, deltaDir, tpMinVal, dirMinVal, &
                  dirForTpMin, tpForDirMin
       REAL, ALLOCATABLE :: sysOrdered(:), TEMP(:), dirs(:)
       REAL, POINTER :: DIFARR(:)
@@ -2133,8 +2133,8 @@
             WRITE(20,*) 'sysMem(',i,')%latMean =',sysMem(i)%latMean
             WRITE(20,*) 'sysMem(',i,')%tpMean =',sysMem(i)%tpMean
             WRITE(20,*) 'sysMem(',i,')%dirMean =',sysMem(i)%dirMean
-            WRITE(20,*) 'sysMem(',i,')%updated =',sysMem(i)%updated 
-            WRITE(20,*) 'sysMem(',i,')%length =',sysMem(i)%length         
+            WRITE(20,*) 'sysMem(',i,')%updated =',sysMem(i)%updated
+            WRITE(20,*) 'sysMem(',i,')%length =',sysMem(i)%length
          END DO
 !********************************************
       END IF
@@ -2160,7 +2160,7 @@
             sysA(i)%sys(:)%grp = 9999                                     ! Optimize?
             counter = 0
             leng = LENGTH(REAL(sysMem(:)%grp), &
-                          SIZE(sysMem(:)%grp),REAL(9999)) 
+                          SIZE(sysMem(:)%grp),REAL(9999))
             ALLOCATE( alreadyUsed(leng+10) )                              !Make space for 10 new potential entries. Improve!!!
             WRITE(20,*) 'sysMem(1:leng)%grp =', &
                         sysMem(1:leng)%grp
@@ -2209,21 +2209,21 @@
                sysA(i)%sys(j)%indx(iii) = &
                   (sysA(i)%sys(j)%j(iii)-1)*maxI + &
                    sysA(i)%sys(j)%i(iii)
-            END DO           
+            END DO
 !071012----------- Grid point indexing --------------------------
             WRITE(20,*) 'System no. ',j,' of ',maxSys(i)
             WRITE(20,*) 'Size =', npnts
             WRITE(20,*) 'lonMean =', lonmean
             WRITE(20,*) 'latMean =', latmean
             WRITE(20,*) 'tpMean =', sysA(i)%sys(j)%tpMean
-            WRITE(20,*) 'dirMean =', sysA(i)%sys(j)%dirMean       
+            WRITE(20,*) 'dirMean =', sysA(i)%sys(j)%dirMean
             sysA(i)%sys(j)%grp = 9999                                     !Now redundant?
 
 !           Compute deltas
             Tbsysmem = sysMem(1:maxGroup)%tpMean
             WRITE(20,*) 'Tbsysmem(:) =       ', Tbsysmem(:)
 !           Compute deltas the same way as for field combining - they should
-!           be of the same degree of strictness as the latter, otherwise 
+!           be of the same degree of strictness as the latter, otherwise
 !           the time combining will lose track!
 !3stddev            m1 = -3.645*Tb + 63.211
 !3stddev            m1 = MAX(m1,10.)
@@ -2248,11 +2248,11 @@
             WRITE(20,*) 'deltaDirsysmem(:) = ',deltaDirsysmem
             WRITE(20,*) 'deltaPersysmem(:) = ',deltaPersysmem
 
-!                 Criterion 1: Mean period 
+!                 Criterion 1: Mean period
                   ALLOCATE( TEMP(SIZE(ind2)) )
                   TEMP = ABS( sysA(i)%sys(j)%tpMean - &
                               sysMem(ind2(:))%tpMean )
-                  WRITE(20,*) 'tpMean list =', & 
+                  WRITE(20,*) 'tpMean list =', &
                               sysMem(ind2(:))%tpMean
                   WRITE(20,*) 'tpMinVal list =', TEMP
                   tpMinVal = MINVAL(TEMP)
@@ -2266,12 +2266,12 @@
                   DO idir = 1, SIZE(dirs)
                      IF (dirs(idir).GE.180.) dirs(idir)=360-dirs(idir)
                   END DO
-                  WRITE(20,*) 'dirMean list =', & 
+                  WRITE(20,*) 'dirMean list =', &
                               sysMem(ind2(:))%dirMean
                   WRITE(20,*) 'dirMinVal list =', dirs
 
 !                 Criterion 3: Size
-                  WRITE(20,*) 'Size list =', & 
+                  WRITE(20,*) 'Size list =', &
                               sysMem(ind2(:))%nPoints
 
 !                 Criterion 4: Distance between systems
@@ -2319,8 +2319,8 @@
                      END IF
                      IF ( (TEMP(ii).GT.deltaPersysmem(ii)).OR.&
                           (dirs(ii).GT.deltaDirsysmem(ii)) ) THEN
-                       GOF(j,ii) = 9999. 
-                     END IF      
+                       GOF(j,ii) = 9999.
+                     END IF
                   END DO
                   WRITE(20,*) 'GOF(j,:) =',GOF(j,:)
 
@@ -2357,7 +2357,7 @@
 
          DO j = 1, maxSys(i)
                   new = 0
-!                 Look up sysMem match for this current system. If no match 
+!                 Look up sysMem match for this current system. If no match
 !                 is found, the index value 0 is returned.
                   tpMinInd = 0
                   TEMP1 = 9999.
@@ -2403,7 +2403,7 @@
                             (.NOT.ANY(alreadyUsed(:).EQ.k))) THEN
 !                           Make sure it hasn't been used yet (at previous time level)
                             DO l = 1, maxGroup
-!                              If last update of system was more that *6* time steps 
+!                              If last update of system was more that *6* time steps
 !                              ago, system can be released (TO CALIBRATE)
                                IF ( (sysMem(l)%grp.EQ.k).AND. &
                                    ((i-sysMem(l)%updated).LT.6) ) ok = 0
@@ -2436,7 +2436,7 @@
          END DO
          IF (ALLOCATED(ind)) DEALLOCATE(ind)                  !071212 Shifted
          IF (ALLOCATED(ind2)) DEALLOCATE(ind2)                !071212 Shifted
-         IF (ALLOCATED(GOFMinVal)) DEALLOCATE(GOFMinVal) 
+         IF (ALLOCATED(GOFMinVal)) DEALLOCATE(GOFMinVal)
          IF (ALLOCATED(GOFMinInd)) DEALLOCATE(GOFMinInd)
 
          IF (ALLOCATED(alreadyUsed)) DEALLOCATE(alreadyUsed)
@@ -2479,7 +2479,7 @@
                          sysA(i)%sys(kk)%i(iii)
                   END DO
 !071012----------- Grid point indexing --------------------------
-                  sysMem(k)%updated = i 
+                  sysMem(k)%updated = i
                   sysMem(k)%length = sysMem(k)%length + 1
                END IF
             END DO
@@ -2539,9 +2539,9 @@
                END IF
             END DO
          END DO
-         ELSE  
+         ELSE
             WRITE(20,*) '*** No systems at this time level. ', &
-                        'No. systems =',SIZE(sysA(i)%sys)  
+                        'No. systems =',SIZE(sysA(i)%sys)
             !Test for expired groups
             DO k = 1, maxGroup
                IF ((i-sysMem(k)%updated).GE.6) THEN
@@ -2587,7 +2587,7 @@
          WRITE(27,'(A8,I3,A12,F10.3)') 'sysMem( ',k, &
             ' )%dirMean =',sysMem(k)%dirMean
          WRITE(27,'(A8,I3,A12,I10)') 'sysMem( ',k, &
-            ' )%updated =',sysMem(k)%updated 
+            ' )%updated =',sysMem(k)%updated
          WRITE(27,'(A8,I3,A12,I10)') 'sysMem( ',k, &
             ' )%length  =',sysMem(k)%length
          DO j = maxJ,1,-1
@@ -2623,7 +2623,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -2652,7 +2652,7 @@
 
       INTENT (IN) vertBorder, horizBorder
       INTENT (OUT) stepCount
-      INTENT (IN OUT) way    
+      INTENT (IN OUT) way
 !
 !     Local variables
 !     ----------------------------------------------------------------
@@ -2739,7 +2739,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -2766,8 +2766,8 @@
       INTEGER     :: i, j, maxI, maxJ, vertBorder, horizBorder
 
       INTENT (IN) maxI, maxJ, way
-      INTENT (IN OUT) i, j   
-      INTENT (OUT) vertBorder, horizBorder 
+      INTENT (IN OUT) i, j
+      INTENT (OUT) vertBorder, horizBorder
 !
 !     Local variables
 !     ----------------------------------------------------------------
@@ -2805,7 +2805,7 @@
               IF (i.LT.maxI) THEN
                   i=i+1
               ELSE
-!                 Need to tell findWay that if we hit the border we don't 
+!                 Need to tell findWay that if we hit the border we don't
 !                 increment stepCount...
                   horizBorder=1
               END IF
@@ -2873,7 +2873,7 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     i,j         Int      input   Current grid indices
-!     maxI, maxJ  Int      input   Maximum indices of wave field  
+!     maxI, maxJ  Int      input   Maximum indices of wave field
 !     wsdat   Type(dat2d)  in/out  Input data structure to be spiral tracked
 !     maxSys      Int      in/out  Maximum number of systems identified
 !
@@ -2969,7 +2969,7 @@
           IF (endCount.EQ.0) WRITE(20,*) '***1.Calling UNIQUE w. len=0!'
           CALL UNIQUE (REAL(allFullSys),endCount,realarr,nout)            !Can one do this?
           ALLOCATE(allSys(nout))
-          allSys = INT(realarr)                                           !Can one do this?     
+          allSys = INT(realarr)                                           !Can one do this?
           IF (ASSOCIATED(realarr)) DEALLOCATE(realarr)
           maxS = MAXVAL(allSys)
 
@@ -3019,7 +3019,7 @@
 !              tmpsys(s)%wfMean = SUM(wfAll(1:countAll))/countAll
           END DO
 
-!         Find the partition at current (i,j) point that matches previously 
+!         Find the partition at current (i,j) point that matches previously
 !         identified wave systems if any...
           wsdat%par(i,j)%ngbrSys(1:SIZE(allSys)) = allSys
 
@@ -3154,14 +3154,14 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Combine wave systems. Then remove small and low-energy systems from set, 
+!     Combine wave systems. Then remove small and low-energy systems from set,
 !     based on the parameters maxPts and maxHgt.
 !
 !  2. Method
@@ -3174,16 +3174,16 @@
 !     ----------------------------------------------------------------
 !     wsdat   Type(dat2d)  output  Combined wave system data structure
 !     sys     Type(system) output  Final set of tracked systems, for one time level
-!     maxI, maxJ  Int      input   Maximum indices of wave field  
+!     maxI, maxJ  Int      input   Maximum indices of wave field
 !     maxSys      Int      input   Maximum number of systems identified
 !     maxPts      Int      input   Number of points req for valid system
 !     hsKnob      Real     input   Parameter for identifying valid system
-!     combine     Int      input   Toggle: 1=combine systems; 0=do not combine 
+!     combine     Int      input   Toggle: 1=combine systems; 0=do not combine
 
       TYPE(dat2d) :: wsdat
       TYPE(system), POINTER :: sys(:), systemp(:)
       INTEGER      :: maxSys, maxPts, maxI, maxJ, combine
-      REAL         :: perKnob ,dirKnob, hsKnob 
+      REAL         :: perKnob ,dirKnob, hsKnob
 
       INTENT (IN) maxPts, maxI, maxJ, hsKnob, combine
       INTENT (IN OUT) wsdat, maxSys                                       !In the Matlab code maxSys is only input ???
@@ -3231,7 +3231,7 @@
 !012912      WRITE(20,*) 'maxSys,maxPts,maxI,maxJ,hsKnob,combine =', &
 !012912                  maxSys,maxPts,maxI,maxJ,hsKnob,combine
 
-!     Set up initial index array of active systems      
+!     Set up initial index array of active systems
       IF (.NOT.ALLOCATED(actSysInd)) ALLOCATE( actSysInd(maxSys) )
       actSysInd(1:maxSys) = (/ (ind, ind = 1, maxSys) /)
 !opt      WRITE(20,*) 'actSysInd =',actSysInd
@@ -3252,7 +3252,7 @@
               ELSE
                  nSys = maxSys
               END IF
-              WRITE(20,'(A,A,I3,A,I5,A)') 'Calling combineSys for ', & 
+              WRITE(20,'(A,A,I3,A,I5,A)') 'Calling combineSys for ', &
                            'iteration',iter,' (maxSys =',nSys,').'
 
 !opt              WRITE(20,*) 'SIZE(sys)=',SIZE(sys)
@@ -3270,7 +3270,7 @@
       END IF
 
 !     Remove small and low-energy systems from set, based on
-!     the parameters maxPts and maxHgt. 
+!     the parameters maxPts and maxHgt.
 !      ALLOCATE( sysOut(maxSys) )
 !      sysOut = sys(1:maxSys)%sysInd
 !      mS = maxSys
@@ -3281,7 +3281,7 @@
       DO so = 1, mS
           s = actSysInd(so)
 !opt      NOTE: if we deallocate the individual records without
-!opt      compressing sys, then s and sysInd will remain the same  
+!opt      compressing sys, then s and sysInd will remain the same
           ss = s
 
           leng = LENGTH(sys(ss)%hs,SIZE(sys(ss)%hs),9999.)
@@ -3320,8 +3320,8 @@
 !                          DEALLOCATE( sys(iloop)%ngbr )
                        END DO
                     END IF
-                 END IF       
-              END DO  
+                 END IF
+              END DO
 
 !             Update wsdat as well
               DO iw = 1, maxI
@@ -3333,7 +3333,7 @@
 !                    Identify system index (there are no duplicate
 !                    systems at this point.
                      DO WHILE (ind.LE.leng)
-                        IF ( wsdat%par(iw,jw)%sys(ind).EQ.s ) THEN 
+                        IF ( wsdat%par(iw,jw)%sys(ind).EQ.s ) THEN
                            found = .TRUE.
                            EXIT
                         END IF
@@ -3345,11 +3345,11 @@
                         wsdat%par(iw,jw)%ipart(ind) = 9999
                      END IF
                  END DO
-              END DO        
+              END DO
           END IF
       END DO
 
-!     Compile array index of active systems in sys      
+!     Compile array index of active systems in sys
       actSys = 0
       DO so = 1,maxSys
          IF (sys(so)%nPoints>0) actSys = actSys + 1
@@ -3368,7 +3368,7 @@
       DO so = 1,SIZE(actSysInd)
          s = actSysInd(so)
 !opt         WRITE(20,*) 'sys(',s,')%sysInd =',sys(s)%sysInd
-      END DO     
+      END DO
 
       CALL printFinalSys (wsdat,maxSys,actSysInd,maxI,maxJ,1,sys)
 !opt      WRITE(20,*) 'actSysInd =',actSysInd
@@ -3382,7 +3382,7 @@
 !/ End of combineWaveSystems ----------------------------------------- /
 !/
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE printFinalSys (wsdat    ,maxSys    ,actSysInd , & 
+      SUBROUTINE printFinalSys (wsdat    ,maxSys    ,actSysInd , &
                                 maxI     ,maxJ      ,flag      ,sys    )
 !/
 !/                  +-----------------------------------+
@@ -3400,7 +3400,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -3418,10 +3418,10 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     wsdat   Type(dat2d)  input   Combined data structure
-!     maxI, maxJ  Int      input   Maximum indices of wave field  
+!     maxI, maxJ  Int      input   Maximum indices of wave field
 !     maxSys      Int      input   Maximum number of systems identified
 !     flag        Int      input   Flag for printing system
-!     sys     Type(system) output  Final set of tracked systems, for one time level 
+!     sys     Type(system) output  Final set of tracked systems, for one time level
 !
       TYPE(dat2d)  :: wsdat
       TYPE(system), POINTER :: sys(:)
@@ -3588,7 +3588,7 @@
           IF (ALLOCATED(ngbrSysAll)) DEALLOCATE(ngbrSysAll)
       END IF
 
-!     Print the sorted field to the screen 
+!     Print the sorted field to the screen
       leng = LENGTH(REAL(sys(:)%nPoints), &
                     SIZE(sys(:)%nPoints),REAL(9999))
       ALLOCATE( sysOrdered(leng) )
@@ -3628,7 +3628,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -3646,11 +3646,11 @@
 !     Parameter list
 !     ----------------------------------------------------------------
 !     wsdat   Type(dat2d)  input   Combined data structure
-!     maxI, maxJ  Int      input   Maximum indices of wave field  
+!     maxI, maxJ  Int      input   Maximum indices of wave field
 !     sys     Type(system) output  Final set of tracked systems, for one time level
 !     maxSys      Int      input  Number of systems
 !     dirKnob     Real     input  Parameter in direction for combining fields in space
-!     perKnob     Real     input  Parameter in period for combining fields in space 
+!     perKnob     Real     input  Parameter in period for combining fields in space
 !
       TYPE(dat2d)  :: wsdat                                               !40.PAR
       TYPE(system), POINTER :: sys(:)                                     !40.PAR
@@ -3670,9 +3670,9 @@
       INTEGER, POINTER :: indSys1(:), indSys2(:)
       REAL, ALLOCATABLE    :: sysOrdered(:), rounded(:)
       REAL, POINTER    :: uniarr(:), difarr(:), allngbr(:)
-      INTEGER   :: leng, leng2, s, ss, so, ngb, lsys, lsys2, hh, i, j, & 
+      INTEGER   :: leng, leng2, s, ss, so, ngb, lsys, lsys2, hh, i, j, &
                    ii, jj, ind, ind2, nn, nbr, icEnd,ic,iii,iloop
-      INTEGER   :: myngbr, indMatch, matchSys, keep, replacedInd, & 
+      INTEGER   :: myngbr, indMatch, matchSys, keep, replacedInd, &
                    hhForIndMatch, lMatch, tot, outsize
       INTEGER   :: ngbIndex(10000), keepInd(maxI*maxJ), oneLess(1000)     !Array large enough?
 !      REAL      :: Tb,deltaPerB,deltaDirB,absDir,absPer,absHs,absWf
@@ -3724,7 +3724,7 @@
 !     Initialize pointer (first use)
       NULLIFY(indSys1)
       NULLIFY(indSys2)
-!     Flag to combine systems on a point-by-point basis along boundary, 
+!     Flag to combine systems on a point-by-point basis along boundary,
 !     instead of using mean values.
       ZIPMATCH = .FALSE.
       ngbrExt = 1
@@ -3733,8 +3733,8 @@
       ALLOCATE( sysSortedInd(maxSys) )
       ALLOCATE( sysOut(maxSys) )
       ALLOCATE( rounded(maxSys) )
-!     Sort in descending Tp: the following improves the iterative combining in  
-!     the special case that the wave period is constant over the domain, but  
+!     Sort in descending Tp: the following improves the iterative combining in
+!     the special case that the wave period is constant over the domain, but
 !     tpMean is not because of truncation errors at very high decimals.
       rounded = REAL(INT(sys(1:maxSys)%tpMean*1.E4))*1.E-4
       CALL SORT(rounded,maxSys,sysOrdered,sysSortedInd,'D')
@@ -3760,12 +3760,12 @@
           s = sysOut(so)
           ss = FINDFIRST(REAL(sys(:)%sysInd),SIZE(sys(:)%sysInd), &
                          REAL(s))
-!opt          WRITE(20,*) 's,ss=',s,ss 
+!opt          WRITE(20,*) 's,ss=',s,ss
           ngbIndex(:) = 0
           ii = 1
           leng = LENGTH(REAL(sys(ss)%ngbr),SIZE(sys(ss)%ngbr), &
                         REAL(9999))
-!         Identify the indices of all the systems that neighbour the current system s, 
+!         Identify the indices of all the systems that neighbour the current system s,
 !         store in ngbIndex(:)
           DO ngb = 1, leng
              IF ( sys(ss)%ngbr(ngb).NE.s ) THEN
@@ -3787,8 +3787,8 @@
 
           IF ( ii.GT.0 ) THEN
               DO ngb = 1, ii
-!                 We first need to find the (i,j) points that are either common 
-!                 to both these systems, or at the boundary of the two systems. Here 
+!                 We first need to find the (i,j) points that are either common
+!                 to both these systems, or at the boundary of the two systems. Here
 !                 sys 1 will carry the 'ss' index and sys 2 the ngbIndex(ngb) index.
                   CALL findIJV4 (sys(ss),sys(ngbIndex(ngb)), &
                                  maxI,maxJ,indSys1,indSys2)
@@ -3908,7 +3908,7 @@
 !                                deltaPerB = (m2*1. + 3)*1.
                                 deltaDirB = (m1*1. + 30)*1.
                                 deltaPerB = (m2*1. + 3)*1.
-                                !Remove dHs limitation from criteria 
+                                !Remove dHs limitation from criteria
                                 deltaHsB = 9999.
                                 GOTO 500
                               END IF
@@ -4074,7 +4074,7 @@
                         mean_angleV3((/ sys(ss)%dir(keepInd(1:keep)), &
                         sys(indMatch)%dir(1:leng) /), &
                         (/ sys(ss)%hs(keepInd(1:keep)), &
-                        sys(indMatch)%hs(1:leng) /),tot)                      
+                        sys(indMatch)%hs(1:leng) /),tot)
 !070512----------- Weight averages with Hm0 ---------------------
 
                       sys(indMatch)%i(1:(keep+leng))= &
@@ -4227,7 +4227,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -4293,11 +4293,11 @@
 !
 !/ ------------------------------------------------------------------- /
 
-!     Find indices in dat%sys(:) of all partition associated with 
-!     the same wave system, and store them in the data structure 
-!     dup(1:nsys). Here nsys is the number of systems for which duplicates 
-!     were found, and dup(s)%ndup the number of partitions assigned 
-!     to the same system s. 
+!     Find indices in dat%sys(:) of all partition associated with
+!     the same wave system, and store them in the data structure
+!     dup(1:nsys). Here nsys is the number of systems for which duplicates
+!     were found, and dup(s)%ndup the number of partitions assigned
+!     to the same system s.
       nsys = 0
       dup(:)%ndup = 0
       dup(:)%val = 9999
@@ -4329,7 +4329,7 @@
       END DO
 
 !     Now go through array of duplicates for each of n systems
-!     to add all the wave energy to the most energetic of the 
+!     to add all the wave energy to the most energetic of the
 !     duplicates, and then remove the rest.
       maxInd = 0
       temp = -9999.
@@ -4365,7 +4365,7 @@
 !                       dat%wf( (dup(s)%ind(p)+1):npart)
                dat%sys( dup(s)%ind(p):(npart-1) ) = &
                         dat%sys( (dup(s)%ind(p)+1):npart)
-               dat%ipart( dup(s)%ind(p):(npart-1) ) = & 
+               dat%ipart( dup(s)%ind(p):(npart-1) ) = &
                         dat%ipart( (dup(s)%ind(p)+1):npart)
 !              Shift up indices
                DO ss = 1, nsys
@@ -4408,7 +4408,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -4440,7 +4440,7 @@
 !     theta     Real   Mean direction relative to North
 !
       REAL      :: PI
-      PARAMETER  (PI = 3.1416) 
+      PARAMETER  (PI = 3.1416)
       REAL      :: u(ll), v(ll), vm, um, theta
 !
 !  4. Subroutines used :
@@ -4515,14 +4515,14 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Compute the mean direction from array of directions, 
+!     Compute the mean direction from array of directions,
 !     INCLUDING WEIGHTING WITH HMO
 !
 !  2. Method
@@ -4549,7 +4549,7 @@
 !     theta     Real   Mean direction relative to North
 !
       REAL      :: PI
-      PARAMETER  (PI = 3.1416) 
+      PARAMETER  (PI = 3.1416)
       REAL      :: u(ll), v(ll), vm, um, theta
       INTEGER   :: i
 !
@@ -4582,7 +4582,7 @@
 !     North and East components
       v(:) = COS(ang(:)*(PI/180.))
       u(:) = SIN(ang(:)*(PI/180.))
-      TEMP1 = 0. 
+      TEMP1 = 0.
       TEMP2 = 0.
       DO i = 1,ll
          TEMP1 = TEMP1 + (hsign(i)**2)*v(i)
@@ -4770,8 +4770,8 @@
 !  1. Purpose :
 !
 !     Sorts the array INARRAY in ascending (Direction = 'A') or
-!     descending (Direciton = 'D') order. The sorted array is 
-!     stored in OUTARRAY, and the sorted array of the original 
+!     descending (Direciton = 'D') order. The sorted array is
+!     stored in OUTARRAY, and the sorted array of the original
 !     indices is stored in IY.
 !
 !  2. Method
@@ -4790,7 +4790,7 @@
       CHARACTER         :: DIRECTION *1
       INTEGER           :: INSIZE
       INTEGER           :: IY(INSIZE)
-      REAL              :: INARRAY(INSIZE), OUTARRAY(INSIZE) 
+      REAL              :: INARRAY(INSIZE), OUTARRAY(INSIZE)
 
       INTENT (IN)  INARRAY, INSIZE, DIRECTION
       INTENT (OUT) OUTARRAY, IY
@@ -4883,7 +4883,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -4948,7 +4948,7 @@
 ! 10. Source code :
 !
 !/ ------------------------------------------------------------------- /
-      IF ( (INSIZE1).EQ.0 ) THEN 
+      IF ( (INSIZE1).EQ.0 ) THEN
         OUTSIZE = 0
         ALLOCATE(OUTARRAY(OUTSIZE))
       ELSE IF ( INSIZE2.EQ.0 ) THEN
@@ -4994,7 +4994,7 @@
               I = I + 1
             ELSE IF ( ARRAY2(J).LT.ARRAY1(I) ) THEN
               J = J + 1
-            ELSE 
+            ELSE
               I = I + 1
               J = J + 1
             END IF
@@ -5203,7 +5203,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -5377,16 +5377,16 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Find largest index in ARRAY with a value not equal to the 
+!     Find largest index in ARRAY with a value not equal to the
 !     filler value VAL.
-!     E.g. If VAL = 9999. and ARRAY = [X X X X 9999. 9999. 9999.], 
+!     E.g. If VAL = 9999. and ARRAY = [X X X X 9999. 9999. 9999.],
 !     the function returns 4.
 !
 !  3. Parameters :
@@ -5440,14 +5440,14 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
 !
 !  1. Purpose :
 !
-!     Fast algorithm to find the *first* index IND in ARRAY 
+!     Fast algorithm to find the *first* index IND in ARRAY
 !     for which ARRAY(IND) = VAL. Use only when there are
 !     no duplicates in ARRAY!
 !
@@ -5499,7 +5499,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       IMPLICIT NONE
@@ -5550,7 +5550,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !
@@ -5676,7 +5676,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !

--- a/model/ftn/w3strxmd.ftn
+++ b/model/ftn/w3strxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3swldmd.ftn
+++ b/model/ftn/w3swldmd.ftn
@@ -12,7 +12,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -32,7 +32,7 @@
 !      Name      Type  Scope    Description
 !     ----------------------------------------------------------------
 !      W3SWL4    Subr. Public   Ardhuin et al (2010+) swell dissipation
-!      W3SWL6    Subr. Public   Babanin (2011) swell dissipation 
+!      W3SWL6    Subr. Public   Babanin (2011) swell dissipation
 !
 !      IRANGE    Func. Private  Generate a sequence of integer values
 !     ----------------------------------------------------------------
@@ -74,7 +74,7 @@
 !/
 !  1. Purpose :
 !
-!     FIXME 
+!     FIXME
 !
 !  2. Method :
 !
@@ -85,7 +85,7 @@
 !      A¹      R.A. I  Action density spectrum
 !      CG      R.A. I  Group velocities
 !      WN      R.A. I  Wavenumbers
-!      S¹      R.A. O  Source term 
+!      S¹      R.A. O  Source term
 !      D¹      R.A. O  Diagonal term of derivative
 !      ¹ Stored as 1-D array with dimension NTH*NK (column by column).
 !     ----------------------------------------------------------------
@@ -94,7 +94,7 @@
 !
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
-!      IRANGE    Func. W3SWLDMD 
+!      IRANGE    Func. W3SWLDMD
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !     ----------------------------------------------------------------
 !
@@ -147,7 +147,7 @@
 !/
 !/S      CALL STRACE (IENT, 'W3SWL4')
 !
-      IKN = IRANGE(1,NSPEC,NTH) 
+      IKN = IRANGE(1,NSPEC,NTH)
       D   = 0.
       WN2 = 0.
 !
@@ -159,7 +159,7 @@
       EMEAN  = SUM(EB) + (EB(NK) / DDEN(NK)) * FTE
 !
       AORB   = 2.0*SQRT(EMEAN)
-!     
+!
       EB     = SUM(RESHAPE(A*SIG2**2,(/ NTH,NK /)),1) * DDEN(1:NK) / CG
       UOSIG  = 2.0*SQRT(SUM(EB))
 
@@ -206,7 +206,7 @@
 !  1. Purpose :
 !
 !     Turbulent dissipation of narrow-banded swell as described in
-!     Babanin (2011, Section 7.5). 
+!     Babanin (2011, Section 7.5).
 !
 !     Babanin 2011: Cambridge Press, 295-321, 463pp.
 !
@@ -221,7 +221,7 @@
 !      A¹      R.A. I  Action density spectrum
 !      CG      R.A. I  Group velocities
 !      WN      R.A. I  Wavenumbers
-!      S¹      R.A. O  Source term 
+!      S¹      R.A. O  Source term
 !      D¹      R.A. O  Diagonal term of derivative
 !      ¹ Stored as 1-D array with dimension NTH*NK (column by column).
 !     ----------------------------------------------------------------
@@ -230,7 +230,7 @@
 !
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
-!      IRANGE    Func. W3SWLDMD 
+!      IRANGE    Func. W3SWLDMD
 !      STRACE    Subr. W3SERVMD Subroutine tracing.
 !     ----------------------------------------------------------------
 !
@@ -285,7 +285,7 @@
 !/S      CALL STRACE (IENT, 'W3SWL6')
 !
 !/ 0) --- Initialize parameters -------------------------------------- /
-      IKN   = IRANGE(1,NSPEC,NTH)            ! Index vector for array access, e.g.  
+      IKN   = IRANGE(1,NSPEC,NTH)            ! Index vector for array access, e.g.
 !                                            ! in form of WN(1:NK) == WN2(IKN).
       ABAND = SUM(RESHAPE(A,(/ NTH,NK /)),1) ! action density as function of wavenumber
       DDIS  = 0.
@@ -329,7 +329,7 @@
 !
 !/ 3) --- Apply dissipation term of derivative to all directions ----- /
       DO ITH = 1, NTH
-         D(IKN+(ITH-1)) = DDIS 
+         D(IKN+(ITH-1)) = DDIS
       END DO
 !
       S = D * A

--- a/model/ftn/w3sxxxmd.ftn
+++ b/model/ftn/w3sxxxmd.ftn
@@ -16,7 +16,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -71,8 +71,8 @@
 !        all other routines that require modification.
 !      - Provide a test case with expected results.
 !      - It is strongly recommended that the programming style used
-!        in WAVEWATCH III is followed, in particular 
-!          a) for readability, write as if in fixed FORTRAN format 
+!        in WAVEWATCH III is followed, in particular
+!          a) for readability, write as if in fixed FORTRAN format
 !             regarding column use, even though all files are F90
 !             free format.
 !          b) I prefer upper case programming for permanent code,
@@ -83,14 +83,14 @@
 !      a) All saved variables connected with this source term need
 !         to be declared in the module header. Upon acceptance as
 !         permanent code, they will be converted to the WAVEWATCH III
-!         dynamic data structure.  
+!         dynamic data structure.
 !      b) Provide a separate computation and initialization routine.
 !         In the submission, the initialization should be called
 !         from the computation routine upon the first call to the
 !         routine. Upon acceptance as permanent code, the
 !         initialization routine will be moved to a more appropriate
 !         location in the code (i.e., being absorbed in ww3_grid or
-!         being moved to W3IOGR). 
+!         being moved to W3IOGR).
 !
 !     See notes in the file below where to add these elements.
 !

--- a/model/ftn/w3tidemd.ftn
+++ b/model/ftn/w3tidemd.ftn
@@ -14,19 +14,19 @@
 !/
 !  1. Purpose :
 !
-!     Tidal analysis of time series for storage of tidal constituents 
-!     only. This module is built around the versatile tidal analysis 
+!     Tidal analysis of time series for storage of tidal constituents
+!     only. This module is built around the versatile tidal analysis
 !     package : http://www.pac.dfo-mpo.gc.ca/science/oceans/tidal-marees/index-eng.htm
-!     by Mike Foreman et al.  (see publication in J. Ocean Atmos. Tech.: vol. 
-!                http://journals.ametsoc.org/doi/pdf/10.1175/2008JTECHO615.1 )     
+!     by Mike Foreman et al.  (see publication in J. Ocean Atmos. Tech.: vol.
+!                http://journals.ametsoc.org/doi/pdf/10.1175/2008JTECHO615.1 )
 !     Adaptation to WAVEWATCH III was performed by F. Ardhuin
 !
-!     STILL TO BE DONE: 
+!     STILL TO BE DONE:
 !     - adding a namelist in ww3_grid to allow adjustment of TIDE_DT
-!     - check on constituents (M2, S2, N2 ...) when running ww3_shel, 
+!     - check on constituents (M2, S2, N2 ...) when running ww3_shel,
 !        in order to allow use of different sets of constituents
-!     - add residual currents (or geostrophic ...) ... 
-!     - make this work with multigrids 
+!     - add residual currents (or geostrophic ...) ...
+!     - make this work with multigrids
 !
 !  2. Variables and types :
 !
@@ -38,29 +38,29 @@
 !
 !      Name                  Type  Scope    Description
 !     ----------------------------------------------------------------
-!      TIDE_WRITE_RESULTS    Subr. Public   Writes tidal results 
+!      TIDE_WRITE_RESULTS    Subr. Public   Writes tidal results
 !                                          (with M. Forman's format)
 !      TIDE_PREDICT          Subr. Public  Predicts tide from amp. & phases
-!      TIDE_SETTINGS_FULL    Subr. Public  Choice of constituents 
-!      TIDE_SETTINGS_FAST    Subr. Public  Choice of constituents 
-!      TIDE_SETTINGS_VFAST   Subr. Public  Choice of constituents 
-!      TIDE_SET_INDICES      Subr. Public 
-!      SETVUF_FAST           Subr. Public Calculates the V,u,f values 
+!      TIDE_SETTINGS_FULL    Subr. Public  Choice of constituents
+!      TIDE_SETTINGS_FAST    Subr. Public  Choice of constituents
+!      TIDE_SETTINGS_VFAST   Subr. Public  Choice of constituents
+!      TIDE_SET_INDICES      Subr. Public
+!      SETVUF_FAST           Subr. Public Calculates the V,u,f values
 !      TIDE_READ_SETTINGS    Subr. Public Reads data from file (IOS format)
 !      TIDE_READ_ANAPAR      Subr. Public Reads data from file (IOS format)
 !      TIDE_READ_TIMESERIES  Subr. Public Reads data from file (IOS format)
 !      ASTR                  Subr. Public Calculates the ephermides
 !      JULDAYT               Func. Public Julian day
-!      CALDATT               Subr. Public 
-!      dsvbksb               Subr. Public 
-!      dsvdcmp               Subr. Public 
+!      CALDATT               Subr. Public
+!      dsvbksb               Subr. Public
+!      dsvdcmp               Subr. Public
 !      svd                   Subr. Public Matrix singular value decomposition
-!      VUF_SET_PARAMETERS    Subr. Public 
-!      VUF                   Subr. Public 
-!      OPNVUF                Subr. Public 
-!      SETVUF                Subr. Public 
-!      flex_tidana_webpage   Subr. Public 
-!      TIDE_PREDICT          Subr. Public Tide prediction and error estimate 
+!      VUF_SET_PARAMETERS    Subr. Public
+!      VUF                   Subr. Public
+!      OPNVUF                Subr. Public
+!      SETVUF                Subr. Public
+!      flex_tidana_webpage   Subr. Public
+!      TIDE_PREDICT          Subr. Public Tide prediction and error estimate
 !      TIDE_PREDICT_ONLY     Subr. Public Tide prediction only
 !     ----------------------------------------------------------------
 !
@@ -78,7 +78,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/
-!      PUBLIC 
+!      PUBLIC
 !/
 !/ Private variables
 !/
@@ -94,13 +94,13 @@
 !
       INTEGER                     :: NTIDAL_CON, NTOTAL_CON, NKONCO
       CHARACTER*5,    ALLOCATABLE :: TIDECON_ALLNAMES(:)       ! array of names of tidal constituents
-      CHARACTER*5,    ALLOCATABLE   :: KONCO_CON(:)         
+      CHARACTER*5,    ALLOCATABLE   :: KONCO_CON(:)
       INTEGER, ALLOCATABLE, PRIVATE :: II(:),JJ(:),KK(:),LL(:),MM(:),NN(:),NJ(:)
       REAL, ALLOCATABLE             :: SEMI(:),COEF_CON(:)
       REAL , ALLOCATABLE            :: V_ARG(:,:),F_ARG(:,:),U_ARG(:,:)
       REAL                          :: EE(180),PH(180)
       INTEGER                       :: LDEL(180),MDEL(180),NDEL(180),IR(180)
-! these two index table are used in VUF ... 
+! these two index table are used in VUF ...
       INTEGER , ALLOCATABLE         :: TIDE_INDEXJ(:),TIDE_INDEXJK(:)
 !
 ! Parameters for tidal analysis
@@ -130,7 +130,7 @@
                                       TIDE_SIG3(MC,2), TIDE_TTEST(MC,2)
       REAL                         :: TIDE_ampci(10,10,2), TIDE_phgi(10,10,2)
       INTEGER                      :: TIDE_INDEX(MC),TIDE_INDEX2(MC)
-      
+
 
       INTEGER                      :: NDSET, TIDE_VERBOSE = 0
 
@@ -152,7 +152,7 @@
       REAL(KIND=8),  INTENT(IN)     :: RMSR0(NDEF), &
                                        SDEV0(NDEF), SDEV(NDEF), RMSR(NDEF), RESMAX(NDEF), RMSRP(NDEF)
       REAL         , INTENT(IN)     :: RES(NDEF), SSQ(NDEF), XLAT,XLON
-! 
+!
       INTEGER                       :: IDEF, I, K, K2, L, I1, INFTOT
       INTEGER                       :: ID1,IM1,IY1,ID2,IM2,IY2
 
@@ -197,13 +197,13 @@
           WRITE(LP,43) TIDECON_NAME(I),TIDE_FREQC(I),TIDE_AMPC(I,idef),TIDE_PHG(I,idef),     &
                    TIDE_sig1(I,idef),TIDE_sig2(I,idef),TIDE_sig3(I,idef),TIDE_ttest(I,idef)
           END DO
- 
+
    43 FORMAT(5X,A5,4X,F12.9,2X,F10.5,2X,F10.3,5x,4f8.3)
 
 !
 !*  INFERENCE results are given now
 !
-      IF (TIDE_NIN.GE.0) THEN 
+      IF (TIDE_NIN.GE.0) THEN
         write(lp,*) ' INFERENCE RESULTS'
         l=0
         do k=1,TIDE_NIN
@@ -289,21 +289,21 @@
 !
 !/S      USE W3SERVMD, ONLY: STRACE
 !/ ------------------------------------------------------------------- /
-      IMPLICIT NONE   
+      IMPLICIT NONE
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
 !/
       CHARACTER(LEN=100), INTENT(IN) :: LIST(70)
       INTEGER, INTENT(OUT)    :: INDS(70), TIDE_PRMF
- 
+
       INTEGER J, FOUND
 !/S      INTEGER, SAVE           :: IENT   =   0
 !
 !/S      CALL STRACE (IENT, 'TIDE_FIND_INDICES_PREDICTION')
 !
       TIDE_PRMF=0
-      IF (TRIM(LIST(1)).EQ.'ALL') THEN 
+      IF (TRIM(LIST(1)).EQ.'ALL') THEN
         DO J=1,TIDE_MF
           INDS(J)=J
           END DO
@@ -315,7 +315,7 @@
         TIDE_PRMF=TIDE_PRMF+1
         FOUND = 0
         DO J=1,TIDE_MF
-          IF (TRIM(TIDECON_NAME(J)).EQ.TRIM(LIST(TIDE_PRMF))) THEN 
+          IF (TRIM(TIDECON_NAME(J)).EQ.TRIM(LIST(TIDE_PRMF))) THEN
             INDS(TIDE_PRMF)=J
             FOUND=1
             WRITE(6,*) 'Tidal constituent to be used in pre:',TRIM(LIST(TIDE_PRMF)),TIDE_FREQC(J)
@@ -376,7 +376,7 @@
 !/S      USE W3SERVMD, ONLY: STRACE
 !
 !/ ------------------------------------------------------------------- /
-      IMPLICIT NONE   
+      IMPLICIT NONE
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -397,7 +397,7 @@
        'J1   ', 'SO1  ', 'OO1  ', 'UPS1 ', 'OQ2  ', 'EPS2 ', '2N2  ', 'MU2  ', 'N2   ', 'NU2  ',  &
        'M2   ', 'MKS2 ', 'LDA2 ', 'L2   ', 'S2   ', 'K2   ', 'MSN2 ', 'ETA2 ', 'MO3  ', 'M3   ',  &
        'SO3  ', 'MK3  ', 'SK3  ', 'MN4  ', 'M4   ', 'SN4  ', 'MS4  ', 'MK4  ', 'S4   ', 'SK4  ',  &
-       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /) 
+       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /)
 !
        TIDE_FREQC_ALL(:)=(/0.0000000000, 0.0002281591, 0.0013097807, 0.0015121520, 0.0028219327, 0.0030500918, &
                   0.0343965698, 0.0357063505, 0.0359087218, 0.0372185025, 0.0374208738, &
@@ -413,20 +413,20 @@
                   0.2471780673, 0.2474062264, 0.2833149482, 0.3220456027 /)
 
       INDS(:) = 0
-      IF (TRIM(LIST(1)).EQ.'ALL') THEN 
+      IF (TRIM(LIST(1)).EQ.'ALL') THEN
         WRITE(6,*) 'Tidal constituent ALL not available anymore.'
         RETURN
         END IF
 !
-      IF (TRIM(LIST(1)).EQ.'FAST') THEN 
+      IF (TRIM(LIST(1)).EQ.'FAST') THEN
         TIDE_MF = 44
         INDS(1:44)= (/ 1, 2, 3, 4, 5, 6, 12, 17, 18, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,  &
                       37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,&
-                      55, 56, 57, 58, 59, 60 /) 
+                      55, 56, 57, 58, 59, 60 /)
 !
-      ELSE IF (TRIM(LIST(1)).EQ.'VFAST') THEN 
+      ELSE IF (TRIM(LIST(1)).EQ.'VFAST') THEN
         TIDE_MF = 20
-        INDS(1:20)= (/ 1, 2, 3, 5, 6, 27, 28, 29, 30, 31, 35, 36, 37, 44, 45, 47, 49, 54, 55, 60 /) 
+        INDS(1:20)= (/ 1, 2, 3, 5, 6, 27, 28, 29, 30, 31, 35, 36, 37, 44, 45, 47, 49, 54, 55, 60 /)
 !
       ELSE
         TIDE_MF=0
@@ -437,7 +437,7 @@
           TIDE_MF=TIDE_MF+1
           FOUND = 0
           DO J=1,60
-            IF (TRIM(TIDECON_NAME_ALL(J)).EQ.TRIM(LIST(TIDE_MF))) THEN 
+            IF (TRIM(TIDECON_NAME_ALL(J)).EQ.TRIM(LIST(TIDE_MF))) THEN
               NTIDES=NTIDES+1
               INDS(NTIDES)=J
               FOUND = 1
@@ -445,7 +445,7 @@
               END IF
             END DO
           IF (FOUND.EQ.0) WRITE(6,*) 'Tidal constituent ',TIDE_MF,TRIM(LIST(TIDE_MF)),' not available.'
-! 
+!
           END DO
 !
         TIDE_MF=NTIDES
@@ -456,7 +456,7 @@
         IF (ALLOCATED(TIDE_FREQC)) DEALLOCATE(TIDE_FREQC)
         ALLOCATE(TIDE_FREQC(TIDE_MF),TIDECON_NAME(TIDE_MF))
 
-        DO J=1,TIDE_MF 
+        DO J=1,TIDE_MF
           TIDECON_NAME(J) = TIDECON_NAME_ALL(INDS(J))
           TIDE_FREQC(J) = TIDE_FREQC_ALL(INDS(J))
           END DO
@@ -471,18 +471,18 @@
 !/ ------------------------------------------------------------------- /
       SUBROUTINE TIDE_SET_INDICES
 !
-      IMPLICIT NONE   
+      IMPLICIT NONE
 !
-      INTEGER J, K, K1, L, J1, JL, L2, KM1, JBASE 
+      INTEGER J, K, K1, L, J1, JL, L2, KM1, JBASE
 !
-      DO L=1,TIDE_MF 
+      DO L=1,TIDE_MF
         DO K=1,NTOTAL_CON
           IF (TIDECON_ALLNAMES(k).EQ.TIDECON_NAME(L)) TIDE_INDEX2(L)=K
-          END DO 
-        END DO 
-!     
-      TIDE_INDEXJ(:)=0    
-      TIDE_INDEXJK(:)=0    
+          END DO
+        END DO
+!
+      TIDE_INDEXJ(:)=0
+      TIDE_INDEXJK(:)=0
       JBASE=0
       K1=NTIDAL_CON+1
 !
@@ -494,7 +494,7 @@
           KM1=K-1
           L2=0
           DO L2=1,KM1
-            IF (TIDECON_ALLNAMES(L2).EQ.KONCO_CON(J)) THEN 
+            IF (TIDECON_ALLNAMES(L2).EQ.KONCO_CON(J)) THEN
               TIDE_INDEXJK(J)=L2
               END IF
             END DO ! L2
@@ -508,7 +508,7 @@
 !/ ------------------------------------------------------------------- /
      SUBROUTINE SETVUF_FAST(h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau,XLAT,F,U,V)
 !      setvuf calculates the V,u,f values at time hr for all constituents
-      IMPLICIT NONE 
+      IMPLICIT NONE
       REAL,         INTENT(IN)  :: XLAT
       REAL(KIND=8), INTENT(IN)  :: h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau
       INTEGER, PARAMETER        :: NTIL=44
@@ -523,11 +523,11 @@
 
       REAL                      :: SLAT, VDBL, RR, SUMC, SUMS, UUDBL, UU
       INTEGER                   :: IUU, IV
- 
+
       SLAT=SIN(PI*XLAT/180.)
 
       JBASE=0
-! All 
+! All
 ! 1'Z0  *','SA   ','SSA *','MSM *','MM   *,'MSF *','MF  *','ALP1*','2Q1  ','SIG1 ', &
 !11'Q1   ','RHO1 ','O1  *','TAU1 ','BET1 ','NO1  ','CHI1 ','PI1  ','P1  *','S1   ', &
 !21'K1  *','PSI1 ','PHI1 ','THE1 ','J1   ','OO1  ','UPS1 ','OQ2  ','EPS2*','2N2 *', &
@@ -550,7 +550,7 @@
 !       'J1   ', 'SO1  ', 'OO1  ', 'UPS1 ', 'OQ2  ', 'EPS2 ', '2N2  ', 'MU2  ', 'N2   ', 'NU2  ',  &
 !       'M2   ', 'MKS2 ', 'LDA2 ', 'L2   ', 'S2   ', 'K2   ', 'MSN2 ', 'ETA2 ', 'MO3  ', 'M3   ',  &
 !       'SO3  ', 'MK3  ', 'SK3  ', 'MN4  ', 'M4   ', 'SN4  ', 'MS4  ', 'MK4  ', 'S4   ', 'SK4  ',  &
-!       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /) 
+!       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /)
 
 ! Subset
 !       'Z0   ', 'SSA  ', 'MSM  ', 'MM   ', 'MSF  ', 'MF   ',  &
@@ -558,7 +558,7 @@
 !                                                    'EPS2 ', '2N2  ', 'MU2  ', 'N2   ', 'NU2  ',  &
 !       'M2   ', 'MKS2 ', 'LDA2 ', 'L2   ', 'S2   ', 'K2   ', 'MSN2 ', 'ETA2 ', 'MO3  ', 'M3   ',  &
 !       'SO3  ', 'MK3  ', 'SK3  ', 'MN4  ', 'M4   ', 'SN4  ', 'MS4  ', 'MK4  ', 'S4   ', 'SK4  ',  &
-!       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /) 
+!       '2MK5 ', '2SK5 ', '2MN6 ', 'M6   ', '2MS6 ', '2MK6 ', '2SM6 ', 'MSK6 ', '3MK7 ', 'M8   ' /)
 
 
 !
@@ -567,15 +567,15 @@
       DO K=1,NTIDAL_CON
         J1=JBASE+1
         JL=JBASE+NJ(K)
-        DO L=1,TIDE_MF 
-          IF (TIDE_INDEX2(L).EQ.K) THEN 
+        DO L=1,TIDE_MF
+          IF (TIDE_INDEX2(L).EQ.K) THEN
             VDBL=II(K)*TAU+JJ(K)*S+KK(K)*H+LL(K)*P+MM(K)*ENP+NN(K)*PP+SEMI(K)
             IV=VDBL
             IV=(IV/2)*2
             SUMC=1.
             SUMS=0.
             DO J=J1,JL
-! ITIME ??? 
+! ITIME ???
 !***********************************************************************
 !*  HERE THE SATELLITE AMPLITUDE RATIO ADJUSTMENT FOR LATITUDE IS MADE
 !
@@ -598,7 +598,7 @@
             UA(K)=ATAN2(SUMS,SUMC)/TWOPI
             END IF
           JBASE=JL ! (indx(L).EQ.K)
-          END DO   ! L 
+          END DO   ! L
         END DO     ! K
 !
 !  HERE F AND V+U OF THE SHALLOW WATER CONSTITUENTS ARE COMPUTED FROM
@@ -619,7 +619,7 @@
           END DO   ! J
         END DO     ! K
 !
-        DO L=1,TIDE_MF 
+        DO L=1,TIDE_MF
           F(L)=FA(TIDE_INDEX2(L))
           U(L)=UA(TIDE_INDEX2(L))
           V(L)=VA(TIDE_INDEX2(L))
@@ -637,17 +637,17 @@
       CHARACTER*256, INTENT(OUT)    :: fnam6,fnam7,fnam8,fnam9,fnam11
 
       INTEGER KIN
-      
+
 ! Parameters for reading KR1
 !      FILE I/O
-!      KIN is the master input file. 
+!      KIN is the master input file.
 !      fnam6 is the file to which the output is sent. It is assigned the number
 !            lp.
 !      fnam7 is file containing the constituents to be included in the analysis,
 !            the analysis period, inference parameters, the flag controlling
 !            height or current analyses, and site information. It is assigned the
 !            number kr1.
-!      fnam8 is the file containing all the astronomical argument information 
+!      fnam8 is the file containing all the astronomical argument information
 !            (it should not have to be changed)
 !      fnam11 is a file to which information on the SVD matrix fit is output when
 !
@@ -655,7 +655,7 @@
 !      the same are also output to file 26 in a format that could be input to
 !      Excel for plotting.
 !
-      KIN=40   ! Input file assigned to unit 4 
+      KIN=40   ! Input file assigned to unit 4
 
 !      OPEN(UNIT=KIN,FILE='tuk75_tidana.inp',STATUS='OLD')
 !      OPEN(UNIT=KIN,FILE='victoria_2008_test.inp',STATUS='OLD')
@@ -699,7 +699,7 @@
 !***********************************************************************
 !*  READ FROM DEVICE KR1 THE ANALYSIS TYPE AND TIDAL STATION DETAILS.
 !*
-!*  1)ONE RECORD FOR THE VARIABLES TIDE_MF 
+!*  1)ONE RECORD FOR THE VARIABLES TIDE_MF
 !*  TIDE_MF   = THE NUMBER OF CONSTITUENTS, INCLUDING THE CONSTANT TERM Z0,
 !*         TO BE IN THE LEAST SQUARES FIT.
 !*
@@ -726,18 +726,18 @@
 !              *  LATD,LATM = STATION LATITUDE IN DEGREES AND MINUTES,
 !              *  LOND,LONM = STATION LONGITUDE IN DEGREES AND MINUTES.
 !              *
-!              *  5)ONE SET RECORDS FOR EACH POSSIBLE INFERENCE. THE FIRST RECORD HAS THE 
+!              *  5)ONE SET RECORDS FOR EACH POSSIBLE INFERENCE. THE FIRST RECORD HAS THE
 !              *      CONSITUENT NAME, ITS FREQUENCY, AND THE NUMBER OF CONSTITUENTS TO BE
-!              *      INFERRED (4X,A5,E16.10,i5), WHILE THERE IS ONE RECORD FOR EACH OF THE 
-!              *      CONSTITUENTS TO BE INFERRED WITH THE NAME, FREQUENCY, AMPLITUDE RATIO 
-!              *      (INFERRED TO REFERENCE) AND PHASE DIFFERENCE (GREENWICH PHASE LAG OF 
+!              *      INFERRED (4X,A5,E16.10,i5), WHILE THERE IS ONE RECORD FOR EACH OF THE
+!              *      CONSTITUENTS TO BE INFERRED WITH THE NAME, FREQUENCY, AMPLITUDE RATIO
+!              *      (INFERRED TO REFERENCE) AND PHASE DIFFERENCE (GREENWICH PHASE LAG OF
 !              *      THE INFERRED CONSTITUENT SUBTRACTED FROM THE GREENWICH PHASE LAG OF THE
 !              *    (ANALYSED CONSTITUENT IN THE FORMAT(4X,A5,E16.10,2F10.3)
 !              *
 !              *  FOR KR1 INPUT, ALL CONSTITUENT NAMES SHOULD BE LEFT JUSTIFIED IN
 !              *  THE ALPHANUMERIC FIELD, FREQUENCIES ARE MEASURED IN CYCLES/HOUR, AND
 !              *  ALL CONSTITUENTS MUST BE INCLUDED IN THE LIST IN READ FROM FNAM8.
-!              
+!
 !                    write(6,*) ' reading from unit kr1'
       READ(KR1,*) TIDE_MF,ndef,itrend
       ALLOCATE(TIDE_FREQC(TIDE_MF),TIDECON_NAME(TIDE_MF))
@@ -772,7 +772,7 @@
 
       iy=ic2*100+iy2
       kd2=JULDAYT(id2,im2,iy)
-!      
+!
 !      read in inference information now as it will be used in the lsq matrix
 !
       DO K=1,10
@@ -810,36 +810,36 @@
       REAL                          :: htt(NDEF)
 !
 ! Initialize Variables
-!      
-      ALLOCATE( TIDE_DATATMP(NR,NDEF), TIDE_DAYSTMP(NR), TIDE_SECSTMP(NR) )  
+!
+      ALLOCATE( TIDE_DATATMP(NR,NDEF), TIDE_DAYSTMP(NR), TIDE_SECSTMP(NR) )
 
-! Reads in data between dates kd1 and kd2 in file kr2 
-!  
+! Reads in data between dates kd1 and kd2 in file kr2
+!
       OPEN(unit=kr2,file=filename,status='old',form='formatted')
-      
+
       ICODE = 0
       KDD = KD1
       I=0
-      DO WHILE(ICODE.EQ.0.AND.KDD.LE.KD2) 
+      DO WHILE(ICODE.EQ.0.AND.KDD.LE.KD2)
 !
 ! reads with the original Foreman's format
 !
-        READ(kr2,145,IOSTAT=ICODE) idd,imm,icc,iyy,ihh,imin,htt(1:NDEF)  
+        READ(kr2,145,IOSTAT=ICODE) idd,imm,icc,iyy,ihh,imin,htt(1:NDEF)
 145     format(6i2,4f10.4)
         isec=0
         iy=icc*100+iyy
-      
+
         kdd=JULDAYT(idd,imm,iy)
 
         IF (kdD.lt.kd1) then
           WRITE(*,*) icc,iyy,imm,idd,ihh,imin
           WRITE(*,*)'kd, kd1, kd2 =',kdd,kd1,kd2
           write(*,*) ' observation before analysis period'
-        ELSE 
+        ELSE
 !
 !  Fills in data array
 !
-          IF (ICODE.EQ.0.AND.KDD.LE.KD2) THEN 
+          IF (ICODE.EQ.0.AND.KDD.LE.KD2) THEN
             i=i+1
             TIDE_DATATMP(I,:)=htt(:)
             TIDE_DAYSTMP(I)=kdd
@@ -847,10 +847,10 @@
             END IF
           END IF
         END DO
-     
+
       TIDE_NTI=i
-      ALLOCATE( TIDE_DATA(TIDE_NTI,NDEF) )  
-      ALLOCATE( TIDE_DAYS(TIDE_NTI), TIDE_SECS(TIDE_NTI), TIDE_HOURS(TIDE_NTI) )  
+      ALLOCATE( TIDE_DATA(TIDE_NTI,NDEF) )
+      ALLOCATE( TIDE_DAYS(TIDE_NTI), TIDE_SECS(TIDE_NTI), TIDE_HOURS(TIDE_NTI) )
       TIDE_DATA(1:TIDE_NTI,1:NDEF)=TIDE_DATATMP(1:TIDE_NTI,1:NDEF)
       TIDE_DAYS(1:TIDE_NTI)=TIDE_DAYSTMP(1:TIDE_NTI)
       TIDE_SECS(1:TIDE_NTI)=TIDE_SECSTMP(1:TIDE_NTI)
@@ -980,7 +980,7 @@
 
       INTEGER i,its,j,jj,k,l,nm
       DOUBLE PRECISION anorm,c,f,g,h,s,scale,x,y,z,rv1(NMAX)
-      
+
       g=0.0d0
       scale=0.0d0
       anorm=0.0d0
@@ -994,7 +994,7 @@
           DO k=i,m
             scale=scale+abs(a(k,i))
             END DO
-          IF (scale.ne.0.0d0) THEN 
+          IF (scale.ne.0.0d0) THEN
             DO  k=i,m
               a(k,i)=a(k,i)/scale
               s=s+a(k,i)*a(k,i)
@@ -1146,7 +1146,7 @@
             endif
             goto 3
           endif
-          IF (ITS.eq.30) THEN 
+          IF (ITS.eq.30) THEN
             WRITE(6,*) 'no convergence in svdcmp'
             STOP
             END IF
@@ -1211,7 +1211,7 @@
 !*********************************************************************
       IMPLICIT NONE
            INTEGER id,mm,iyyy
-      INTEGER IGREG 
+      INTEGER IGREG
       INTEGER*4 ja,jm,jy
       INTEGER*4 JULDAYT
       IGREG=15+31*(10+12*1582)
@@ -1266,7 +1266,7 @@
                     ,ssq,res)
 !-----------------------------------------------------------------------
 ! svd uses singular-value-decomposition to calculate the least-squares
-! solution p to an overdetermined system of linear equations with 
+! solution p to an overdetermined system of linear equations with
 ! coefficient matrix q, which includes right hand side vector b.
 !
 ! there are two ways to use svd:
@@ -1283,9 +1283,9 @@
 ! n      the total number of columns of q to be used (<N2)
 ! N2   the number of columns of q, at least n+1.
 ! mm   the number of rows of q, at least N2+m.
-! q      an mm-by-N2 array which on entry must contain the 
-!        matrix a in its first m rows and n columns, and the vector 
-!        b in its first m rows of column mm. on exit the residual 
+! q      an mm-by-N2 array which on entry must contain the
+!        matrix a in its first m rows and n columns, and the vector
+!        b in its first m rows of column mm. on exit the residual
 !        of equation i is stored in q(i,N2), i=1 to m.
 ! sig    measurement error (standard deviation) for the rhs
 !        from the calling program (can be set to 1.)
@@ -1323,7 +1323,7 @@
       integer                   :: i, j, k
       real                      :: wmax, thresh
       double precision          :: eps, sum, resi
-      
+
       jc=0
       sig(:)=1.
       do i=1,mm
@@ -1338,7 +1338,7 @@
         enddo
       enddo
 ! compute svd decomposition of u(=a), with a being replaced by its upper
-! matrix u, viz a=u*w*transpose(v), and vector w is output of a diagonal 
+! matrix u, viz a=u*w*transpose(v), and vector w is output of a diagonal
 ! matrix of singular values w(i), i=1,n.
       call dsvdcmp(u,m,n,mm,N2,w,v)
 ! check for small singular values
@@ -1420,7 +1420,7 @@
       ALLOCATE(TIDECON_ALLNAMES(NTOTAL_CON))
       ALLOCATE(II(NTIDAL_CON),JJ(NTIDAL_CON),KK(NTIDAL_CON),LL(NTIDAL_CON),MM(NTIDAL_CON), &
                NN(NTIDAL_CON),SEMI(NTIDAL_CON), NJ(NTOTAL_CON))
-      
+
       ALLOCATE(KONCO_CON(NKONCO),COEF_CON(NKONCO))
 
       TIDECON_ALLNAMES(:)=(/ &
@@ -1507,7 +1507,7 @@
  -2, -1,  0,  0,  1, -1, -1,  0,  0,  1, &
   1,  1,  2,  2,  0,  0,  0,  2,  2,  2, &
   2,  0,  0,  1,  2,  0,  0, -1, -1,  0, &
-  0,  0,  0,  0,  0,  1,  1,  1,  2,  0/) 
+  0,  0,  0,  0,  0,  1,  1,  1,  2,  0/)
       MDEL(1:JLM)=(/  0,  0,  0,  0,  0,  0,  0,  0, -1, -2, &
                      -1,  0, -2, -1,  0, -2, -1,  0, -3, -2, &
                      -2, -1,  0, -2,  0, -1,  0,  0, -2, -1, &
@@ -1524,7 +1524,7 @@
                       -2,  0, -1, -1,  0, -1,  0, -2, -1, -1, &
                        0,  1,  0,  1, -1, -1, -1, -1,  0,  1, &
                        2,  0, -1,  0,  0,  0,  1,  0,  1, -1, &
-                       1,  2, -1,  1,  2,  0,  1,  2,  0, -1 /) 
+                       1,  2, -1,  1,  2,  0,  1,  2,  0, -1 /)
      NDEL(1:JLM)=(/ 0,  0,  0,  0,  0,  0,  0,  0,  0,  0, &
                     0,  0,  0,  0,  0,  0,  0,  0,  0,  0, &
                     0,  0,  0,  0,  1,  0,  0,  0,  0,  0, &
@@ -1541,7 +1541,7 @@
                     0,  0,  0,  0, -1,  0,  0,  0,  0,  0, &
                     0,  0,  0,  0,  0,  0,  0,  0,  0,  0, &
                     0,  0,  0,  0,  0,  2,  2,  0,  0,  0, &
-                    0,  0,  0,  0,  0,  0,  0,  0,  0,  0 /) 
+                    0,  0,  0,  0,  0,  0,  0,  0,  0,  0 /)
      PH(1:JLM)=(/ 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.75, 0.00, 0.50, &
                   0.75, 0.75, 0.50, 0.00, 0.75, 0.50, 0.00, 0.50, 0.50, 0.50, &
                   0.75, 0.75, 0.75, 0.50, 0.00, 0.00, 0.75, 0.50, 0.50, 0.00, &
@@ -1558,7 +1558,7 @@
                   0.00, 0.25, 0.50, 0.50, 0.50, 0.75, 0.75, 0.00, 0.50, 0.25, &
                   0.75, 0.75, 0.00, 0.00, 0.50, 0.50, 0.50, 0.00, 0.50, 0.50, &
                   0.50, 0.00, 0.00, 0.75, 0.00, 0.50, 0.00, 0.75, 0.75, 0.50, &
-                  0.00, 0.00, 0.50, 0.00, 0.00, 0.75, 0.75, 0.75, 0.50, 0.50 /) 
+                  0.00, 0.00, 0.50, 0.00, 0.00, 0.75, 0.75, 0.75, 0.50, 0.50 /)
 
      EE(1:JLM)=(/ 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0000, 0.0360, 0.1906, 0.0063, &
                   0.0241, 0.0607, 0.0063, 0.1885, 0.0095, 0.0061, 0.1884, 0.0087, 0.0007, 0.0039, &
@@ -1576,7 +1576,7 @@
                   0.1429, 0.0293, 0.0330, 0.0224, 0.0447, 0.0001, 0.0004, 0.0005, 0.0373, 0.0001, &
                   0.0009, 0.0002, 0.0006, 0.0002, 0.0217, 0.0448, 0.0366, 0.0047, 0.2505, 0.1102, &
                   0.0156, 0.0000, 0.0022, 0.0001, 0.0001, 0.2535, 0.0141, 0.0024, 0.0004, 0.0128, &
-                  0.2980, 0.0324, 0.0187, 0.4355, 0.0467, 0.0747, 0.0482, 0.0093, 0.0078, 0.0564 /) 
+                  0.2980, 0.0324, 0.0187, 0.4355, 0.0467, 0.0747, 0.0482, 0.0093, 0.0078, 0.0564 /)
 
      IR(1:JLM)=(/ 0,  0,  0,  0,  0,  0,  0,  1,  0,  0, &
                    1,  1,  0,  0,  1,  0,  0,  0,  0,  0, &
@@ -1594,7 +1594,7 @@
                    0,  2,  0,  0,  0,  2,  2,  0,  0,  2, &
                    2,  2,  0,  0,  0,  0,  0,  0,  0,  0, &
                    0,  0,  0,  2,  0,  0,  0,  2,  2,  0, &
-                   0,  0,  0,  0,  0,  2,  2,  2,  0,  0 /) 
+                   0,  0,  0,  0,  0,  2,  2,  2,  0,  0 /)
 
       COEF_CON(:)=(/ 2.00,-1.00, 1.00,-1.00, 2.00, 1.00,-2.00, 2.00,-1.00, 3.00, &
                     -2.00, 2.00, 1.00,-2.00, 1.00, 1.00, 1.00,-2.00, 2.00, 1.00, &
@@ -1658,7 +1658,7 @@
 !
 !
 !* GIVEN CONSTITUENT KONX , THE NODAL CORRECTIONS V+U AND F ARE RETURNED
-! That subroutine can now be replaced by look-up table to get K from J 
+! That subroutine can now be replaced by look-up table to get K from J
 !
 !
       IMPLICIT NONE
@@ -1706,7 +1706,7 @@
 
       DOUBLE PRECISION, PARAMETER   :: TWOPI=3.1415926535898*2.
       DOUBLE PRECISION, PARAMETER   :: FAC=TWPI/360.
-      
+
       KR=8
 !
 !***********************************************************************
@@ -1735,7 +1735,7 @@
         !           NJ(K)
         IF (TIDECON_ALLNAMES(K).eq.KBLANK) go to 100
 70      J1=JBASE+1
-        IF (NJ(K).LT.1) THEN 
+        IF (NJ(K).LT.1) THEN
           NJ(K)=1
           JL=J1
           PH(J1)=0.
@@ -1744,7 +1744,7 @@
           MDEL(J1)=0
           NDEL(J1)=0
           IR(J1)=0
-        ELSE 
+        ELSE
           JL=JBASE+NJ(K)
 !
 !***********************************************************************
@@ -1796,7 +1796,7 @@
 
 170   NTOTAL_CON=K-1
 
-!  Write out  for cut and paste ... 
+!  Write out  for cut and paste ...
 !    WRITE(6,*) 'Numbers:',NTIDAL_CON, NTOTAL_CON, JLM, J1, J4
 !    WRITE(996,*) NTIDAL, NTOTAL_CON, JLM, J1, J4
 !999      FORMAT(10("'",A5,"',"),' &')
@@ -1836,7 +1836,7 @@
 !
 !      setvuf calculates the V,u,f values at time hr for all constituents
 !
-      END SUBROUTINE OPNVUF 
+      END SUBROUTINE OPNVUF
 
 !/ ------------------------------------------------------------------- /
      SUBROUTINE SETVUF(hr,XLAT,ITIME)
@@ -1868,7 +1868,7 @@
       d1=hr/24.d0
       ! This was with "gregorian days from KDAY"
       !call gday(31,12,99,18,kd0)   !  CALL GDAY(IDd,IMm,IYy,ICc,KDd)
-      ! Now uses "julian days from JULDAYT" 
+      ! Now uses "julian days from JULDAYT"
       ! KD0= 693961
       !KD0=JULDAYT(31,12,1899)   ! JULDAYT(id,mm,iyyy)
       KD0= 2415020
@@ -1937,7 +1937,7 @@
         DO lk=1,TIDE_MF
           IF (TIDECON_ALLNAMES(K).eq.TIDECON_NAME(lk)) then
            iflag=1
-            EXIT 
+            EXIT
             END IF
           END DO   ! lk
 
@@ -1949,8 +1949,8 @@
           END DO   ! J
         END DO     ! K
 
-!  Test output for verification purposes 
-        IF (ITIME.EQ.-1) THEN 
+!  Test output for verification purposes
+        IF (ITIME.EQ.-1) THEN
           WRITE(992,'(A,F20.2,13F8.3)') 'TEST ISEA 0:',    &
                          d1,H,S,TAU,pp,s,p,enp,dh,dpp,ds,dp,dnp,XLAT
           do l=1,TIDE_MF
@@ -1962,7 +1962,7 @@
                END IF
              END DO
            ENDDO
-         ENDIF 
+         ENDIF
 
       RETURN
 !
@@ -1977,10 +1977,10 @@
 !*
 !*  THIS PROGRAM DOES A TIDAL HEIGHTS 'HARMONIC' ANALYSIS OF IRREGULARLY
 !*  SAMPLED OBSERVATIONS.  THE ANALYSIS METHOD IS A LEAST SQUARES FIT
-!*  USING SVD COUPLED WITH NODAL MODULATION AND INFERENCE(IF SO REQUESTED).  
-!*      
-!*      The code is based on TOPEX analysis code originally developed by Josef 
-!*      Cherniawsky (JAOT, 2001, 18(4): 649-664) and modified by Rob Bell and 
+!*  USING SVD COUPLED WITH NODAL MODULATION AND INFERENCE(IF SO REQUESTED).
+!*
+!*      The code is based on TOPEX analysis code originally developed by Josef
+!*      Cherniawsky (JAOT, 2001, 18(4): 649-664) and modified by Rob Bell and
 !*      Mike Foreman. Enhancements to that version include
 !*
 !*      1. Provision for multi-constituent inferences computed directly within
@@ -1991,14 +1991,14 @@
 !*      2. An extension to permit the analysis of current observations.
 !*
 !*      3. Removal of a central time as the basis for the calculation of the
-!*        astronomical arguments V. Now the V value for each observation, as well 
-!*        as those for the nodal corrections f and u (done for the JAOT analysis), 
+!*        astronomical arguments V. Now the V value for each observation, as well
+!*        as those for the nodal corrections f and u (done for the JAOT analysis),
 !*        are incorporated directly into the overdetermined matrix. These changes
 !*        mean that analyses no longer need be restricted to periods of a year or
-!*        less. (Though as the period approaches 18.6 years, using another "long 
+!*        less. (Though as the period approaches 18.6 years, using another "long
 !*        period" analysis program that solves for the "nodal satellites" directly
 !*        is advisable.)
-!* 
+!*
 !***********************************************************************
 !*
 !*  FILE REFERENCE NUMBERS OF DEVICES REQUIRED BY THIS PROGRAM.
@@ -2024,7 +2024,7 @@
 !*         NEQ     BE TIDE_NTI*2 IF ALL THE OBSERVATIONS ARE EXTREMES AND
 !*                 THE DERIVATIVE CONDITION IS TO BE INCLUDED FOR EACH,
 !*                 AND TIDE_NTI OTHERWISE (= NR for T/P data).
-!*  THEN PARAMETERS NMAXP1, AND NMAXPM SHOULD BE AT LEAST MPAR+1, AND 
+!*  THEN PARAMETERS NMAXP1, AND NMAXPM SHOULD BE AT LEAST MPAR+1, AND
 !*  NEQ+MPAR RESPECTIVELY.  THEY ARE CURRENTLY SET TO 40 AND 240.
 !*
 !*  TIDECON_NAME(I) IS THE ARRAY CONTAINING ALL THE CONSTITUENT NAMES,
@@ -2060,7 +2060,7 @@
 !***********************************************************************
 !
       IMPLICIT NONE
-  
+
       INTEGER, INTENT(IN)         :: NDEF, ITREND, ITEST
       INTEGER(KIND=4), INTENT(IN) :: KD1, KD2, IX, IY
       REAL           , INTENT(IN) :: XLON, XLAT
@@ -2068,7 +2068,7 @@
       REAL           , INTENT(OUT):: SSQ(NDEF), RES(NDEF)
       INTEGER        , INTENT(OUT):: IMAX(NDEF)
 !
-      INTEGER                     :: I, I1, I2, I21, II1, IDEF, ICODE,  INFLAG,  & 
+      INTEGER                     :: I, I1, I2, I21, II1, IDEF, ICODE,  INFLAG,  &
                                      J, INFTOT, IREP, J2, JCODE, JJ1, K, K2, KH1,     &
                                      KH2, KHM, KINF, L, M, MEQ, N, NCOL, NEW, NMAX
       REAL(KIND=8)                :: AAMP, ARG, ARG1, ARG2, ARG3, C, C2, C3,     &
@@ -2077,8 +2077,8 @@
       REAL                        :: TOLER
       REAL(KIND=8)                :: AV, SDEV, SUM2, hrm
       DOUBLE PRECISION            :: X(NR),Y(NR), TIME(NR)
-      REAL                        :: Q(NMAXPM,NMAXP1),FREQ(MC),AMP(MC),PH(MC) 
-      DOUBLE PRECISION            :: P(NMAXP1),CENHR,CUMHR  
+      REAL                        :: Q(NMAXPM,NMAXP1),FREQ(MC),AMP(MC),PH(MC)
+      DOUBLE PRECISION            :: P(NMAXP1),CENHR,CUMHR
       DOUBLE PRECISION            :: yy
 !
 !     Additional arrays, for use in the SVD routine (J.Ch., Aug. 1997)
@@ -2129,7 +2129,7 @@
       DO idef=1,ndef   ! loop thru once or twice
 
 ! Modifies the time reference xmid and puts it at 0 : modification by FA, 2012/09/26
-! the impact of that change has not been verified ... 
+! the impact of that change has not been verified ...
         xmid=0. !0.5*(TIDE_HOURS(1)+TIDE_HOURS(TIDE_NTI))
         Q(1:NMAXPM,1:NMAXP1)=0.0
         DO I=1,N
@@ -2138,7 +2138,7 @@
 !      fitted as const+trend(t-tmid) where tmid (=xmid) is the middle time
 !      of the analysis period (This makes the constant consistent with z0
 !      in the old analysis program)
-!      If itrend=0 then the second parameter is is associated with the next 
+!      If itrend=0 then the second parameter is is associated with the next
 !      constituent
           Q(I,1)=1.
           IF (itrend.eq.1) then
@@ -2151,11 +2151,11 @@
 !      but something is not right if don't do it 2nd time too
          ! CALL SETVUF(TIDE_HOURS(I),xlat,I)
           DO J=2,TIDE_MF
-            CALL VUF(TIDECON_NAME(j),VX,ux,FX,I) 
+            CALL VUF(TIDECON_NAME(j),VX,ux,FX,I)
 !      check to see if this constituent is to be used for inference
               inflag=0
               kinf=0
-              IF (TIDE_NIN.GE.0) THEN 
+              IF (TIDE_NIN.GE.0) THEN
                 do k=1,TIDE_NIN
                   IF (TIDECON_NAME(j).eq.TIDE_KONAN(k)) then
                     inflag=1
@@ -2186,8 +2186,8 @@
                 Q(I,J2)=COS(ARG1)*fx
                 Q(I,JJ1)=SIN(ARG1)*fx
                 do k2=1,TIDE_NINF(kinf)
-                  CALL VUF(TIDE_KONIN(kinf,k2),VXi,uxi,FXi,I) 
-!      freq is radians/hr but sigin is cycles/hr 
+                  CALL VUF(TIDE_KONIN(kinf,k2),VXi,uxi,FXi,I)
+!      freq is radians/hr but sigin is cycles/hr
                   ARG2=(vxi+uxi)*twpi
                   c2=cos(arg2)
                   s2=sin(arg2)
@@ -2200,7 +2200,7 @@
               END IF
             END DO ! j
           END DO  !i
-      
+
 !/T      WRITE(6,*) 'assembled overdetermined matrix and/or rhs'
         NMAX=M
         MEQ=N
@@ -2285,7 +2285,7 @@
 !***********************************************************************
 !*  CALCULATE AMPLITUDES AND PHASES
 !
-!      if itrend=1 then the linear trend is shown as the phase of the constant 
+!      if itrend=1 then the linear trend is shown as the phase of the constant
 !      Z0 term (& the true phase of Z0 is zero)
 !      otherwise, the phase of Z0 is shown as zero
       AMP(1)=P(1)
@@ -2305,14 +2305,14 @@
           C=P(I2)
           S=P(I21)
           AAMP=SQRT(C*C+S*S)
-          IF (AAMP.LT.1.E-5) THEN 
+          IF (AAMP.LT.1.E-5) THEN
             PH(I)=0.
-          ELSE 
+          ELSE
             PH(I)=ATAN2(S,C)/FAC
             IF (PH(I).LT.0.) PH(I)=PH(I)+360.
             END IF
           AMP(I)=AAMP
-          END DO  ! end of loop on TIDE_MF 
+          END DO  ! end of loop on TIDE_MF
 !***********************************************************************
 !      Note that with f & u included in the lsq fit, we only need V from routine VUF
 !      but we don't want to correct with V for a central hour. Better to include
@@ -2328,7 +2328,7 @@
       TIDE_sig3(:,idef)=0.
       TIDE_ttest(:,idef)=0.
 !
-      IF (ITEST.GE.1) THEN 
+      IF (ITEST.GE.1) THEN
 !---------------------------------------------------
 !
       i=1
@@ -2379,7 +2379,7 @@
 !
 !  now inferred constituents
 !
-      IF (TIDE_NIN.GE.0) THEN 
+      IF (TIDE_NIN.GE.0) THEN
         l=0
         do k=1,TIDE_NIN
           do i=2,TIDE_MF
@@ -2421,7 +2421,7 @@
 !              jmax=j
 !             END IF
 !            END DO
-!          END DO 
+!          END DO
 !        if (itrend.eq.1) then
 !          iconst=(imax+1)/2
 !          jconst=(jmax+1)/2
@@ -2431,7 +2431,7 @@
 !          END IF
 !        write(lp,83) iter,cormax,imax,jmax,TIDECON_NAME(iconst),TIDECON_NAME(jconst)
 !83      format(i5,' largest correlation coefficient is ',f8.3,' at (i,j)='     &
-!           ,2i5,' for constituents ',a5,' and ',a5) 
+!           ,2i5,' for constituents ',a5,' and ',a5)
 !        cor(imax,jmax)=0.
 !        END DO
 !
@@ -2461,14 +2461,14 @@
       REAL                           :: ARG, ADD, SUM1, SSQ
       REAL(KIND=8)                   :: VX, UX, FX
 
-      M = 2*TIDE_MF 
+      M = 2*TIDE_MF
 
       DO IDEF=1,NDEF
         SDEV=0.D0
         DO I=1,N
-          IF (itrend.eq.1) THEN 
+          IF (itrend.eq.1) THEN
             SUM1=TIDE_AMPC(1,idef)+TIDE_PHG(1,idef)*HOURS(i)/(365.*24.)
-          ELSE 
+          ELSE
             SUM1=TIDE_AMPC(1,idef)
             END IF
 !
@@ -2479,15 +2479,15 @@
           SUM1=SUM1+ADD
           END DO
 !
-        IF (TIDE_NIN.NE.0) THEN 
+        IF (TIDE_NIN.NE.0) THEN
           DO k=1,TIDE_NIN
             DO k2=1,TIDE_NINF(k)
               CALL VUF(TIDE_KONIN(k,k2),VX,ux,FX,I)
               ARG=(vx+ux)*twpi-TIDE_phgi(k,k2,idef)*fac
               ADD=fx*TIDE_AMPci(k,k2,idef)*COS(ARG)
               SUM1=SUM1+ADD
-              END DO 
-            END DO 
+              END DO
+            END DO
           END IF
 !
         PREDICTED(I,IDEF)=SUM1
@@ -2499,7 +2499,7 @@
       SSQ=SDEV(IDEF)
       RMSR(IDEF)=SQRT(SSQ/(N-M))
       SDEV(IDEF)=sqrt(ssq/N)
-      ENDDO 
+      ENDDO
 !
       END SUBROUTINE TIDE_PREDICT
 
@@ -2520,9 +2520,9 @@
 
       DO IDEF=1,NDEF
         DO I=1,N
-          IF (itrend.eq.1) THEN 
+          IF (itrend.eq.1) THEN
             SUM1=TIDE_AMPC(1,idef)+TIDE_PHG(1,idef)*TIDE_HOURS(i)/(365.*24.)
-          ELSE 
+          ELSE
             SUM1=TIDE_AMPC(1,idef)
             END IF
 !
@@ -2533,22 +2533,22 @@
           SUM1=SUM1+ADD
           END DO
 !
-        IF (TIDE_NIN.NE.0) THEN 
+        IF (TIDE_NIN.NE.0) THEN
           DO k=1,TIDE_NIN
             DO k2=1,TIDE_NINF(k)
               CALL VUF(TIDE_KONIN(k,k2),VX,ux,FX,I)
               ARG=(vx+ux)*twpi-TIDE_phgi(k,k2,idef)*fac
               ADD=fx*TIDE_AMPci(k,k2,idef)*COS(ARG)
               SUM1=SUM1+ADD
-              END DO 
-            END DO 
+              END DO
+            END DO
           END IF
 !
         PREDICTED(I,IDEF)=SUM1
 !
         END DO
 !
-      ENDDO 
+      ENDDO
 !
       END SUBROUTINE TIDE_PREDICT_ONLY
 

--- a/model/ftn/w3timemd.ftn
+++ b/model/ftn/w3timemd.ftn
@@ -11,7 +11,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -36,7 +36,7 @@
 !      DSEC21    R.F.  Public   Calculate the difference in seconds
 !                               between two data/time arrays.
 !      TDIFF     R.F.  Public   Calculate the difference in seconds
-!                               between two date/time arrays that 
+!                               between two date/time arrays that
 !                               were generated from DATE_AND_TIME
 !      MYMD21    I.F.  DSEC21   Julian date function.
 !      STME21    Subr. Public   Converts integer time to string.
@@ -541,18 +541,18 @@
 !  1. Purpose :
 !
 !     Calculate the time difference in seconds between two time arrays
-!     that have been generated from the F90 internal function 
+!     that have been generated from the F90 internal function
 !
 !  3. Parameters :
 !
 !     Parameter list
 !     ----------------------------------------------------------------
-!       Tn      I.A.   I   This is an integer array returned from the 
+!       Tn      I.A.   I   This is an integer array returned from the
 !                          internal subroutine DATE_AND_TIME. The type
 !                          is integer(8). Individual values are
-!                          Tn(1)    the year 
-!                          Tn(2)    the month 
-!                          Tn(3)    day of the month 
+!                          Tn(1)    the year
+!                          Tn(2)    the month
+!                          Tn(3)    day of the month
 !                          Tn(4)    time difference with UTC in minutes
 !                          Tn(5)    hour of the day
 !                          Tn(6)    minutes of the hour
@@ -572,7 +572,7 @@
 !     Any routine.
 !
 !  7. Remarks :
-!     
+!
 !     This code has been provided by Mark Szyszka of RPSGROUP
 !
 !  8. Structure :
@@ -863,7 +863,7 @@
       IH     = TIME(2) / 10000
       IMI    = MOD(TIME(2),10000) / 100
       IS     = MOD(TIME(2),100)
-      JDAY    = julday(id,IMO,iy)    
+      JDAY    = julday(id,IMO,iy)
       TIME2HOURS = 24.d0*dfloat(JDAY)+dfloat(IH)+dfloat(IS+IMI*60)/3600.d0
       RETURN
 !/
@@ -880,7 +880,7 @@
 !/                  | Last update :         06-May-2005 !
 !/                  +-----------------------------------+
 !/
-!/    06-May-2005 : Origination.                        ( version 3.07 )    
+!/    06-May-2005 : Origination.                        ( version 3.07 )
 !/
 !  1. Purpose :
 !
@@ -1180,7 +1180,7 @@
 !     Converts proleptic Gregorian date array to Julian Day
 !
 !
-! * UDUNITS standard : mixed Gregorian/Julian  calendar  system.   
+! * UDUNITS standard : mixed Gregorian/Julian  calendar  system.
 !                      Dates  prior to 1582-10-15 are assumed to use
 !                      the Julian calendar, which was introduced by Julius Caesar
 !                      in 46 BCE and is based on a year that is exactly 365.25 days
@@ -1269,7 +1269,7 @@
    JULIAN=DBLE(JDN) + DBLE(HOUR-12)/24.0d0 + DBLE(MINUTE)/1440.0d0 + DBLE(SECOND)/86400.0d0
 
    ! Check if Julian Day is non-negative
-   IF(JULIAN.lt.0.d0) THEN                  
+   IF(JULIAN.lt.0.d0) THEN
      IERR=1
    ELSE
      IERR=0

--- a/model/ftn/w3triamd.ftn
+++ b/model/ftn/w3triamd.ftn
@@ -1,7 +1,7 @@
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
       MODULE W3TRIAMD
-!/ ------------------------------------------------------------------- 
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |       F. Ardhuin and A. Roland    |
@@ -15,7 +15,7 @@
 !/    02-Sep-2012 : Clean up of open BC for UG grids    ( version 4.08 )
 !/    14-Oct-2013 : Correction  of latitude factor      ( version 4.12 )
 !/    26-Jan-2014 : Correction  interpolation weights   ( version 4.18 )
-!/    21-Apr-2016 : New algorithm to detect boundary    ( version 5.12 ) 
+!/    21-Apr-2016 : New algorithm to detect boundary    ( version 5.12 )
 !/
 !
 !  1. Purpose :
@@ -76,8 +76,8 @@
 !      USE W3ODATMD, ONLY: NDSE, NDST, NDSO
 !      USE W3ODATMD, ONLY: NBI, NBI2, NFBPO, NBO, NBO2, FLBPI, FLBPO,  &
 !                         IPBPO, ISBPO, XBPO, YBPO, RDBPO, FNMPRE
-!--------------------------------------------------------------------- 
-! 
+!---------------------------------------------------------------------
+!
 !C
         integer :: node_num
         integer :: dim_num
@@ -85,12 +85,12 @@
         integer :: triangle_num
         integer :: bound_edge_num
         integer :: bound_num
-!C        
+!C
         logical,save, allocatable :: edge_boundary(:)
         logical,save, allocatable :: node_boundary(:)
         integer,save, allocatable :: edge_nums(:)
         integer,save, allocatable :: boundary_node_index(:)
-!C        
+!C
         integer,save, allocatable :: triangle_node(:,:)
         integer,save, allocatable :: edge(:,:)
         integer,save, allocatable :: edge_index(:,:)
@@ -100,11 +100,11 @@
         INTEGER, SAVE, ALLOCATABLE         :: OUTSIDE_BOUNDARY(:)
         real (kind = 8), save, allocatable :: node_xy(:,:)
         real (kind = 8), save, allocatable :: edge_angle(:,:)
-  
+
 CONTAINS
 !/ -------------------------------------------------------------------/
-      SUBROUTINE READMSH(NDS,FNAME) 
-!/ ------------------------------------------------------------------- 
+      SUBROUTINE READMSH(NDS,FNAME)
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           F. Ardhuin              |
@@ -114,7 +114,7 @@ CONTAINS
 !/
 !/    15-Feb-2008 : Origination.                        ( version 3.13 )
 !/    25-Aug-2011 : Change of method for IOBPD          ( version 4.04 )
-!/    06-Jun-2018 : Add DEBUGINIT/PDLIB/DEBUGSTP/DEBUGSETIOBP   
+!/    06-Jun-2018 : Add DEBUGINIT/PDLIB/DEBUGSTP/DEBUGSETIOBP
 !/                                                      ( version 6.04 )
 !/
 !
@@ -187,8 +187,8 @@ CONTAINS
       INTEGER, INTENT(IN)                :: NDS
       CHARACTER(60), INTENT(IN)          :: FNAME
 !/
-!/ local parameters 
-!/      
+!/ local parameters
+!/
       INTEGER                            :: i,j,k, NODES, NELTS, ID, KID
       INTEGER                            :: ID1, ID2, KID1, ITMP(3)
       INTEGER                            :: I1, I2, I3
@@ -230,14 +230,14 @@ CONTAINS
       CALL NEXTLN(COMSTR, NDS, NDSE)
       READ(NDS,*) NELTS
       ALLOCATE(TRIGPTMP1(NELTS, 3))
-      J = 0 
+      J = 0
       DO I= 1, NELTS
         READ(NDS,'(A100)') LINE
         READ(LINE,*) Ind,eltype,ntag
         ALLOCATE(TAGS(ntag))
-        SELECT CASE (eltype) 
+        SELECT CASE (eltype)
 !
-! eltype = 15 : boundary points  (this is used to make the difference 
+! eltype = 15 : boundary points  (this is used to make the difference
 !                                between the outside polygon and islands)
 !
         CASE(15)
@@ -260,41 +260,41 @@ CONTAINS
 !
       ALLOCATE(OUTSIDE_BOUNDARY(N_OUTSIDE_BOUNDARY))
       OUTSIDE_BOUNDARY(:)=BOUNDTMP(1:N_OUTSIDE_BOUNDARY)
-      NTRI = J 
-  
+      NTRI = J
+
       ALLOCATE(IFOUND(NODES))
- 
+
       IFOUND = 0
 !
 ! Verifies that the nodes are used in at least one triangle
-! 
+!
       DO K = 1, NTRI
         I1 = TRIGPTMP1(K,1)
         I2 = TRIGPTMP1(K,2)
         I3 = TRIGPTMP1(K,3)
-    
+
         IFOUND(I1)= IFOUND(I1) + 1
         IFOUND(I2)= IFOUND(I2) + 1
         IFOUND(I3)= IFOUND(I3) + 1
         END DO
- 
+
       J = 0
- 
-      ALLOCATE(TRIGPTMP2(NTRI,3),VERTEX(NODES),XYBTMP2(NODES,3)) 
+
+      ALLOCATE(TRIGPTMP2(NTRI,3),VERTEX(NODES),XYBTMP2(NODES,3))
       VERTEX(:)=0
       XYBTMP2 = 0
 
       DO I = 1, NODES
         IF( IFOUND(I) .GT. 0) THEN
           J = J+1
-          XYBTMP2(J,:) = XYBTMP1(I,:) 
+          XYBTMP2(J,:) = XYBTMP1(I,:)
           VERTEX(I) = J
           END IF
         END DO
 !
-! Number of nodes after clean up 
-! 
-      NX = J  
+! Number of nodes after clean up
+!
+      NX = J
 !
       DO I = 1, NTRI
         I1 = TRIGPTMP1(I,1)
@@ -303,24 +303,24 @@ CONTAINS
         TRIGPTMP2(I,1) = VERTEX(I1)
         TRIGPTMP2(I,2) = VERTEX(I2)
         TRIGPTMP2(I,3) = VERTEX(I3)
-        END DO   
+        END DO
 !
       DEALLOCATE(XYBTMP1, IFOUND,TRIGPTMP1)
       DEALLOCATE(VERTEX)
 !
-!count points connections to allocate array in W3DIMUG 
+!count points connections to allocate array in W3DIMUG
 !
       CALL COUNT(TRIGPTMP2)
 !/DEBUGINIT     WRITE(*,*) 'Call W3DIMUG from READMSH'
 !/DEBUGINIT     WRITE(740+IAPROC,*) 'Call W3DIMUG from READMSH'
 !/DEBUGINIT     FLUSH(740+IAPROC)
-      CALL W3DIMUG ( 1, NTRI, NX, COUNTOT, NNZ, NDSE, NDST ) 
+      CALL W3DIMUG ( 1, NTRI, NX, COUNTOT, NNZ, NDSE, NDST )
 !
 ! fills arrays
 !
       DO I = 1, NX
-        XYB(I,1) = XYBTMP2(I,1) 
-        XYB(I,2) = XYBTMP2(I,2) 
+        XYB(I,1) = XYBTMP2(I,1)
+        XYB(I,2) = XYBTMP2(I,2)
         XYB(I,3) = XYBTMP2(I,3)
         END DO
 !
@@ -332,18 +332,18 @@ CONTAINS
 !
       DO I=1, NTRI
         ITMP = TRIGPTMP2(I,:)
-        TRIGP(I,:) = ITMP 
-        END DO   
-!   
-      DEALLOCATE(TRIGPTMP2,XYBTMP2)   
+        TRIGP(I,:) = ITMP
+        END DO
+!
+      DEALLOCATE(TRIGPTMP2,XYBTMP2)
 !
 ! call the various routines which define the point spotting strategy
 !
-      CALL SPATIAL_GRID    
+      CALL SPATIAL_GRID
       CALL NVECTRI
       CALL COORDMAX
 !
-!READMSH is only called by ww3_grid, thus the grid index is always 1. 
+!READMSH is only called by ww3_grid, thus the grid index is always 1.
 !
       CALL AREA_SI(1)
 !
@@ -354,7 +354,7 @@ CONTAINS
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -365,7 +365,7 @@ CONTAINS
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : boundary status (code duplication)
-!  2. Method : 
+!  2. Method :
 !  3. Parameters :
 !
 !     Parameter list
@@ -488,8 +488,8 @@ CONTAINS
       END SUBROUTINE
 
 !/ -------------------------------------------------------------------/
-      SUBROUTINE READMSHOBC(NDS, FNAME, TMPSTA, UGOBCOK) 
-!/ ------------------------------------------------------------------- 
+      SUBROUTINE READMSHOBC(NDS, FNAME, TMPSTA, UGOBCOK)
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           F. Ardhuin              |
@@ -529,7 +529,7 @@ CONTAINS
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !  8. Structure :
 !
 !  9. Switches :
@@ -541,7 +541,7 @@ CONTAINS
       USE W3ODATMD, ONLY: NDSE, NDST, NDSO
       USE W3SERVMD, ONLY: ITRACE, NEXTLN, EXTCDE
 !/S      USE W3SERVMD, ONLY: STRACE
-      
+
       IMPLICIT NONE
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -551,8 +551,8 @@ CONTAINS
       INTEGER, INTENT(INOUT)    :: TMPSTA(NY,NX)
       LOGICAL, INTENT(OUT)      :: UGOBCOK
 !/
-!/ local parameters 
-!/      
+!/ local parameters
+!/
       INTEGER                            :: I, IERR
       INTEGER(KIND=4)                    :: Ind,ntag, INode
       CHARACTER                          :: COMSTR*1, SPACE*1 = ' ', CELS*64
@@ -569,14 +569,14 @@ CONTAINS
       DO WHILE (IERR.EQ.0)
         READ (NDS,'(A100)',END=2001,ERR=2002,IOSTAT=IERR) LINE
         READ(LINE,*,IOSTAT=IERR) Ind,ntag
-        IF (IERR.EQ.0) THEN 
+        IF (IERR.EQ.0) THEN
           ALLOCATE(TAGS(ntag))
           READ(LINE,*,IOSTAT=IERR) Ind,ntag,TAGS,INODE
-          IF (IERR.EQ.0) THEN 
-            TMPSTA(1,INODE)=2  
+          IF (IERR.EQ.0) THEN
+            TMPSTA(1,INODE)=2
             DEALLOCATE(TAGS)
-          ELSE 
-            GOTO 2001 
+          ELSE
+            GOTO 2001
             END IF
           END IF
         END DO
@@ -597,10 +597,10 @@ CONTAINS
                '     ERROR IN READING ',A,'  IOSTAT =',I8/)
 
       END SUBROUTINE READMSHOBC
-!/ ------------------------------------------------------------------- / 
+!/ ------------------------------------------------------------------- /
 
 
-!/ ------------------------------------------------------------------- / 
+!/ ------------------------------------------------------------------- /
       SUBROUTINE UG_GETOPENBOUNDARY(TMPSTA,ZBIN,ZLIM)
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -610,12 +610,12 @@ CONTAINS
 !/                  +-----------------------------------+
 !/
 !/    30-Aug-2012 : Adpatation from SHOM-Ifremer program( version 4.07 )
-!/      
+!/
 !
 !  1. purpose: defines open boundary points based on depth
 !  2. Method : a boundary node has more node around it than triangles
-!      
-!    
+!
+!
 !
 !  3. Parameters :
 !     TMPSTA: status map to be updated (for OBC, TMPSTA = 2)
@@ -632,7 +632,7 @@ CONTAINS
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 
 !
 !  8. Structure :
@@ -643,7 +643,7 @@ CONTAINS
       USE W3GDATMD, ONLY: NX, NY, CCON, COUNTCON, IOBP
 
 !/S      USE W3SERVMD, ONLY: STRACE
-      
+
       IMPLICIT NONE
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -661,8 +661,8 @@ CONTAINS
 !
       MASK(:)=1
       CALL SET_IOBP (MASK, STATUS)
-!        
-!/S      CALL STRACE (IENT, 'UG_GETOPENBOUNDARY')      
+!
+!/S      CALL STRACE (IENT, 'UG_GETOPENBOUNDARY')
         DO IBC = 1, N_OUTSIDE_BOUNDARY
            IX = OUTSIDE_BOUNDARY(IBC)
            !write(*,*) 'TEST1', IX, TMPSTA(1,IX), CCON(IX), COUNTCON(IX), ZBIN(1,IX), ZLIM
@@ -671,21 +671,21 @@ CONTAINS
            ! whereas TMPSTA and ZBIN are defined over the clean up list of nodes NX
            IF ((IX.NE.0).AND.(IX.LE.NX)) THEN
              IF ((TMPSTA(1,IX).EQ.1).AND.(STATUS(IX).EQ.0)  &
-               .AND.(ZBIN(1,IX).LT.ZLIM))  TMPSTA(1,IX)=2  
-            END IF       
-          END DO     
+               .AND.(ZBIN(1,IX).LT.ZLIM))  TMPSTA(1,IX)=2
+            END IF
+          END DO
 !
     END SUBROUTINE UG_GETOPENBOUNDARY
-!/ ------------------------------------------------------------------- /    
+!/ ------------------------------------------------------------------- /
 
 
 !/----------------------------------------------------------------------
       SUBROUTINE SPATIAL_GRID
-!/ ------------------------------------------------------------------- 
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |      A. Roland  (BGS IT&E GbmH)   |
-!/                  |      F. Ardhuin (IFREMER)         | 
+!/                  |      F. Ardhuin (IFREMER)         |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :          31-Aug-2011|
 !/                  +-----------------------------------+
@@ -696,8 +696,8 @@ CONTAINS
 !
 !  1. Purpose :
 !
-!      Calculates triangle areas and reorders the triangles to have them 
-!      oriented counterclockwise 
+!      Calculates triangle areas and reorders the triangles to have them
+!      oriented counterclockwise
 !
 !  2. Method :
 !
@@ -717,7 +717,7 @@ CONTAINS
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !     This part of code is adapted from the WWM wave model develop at the Darmstadt University
 !     (Aaron Roland)
 !
@@ -727,36 +727,36 @@ CONTAINS
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /   
-         USE W3GDATMD  
+!/ ------------------------------------------------------------------- /
+         USE W3GDATMD
 !/S      USE W3SERVMD, ONLY: STRACE
          IMPLICIT NONE
-!	 
-!local parameters	 
-! 
+!
+!local parameters
+!
          REAL              :: TL1, TL2, TL3, TMPTRIGP
          INTEGER           :: I1, I2, I3
          INTEGER           :: K
-!/S        INTEGER                      ::  IENT = 0          
-!/ ------------------------------------------------------------------- /   
-!/S      CALL STRACE (IENT, 'SPATIAL_GRID')   
+!/S        INTEGER                      ::  IENT = 0
+!/ ------------------------------------------------------------------- /
+!/S      CALL STRACE (IENT, 'SPATIAL_GRID')
 
                 DO K = 1, NTRI
-               
+
                    I1 = TRIGP(K,1)
                    I2 = TRIGP(K,2)
                    I3 = TRIGP(K,3)
 !
 ! cross product of edge-vector  (orientated anticlockwise)
-!                                   
+!
                    TRIA(K) = REAL( (XYB(I2,2)-XYB(I1,2))      &     !  (Y2-Y1)
                                   *(XYB(I1,1)-XYB(I3,1))      &     ! *(X1-X3)
                                   +(XYB(I3,2)-XYB(I1,2))      &     !  (Y3-Y1)*(X2-X1)
                                   *(XYB(I2,1)-XYB(I1,1))      )*0.5
 !
-! test on negative triangle area, which means that the orientiation is not as assumed to be anticw. 
-! therefore we swap the nodes !!! 
-!      
+! test on negative triangle area, which means that the orientiation is not as assumed to be anticw.
+! therefore we swap the nodes !!!
+!
                   IF (TRIA(K) .lt. TINY(1.)) THEN
          TMPTRIGP = TRIGP(K,2)
          TRIGP(K,2) = TRIGP(K,3)
@@ -764,15 +764,15 @@ CONTAINS
          I2 = TRIGP(K,2)
          I3 = TRIGP(K,3)
          TRIA(K) = -1.d0*TRIA(K)
-         STOP 'WRONG TRIANGLE' 
-         END IF    
+         STOP 'WRONG TRIANGLE'
+         END IF
        END DO
      END SUBROUTINE
 !/--------------------------------------------------------------------/
 !
 !/--------------------------------------------------------------------/
     SUBROUTINE NVECTRI
-!/ ------------------------------------------------------------------- 
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           A. Roland               |
@@ -789,7 +789,7 @@ CONTAINS
 !
 !  2. Method :
 !      To get inward pointing normals, triangle are glanced through anti-clockwisely
-!     
+!
 !
 !  3. Parameters :
 !
@@ -805,22 +805,22 @@ CONTAINS
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !  8. Structure :
 !
 !  9. Switches :
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /       
+!/ ------------------------------------------------------------------- /
     USE W3GDATMD
 !/S      USE W3SERVMD, ONLY: STRACE
     USE CONSTANTS
 
          IMPLICIT NONE
 !
-!local parameter 
-!	 
+!local parameter
+!
          INTEGER :: IP, IE
          INTEGER :: I1, I2, I3, I11, I22, I33
          REAL*8    :: P1(2), P2(2), P3(2)
@@ -828,11 +828,11 @@ CONTAINS
          REAL*8    :: N1(2), N2(2), N3(2)
 	 REAL*8    :: TMP(3)
 	 REAL*8    :: TMPINV(3)
-!/S        INTEGER                      ::  IENT = 0 	 
-!/ ------------------------------------------------------------------- /   
-!/S      CALL STRACE (IENT, 'NVECTRI')   
+!/S        INTEGER                      ::  IENT = 0
+!/ ------------------------------------------------------------------- /
+!/S      CALL STRACE (IENT, 'NVECTRI')
 
-    
+
          DO IE = 1, NTRI
 !
 ! vertices
@@ -840,7 +840,7 @@ CONTAINS
             I1 = TRIGP(IE,1)
             I2 = TRIGP(IE,2)
             I3 = TRIGP(IE,3)
-                           
+
             P1(1) = XYB(I1,1)
             P1(2) = XYB(I1,2)
             P2(1) = XYB(I2,1)
@@ -849,46 +849,46 @@ CONTAINS
             P3(2) = XYB(I3,2)
 !
 ! I1 -> I2, I2 -> I3, I3 -> I1 (anticlockwise orientation is preserved)
-!                    
+!
             R1 = P3-P2
             R2 = P1-P3
             R3 = P2-P1
-        
+
             N1(1) = (-R1(2))
             N1(2) = ( R1(1))
             N2(1) = (-R2(2))
             N2(2) = ( R2(1))
             N3(1) = (-R3(2))
-            N3(2) = ( R3(1))  
+            N3(2) = ( R3(1))
 !
 ! edges length
-!            
+!
             LEN(IE,1) = DSQRT(R1(1)**2+R1(2)**2)
             LEN(IE,2) = DSQRT(R2(1)**2+R2(2)**2)
-            LEN(IE,3) = DSQRT(R3(1)**2+R3(2)**2)   
+            LEN(IE,3) = DSQRT(R3(1)**2+R3(2)**2)
 !
 ! inward normal used for propagation (not normalized)
-!            
+!
             IEN(IE,1) = N1(1)
             IEN(IE,2) = N1(2)
             IEN(IE,3) = N2(1)
             IEN(IE,4) = N2(2)
             IEN(IE,5) = N3(1)
             IEN(IE,6) = N3(2)
-    
+
          END DO
- 
+
      END SUBROUTINE
 !/---------------------------------------------------------------------------
 
 !/------------------------------------------------------------------------
 
-      SUBROUTINE COUNT(TRIGPTEMP)      
-     
-!/ ------------------------------------------------------------------- 
+      SUBROUTINE COUNT(TRIGPTEMP)
+
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |           A. Roland               | 
+!/                  |           A. Roland               |
 !/                  |           F. Ardhuin              |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :          15-May-2008|
@@ -896,22 +896,22 @@ CONTAINS
 !/
 !/    15-May-2007 : Origination.                        ( version 3.13 )
 !/
-!      
+!
 !  1. Purpose :
 !
 !      Calculate global and maximum number of connection for array allocations .
 !
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !     Parameter list
 !     ----------------------------------------------------------------
 !       NTRI         Int.   I   Total number of triangle.
 !       TRIGPTEMP    Int    I   Temporary array of triangle vertices
-!       COUNTRI      Int    O   Maximum number of connected triangle 
+!       COUNTRI      Int    O   Maximum number of connected triangle
 !                               for a given points
-!       COUNTOT      Int    O   Global number of triangle connection 
-!                               for the whole grid.   	
+!       COUNTOT      Int    O   Global number of triangle connection
+!                               for the whole grid.
 !     ----------------------------------------------------------------
 !  4. Subroutines used :
 !
@@ -925,28 +925,28 @@ CONTAINS
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !  8. Structure :
 !
 !  9. Switches :
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /  
+!/ ------------------------------------------------------------------- /
         USE W3GDATMD
 !/S      USE W3SERVMD, ONLY: STRACE
         IMPLICIT NONE
 
-     
+
 !/ parameter list
 
    INTEGER,INTENT(IN) :: TRIGPTEMP(:,:)
-!/ ------------------------------------------------------------------- /   
+!/ ------------------------------------------------------------------- /
 !/ local parameter
 
    INTEGER               :: CONN(NX)
    INTEGER               :: COUNTER, IP, IE, I, J, N(3)
-!/S        INTEGER                      ::  IENT = 0    
+!/S        INTEGER                      ::  IENT = 0
 !/------------------------------------------------------------------------
 
 !/S      CALL STRACE (IENT, 'COUNT')
@@ -968,9 +968,9 @@ DO IE = 1,NTRI
    CONN(N(2)) = CONN(N(2)) + 1
    CONN(N(3)) = CONN(N(3)) + 1
 ENDDO
- 
+
  COUNTRI = MAXVAL(CONN)
-! 
+!
 ! calculate the global number of connections available through the mesh
 !
 J=0
@@ -979,13 +979,13 @@ J=0
       J=J+1
    ENDDO
  ENDDO
- COUNTOT=J  
+ COUNTOT=J
 
 END SUBROUTINE
 
-!/----------------------------------------------------------------------------  
+!/----------------------------------------------------------------------------
       SUBROUTINE COORDMAX
-!/ ------------------------------------------------------------------- 
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           F. Ardhuin              |
@@ -1000,7 +1000,7 @@ END SUBROUTINE
 !      Calculate first point and last point coordinates, and minimum and maximum edge length.
 !
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !
 !  4. Subroutines used :
@@ -1015,43 +1015,43 @@ END SUBROUTINE
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !  8. Structure :
 !
 !  9. Switches :
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- / 
+!/ ------------------------------------------------------------------- /
           USE W3GDATMD
 !/S      USE W3SERVMD, ONLY: STRACE
           IMPLICIT NONE
-!/S        INTEGER                      ::  IENT = 0  
-            
-  
-!/S      CALL STRACE (IENT, 'COORDMAX') 
-!     
+!/S        INTEGER                      ::  IENT = 0
+
+
+!/S      CALL STRACE (IENT, 'COORDMAX')
+!
 ! maximum of coordinates s
 !
     MAXX = MAXVAL(XYB(:,1))
     MAXY = MAXVAL(XYB(:,2))
-! 
-! minimum of coordinates 
+!
+! minimum of coordinates
 !
     X0 = MINVAL(XYB(:,1))
     Y0 = MINVAL(XYB(:,2))
-! 
+!
 !maximum and minimum length of edges
 !
     DXYMAX = MAXVAL(LEN(:,:))
     SX = MINVAL(LEN(:,:))
     SY = SX
-! 
+!
  END SUBROUTINE
 !-------------------------------------------------------------------------
 
   SUBROUTINE AREA_SI(IMOD)
-!/ ------------------------------------------------------------------- 
+!/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           A. Roland               |
@@ -1061,14 +1061,14 @@ END SUBROUTINE
 !/
 !/    15-May-2007 : Origination: adjustment from the WWM code       ( version 3.13 )
 !/    23-Aug-2011 : Removes double entries in VNEIGH                ( version 4.04 )
-!/  
+!/
 !
 !  1. Purpose :
 !
 !      Define optimized connection arrays (points and triangles) for spatial propagation schemes.
 !
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !
 !  4. Subroutines used :
@@ -1083,29 +1083,29 @@ END SUBROUTINE
 !  6. Error messages :
 !
 !  7. Remarks :
-!      
+!
 !     The storage is optimize especially considering the iterative solver used.
 !     The schemes used are vertex-centered, a point has to be considered within its
 !     median dual cell. For a given point, the surface of the dual cell is one third
-!     of the sum of the surface of connected triangles. 
-!     This routine is from WWM developped in Darmstadt(Aaron Roland) 
-!     
+!     of the sum of the surface of connected triangles.
+!     This routine is from WWM developped in Darmstadt(Aaron Roland)
+!
 !  8. Structure :
 !
 !  9. Switches :
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /      
+!/ ------------------------------------------------------------------- /
 
         USE W3GDATMD
 !/S      USE W3SERVMD, ONLY: STRACE
          IMPLICIT NONE
-!/ input 
+!/ input
 
-         INTEGER, INTENT(IN) :: IMOD 
+         INTEGER, INTENT(IN) :: IMOD
 
-!/ local parameters   
+!/ local parameters
 
          INTEGER :: COUNTER,ifound,alreadyfound
          INTEGER :: I, J, K, II
@@ -1116,8 +1116,8 @@ END SUBROUTINE
          DOUBLE PRECISION   :: TRIA03
          INTEGER, ALLOCATABLE :: PTABLE(:,:)
 
-!/S        INTEGER                      ::  IENT = 0    
-!/ ------------------------------------------------------------------- /      
+!/S        INTEGER                      ::  IENT = 0
+!/ ------------------------------------------------------------------- /
 
 !/S      CALL STRACE (IENT, 'AREA_SI')
 
@@ -1126,7 +1126,7 @@ END SUBROUTINE
          SI(:) = 0.D0
 !
          CCON(:) = 0     ! Number of connected Elements
-         DO IE = 1 , NTRI 
+         DO IE = 1 , NTRI
            I1 = TRIGP(IE,1)
            I2 = TRIGP(IE,2)
            I3 = TRIGP(IE,3)
@@ -1146,7 +1146,7 @@ END SUBROUTINE
 
          CHILF             = 0
 
-         DO IE = 1, NTRI 
+         DO IE = 1, NTRI
            DO J=1,3
              I = TRIGP(IE,J)!INE(J,IE)
              CHILF(I) = CHILF(I)+1
@@ -1161,14 +1161,14 @@ END SUBROUTINE
 ! the global index is J . From now, all the computation step based on these arrays must
 ! abide by the conservation of the 2 loop algorithm (points + connected triangles)
 ! AR: I will change this now to pointers in order to omit fix loop structure for the LTS stuff ...
-!	   
+!
          INDEX_CELL(1)=1
          J = 0
          DO IP = 1, NX
            DO I = 1, CCON(IP)
              J = J + 1
              IE_CELL(J)  = CELLVERTEX(IP,I,1)
-             POS_CELL(J) = CELLVERTEX(IP,I,2) 
+             POS_CELL(J) = CELLVERTEX(IP,I,2)
            END DO
            INDEX_CELL(IP+1)=J+1
          END DO
@@ -1176,7 +1176,7 @@ END SUBROUTINE
          IF (.NOT. FSNIMP) RETURN
 
          J = 0
-         DO IP = 1, NX 
+         DO IP = 1, NX
            DO I = 1, CCON(IP)
              J = J + 1
            END DO
@@ -1188,7 +1188,7 @@ END SUBROUTINE
 
            J = 0
            PTABLE(:,:) = 0.
-           DO IP = 1, NX 
+           DO IP = 1, NX
              DO I = 1, CCON(IP)
                J = J + 1
                IE    = IE_CELL(J)
@@ -1223,7 +1223,7 @@ END SUBROUTINE
 
            J = 0
            K = 0
-           DO IP = 1, NX 
+           DO IP = 1, NX
              TMP(:) = 0
              DO I = 1, CCON(IP)
                J = J + 1
@@ -1254,7 +1254,7 @@ END SUBROUTINE
            K = 0
            IAA(1) = 1
            JAA    = 0
-           DO IP = 1, NX ! Run through all rows 
+           DO IP = 1, NX ! Run through all rows
              TMP(:)=0
              DO I = 1, CCON(IP)         ! Check how many entries there are ...
                J = J + 1                ! this is the same J index as in IE_CELL
@@ -1264,18 +1264,18 @@ END SUBROUTINE
                TMP(IP_J) = 1
                TMP(IP_K) = 1
              END DO
-             DO I = 1, NX               ! Run through all columns 
+             DO I = 1, NX               ! Run through all columns
                IF (TMP(I) .GT. 0) THEN  ! this is true only for the connected points
-                 K = K + 1              
+                 K = K + 1
                  JAA(K) = I
                END IF
              END DO
-             IAA(IP + 1) = K + 1    
+             IAA(IP + 1) = K + 1
            END DO
 
            POSI = 0
            J = 0
-           DO IP = 1, NX  
+           DO IP = 1, NX
              DO I = 1, CCON(IP)
                J = J + 1
                IP_J  = PTABLE(J,2)
@@ -1295,7 +1295,7 @@ END SUBROUTINE
           DEALLOCATE(PTABLE)
 
        END SUBROUTINE
-       
+
      SUBROUTINE IS_IN_UNGRID(IMOD, XTIN, YTIN, ITOUT, IS, JS, RW)
 !/ -------------------------------------------------------------------
 !/                  +-----------------------------------+
@@ -1307,21 +1307,21 @@ END SUBROUTINE
 !/                  | Last update :          26-Jan-2014|
 !/                  +-----------------------------------+
 !/
-!/ Adapted from other subroutine 
+!/ Adapted from other subroutine
 !/    15-Oct-2007 : Origination.                        ( version 3.13 )
 !/    21-Sep-2012 : Uses same interpolation as regular  ( version 4.08 )
 !/    26-Jan-2014 : Correcting bug in RW                ( version 4.18 )
 !/
 !  1. Purpose :
 !
-!      Determine whether a point is inside or outside an unstructured grid, 
-!      and returns index of triangle and interpolation weights 
+!      Determine whether a point is inside or outside an unstructured grid,
+!      and returns index of triangle and interpolation weights
 !      This is the analogue for triangles of the FUNCTION W3GRMP
 !
 !  2. Method :
 !
-!     Using barycentric coordinates defined as the ratio of triangle algebric areas 
-!     which are positive or negative. 
+!     Using barycentric coordinates defined as the ratio of triangle algebric areas
+!     which are positive or negative.
 !     Computes the 3 interpolation weights for each triangle until they are all positive
 !
 !  3. Parameters :
@@ -1381,7 +1381,7 @@ END SUBROUTINE
 !  7. Remarks :
 !
 !      This subroutine is adjusted from CREST code (Fabrice Ardhuin)
-!      For a given output point, the algorithm enable to glance through all the triangles 
+!      For a given output point, the algorithm enable to glance through all the triangles
 !      to find the one the point belong to, and then make interpolation.
 !
 !  8. Structure :
@@ -1423,9 +1423,9 @@ END SUBROUTINE
 !
      itout = 0
      nbFound=0
-     ITRI = 0 
+     ITRI = 0
      DO WHILE (nbFound.EQ.0.AND.ITRI.LT.GRIDS(IMOD)%NTRI)
-       ITRI = ITRI +1 
+       ITRI = ITRI +1
        I1=GRIDS(IMOD)%TRIGP(ITRI,1)
        I2=GRIDS(IMOD)%TRIGP(ITRI,2)
        I3=GRIDS(IMOD)%TRIGP(ITRI,3)
@@ -1438,7 +1438,7 @@ END SUBROUTINE
 !coordinates of the 3rd vertex C
        x3=GRIDS(IMOD)%XYB(I3,1)
        y3=GRIDS(IMOD)%XYB(I3,2)
-!with M = (XTIN,YTIN) the target point ... 
+!with M = (XTIN,YTIN) the target point ...
 !vector product of AB and AC
        sg3=(y3-y1)*(x2-x1)-(x3-x1)*(y2-y1)
 !vector product of AB and AM
@@ -1478,21 +1478,21 @@ END SUBROUTINE
 !/                  | Last update :          26-Jan-2014|
 !/                  +-----------------------------------+
 !/
-!/ Adapted from other subroutine 
+!/ Adapted from other subroutine
 !/    15-Oct-2007 : Origination.                        ( version 3.13 )
 !/    21-Sep-2012 : Uses same interpolation as regular  ( version 4.08 )
 !/    26-Jan-2014 : Correcting bug in RW                ( version 4.18 )
 !/
 !  1. Purpose :
 !
-!      Determine whether a point is inside or outside an unstructured grid, 
-!      and returns index of triangle and interpolation weights 
+!      Determine whether a point is inside or outside an unstructured grid,
+!      and returns index of triangle and interpolation weights
 !      This is the analogue for triangles of the FUNCTION W3GRMP
 !
 !  2. Method :
 !
-!     Using barycentric coordinates defined as the ratio of triangle algebric areas 
-!     which are positive or negative. 
+!     Using barycentric coordinates defined as the ratio of triangle algebric areas
+!     which are positive or negative.
 !     Computes the 3 interpolation weights for each triangle until they are all positive
 !
 !  3. Parameters :
@@ -1552,7 +1552,7 @@ END SUBROUTINE
 !  7. Remarks :
 !
 !      This subroutine is adjusted from CREST code (Fabrice Ardhuin)
-!      For a given output point, the algorithm enable to glance through all the triangles 
+!      For a given output point, the algorithm enable to glance through all the triangles
 !      to find the one the point belong to, and then make interpolation.
 !
 !  8. Structure :
@@ -1600,7 +1600,7 @@ END SUBROUTINE
      ssum = 0
      smin = 0
      DO WHILE (nbFound.EQ.0.AND.ITRI.LT.GRIDS(IMOD)%NTRI)
-       ITRI = ITRI +1 
+       ITRI = ITRI +1
        I1=GRIDS(IMOD)%TRIGP(ITRI,1)
        I2=GRIDS(IMOD)%TRIGP(ITRI,2)
        I3=GRIDS(IMOD)%TRIGP(ITRI,3)
@@ -1613,7 +1613,7 @@ END SUBROUTINE
 !coordinates of the 3rd vertex C
        x3=GRIDS(IMOD)%XYB(I3,1)
        y3=GRIDS(IMOD)%XYB(I3,2)
-!with M = (XTIN,YTIN) the target point ... 
+!with M = (XTIN,YTIN) the target point ...
 !vector product of AB and AC
        sg3=(y3-y1)*(x2-x1)-(x3-x1)*(y2-y1)
 !vector product of AB and AM
@@ -1633,7 +1633,7 @@ END SUBROUTINE
        ssum = (XTIN-(x1+x2+x3)/3.)**2+(YTIN-(y1+y2+y2)/3.)**2
        IF (smin.EQ.0.AND. MAPSTAOK ) smin=ssum
        !WRITE(6,*) 'ssum',ITRI,MAPSTAOK,ssum,smin
-       IF (ssum.LT.smin .AND.  MAPSTAOK  ) THEN 
+       IF (ssum.LT.smin .AND.  MAPSTAOK  ) THEN
           smin=ssum
           ITRIS=ITRI
        ENDIF
@@ -1676,15 +1676,15 @@ END SUBROUTINE
          RW(1)=1
          RW(2:4)=0.
          ITOUT=ITRI
- 
+
      ENDIF
      END SUBROUTINE IS_IN_UNGRID2
-!/ ------------------------------------------------------------------- / 
+!/ ------------------------------------------------------------------- /
       SUBROUTINE UG_GRADIENTS (PARAM, DIFFX, DIFFY)
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           F. Ardhuin              |
-!/                  |           A. Roland               | 
+!/                  |           A. Roland               |
 !/                  |                        FORTRAN 90 |
 !/                  | Last update :          14-Oct-2013|
 !/                  +-----------------------------------+
@@ -1694,14 +1694,14 @@ END SUBROUTINE
 !/    08-Nov-2011 : Correction for zero grad. on contour( version 4.04 )
 !/    14-Oct-2013 : Correction  of latitude factor      ( version 4.12 )
 !/    01-Mai-2018 : Using linear shape function for gradients [ version 6.04)
-!/      
+!/
 !
 !  1. purpose: calculate gradients at a point via its connection.
-!  2. Method : using linear shape function this is a basis on which 
-!              all advection schemes in Roland (2008) are checked. 
+!  2. Method : using linear shape function this is a basis on which
+!              all advection schemes in Roland (2008) are checked.
 !
 !  3. Parameters :
-!     PARAM : depth or current field (indices 0 to NSEA) 
+!     PARAM : depth or current field (indices 0 to NSEA)
 !     DIFFX :  x gradient            (indices 1 to NX)
 !     DIFFY :  y gradient            (indices 1 to NX)
 !
@@ -1717,30 +1717,30 @@ END SUBROUTINE
 !  6. Error messages :
 !
 !  7. Remarks :
-!     
+!
 !      This subroutine is adjusted from WWM code (Aaron Roland)
 !
 !  8. Structure :
 !
 !  9. Switches :
 !
-! 10. Source code :     
+! 10. Source code :
       USE CONSTANTS
       USE W3GDATMD, ONLY : TRIGP, NTRI, NX, NSEA, MAPFS, CLATIS, &
-                           MAPSTA, ANGLE, FLAGLL,  IOBP, IEN, TRIA, NSEAL, NTRI 
+                           MAPSTA, ANGLE, FLAGLL,  IOBP, IEN, TRIA, NSEAL, NTRI
       USE W3ADATMD, ONLY : NSEALM
 !/PDLIB     USE yowElementpool
 !/PDLIB     use yowNodepool,    only: PDLIB_IEN, PDLIB_TRIA, NPA
 !/PDLIB      USE yowExchangeModule, only : PDLIB_exchange1Dreal
 
-      IMPLICIT NONE     
-      
-      
+      IMPLICIT NONE
+
+
       REAL, INTENT(IN)     :: PARAM(0:NSEA)
       REAL, INTENT(OUT)    :: DIFFX(:,:), DIFFY(:,:)
- 
-! local parameters      
-      
+
+! local parameters
+
       INTEGER              :: VERTICES(3), NI(3), NI_GL(3)
       REAL                 :: TMP1(3), TMP2(3)
       INTEGER              :: I, IX, IE, IE_GL
@@ -1749,11 +1749,11 @@ END SUBROUTINE
       REAL                 :: DEDX(3), DEDY(3)
       REAL                 :: DVDXIE, DVDYIE
       REAL                 :: WEI(NX), WEI_LOCAL(NSEAL)
-       
-     DIFFX = 0.              
-     DIFFY = 0. 
+
+     DIFFX = 0.
+     DIFFY = 0.
 !
-     IF (FLAGLL) THEN 
+     IF (FLAGLL) THEN
        FACT=1./(DERA*RADIUS)
      ELSE
        FACT=1.
@@ -1778,14 +1778,14 @@ END SUBROUTINE
          VAR         = PARAM(MAPFS(1,NI)) * FACT
          DVDXIE      = DOT_PRODUCT( VAR,DEDX)
          DVDYIE      = DOT_PRODUCT( VAR,DEDY)
-         DIFFX(1,NI) = DIFFX(1,NI) + DVDXIE * LATMEAN 
+         DIFFX(1,NI) = DIFFX(1,NI) + DVDXIE * LATMEAN
          DIFFY(1,NI) = DIFFY(1,NI) + DVDYIE
        END DO
        DIFFX(1,:) = DIFFX(1,:)/WEI
        DIFFY(1,:) = DIFFY(1,:)/WEI
 !/PDLIB     ELSE
 !/PDLIB       WEI_LOCAL = 0.
-!/PDLIB       DO IE = 1, NE 
+!/PDLIB       DO IE = 1, NE
 !/PDLIB         NI      = INE(:,IE)
 !/PDLIB         IE_GL   = IELG(IE)
 !/PDLIB         NI_GL   = INE_GLOBAL(:,IE_GL)
@@ -1804,7 +1804,7 @@ END SUBROUTINE
 !/PDLIB         VAR         = PARAM(MAPFS(1,NI_GL)) * FACT
 !/PDLIB         DVDXIE      = DOT_PRODUCT(VAR,DEDX)
 !/PDLIB         DVDYIE      = DOT_PRODUCT(VAR,DEDY)
-!/PDLIB         DIFFX(1,NI) = DIFFX(1,NI) + DVDXIE * LATMEAN ! AR: This must be correctly computer later ... 
+!/PDLIB         DIFFX(1,NI) = DIFFX(1,NI) + DVDXIE * LATMEAN ! AR: This must be correctly computer later ...
 !/PDLIB         DIFFY(1,NI) = DIFFY(1,NI) + DVDYIE
 !/PDLIB       END DO
 !/PDLIB       DIFFX(1,:) = DIFFX(1,:)/WEI_LOCAL
@@ -1812,15 +1812,15 @@ END SUBROUTINE
 !/PDLIB     ENDIF
 !/PDLIB  CALL PDLIB_exchange1Dreal(DIFFX(1,1:NPA))
 !/PDLIB  CALL PDLIB_exchange1Dreal(DIFFY(1,1:NPA))
-     
+
 !
     END SUBROUTINE UG_GRADIENTS
-!/ ------------------------------------------------------------------- /    
+!/ ------------------------------------------------------------------- /
     SUBROUTINE W3NESTUG(DISTMIN,FLOK)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1830,7 +1830,7 @@ END SUBROUTINE
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : UGTYPE nesting initialization  
+!  1. Purpose : UGTYPE nesting initialization
 !  2. Method :
 !  3. Parameters :
 !
@@ -1873,7 +1873,7 @@ END SUBROUTINE
     INTEGER                   :: I, J, JMEMO, IS, IX,  N, IX1(NBI)
     REAL                      :: DIST, DIST0
 !
-    N = 0 
+    N = 0
 !
 !1. look for input boundary point index
 ! warning: if land points are included as boundary points to abide by the nest
@@ -1883,7 +1883,7 @@ END SUBROUTINE
     ISBPI = 1
     DO IX = 1, NX
       IF (ABS(MAPSTA (1,IX)) .EQ. 2) THEN
-        N = N + 1 
+        N = N + 1
         IF (N.GT.NBI) THEN
           WRITE(NDSE,*) 'Error: boundary node index > NBI ... nest.ww3 file is not consistent with mod_def.ww3'
           STOP
@@ -1896,35 +1896,35 @@ END SUBROUTINE
 !2. Matches the model grid points (where MAPSTA = 2) with the points in nest.ww3
 !   For this, we use the nearest point in the nest file.
 !
-    DO I = 1, NBI 
+    DO I = 1, NBI
 !FA: This will not work with FLAGLL=.F.  (XY grid)
       DIST0 = 360**2
       IS=1
       DO J = 1, N
         DIST=(XBPI(I)-XYB(IX1(J),1))**2+(YBPI(I)-XYB(IX1(J),2))**2
-        IF (DIST.LT.DIST0) THEN 
+        IF (DIST.LT.DIST0) THEN
           IS = MAPFS(1,IX1(J))
           DIST0=DIST
           JMEMO=J
           END IF
         END DO
       DIST0=SQRT(DIST0)
-      IF (DIST0.LE.DISTMIN) THEN          
+      IF (DIST0.LE.DISTMIN) THEN
         ISBPI(I)=IS
 !/T        WRITE(NDSE ,'(A,I6,A,I7,A,I6)') 'MATCHED BOUNDARY POINT:',I,'GRID POINT:', &
 !/T                                         MAPSF(IS,1),'INDEX IN nest.ww3:', JMEMO
      ELSE
         FLOK=.TRUE.
         END IF
-      END DO  
-    IF ( N .NE. NBI) THEN 
+      END DO
+    IF ( N .NE. NBI) THEN
       WRITE(NDSE ,900) N, NBI
       DO J=1,N
-        WRITE(6,*) 'THIS POINT HAS MAPSTA=2:',ISBPI(J)  
+        WRITE(6,*) 'THIS POINT HAS MAPSTA=2:',ISBPI(J)
         END DO
       ISBPI(N+1:NBI)=ISBPI(1)
       END IF
-      
+
 900 FORMAT (/' *** WAVEWATCH III ERROR IN W3IOBC : '/                &
              '     NUMBER OF MAPSTA=2 DIFFERS FROM NUMBER IN nest.ww3    '/                &
              '     CHECK nest.ww3 AND ww3_grid.inp ',2I8/)
@@ -1932,11 +1932,11 @@ END SUBROUTINE
 
 
 !/ ------------------------------------------------------------------- /
-   SUBROUTINE SET_IOBP (MASK, STATUS)    
+   SUBROUTINE SET_IOBP (MASK, STATUS)
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1946,7 +1946,7 @@ END SUBROUTINE
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : setup boundary pointer 
+!  1. Purpose : setup boundary pointer
 !  2. Method :
 !  3. Parameters :
 !
@@ -1984,7 +1984,7 @@ END SUBROUTINE
       USE CONSTANTS
 !
 !
-      USE W3GDATMD, ONLY: NX, NTRI, TRIGP 
+      USE W3GDATMD, ONLY: NX, NTRI, TRIGP
       USE W3ODATMD, ONLY: IAPROC
 
 
@@ -2009,9 +2009,9 @@ END SUBROUTINE
       IPREV=(/ 3, 1, 2 /) !INEXT=1+MOD(I,3)
 !/DEBUGSETIOBP      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 2'
 !/DEBUGSETIOBP      FLUSH(740+IAPROC)
-      DO IE=1,NTRI 
-! If one of the points of the triangle is masked out (land) then do as if triangle does not exist... 
-!        IF ((MASK(TRIGP(IE,1)).GT.0).AND.(MASK(TRIGP(IE,2)).GT.0).AND.(MASK(TRIGP(IE,3)).GT.0)) THEN 
+      DO IE=1,NTRI
+! If one of the points of the triangle is masked out (land) then do as if triangle does not exist...
+!        IF ((MASK(TRIGP(IE,1)).GT.0).AND.(MASK(TRIGP(IE,2)).GT.0).AND.(MASK(TRIGP(IE,3)).GT.0)) THEN
         DO I=1,3
           IP=TRIGP(IE,I)
           CALL TRIANG_INDEXES(I, IPNEXT, IPPREV)
@@ -2027,12 +2027,12 @@ END SUBROUTINE
         END DO
       STATUS(:)=-1
  !
-      COUNT = 0 
+      COUNT = 0
       DO
         COUNT = COUNT + 1
         COLLECTED(:)=0
         DO IE=1,NTRI
-!        IF ((MASK(TRIGP(IE,1)).GT.0).AND.(MASK(TRIGP(IE,2)).GT.0).AND.(MASK(TRIGP(IE,3)).GT.0)) THEN 
+!        IF ((MASK(TRIGP(IE,1)).GT.0).AND.(MASK(TRIGP(IE,2)).GT.0).AND.(MASK(TRIGP(IE,3)).GT.0)) THEN
           DO I=1,3
             IP=TRIGP(IE,I)
             CALL TRIANG_INDEXES(I, IPNEXT, IPPREV)
@@ -2042,7 +2042,7 @@ END SUBROUTINE
               ZNEXT=NEXTVERT(IP)
               IF (ZNEXT.EQ.IPPREV) THEN
                 COLLECTED(IP)=1
-                NEXTVERT(IP)=IPNEXT 
+                NEXTVERT(IP)=IPNEXT
                 IF (NEXTVERT(IP).EQ.PREVVERT(IP)) THEN
                   STATUS(IP)=1
                   END IF
@@ -2056,9 +2056,9 @@ END SUBROUTINE
 !
        ISFINISHED=1
        DO IP=1,NX
-          IF (MASK(IP).LE.0) THEN 
+          IF (MASK(IP).LE.0) THEN
              STATUS(IP)=0
-          ELSE 
+          ELSE
             IF ((COLLECTED(IP).EQ.0).AND.(STATUS(IP).EQ.-1)) THEN
               STATUS(IP)=0
               END IF
@@ -2074,7 +2074,7 @@ END SUBROUTINE
 !/DEBUGSETIOBP      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 3'
 !/DEBUGSETIOBP      FLUSH(740+IAPROC)
 
-      STATUS = 1 
+      STATUS = 1
       CALL GET_BOUNDARY(NX, NTRI, TRIGP, STATUS, PREVVERT, NEXTVERT)
 !/DEBUGSETIOBP      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 4'
 !/DEBUGSETIOBP      FLUSH(740+IAPROC)
@@ -2097,7 +2097,7 @@ END SUBROUTINE
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2107,7 +2107,7 @@ END SUBROUTINE
 !/
 !/    01-June-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : find boundary points 
+!  1. Purpose : find boundary points
 !  2. Method :
 !  3. Parameters :
 !
@@ -2319,7 +2319,7 @@ END SUBROUTINE
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2394,7 +2394,7 @@ END SUBROUTINE
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2472,16 +2472,16 @@ END SUBROUTINE
       DO IP = 1, NSEAL
         IF (IOBP(IP) .NE. 1 .OR. IOBDP(IP) .EQ. 0) CYCLE
         DO I = 1, CCON(IP)
-          J = J + 1 
+          J = J + 1
           IE = IE_CELL(J)
           IF (ANY(IOBDP(TRIGP(IE,:)) .EQ. 0)) THEN
-            IOBDP(IP) = -1 ! Set this node as a wet node adjacent to a dry one ... now what's next? Here on this points we want to compute the reflection source term, yes?  
-            EXIT 
+            IOBDP(IP) = -1 ! Set this node as a wet node adjacent to a dry one ... now what's next? Here on this points we want to compute the reflection source term, yes?
+            EXIT
           ENDIF
         ENDDO
       ENDDO
 !/PDLIB ENDIF
-   
+
    END SUBROUTINE
 !/ ------------------------------------------------------------------- /
    SUBROUTINE SETUGIOBP ( )
@@ -2541,7 +2541,7 @@ END SUBROUTINE
 !       !/S     Enable subroutine tracing.
 !
 !
-! 10. Source code :     
+! 10. Source code :
 !/ ------------------------------------------------------------------- /
 !/
 !
@@ -2560,7 +2560,7 @@ END SUBROUTINE
       USE W3IDATMD, ONLY: FLCUR
       USE W3ODATMD, only : IAPROC
 !/S      USE W3SERVMD, ONLY: STRACE
-      
+
       IMPLICIT NONE
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
@@ -2571,40 +2571,40 @@ END SUBROUTINE
 !/
       INTEGER                 :: ITH, IX, I, J, IP, IE, NDIRSUM
       REAL (KIND = 8)         :: COSSUM, SINSUM
-      REAL (KIND = 8)         :: DIRMIN, DIRMAX, SHIFT, TEMPO, DIRCOAST 
+      REAL (KIND = 8)         :: DIRMIN, DIRMAX, SHIFT, TEMPO, DIRCOAST
       REAL (KIND = 8)         :: X1, X2, Y1, Y2, DXP1, DXP2, DXP3
       REAL (KIND = 8)         :: DYP1, DYP2, DYP3, eDet1, eDet2, EVX, EVY
       REAL(KIND=8), PARAMETER :: THR    = TINY(1.)
       INTEGER                 :: I1, I2, I3
       INTEGER                 :: ITMP(NX), NEXTVERT(NX), PREVVERT(NX)
 !/S      INTEGER, SAVE           :: IENT = 0
-!/ ------------------------------------------------------------------- /                                     
+!/ ------------------------------------------------------------------- /
 !
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Set constants
-!      
+!
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 1'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
-      
+
 !/S      CALL STRACE (IENT, 'SETUGIOBP')
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 2.  Searches for boundary points
-! 
+!
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 2'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
       ITMP = MAPSTA(1,:)
-      CALL SET_IOBP(ITMP, IOBP) 
+      CALL SET_IOBP(ITMP, IOBP)
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 3'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-! 3. Defines directions pointing into land or sea 
-! 
+! 3. Defines directions pointing into land or sea
+!
       IOBPD(:,:) = 0
       IOBPA(:) = 0
 !
-      DO IP=1,NX 
+      DO IP=1,NX
         IF ((MAPSTA(1,IP).EQ.2).AND.(IOBP(IP).EQ.0)) IOBPA(IP)=1
 !WRITE(600,*) IP,ITMP(IP),IOBP(IP),IOBPA(IP)
       END DO
@@ -2646,13 +2646,13 @@ END SUBROUTINE
               y2 = - DYP2
               IP =   I3
             END IF
-            IF (IOBP(IP) .eq. 0) THEN ! physical boundary 
+            IF (IOBP(IP) .eq. 0) THEN ! physical boundary
               eDet1 = THR-x1*EVY+y1*EVX
               eDet2 = THR+x2*EVY-y2*EVX
               IF ((eDet1.gt.0.).and.(eDet2.gt.0.)) THEN
 ! this is the case of waves going towards the boundary ...
                 IOBPD(ITH,IP)=1
-              ENDIF 
+              ENDIF
             ELSE ! water ...
               IOBPD(ITH,IP)=1
             END IF
@@ -2661,10 +2661,10 @@ END SUBROUTINE
       END DO
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 5'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
-      DO IP = 1, NX 
+      DO IP = 1, NX
         IF ( IOBPA(IP) .eq. 1 .OR. IOBP(IP) .eq. 3 .OR. IOBP(IP) .eq. 4) IOBPD(:,IP) = 1
       END DO
-!2do: recode for mpi 
+!2do: recode for mpi
 !        IF (LBCWA .OR. LBCSP) THEN
 !          IF (.NOT. ANY(IOBP .EQ. 2)) THEN
 !            CALL WWM_ABORT('YOU IMPOSED BOUNDARY CONDITIONS BUT IN THE BOUNDARY FILE ARE NO NODES WITH FLAG = 2')
@@ -2683,13 +2683,13 @@ END SUBROUTINE
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3. Updates the reflection direction and sharp / flat shoreline angle
 
-!/REF1 ! 
+!/REF1 !
 !/REF1 ! Finds the shoreline direction from IOBPD
 !/REF1 !
 !/REF1          REFLC(1,:)= 0.
 !/REF1          REFLD(:,:)= 1
 !/REF1          DO IP=1,NX
-!/REF1            IF (IOBP(IP).EQ.0.AND.MAPSTA(1,IP).EQ.1) THEN 
+!/REF1            IF (IOBP(IP).EQ.0.AND.MAPSTA(1,IP).EQ.1) THEN
 !/REF1              COSSUM=0.
 !/REF1              SINSUM=0.
 !/REF1              NDIRSUM=0.
@@ -2706,23 +2706,23 @@ END SUBROUTINE
 !/REF1            END DO
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 8'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
-          
+
 
 !DO IX=1,NX
 !DO ITH=1,NTH
 !  WRITE(500+IAPROC,*) IX,ITH,IOBP(IX),IOBPA(IX),IOBPD(ITH,IX) !,REFLD(1:2,MAPFS(1,IX))
-!ENDDO 
+!ENDDO
 !ENDDO
 
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 9'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
 !
-! Recomputes the angles used in the gradients estimation 
-! 
+! Recomputes the angles used in the gradients estimation
+!
 !/DEBUGSETUGIOBP      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 10'
 !/DEBUGSETUGIOBP      FLUSH(740+IAPROC)
 !
-      RETURN    
+      RETURN
       END SUBROUTINE SETUGIOBP
 !/ ------------------------------------------------------------------- /
 END MODULE W3TRIAMD

--- a/model/ftn/w3uno2md.ftn
+++ b/model/ftn/w3uno2md.ftn
@@ -9,8 +9,8 @@
 !/                  | Last update :         01-Jul-2013 |
 !/                  +-----------------------------------+
 !/
-!/    Adapted from   WAVEWATCH-III  W3UQCKMD 
-!/            for    UNO2 advection scheme. 
+!/    Adapted from   WAVEWATCH-III  W3UQCKMD
+!/            for    UNO2 advection scheme.
 !/
 !/    18-Mar-2008 : Origination.                        ( version 3.14 )
 !/    ..-...-...  : .....                               ( version 3.14 )
@@ -44,7 +44,7 @@
 !
 !  5. Remarks :
 !
-!     - STRACE and !/S irrelevant for running code. The module is 
+!     - STRACE and !/S irrelevant for running code. The module is
 !       therefore fully portable to any other model.
 !
 !  6. Switches :
@@ -219,7 +219,7 @@
         IXY  = MAPBOU(IP)
         VEL  = 0.5 * ( VELO(IXY) + VELO(IXY+INC) )
 !  Assuming velocity is at cell centre, so face velocity is an average.
-        CFL  = DT *  VEL 
+        CFL  = DT *  VEL
 !  Courant number without gradient distance (between IXY and IXY+INC cells)
         IXYC = IXY - INC * INT( MIN ( 0. , SIGN(1.1,CFL) ) )
 !  Central cell index, depending on flow direction.
@@ -815,7 +815,7 @@
 !/T1      WRITE (NDST,9010)
 !/T1      WRITE (NDST,9011) NB0, 'CENTRAL'
 !
-!/OMPH/!$OMP PARALLEL DO PRIVATE (IP, IXY, CFL, IXYC, IXYD, QB)  
+!/OMPH/!$OMP PARALLEL DO PRIVATE (IP, IXY, CFL, IXYC, IXYD, QB)
 !
       DO IP=1, NB0
 !

--- a/model/ftn/w3uostmd.ftn
+++ b/model/ftn/w3uostmd.ftn
@@ -21,7 +21,7 @@
 !
 !      Name               Type  Scope    Description
 !     ----------------------------------------------------------------
-!    UOST_INITGRID        Subr. Public   allocates UOST variables on each grid, 
+!    UOST_INITGRID        Subr. Public   allocates UOST variables on each grid,
 !                                        and loads the matrices of alpha and beta coefficient
 !    UOST_SETGRID         Subr. Public   sets the actual computation grid in the source term
 !    UOST_SRCTRMCOMPUTE   Subr. Public   computes the source term for a given input spectrum
@@ -40,15 +40,15 @@
 !/S      USE W3SERVMD, ONLY: STRACE
 
       IMPLICIT NONE
-  
+
       PUBLIC :: UOST_INITGRID
       PUBLIC :: UOST_SETGRID
       PUBLIC :: UOST_SRCTRMCOMPUTE
-  
-  
+
+
       PRIVATE
-  
-  
+
+
       TYPE UOST_SOURCETERM
         REAL, ALLOCATABLE :: COSTH(:), SINTH(:)
         REAL :: GAMMAUP = 10
@@ -68,7 +68,7 @@
         !setgrid: sets grd pointer and computes some cached structures
         PROCEDURE, PASS :: SETGRID => UOST_SOURCETERM_SETGRID
       END TYPE UOST_SOURCETERM
-    
+
       ! srctrm: global singleton source term
       CLASS(UOST_SOURCETERM), ALLOCATABLE :: SRCTRM
 
@@ -96,10 +96,10 @@
 !     ----------------------------------------------------------------
 !     IGRID, integer:        id of the grid being initialized
 !     FILELOCAL, string:     file from where the alpha/beta coefficient
-!                            for the local dissipation are loaded 
+!                            for the local dissipation are loaded
 !     FILESHADOW, string:    file from where the alpha/beta coefficient
-!                            for the shadow effect are loaded 
-!     LOCALFACTOR, double:   adjustment parameter for the local 
+!                            for the shadow effect are loaded
+!     LOCALFACTOR, double:   adjustment parameter for the local
 !                            dissipation alpha and beta
 !     SHADOWFACTOR, double:  adjustment parameter for the shadow
 !                            dissipation alpha and beta
@@ -116,7 +116,7 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-  
+
       INTEGER, INTENT(IN) :: IGRID
       CHARACTER(LEN=*), INTENT(IN) :: FILELOCAL, FILESHADOW
       REAL, INTENT(IN) :: LOCALFACTOR, SHADOWFACTOR
@@ -125,19 +125,19 @@
       REAL :: CGMAX, MINSIZE
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_INITGRID') 
+!/S      CALL STRACE (IENT, 'UOST_INITGRID')
 
       IF ( (IGRID .LE. 0) .OR. (.NOT. ALLOCATED(GRIDS)) ) THEN
         RETURN
       ENDIF
-  
+
       GRD => GRIDS(IGRID)
       SGD => SGRDS(IGRID)
       GRD%UOSTFILELOCAL = FILELOCAL
       GRD%UOSTFILESHADOW = FILESHADOW
       GRD%UOSTLOCALFACTOR = LOCALFACTOR
       GRD%UOSTSHADOWFACTOR = SHADOWFACTOR
-  
+
       ALLOCATE( GRD%UOST_LCL_OBSTRUCTED(GRD%NX, GRD%NY) )
       GRD%UOST_LCL_OBSTRUCTED = .FALSE.
       ALLOCATE( GRD%UOST_SHD_OBSTRUCTED(GRD%NX, GRD%NY) )
@@ -152,12 +152,12 @@
       GRD%UOSTSHADOWALPHA = 100
       ALLOCATE( GRD%UOSTSHADOWBETA(GRD%NX, GRD%NY, SGD%NK, SGD%NTH) )
       GRD%UOSTSHADOWBETA = 100
-  
-  
+
+
       IF ( (IGRID .GT. 0) .AND. ( ALLOCATED(SRCTRM)) ) THEN
         !  loading local/shadow alpha/beta
         CALL LOAD_ALPHABETA(GRD, SGD, 100)
-  
+
         !  warning the user that for cells too small UOST may be inaccurate
         CGMAX = 20 ! simply taking a high value for the max group velocity to give an indication of this threshold
         MINSIZE = CGMAX*GRD%DTMAX/1000
@@ -171,7 +171,7 @@
       END SUBROUTINE UOST_INITGRID
 
 
-  
+
 !/ ------------------------------------------------------------------- /
       SUBROUTINE UOST_SETGRID(IGRID)
 !/
@@ -197,7 +197,7 @@
 !      Name      Type  Module     Description
 !     ----------------------------------------------------------------
 !      W3INIT    Subr. W3INITMD   Initialization of grid objects
-!      W3WAVE    Subr. W3WAVEMD   Initialization of grid objects 
+!      W3WAVE    Subr. W3WAVEMD   Initialization of grid objects
 !                                 before computation
 !     ----------------------------------------------------------------
 !
@@ -205,22 +205,22 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-  
+
       INTEGER, INTENT(IN) :: IGRID
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SETGRID') 
+!/S      CALL STRACE (IENT, 'UOST_SETGRID')
 
       IF ( .NOT. ALLOCATED(SRCTRM) ) THEN
         ALLOCATE(SRCTRM)
       ENDIF
-      
+
       CALL SRCTRM%SETGRID(GRIDS(IGRID), SGRDS(IGRID))
       END SUBROUTINE UOST_SETGRID
 !/ ------------------------------------------------------------------- /
-  
-  
-!/ ------------------------------------------------------------------- /  
+
+
+!/ ------------------------------------------------------------------- /
       SUBROUTINE UOST_SRCTRMCOMPUTE(IX, IY, SPEC, CG, DT, U10ABS, U10DIR, S, D)
 !/
 !/                  +-----------------------------------+
@@ -251,7 +251,7 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-  
+
       INTEGER, INTENT(IN) :: IX, IY
       REAL, INTENT(IN) :: DT
       REAL, INTENT(IN) :: SPEC(SRCTRM%SGD%NSPEC), CG(SRCTRM%SGD%NK)
@@ -259,12 +259,12 @@
       REAL, INTENT(OUT) :: S(SRCTRM%SGD%NSPEC), D(SRCTRM%SGD%NSPEC)
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SRCTRMCOMPUTE') 
+!/S      CALL STRACE (IENT, 'UOST_SRCTRMCOMPUTE')
 
       CALL SRCTRM%COMPUTE(IX, IY, SPEC, CG, DT, U10ABS, U10DIR, S, D)
-      END SUBROUTINE UOST_SRCTRMCOMPUTE  
-  
-!/ ------------------------------------------------------------------- /  
+      END SUBROUTINE UOST_SRCTRMCOMPUTE
+
+!/ ------------------------------------------------------------------- /
       SUBROUTINE LOAD_ALPHABETA(GRD, SGD, FILEUNIT)
 !/
 !/                  +-----------------------------------+
@@ -281,7 +281,7 @@
 !
 !     Parameter list
 !     ----------------------------------------------------------------
-!     GRD, GRID type:        object representing the spatial grid to 
+!     GRD, GRID type:        object representing the spatial grid to
 !                            be loaded
 !     SGD, SGRD type:        object representing the current spectral grid
 !     FILEUNIT, Integer:     unit id of the input files
@@ -291,7 +291,7 @@
 !
 !      Name            Type  Module     Description
 !     ----------------------------------------------------------------
-!      UOST_INITGRID   Subr. W3UOSTMD   Initialization of the UOST grid 
+!      UOST_INITGRID   Subr. W3UOSTMD   Initialization of the UOST grid
 !     ----------------------------------------------------------------
 !
 !  4. Source code :
@@ -307,49 +307,49 @@
       INTEGER :: JG, J, L, I, IX, IY
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'LOAD_ALPHABETA') 
-    
+!/S      CALL STRACE (IENT, 'LOAD_ALPHABETA')
+
 
       ! LOADING LOCAL ALPHA/BETA
       FILENAME = GRD%UOSTFILELOCAL
       INQUIRE(FILE=FILENAME, EXIST=FILEEXISTS)
-      
-      J = LEN_TRIM(FILENAME)
-      IF (.NOT. FILEEXISTS) THEN
-        WRITE(NDSE,*)'*** WAVEWATCH III ERROR IN W3UOST: '// & 
-                'FILE '//FILENAME(:J)//' NOT FOUND. QUITTING'
-        CALL EXTCDE (9999) 
-      ENDIF  
-      WRITE(NDSO,*)'FILE '//FILENAME(:J)//' FOUND.'// &  
-             'LOADING UOST SETTINGS FOR GRID '//GRD%GNAME
-  
-      CALL LOAD_ALPHABETA_FROMFILE(FILEUNIT, FILENAME(:J), GRD%NX, GRD%NY, SGD%NK, SGD%NTH,&
-        GRD%UOSTABMULTFACTOR, GRD%UOSTLOCALALPHA, GRD%UOSTLOCALBETA,&
-        GRD%UOSTCELLSIZE, GRD%UOST_LCL_OBSTRUCTED)
-  
-  
-      ! LOADING SHADOW ALPHA/BETA
-      FILENAME = GRD%UOSTFILESHADOW
-      INQUIRE(FILE=FILENAME, EXIST=FILEEXISTS)
-      
+
       J = LEN_TRIM(FILENAME)
       IF (.NOT. FILEEXISTS) THEN
         WRITE(NDSE,*)'*** WAVEWATCH III ERROR IN W3UOST: '// &
                 'FILE '//FILENAME(:J)//' NOT FOUND. QUITTING'
         CALL EXTCDE (9999)
-      ENDIF  
-      WRITE(NDSO,*)'FILE '//FILENAME(:J)//' FOUND.'//& 
+      ENDIF
+      WRITE(NDSO,*)'FILE '//FILENAME(:J)//' FOUND.'// &
+             'LOADING UOST SETTINGS FOR GRID '//GRD%GNAME
+
+      CALL LOAD_ALPHABETA_FROMFILE(FILEUNIT, FILENAME(:J), GRD%NX, GRD%NY, SGD%NK, SGD%NTH,&
+        GRD%UOSTABMULTFACTOR, GRD%UOSTLOCALALPHA, GRD%UOSTLOCALBETA,&
+        GRD%UOSTCELLSIZE, GRD%UOST_LCL_OBSTRUCTED)
+
+
+      ! LOADING SHADOW ALPHA/BETA
+      FILENAME = GRD%UOSTFILESHADOW
+      INQUIRE(FILE=FILENAME, EXIST=FILEEXISTS)
+
+      J = LEN_TRIM(FILENAME)
+      IF (.NOT. FILEEXISTS) THEN
+        WRITE(NDSE,*)'*** WAVEWATCH III ERROR IN W3UOST: '// &
+                'FILE '//FILENAME(:J)//' NOT FOUND. QUITTING'
+        CALL EXTCDE (9999)
+      ENDIF
+      WRITE(NDSO,*)'FILE '//FILENAME(:J)//' FOUND.'//&
               'LOADING UOST SETTINGS FOR GRID '//GRD%GNAME
-  
+
       CALL LOAD_ALPHABETA_FROMFILE(FILEUNIT, FILENAME(:J), GRD%NX, GRD%NY, SGD%NK, SGD%NTH,&
         GRD%UOSTABMULTFACTOR, GRD%UOSTSHADOWALPHA, GRD%UOSTSHADOWBETA,&
         GRD%UOSTCELLSIZE, GRD%UOST_SHD_OBSTRUCTED)
-  
+
 
       END SUBROUTINE LOAD_ALPHABETA
-  
-!/ ------------------------------------------------------------------- /  
-      SUBROUTINE LOAD_ALPHABETA_FROMFILE(FILEUNIT, FILENAME, NX, NY, NK, NTH,& 
+
+!/ ------------------------------------------------------------------- /
+      SUBROUTINE LOAD_ALPHABETA_FROMFILE(FILEUNIT, FILENAME, NX, NY, NK, NTH,&
           MULTFACTOR, ALPHAMTX, BETAMTX, CELLSIZE, ISOBSTRUCTED)
 !/
 !/                  +-----------------------------------+
@@ -383,14 +383,14 @@
 !
 !      Name            Type  Module     Description
 !     ----------------------------------------------------------------
-!      LOAD_ALPHABETA  Subr. W3UOSTMD   Initialization of the UOST grid 
+!      LOAD_ALPHABETA  Subr. W3UOSTMD   Initialization of the UOST grid
 !     ----------------------------------------------------------------
 !
 !  4. Source code :
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-  
+
       CHARACTER(*), INTENT(IN) :: FILENAME
       REAL, INTENT(IN) :: MULTFACTOR
       INTEGER, INTENT(IN) :: FILEUNIT, NX, NY, NK, NTH
@@ -404,25 +404,25 @@
       REAL, ALLOCATABLE :: TRANS(:)
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'LOAD_ALPHABETA_FROMFILE') 
-    
+!/S      CALL STRACE (IENT, 'LOAD_ALPHABETA_FROMFILE')
+
       !  INITIALIZING LOGICALS REPRESENTING THE DIFFERENT PHASES OF THE LOAD
       FILESTART = .TRUE.
       HEADER = .TRUE.;
       READINGCELLSIZE = .FALSE.
       READINGALPHA = .FALSE.
       IK = 0
-      
+
       ALLOCATE(TRANS(NTH))
-      
+
       OPEN(FILEUNIT, FILE=FILENAME, STATUS='OLD', ACTION='READ')
       READ_LOOP: DO
         READ(FILEUNIT, '(A)', IOSTAT=FIOSTAT) LINE
-  
+
         IF (FIOSTAT .NE. 0) EXIT READ_LOOP
-          
+
         IF (LINE(1:1) .EQ. '$') CYCLE
-        
+
         IF (FILESTART) THEN
           !  reading the first line
           READ(LINE, '(I5)') SPGRDS_SIZE
@@ -446,7 +446,7 @@
           READ(LINE, *) CELLSIZE(IX, IY, :)
           READINGCELLSIZE = .FALSE.
           READINGALPHA = .TRUE.
-        ELSE        
+        ELSE
           READ(LINE, *) TRANS
           IF (READINGALPHA) THEN
             !  reading alpha for frequency IK
@@ -468,13 +468,13 @@
         ENDIF
       ENDDO READ_LOOP
       CLOSE(FILEUNIT)
-  
+
       DEALLOCATE(TRANS)
-    
+
       END SUBROUTINE LOAD_ALPHABETA_FROMFILE
-  
-!/ ------------------------------------------------------------------- /  
-  
+
+!/ ------------------------------------------------------------------- /
+
       SUBROUTINE UOST_SOURCETERM_SETGRID(THIS, GRD, SGD)
 !/
 !/                  +-----------------------------------+
@@ -486,13 +486,13 @@
 !/
 !/    Aug-2018 : Origination.                        ( version 6.07 )
 !/
-!  1. Purpose : method of the class UOST_SOURCETERM, 
+!  1. Purpose : method of the class UOST_SOURCETERM,
 !               to set the actual spatial and spectral grid
 !  2. Parameters :
 !
 !     Parameter list
 !     ----------------------------------------------------------------
-!     GRD, GRID type:        object representing the spatial grid to 
+!     GRD, GRID type:        object representing the spatial grid to
 !                            be loaded
 !     SGD, SGRD type:        object representing the current spectral grid
 !     ----------------------------------------------------------------
@@ -508,23 +508,23 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-      
+
       CLASS(UOST_SOURCETERM), INTENT(INOUT) :: THIS
       TYPE(GRID), TARGET, INTENT(IN) :: GRD
       TYPE(SGRD), TARGET, INTENT(IN) :: SGD
       INTEGER :: ITH, NTH
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_SETGRID') 
-    
+!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_SETGRID')
+
       THIS%GRD => GRD
       THIS%SGD => SGD
-      
+
       IF (ALLOCATED(THIS%COSTH)) THEN
         DEALLOCATE(THIS%COSTH)
         DEALLOCATE(THIS%SINTH)
       ENDIF
-      
+
       NTH = THIS%SGD%NTH
       ALLOCATE(THIS%COSTH(NTH))
       ALLOCATE(THIS%SINTH(NTH))
@@ -532,9 +532,9 @@
         THIS%COSTH(ITH) = COS(SGD%TH(ITH))
         THIS%SINTH(ITH) = SIN(SGD%TH(ITH))
       ENDDO
-      END SUBROUTINE UOST_SOURCETERM_SETGRID 
+      END SUBROUTINE UOST_SOURCETERM_SETGRID
 
-!/ ------------------------------------------------------------------- /  
+!/ ------------------------------------------------------------------- /
 
 
       SUBROUTINE COMPUTE_REDUCTION_PSI(U10ABS, U10DIR, CGABS, CGDIR, DT, PSI)
@@ -576,18 +576,18 @@
 !
 !/ ------------------------------------------------------------------- /
       USE CONSTANTS, ONLY: PI
-  
+
       IMPLICIT NONE
-      
+
       REAL, PARAMETER :: TOLERANCE = 0.000001
       REAL, PARAMETER :: WHTHR1 = .5, WHTHR2 = 1.5
-  
+
       REAL, INTENT(IN) :: U10ABS, U10DIR, CGABS, CGDIR, DT
       REAL, INTENT(OUT) :: PSI
       REAL :: THDELTA, CP, WA
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'COMPUTE_REDUCTION_PSI') 
+!/S      CALL STRACE (IENT, 'COMPUTE_REDUCTION_PSI')
 
       ! computing the wave age
       THDELTA = ABS(U10DIR - CGDIR)
@@ -601,14 +601,14 @@
       ELSE
         WA = 9999999 ! a very high number
       ENDIF
-  
+
       IF (WA .LE. WHTHR1) THEN
-        !  if the wave age is less that 0.5, psi = 0, i.e. 
+        !  if the wave age is less that 0.5, psi = 0, i.e.
         !  no unresolved obstacle is considered
         PSI = 0
       ELSEIF ((WA .GT. WHTHR1) .AND. (WA .LT. WHTHR2)) THEN
         !  if the wave age is between 0.5 and 1.5
-        !  psi scales linearly with WA 
+        !  psi scales linearly with WA
         PSI = (WA - WHTHR1)/(WHTHR2 - WHTHR1)
       ELSE
         !  if the wave age is greater than 1.5 psi = 1
@@ -617,7 +617,7 @@
 
       END SUBROUTINE COMPUTE_REDUCTION_PSI
 
-!/ ------------------------------------------------------------------- /  
+!/ ------------------------------------------------------------------- /
 
       SUBROUTINE UOST_SOURCETERM_COMPUTE_LD(THIS, IX, IY, SPEC, CG, DT, U10ABS, U10DIR, S, D)
 !/
@@ -630,13 +630,13 @@
 !/
 !/    Aug-2018 : Origination.                        ( version 6.07 )
 !/
-!  1. Purpose : Method of the class UOST_SOURCETERM. 
+!  1. Purpose : Method of the class UOST_SOURCETERM.
 !               Computation of the local dissipation of the spectrum
 !  2. Parameters :
-!   
+!
 !     Parameter list
 !     ----------------------------------------------------------------
-!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method 
+!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method
 !                           (compulsory in oo programming)
 !     IX, IY: Integer       coordinates of the actual cell
 !     SPEC: real            input spectrum
@@ -659,70 +659,70 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-      
+
       CLASS(UOST_SOURCETERM), INTENT(INOUT) :: THIS
       INTEGER, INTENT(IN) :: IX, IY
       REAL, INTENT(IN) :: SPEC(THIS%SGD%NSPEC), CG(THIS%SGD%NK)
       REAL, INTENT(OUT) :: S(THIS%SGD%NSPEC), D(THIS%SGD%NSPEC)
       REAL, INTENT(IN) :: U10ABS, U10DIR
       REAL, INTENT(IN) :: DT
-      
+
       INTEGER :: IK, ITH, ISP, NK, NTH
       REAL :: ALPHA, BETA, CGI, CELLSIZE, SPECI, SFC
       LOGICAL :: CELLOBSTRUCTED
       REAL :: TH, PSI
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE_LD') 
+!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE_LD')
 
       S = 0
       D = 0
-  
+
       CELLOBSTRUCTED =  THIS%GRD%UOST_LCL_OBSTRUCTED(IX, IY)
-      IF (.NOT. CELLOBSTRUCTED) RETURN    
-  
+      IF (.NOT. CELLOBSTRUCTED) RETURN
+
       NK = THIS%SGD%NK
       NTH = THIS%SGD%NTH
-      
+
       DO IK = 1,NK
         CGI = CG(IK)
         DO ITH = 1,NTH
-  
+
           !  Getting alpha and beta for local dissipation
           ALPHA = THIS%GRD%UOSTLOCALALPHA(IX, IY, IK, ITH)/THIS%GRD%UOSTABMULTFACTOR
           ALPHA = MAX(MIN(ALPHA*THIS%GRD%UOSTLOCALFACTOR, 1.), 0.)
           BETA = THIS%GRD%UOSTLOCALBETA(IX, IY, IK, ITH)/THIS%GRD%UOSTABMULTFACTOR
           BETA = MAX(MIN(BETA*THIS%GRD%UOSTLOCALFACTOR, 1.), 0.)
-  
-          
+
+
           IF (ALPHA .EQ. 1) CYCLE
-          
+
           !  Getting the size of the cell along direction ith
           CELLSIZE = THIS%GRD%UOSTCELLSIZE(IX, IY, ITH)*THIS%GRD%UOSTCELLSIZEFACTOR
-  
+
           ISP = ITH + (IK-1)*NTH
           SPECI = SPEC(ISP)
-  
+
           TH = THIS%SGD%TH(ITH)
           CALL COMPUTE_REDUCTION_PSI(U10ABS, U10DIR, CG(IK), TH, DT, PSI)
-  
+
           IF (BETA > 0.09) THEN
             !  Computing the local dissipation for a partially obstructed cell
             SFC = - CGI/CELLSIZE * (1 - BETA)/BETA
           ELSE
-            !  The cell is almost completely obstructed. 
+            !  The cell is almost completely obstructed.
             !  Dissipating the energy almost completely.
             SFC = - CGI/CELLSIZE * THIS%GAMMAUP
           ENDIF
-          
+
           S(ISP) = SFC * SPECI * PSI
           D(ISP) = SFC * PSI
         ENDDO
       ENDDO
-    
+
       END SUBROUTINE UOST_SOURCETERM_COMPUTE_LD
 
-!/ ------------------------------------------------------------------- /  
+!/ ------------------------------------------------------------------- /
       SUBROUTINE UOST_SOURCETERM_COMPUTE_SE(THIS, IX, IY, SPEC, CG, DT, U10ABS, U10DIR, S, D)
 !/
 !/                  +-----------------------------------+
@@ -734,13 +734,13 @@
 !/
 !/    Aug-2018 : Origination.                        ( version 6.07 )
 !/
-!  1. Purpose : Method of the class UOST_SOURCETERM. 
+!  1. Purpose : Method of the class UOST_SOURCETERM.
 !               Computation of the shadow dissipation of the spectrum
 !  2. Parameters :
-!   
+!
 !     Parameter list
 !     ----------------------------------------------------------------
-!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method 
+!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method
 !                           (compulsory in oo programming)
 !     IX, IY: Integer       coordinates of the actual cell
 !     SPEC: real            input spectrum
@@ -763,14 +763,14 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-      
+
       CLASS(UOST_SOURCETERM), INTENT(INOUT), TARGET :: THIS
       INTEGER, INTENT(IN) :: IX, IY
       REAL, INTENT(IN) :: SPEC(THIS%SGD%NSPEC), CG(THIS%SGD%NK)
       REAL, INTENT(OUT) :: S(THIS%SGD%NSPEC), D(THIS%SGD%NSPEC)
       REAL, INTENT(IN) :: U10ABS, U10DIR
       REAL, INTENT(IN) :: DT
-      
+
       INTEGER :: IK, ITH, IS
       REAL :: CGI, SPECI, SFC, CELLSIZE, &
               SFCLEFT, SFCRIGHT, SFCCENTER, THDIAG, CGDIAG, &
@@ -780,39 +780,39 @@
       REAL :: TH, PSI
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE_SE') 
- 
+!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE_SE')
+
       S = 0
       D = 0
-  
+
       NK = THIS%SGD%NK
       NTH = THIS%SGD%NTH
       NX = THIS%GRD%NX
       NY = THIS%GRD%NY
-      
+
       IF ((IX .EQ. 1) .OR. (IX .EQ. NX) .OR. (IY .EQ. 1) .OR. (IY .EQ. NY)) RETURN
-  
+
       CELLOBSTRUCTED = THIS%GRD%UOST_SHD_OBSTRUCTED(IX, IY)
       IF (.NOT. CELLOBSTRUCTED) RETURN
-      
+
       DO IK=1,NK
         DO ITH=1,NTH
-  
+
           !  Getting alpha and beta of the shadow
           ALPHASH = THIS%GRD%UOSTSHADOWALPHA(IX, IY, IK, ITH)/THIS%GRD%UOSTABMULTFACTOR
           ALPHASH = MAX(MIN(ALPHASH*THIS%GRD%UOSTSHADOWFACTOR, 1.), 0.)
           BETASH = THIS%GRD%UOSTSHADOWBETA(IX, IY, IK, ITH)/THIS%GRD%UOSTABMULTFACTOR
           BETASH = MAX(MIN(BETASH*THIS%GRD%UOSTSHADOWFACTOR, 1.), 0.)
-   
-          IF (ALPHASH .EQ. 1) CYCLE        
-   
+
+          IF (ALPHASH .EQ. 1) CYCLE
+
           !  Getting the size of the cell along direction ith
           CELLSIZE = THIS%GRD%UOSTCELLSIZE(IX, IY, ITH)*THIS%GRD%UOSTCELLSIZEFACTOR
-  
+
           CGI = CG(IK)
-  
+
           GG = CGI/CELLSIZE
-  
+
           IF (ALPHASH > 0.2) THEN
             !  Computing the shadow gamma coefficient for a partially obstructed cell
             GAMMMA = (BETASH/ALPHASH - 1)
@@ -820,23 +820,23 @@
             !  Alpha is small. The shadow dissipates the energy almost completely
             GAMMMA = THIS%GAMMADOWN
           ENDIF
-          
+
           TH = THIS%SGD%TH(ITH)
           !  Computing the reduction psi related with the wind component of the spectrum
           CALL COMPUTE_REDUCTION_PSI(U10ABS, U10DIR, CG(IK), TH, DT, PSI)
-          
+
           SFC = - GG*GAMMMA
-  
+
           ISP = ITH + (IK-1)*NTH
           SPECI = SPEC(ISP)
           S(ISP) = SFC * SPECI * PSI
           D(ISP) = SFC * PSI
         ENDDO
-      ENDDO  
+      ENDDO
       END SUBROUTINE UOST_SOURCETERM_COMPUTE_SE
-  
-!/ ------------------------------------------------------------------- /  
-  
+
+!/ ------------------------------------------------------------------- /
+
       SUBROUTINE UOST_SOURCETERM_COMPUTE(THIS, IX, IY, SPEC, CG, DT, U10ABS, U10DIR, S, D)
 !/
 !/                  +-----------------------------------+
@@ -848,13 +848,13 @@
 !/
 !/    Aug-2018 : Origination.                        ( version 6.07 )
 !/
-!  1. Purpose : Method of the class UOST_SOURCETERM. 
+!  1. Purpose : Method of the class UOST_SOURCETERM.
 !               Computation of the source term
 !  2. Parameters :
-!   
+!
 !     Parameter list
 !     ----------------------------------------------------------------
-!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method 
+!     THIS: UOST_SOURCETERM      instance of UOST_SOURCETERM passed to the method
 !                           (compulsory in oo programming)
 !     IX, IY: Integer       coordinates of the actual cell
 !     SPEC: real            input spectrum
@@ -877,25 +877,25 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-      
+
       CLASS(UOST_SOURCETERM), INTENT(INOUT) :: THIS
       INTEGER, INTENT(IN) :: IX, IY
       REAL, INTENT(IN) :: SPEC(THIS%SGD%NSPEC), CG(THIS%SGD%NK)
       REAL, INTENT(IN) :: DT
       REAL, INTENT(IN) :: U10ABS, U10DIR
       REAL, INTENT(OUT) :: S(THIS%SGD%NSPEC), D(THIS%SGD%NSPEC)
-  
+
       REAL :: S_LD(THIS%SGD%NSPEC), S_SE(THIS%SGD%NSPEC)
       REAL :: D_LD(THIS%SGD%NSPEC), D_SE(THIS%SGD%NSPEC)
 !/S      INTEGER, SAVE           :: IENT   = 0
 
-!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE') 
-      
+!/S      CALL STRACE (IENT, 'UOST_SOURCETERM_COMPUTE')
+
       IF (.NOT. THIS%GRD%UOSTENABLED) THEN
         S = 0
         RETURN
       ENDIF
-  
+
       !  Initializing the LD and SE components
       S_LD = 0
       S_SE = 0
@@ -906,11 +906,11 @@
       S = S_LD + S_SE
       D = D_LD + D_SE
       END SUBROUTINE UOST_SOURCETERM_COMPUTE
-  
-  
-!/ ------------------------------------------------------------------- /  
-  
-      END MODULE W3UOSTMD  
 
-!/ ------------------------------------------------------------------- /  
-  
+
+!/ ------------------------------------------------------------------- /
+
+      END MODULE W3UOSTMD
+
+!/ ------------------------------------------------------------------- /
+

--- a/model/ftn/w3updtmd.ftn
+++ b/model/ftn/w3updtmd.ftn
@@ -32,17 +32,17 @@
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
-!/    05-Apr-2011 : Place holder for XGR in UNGTYPE     ( version 4.04 ) 
+!/    05-Apr-2011 : Place holder for XGR in UNGTYPE     ( version 4.04 )
 !/                  (A. Roland/F. Ardhuin)
 !/    13-Mar-2012 : Add initialization of UST on re-    ( version 4.07 )
 !/                  activation of grid point.
 !/    06-Jun-2012 : Porting bugfixes from 3.14 to 4.07  ( version 4.07 )
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.07 )
 !/    26-Sep-2012 : Adding update from tidal analysis   ( version 4.08 )
 !/                  (F. Ardhuin)
 !/    16-Sep-2013 : Add Arctic part for SMC grid.       ( version 4.11 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    13-Nov-2013 : Moved reflection from ww3_grid.ftn  ( version 4.13 )
 !/    27-May-2014 : Ading OMPG parallelizations dir,    ( version 5.02 )
@@ -57,7 +57,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -205,8 +205,8 @@
 !
 !/ ------------------------------------------------------------------- /
       USE W3GDATMD, ONLY: NX, NY, NSEA, MAPSF
-!/ARC      USE W3GDATMD, ONLY: NARC, NGLO, ANGARC 
-!/SMC      USE W3GDATMD, ONLY: FSWND 
+!/ARC      USE W3GDATMD, ONLY: NARC, NGLO, ANGARC
+!/SMC      USE W3GDATMD, ONLY: FSWND
       USE W3WDATMD, ONLY: TIME
       USE W3ADATMD, ONLY: CX, CY, CA0, CAI, CD0, CDI
       USE W3IDATMD, ONLY: TC0, CX0, CY0, TCN, CXN, CYN
@@ -243,9 +243,9 @@
       IF ( FLFRST ) THEN
           DO ISEA=1, NSEA
 !/SMC !!Li  For sea-point SMC grid current, the 1-D current is stored on
-!/SMC !!Li  2-D CX0(NSEA, 1) variable. 
+!/SMC !!Li  2-D CX0(NSEA, 1) variable.
 !/SMC        IF( FSWND ) THEN
-!/SMC            IX = ISEA 
+!/SMC            IX = ISEA
 !/SMC            IY = 1
 !/SMC        ELSE
             IX        = MAPSF(ISEA,1)
@@ -289,7 +289,7 @@
 !
 !/T      WRITE (NDST,9000) DT0N, DT0T, RD
 
-!/TIDE        IF (FLCURTIDE) THEN 
+!/TIDE        IF (FLCURTIDE) THEN
 !/TIDE!          WRITE(6,*) 'TIME CUR:',TIME, '##',TC0, '##',TCN
 !/TIDE          TIDE_HOUR = TIME2HOURS(TIME)
 !/TIDE!
@@ -313,24 +313,24 @@
 ! 3.  Actual currents for all grid points
 !
       DO ISEA=1, NSEA
-!/TIDE        IF (FLCURTIDE) THEN  ! could move IF test outside of ISEA loop ... 
+!/TIDE        IF (FLCURTIDE) THEN  ! could move IF test outside of ISEA loop ...
 !/TIDE! VUF should only be updated in latitude changes significantly ...
 !/TIDE          IX        = MAPSF(ISEA,1)
 !/TIDE          IY        = MAPSF(ISEA,2)
 !/TIDE          CALL SETVUF_FAST(h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau,YGRD(IY,IX),FX,UX,VX)
 !/TIDE          WCURTIDEX = CXTIDE(IX,IY,1,1)
 !/TIDE          WCURTIDEY = CYTIDE(IX,IY,1,1)
-!/TIDE 
+!/TIDE
 !/TIDE            DO J=2,TIDE_MF
 !/TIDE              TIDE_ARGX=(VX(J)+UX(J))*twpi-CXTIDE(IX,IY,J,2)*DERA
 !/TIDE              TIDE_ARGY=(VX(J)+UX(J))*twpi-CYTIDE(IX,IY,J,2)*DERA
 !/TIDE              WCURTIDEX = WCURTIDEX+FX(J)*CXTIDE(IX,IY,J,1)*COS(TIDE_ARGX)
-!/TIDE              WCURTIDEY = WCURTIDEY+FX(J)*CYTIDE(IX,IY,J,1)*COS(TIDE_ARGY)                    
+!/TIDE              WCURTIDEY = WCURTIDEY+FX(J)*CYTIDE(IX,IY,J,1)*COS(TIDE_ARGY)
 !/TIDE              END DO
-!/TIDE     
+!/TIDE
 
-!/TIDET !Verification 
-!/TIDET         IF (ISEA.EQ.1) THEN 
+!/TIDET !Verification
+!/TIDET         IF (ISEA.EQ.1) THEN
 !/TIDET
 !/TIDET            TIDE_AMPC(1:NTIDE,1)=CXTIDE(IX,IY,1:NTIDE,1)
 !/TIDET            TIDE_PHG(1:NTIDE,1 )=CXTIDE(IX,IY,1:NTIDE,2)
@@ -357,7 +357,7 @@
 !/TIDET ! End of verification
 !/TIDE            CX(ISEA) = WCURTIDEX
 !/TIDE            CY(ISEA) = WCURTIDEY
-!/TIDE          ELSE 
+!/TIDE          ELSE
 
         CABS    = CA0(ISEA) + RD * CAI(ISEA)
 !/CRT2        CI2      = SQRT ( RD2 *      CA0(ISEA)**2 +             &
@@ -374,7 +374,7 @@
         CX(ISEA) = CABS * COS(CDIR)
         CY(ISEA) = CABS * SIN(CDIR)
 !/TIDE  !        IF (ISEA.EQ.1)  WRITE(6,'(A,4F8.4,A,4F8.4)') 'CUR#:',RD,CA0(ISEA),CAI(ISEA),CABS,'##', &
-!/TIDE  !                                      CX(ISEA), CY(ISEA),WCURTIDEX, WCURTIDEY        
+!/TIDE  !                                      CX(ISEA), CY(ISEA),WCURTIDEX, WCURTIDEY
 !/TIDE          END IF
 !
         END DO
@@ -481,8 +481,8 @@
 !/WCOR      USE W3GDATMD, ONLY:   WWCOR
 !/RWND      USE W3GDATMD, ONLY:   RWINDC
 !/ST2      USE W3GDATMD, ONLY: ZWIND, OFSTAB, FFNG, FFPS, CCNG, CCPS, SHSTAB
-!/ARC      USE W3GDATMD, ONLY: NARC, NGLO, ANGARC 
-!/SMC      USE W3GDATMD, ONLY: FSWND 
+!/ARC      USE W3GDATMD, ONLY: NARC, NGLO, ANGARC
+!/SMC      USE W3GDATMD, ONLY: FSWND
       USE W3WDATMD, ONLY: TIME, ASF
       USE W3ADATMD, ONLY: DW, CX, CY, UA, UD, U10, U10D, AS,          &
                           UA0, UAI, UD0, UDI, AS0, ASI
@@ -517,7 +517,7 @@
 !/SMC !!Li  For sea-point only SMC grid wind 1-D wind is stored on
 !/SMC !!Li  2-D WX0(NSEA, 1) variable.
 !/SMC        IF( FSWND ) THEN
-!/SMC            IX = ISEA 
+!/SMC            IX = ISEA
 !/SMC            IY = 1
 !/SMC        ELSE
             IX        = MAPSF(ISEA,1)
@@ -770,12 +770,12 @@
 !
 !/T1      WRITE (NDST,9010)
 !
-!  this is not clear what is going on betwen w3init and this ... 
+!  this is not clear what is going on betwen w3init and this ...
       A(:,:,:)=0
       DO JSEA=1, NSEAL
         CALL INIT_GET_ISEA(ISEA, JSEA)
-        IF (GTYPE.EQ.UNGTYPE) THEN 
-          XGR=1.  ! to be fixed later 
+        IF (GTYPE.EQ.UNGTYPE) THEN
+          XGR=1.  ! to be fixed later
         ELSE
           IX     = MAPSF(ISEA,1)
           IY     = MAPSF(ISEA,2)
@@ -900,7 +900,7 @@
 !/    15-Dec-2004 : Multiple grid version.              ( version 3.06 )
 !/    07-Sep-2005 : Moving update to end of time step.  ( version 3.08 )
 !/    17-Aug-2010 : Add initialization ABPI0-N(:,0).  ( version 3.14.5 )
-!/    12-Jun-2012 : Add /RTD option or rotated grid option. 
+!/    12-Jun-2012 : Add /RTD option or rotated grid option.
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    06-Jun-2018 : Add DEBUGIOBC/SETUP/DEBUGW3ULEV     ( version 6.04 )
 !/
@@ -955,7 +955,7 @@
 !/ ------------------------------------------------------------------- /
       USE W3GDATMD, ONLY: NSPEC, MAPWN, SIG2, DDEN
 !/RTD !!   Use rotation angle and action conversion sub.  JGLi12Jun2012
-!/RTD      USE W3GDATMD, ONLY: NK, NTH, NSPEC, AnglD 
+!/RTD      USE W3GDATMD, ONLY: NK, NTH, NSPEC, AnglD
 !/RTD      USE W3SERVMD, ONLY: W3ACTURN
       USE W3ADATMD, ONLY: CG
       USE W3ODATMD, ONLY: NBI, ABPI0, ABPIN, ISBPI, IPBPI, RDBPI,     &
@@ -971,7 +971,7 @@
       INTEGER                 :: IBI, ISP, ISEA
 !/S      INTEGER, SAVE           :: IENT = 0
 !/T0      REAL                    :: HS1, HS2
-!/RTD !!    Declare a temporary spectr variable.  JGLi12Jun2012 
+!/RTD !!    Declare a temporary spectr variable.  JGLi12Jun2012
 !/RTD       REAL :: Spectr(NSPEC), AnglBP
 !/
 !/ ------------------------------------------------------------------- /
@@ -1074,7 +1074,7 @@
 !/                  | Last update :         27-Aug-2015 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Creation                            ( version 5.10 )   
+!/    27-Aug-2015 : Creation                            ( version 5.10 )
 !/
 !  1. Purpose :
 !
@@ -1121,7 +1121,7 @@
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /   
+!/ ------------------------------------------------------------------- /
       USE W3GDATMD, ONLY: NSEA, NSEA, MAPSF, IICEHMIN, IICEHFAC
       USE W3WDATMD, ONLY: TIME, TIC1, ICEH
       USE W3IDATMD, ONLY: TI1, ICEP1, FLIC1
@@ -1131,10 +1131,10 @@
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
       LOGICAL, INTENT(IN)     :: FLFRST
-!/    
+!/
 !/ ------------------------------------------------------------------- /
 !/ Local variables
-!/      
+!/
       INTEGER                 :: IX, IY, ISEA
 !/
 !/
@@ -1162,7 +1162,7 @@
 !/ End of W3UIC1 ----------------------------------------------------- /
 !/
       END SUBROUTINE W3UIC1
-!/ ------------------------------------------------------------------- /  
+!/ ------------------------------------------------------------------- /
       SUBROUTINE W3UIC5( FLFRST )
 !/
 !/                  +-----------------------------------+
@@ -1172,8 +1172,8 @@
 !/                  | Last update :         13-Jan-2016 |
 !/                  +-----------------------------------+
 !/
-!/    27-Aug-2015 : Creation                            ( version 5.08 )   
-!/    13-Jan-2016 : Changed initial value of ICEDMAX    ( version 5.08 )   
+!/    27-Aug-2015 : Creation                            ( version 5.08 )
+!/    13-Jan-2016 : Changed initial value of ICEDMAX    ( version 5.08 )
 !/
 !  1. Purpose :
 !
@@ -1220,7 +1220,7 @@
 !
 ! 10. Source code :
 !
-!/ ------------------------------------------------------------------- /   
+!/ ------------------------------------------------------------------- /
       USE W3IDATMD, ONLY: TI5, ICEP5
       USE W3GDATMD, ONLY: NSEA, MAPSF
       USE W3WDATMD, ONLY: TIME, TIC5, ICE, ICEH, ICEF, ICEDMAX
@@ -1230,11 +1230,11 @@
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
       LOGICAL, INTENT(IN)     :: FLFRST
-!/    
+!/
 !/
 !/ ------------------------------------------------------------------- /
 !/ Local variables
-!/      
+!/
       INTEGER                 :: IX, IY, ISEA
       LOGICAL                 :: FLFLOE
 !/
@@ -1248,17 +1248,17 @@
 
 ! 2.  Main loop over sea points -------------------------------------- *
 
-      DO ISEA=1, NSEA 
+      DO ISEA=1, NSEA
 !
         IX        = MAPSF(ISEA,1)
         IY        = MAPSF(ISEA,2)
         FLFLOE = ICE(ISEA) .EQ. 0 .OR. ICEH(ISEA) .EQ. 0
-        IF ( FLFLOE) THEN          
+        IF ( FLFLOE) THEN
           ICEF(ISEA) = 0.0
           ICEDMAX(ISEA) = 1000.0
         ELSE
           ICEF(ISEA) = ICEP5(IX,IY)
-          ICEDMAX(ISEA) = ICEP5(IX,IY)          
+          ICEDMAX(ISEA) = ICEP5(IX,IY)
         END IF
       END DO
 !
@@ -1272,8 +1272,8 @@
 !/ End of W3UIC5 ----------------------------------------------------- /
 !/
       END SUBROUTINE W3UIC5
-!/ ------------------------------------------------------------------- /      
-      
+!/ ------------------------------------------------------------------- /
+
       SUBROUTINE W3UICE ( A, VA )
 !/
 !/                  +-----------------------------------+
@@ -1621,7 +1621,7 @@
 !/TIDE      REAL             :: FX(44),UX(44),VX(44)
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 1'
 !/DEBUGW3ULEV           FLUSH(740+IAPROC)
-      
+
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -1658,7 +1658,7 @@
 !
 ! 1.d Update water levels and save old
 !
-!/TIDE        IF (FLLEVTIDE) THEN 
+!/TIDE        IF (FLLEVTIDE) THEN
 !/TIDE!          WRITE(6,*) 'TIME:',TIME
 !/TIDE          TIDE_HOUR = TIME2HOURS(TIME)
 !/TIDE!
@@ -1684,12 +1684,12 @@
         IY     = MAPSF(ISEA,2)
         DWO(ISEA) = DW(ISEA)
 !
-!/TIDE        IF (FLLEVTIDE) THEN 
+!/TIDE        IF (FLLEVTIDE) THEN
 !/TIDE! VUF should be updated only if latitude changes significantly ...
 !/TIDE          CALL SETVUF_FAST(h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau,YGRD(IY,IX),FX,UX,VX)
 !/TIDE          WLEVTIDE = WLTIDE(IX,IY,1,1)
-!/TIDE !Verification 
-!/TIDE !          IF (ISEA.EQ.1) THEN 
+!/TIDE !Verification
+!/TIDE !          IF (ISEA.EQ.1) THEN
 !/TIDE
 !/TIDE            TIDE_AMPC(1:NTIDE,1)=WLTIDE(IX,IY,1:NTIDE,1)
 !/TIDE            TIDE_PHG(1:NTIDE,1)=WLTIDE(IX,IY,1:NTIDE,2)
@@ -1715,14 +1715,14 @@
 !/TIDE   !         END IF
 !/TIDE ! End of verification
 !/TIDE            WLV(ISEA) = WLEVTIDE
-!/TIDE          ELSE 
+!/TIDE          ELSE
 !
         WLV(ISEA) = WLEV(IX,IY)
         WLVeff=WLV(ISEA)
 !/SETUP     IF (DO_CHANGE_WLV) THEN
 !/SETUP       WLVeff=WLVeff + ZETA_SETUP(ISEA)
 !/SETUP     END IF
-!/TIDE          ENDIF 
+!/TIDE          ENDIF
         DW (ISEA) = MAX ( 0. , WLVeff-ZB(ISEA) )
         END DO
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 6'
@@ -1933,15 +1933,15 @@
 !
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 8'
 !/DEBUGW3ULEV           FLUSH(740+IAPROC)
-      IF (GTYPE.EQ.UNGTYPE) THEN 
+      IF (GTYPE.EQ.UNGTYPE) THEN
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 9'
 !/DEBUGW3ULEV           FLUSH(740+IAPROC)
         CALL SETUGIOBP
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 10'
 !/DEBUGW3ULEV           FLUSH(740+IAPROC)
-!/REF1      ELSE 
+!/REF1      ELSE
 !/REF1        CALL W3SETREF
-      ENDIF 
+      ENDIF
 !/DEBUGW3ULEV           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 11'
 !/DEBUGW3ULEV           FLUSH(740+IAPROC)
 !
@@ -1993,7 +1993,7 @@
 !
 !  2. Method :
 !
-!     Two arrays are generated with the size (NY*NX,-1:1). The value 
+!     Two arrays are generated with the size (NY*NX,-1:1). The value
 !     at (IXY,-1) indicates the transparency to be used if the lower
 !     or left boundary is an inflow boundary. (IXY,1) is used if the
 !     upper or right boundary is an inflow boundary. (IXY,0) is used
@@ -2046,7 +2046,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
-!/    
+!/
       REAL, INTENT(IN)        :: TRNX(NY*NX), TRNY(NY*NX)
 !/
 !/ ------------------------------------------------------------------- /
@@ -2215,7 +2215,7 @@
 !/IC0              IF (FICEL.GT.0.) THEN
 !/IC0                TRIX(IXY) = EXP(-ICE(ISEA)*DX/FICEL)
 !/IC0                TRIY(IXY) = EXP(-ICE(ISEA)*DY/FICEL)
-!/IC0              ELSE 
+!/IC0              ELSE
 ! Otherwise: original Tolman expression (Tolman 2003)
 !/IC0                LICE0  = FICE0*DX
 !/IC0                LICEN  = FICEN*DX
@@ -2235,8 +2235,8 @@
 !/IC0                END IF
 !
 !/IC0              TRIX(IXY) = MAX ( 0. , MIN ( 1. , TRIX(IXY) ) )
-!/IC0              TRIY(IXY) = MAX ( 0. , MIN ( 1. , TRIY(IXY) ) ) 
-!/IC0              END IF          
+!/IC0              TRIY(IXY) = MAX ( 0. , MIN ( 1. , TRIY(IXY) ) )
+!/IC0              END IF
 !
 !  Adding iceberg attenuation
 !
@@ -2347,7 +2347,7 @@
 !       DZZDY   R.A.  O   Derivative in Y-direction (S-N).
 !       IXP: IX plus 1 (with branch cut incorporated)
 !       IYP, IXM, IYM: ditto
-!       IXPS: value to use for IXP if IXPS is not masked. 
+!       IXPS: value to use for IXP if IXPS is not masked.
 !             (use IX if masked)
 !       IYPS, IXMS, IYMS : ditto
 !       IXTRPL : in case of needing IY+1 for IY=NY, IX needs to be
@@ -2520,7 +2520,7 @@
             IF ( MAPSTA(IY,IX) .NE. 0 ) THEN
 
                STX    = 0.5
-               
+
                IF (IX.EQ.NX)THEN
                   IXPS=1
                ELSE
@@ -2532,7 +2532,7 @@
                ELSE
                   IXP    = IXPS
                END IF
-               
+
                IF(IX.EQ.1)THEN
                   IXMS=NX
                ELSE

--- a/model/ftn/w3uqckmd.ftn
+++ b/model/ftn/w3uqckmd.ftn
@@ -22,7 +22,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -51,7 +51,7 @@
 !
 !  5. Remarks :
 !
-!     - STRACE and !/S irrelevant for running code. The module is 
+!     - STRACE and !/S irrelevant for running code. The module is
 !       therefore fully portable to any other model.
 !
 !  6. Switches :

--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -70,7 +70,7 @@
 !/    12-Dec-2012 : Adding SMC grid.  JG_Li             ( version 4.08 )
 !/    26-Dec-2012 : Move FIELD init. to W3GATH.         ( version 4.OF )
 !/    16-Sep-2013 : Add Arctic part for SMC grid.       ( version 4.11 )
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    14-Nov-2013 : Remove orphaned work arrays.        ( version 4.13 )
 !/    27-Nov-2013 : Fixes for OpenMP versions.          ( version 4.15 )
@@ -83,7 +83,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -175,7 +175,7 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE W3WAVE ( IMOD, TEND, STAMP, NO_OUT & 
+      SUBROUTINE W3WAVE ( IMOD, TEND, STAMP, NO_OUT &
 !/OASIS                  ,ID_LCOMM                 &
                          )
 !/
@@ -229,7 +229,7 @@
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    31-Mar-2010 : Add reflections                     ( version 3.14.4 )
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Mar-2011 : Output of max. CFL (F.Ardhuin)      ( version 3.14.4 )
 !/    05-Apr-2011 : Implement iteration for DTMAX <1s   ( version 3.14.4 )
 !/    02-Jul-2012 : Update for PALM coupling            ( version 4.07 )
@@ -458,7 +458,7 @@
                                  FLOMP = .FALSE.
 !
 !Li   Logical variable to control regular gird lines in conflict with SMC option.
-!AR   SMC option is in conflict with lofical variables for regular grid ... chicken ... egg ... stuff 
+!AR   SMC option is in conflict with lofical variables for regular grid ... chicken ... egg ... stuff
       LOGICAL                 :: RGLGRD = .TRUE., ARCTIC = .FALSE.
 !!Li
 !/MPI      LOGICAL                 :: FLGMPI(0:6)
@@ -466,7 +466,7 @@
 !/IC3      REAL                    :: USE_CHENG, USE_CGICE, HICE
       LOGICAL                 :: UGDTUPDATE    ! true if time step should be updated for UG schemes
       CHARACTER(LEN=8)        :: STTIME
-      CHARACTER(LEN=17)       :: IDACT 
+      CHARACTER(LEN=17)       :: IDACT
       CHARACTER(LEN=13)       :: OUTID
       CHARACTER(LEN=23)       :: IDTIME
       INTEGER eIOBP
@@ -584,9 +584,9 @@
 !
       LOCAL   = IAPROC .LE. NAPROC
       UGDTUPDATE = .FALSE.
-      IF (FLAGLL) THEN 
-        FACX   =  1./(DERA * RADIUS) 
-      ELSE 
+      IF (FLAGLL) THEN
+        FACX   =  1./(DERA * RADIUS)
+      ELSE
         FACX   =  1.
         END IF
 !
@@ -767,7 +767,7 @@
 !/IC3           IF (CALLEDIC3TABLE==0) THEN
 !/IC3             CALL IC3TABLE_CHENG(FIXEDVISC,FIXEDDENS,FIXEDELAS)
 !/IC3             CALLEDIC3TABLE = 1
-!/IC3           ENDIF   
+!/IC3           ENDIF
 !/IC3        ENDIF
 
 ! 2.b Update group velocity and wavenumber from ice parameters ------- /
@@ -789,7 +789,7 @@
 !/IC3            IX     = MAPSF(ISEA,1)
 !/IC3            IY     = MAPSF(ISEA,2)
 
-! 2.b.1 Using Cheng method: requires stationary/uniform rheology. 
+! 2.b.1 Using Cheng method: requires stationary/uniform rheology.
 !       However, ice thickness may be input by either method
 
 !/IC3            IF ( USE_CHENG==1.0 ) THEN
@@ -809,7 +809,7 @@
 !/IC3                    FIXEDDENS, FIXEDELAS, DEPTH)
 !/IC3               END IF ! non-zero ice
 
-!/IC3            ELSE ! not using Cheng method          
+!/IC3            ELSE ! not using Cheng method
 ! 2.b.2 If not using Cheng method: require FLIC1 to FLIC4 (not strictly
 !       necesssary, but makes code simpler)
 
@@ -824,7 +824,7 @@
 !/IC3                  WRITE(NDSE,*)'ICE PARAMETERS NOT AVAILABLE ',   &
 !/IC3                               'FOR CG CALC'
 !/IC3                  CALL EXTCDE(2)
-!/IC3               END IF      
+!/IC3               END IF
 !/IC3            ENDIF ! IF USE_CHENG...
 
 !/IC3            DEALLOCATE(WN_I)
@@ -889,7 +889,7 @@
         DO IT=IT0, NT
 !/TIMINGS         CALL PRINT_MY_TIME("Begin of IT loop")
 !/SETUP     CALL WAVE_SETUP_COMPUTATION
-! copy old values 
+! copy old values
 !/PDLIB     DO IP=1,NSEAL
 !/PDLIB       DO ISPEC=1,NSPEC
 !/PDLIB         VAOLD(ISPEC,IP)=VA(ISPEC,IP)
@@ -942,9 +942,9 @@
 !/DEBUGRUN      ENDIF
 !
           VGX = 0.
-          VGY = 0. 
+          VGY = 0.
           IF(INFLAGS1(8)) THEN
-              DTTST1 = DSEC21 ( TIME, TGN ) 
+              DTTST1 = DSEC21 ( TIME, TGN )
               DTTST2 = DSEC21 ( TG0, TGN )
               FAC    = DTTST1 / MAX ( 1. , DTTST2 )
               VGX    = (FAC*GA0+(1.-FAC)*GAN) *                       &
@@ -987,18 +987,18 @@
 !/MEMCHECK       write(740+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 3b '
 !/MEMCHECK       call getMallocInfo(mallinfos)
 !/MEMCHECK       call printMallInfo(IAPROC,mallInfos)
-            IF (GTYPE .NE. UNGTYPE) THEN       
+            IF (GTYPE .NE. UNGTYPE) THEN
               IF( RGLGRD ) THEN
               CALL W3DZXY(CX(1:UBOUND(CX,1)),'m/s',DCXDX, DCXDY) !CX GRADIENT
               CALL W3DZXY(CY(1:UBOUND(CY,1)),'m/s',DCYDX, DCYDY) !CY GRADIENT
               ENDIF
-!/SMC !!Li  Use new sub for DCXDX/Y and DCYDX/Y assignment.  
-!/SMC         CALL SMCDCXY 
+!/SMC !!Li  Use new sub for DCXDX/Y and DCYDX/Y assignment.
+!/SMC         CALL SMCDCXY
             ELSE
 !/DEBUGDCXDX       WRITE(740+IAPROC,*) 'Before call to UG_GRADIENT for assigning DCXDX/DCXDY array'
               CALL UG_GRADIENTS(CX, DCXDX, DCXDY)
               CALL UG_GRADIENTS(CY, DCYDX, DCYDY)
-              CALL GET_INTERFACE 
+              CALL GET_INTERFACE
               UGDTUPDATE=.TRUE.
               CFLXYMAX = 0.
             END IF
@@ -1012,7 +1012,7 @@
               CFLXYMAX = 0.
               CX = 0.
               CY = 0.
-              END IF ! FLCUR 
+              END IF ! FLCUR
 !/TIMINGS         CALL PRINT_MY_TIME("After CX/CY assignation")
 !
 !/MEMCHECK       write(740+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 5'
@@ -1090,7 +1090,7 @@
 !/DEBUGIOBC       WRITE(740+IAPROC,*) 'After call to W3IOBC'
 !/DEBUGIOBC       WRITE(740+IAPROC,*) 'ITEST=', ITEST
 !/DEBUGIOBC       FLUSH(740+IAPROC)
-                  IF ( ITEST .NE. 1 ) CALL W3UBPT 
+                  IF ( ITEST .NE. 1 ) CALL W3UBPT
                 ELSE
                   ITEST  = 0
                 END IF
@@ -1165,7 +1165,7 @@
                 ELSE
                   IDACT(11:11) = 'I'
                 END IF
-  
+
 !
               IF ( IDACT(11:11).NE.' ' ) THEN
                   CALL W3UIC1 ( FLFRST )
@@ -1290,16 +1290,16 @@
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'FLDDIR=', FLDDIR
 !/DEBUGRUN        FLUSH(740+IAPROC)
           IF ( FLDDIR ) THEN
-            IF (GTYPE .NE. UNGTYPE) THEN  
+            IF (GTYPE .NE. UNGTYPE) THEN
 !!Li          CALL W3DZXY(DW(1:NSEA),'m',DDDX,DDDY) !DEPTH (DW) GRADIENT
-              IF( RGLGRD ) CALL W3DZXY(DW(1:UBOUND(DW,1)),'m',DDDX,DDDY) 
-!/SMC !!Li  Use new sub for DDDX and DDDY assignment.  
-!/SMC         CALL SMCDHXY 
+              IF( RGLGRD ) CALL W3DZXY(DW(1:UBOUND(DW,1)),'m',DDDX,DDDY)
+!/SMC !!Li  Use new sub for DDDX and DDDY assignment.
+!/SMC         CALL SMCDHXY
 !/SMCT        WRITE (NDST,*) " * SMCDHXY completed IT DTG =", IT, DTG
 !
             ELSE
               CALL UG_GRADIENTS(DW, DDDX, DDDY)
-              END IF 
+              END IF
               FLDDIR = .FALSE.
           END IF
 
@@ -1366,18 +1366,18 @@
             CALL INIT_GET_ISEA(ISEA, JSEA)
             IX     = MAPSF(ISEA,1)
             IY     = MAPSF(ISEA,2)
-            DELA=1. 
-            DELX=1. 
-            DELY=1. 
-!/REF1                IF (GTYPE.EQ.RLGTYPE) THEN 
+            DELA=1.
+            DELX=1.
+            DELY=1.
+!/REF1                IF (GTYPE.EQ.RLGTYPE) THEN
 !/REF1                  DELX=SX*CLATS(ISEA)/FACX
 !/REF1                  DELY=SY/FACX
 !/REF1                  DELA=DELX*DELY
 !/REF1                END IF
-!/REF1                IF (GTYPE.EQ.CLGTYPE) THEN 
+!/REF1                IF (GTYPE.EQ.CLGTYPE) THEN
 !/REF1! Maybe what follows works also for RLGTYPE ... to be verified
 !/REF1                  DELX=HPFAC(IY,IX)/ FACX
-!/REF1                  DELY=HQFAC(IY,IX)/ FACX 
+!/REF1                  DELY=HQFAC(IY,IX)/ FACX
 !/REF1                  DELA=DELX*DELY
 !/REF1                END IF
 !
@@ -1439,8 +1439,8 @@
               DTDYN (JSEA) = UNDEF
               FCUT  (JSEA) = UNDEF
             END IF
-          END DO ! JSEA 
-        END IF ! PDLIB 
+          END DO ! JSEA
+        END IF ! PDLIB
 !/PDLIB!/DEBUGSRC          WRITE(740+IAPROC,*) 'ITIME=', ITIME, ' IT=', IT
 !/PDLIB!/DEBUGSRC          CALL ALL_VA_INTEGRAL_PRINT(IMOD, "VA after W3SRCE_IMP_PRE")
 !/PDLIB!/DEBUGSRC          CALL ALL_FIELD_INTEGRAL_PRINT(VSTOT, "VSTOT after W3SRCE_IMP_PRE")
@@ -1460,7 +1460,7 @@
 !/T              WRITE (NDST,9022)
               GOTO 400
             END IF
-          IF ( IT.EQ.0 ) THEN 
+          IF ( IT.EQ.0 ) THEN
             DTG = 1.
 !            DTG = 60.
             GOTO 370
@@ -1481,7 +1481,7 @@
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'FLOGRD(9,3) = ', FLOGRD(9,3)
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'UGDTUPDATE=', UGDTUPDATE
 !/DEBUGRUN        FLUSH(740+IAPROC)
-                IF ( FLOGRD(9,3).AND. UGDTUPDATE ) THEN 
+                IF ( FLOGRD(9,3).AND. UGDTUPDATE ) THEN
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.6'
 !/DEBUGRUN        FLUSH(740+IAPROC)
                   IF (FSTOTALIMP .eqv. .FALSE.) THEN
@@ -1500,7 +1500,7 @@
 !/PR3                                         MAPFS,  CFLXYMAX(JSEA), VGX, VGY )
 !/PDLIB                      ENDIF
 !/PR3                        END IF
-!/PR3                      ELSE 
+!/PR3                      ELSE
 !/PR3                        CALL W3CFLXY ( ISEA, DTG, MAPSTA, MAPFS,      &
 !/PR3                                       CFLXYMAX(JSEA), VGX, VGY )
 !/PR3                      END IF
@@ -1532,7 +1532,7 @@
 !/DEBUGRUN      ENDIF
 
 !
-!/T       IF (GTYPE .EQ. UNGTYPE) THEN 
+!/T       IF (GTYPE .EQ. UNGTYPE) THEN
 !/T         IF ( FLOGRD(9,3) ) THEN
 !/T           DTCFL1(:)=1.
 !/T           DO JSEA=1,NSEAL
@@ -1543,12 +1543,12 @@
 !/T           IF ( IAPROC .EQ. NAPERR ) WRITE(NDSE,*) 'Nodes requesting smallest timesteps:'
 !/T           IF ( IAPROC .EQ. NAPERR ) WRITE(NDSE,'(A,10I10)')   'Nodes      ',NINT(INDSORT(1:10))
 !/T           IF ( IAPROC .EQ. NAPERR ) WRITE(NDSE,'(A,10F10.2)') 'time steps ',DTCFL1(1:10)
-!/T           DO JSEA = 1, MIN(NSEAL,200) 
+!/T           DO JSEA = 1, MIN(NSEAL,200)
 !/T             ISEA   = NINT(INDSORT(JSEA))            ! will not work with MPI
 !/T             IX     = MAPSF(ISEA,1)
 !/T             IF (JSEA.EQ.1) &
 !/T               WRITE(995,*) '       IP  dtmax_exp(ip)        x-coord        y-coord        z-coord'
-!/T             WRITE(995,'(I10,F10.2,3F10.4)') IX,  DTCFL1(JSEA), XYB(IX,1), XYB(IX,2), XYB(IX,3)  
+!/T             WRITE(995,'(I10,F10.2,3F10.4)') IX,  DTCFL1(JSEA), XYB(IX,1), XYB(IX,2), XYB(IX,3)
 !/T           END DO ! JSEA
 !/T           CLOSE(995)
 !/T         END IF
@@ -1623,7 +1623,7 @@
 !/PR3                           CY(ISEA), DCXDX(IY,IXrel), DCXDY(IY,IXrel),     &
 !/PR3                           DCYDX(IY,IXrel), DCYDY(IY,IXrel),               &
 !/PR3                           DCDX(:,IY,IXrel), DCDY(:,IY,IXrel), VA(:,JSEA), &
-!/PR3                           CFLTHMAX(JSEA), CFLKMAX(JSEA) )  
+!/PR3                           CFLTHMAX(JSEA), CFLKMAX(JSEA) )
 !/PRX                      CALL W3KTPX
 !
 !/SMC  !!Li    Refraction and GCT in theta direction is done by rotation.
@@ -1631,8 +1631,8 @@
 !/SMC                           CG(:,ISEA), WN(:,ISEA), DEPTH,            &
 !/SMC                           DHDX(ISEA), DHDY(ISEA), DHLMT(:,ISEA),    &
 !/SMC                           CX(ISEA), CY(ISEA), DCXDX(IY,IX),         &
-!/SMC                           DCXDY(IY,IX), DCYDX(IY,IX), DCYDY(IY,IX), & 
-!/SMC                           DCDX(:,IY,IX), DCDY(:,IY,IX), VA(:,JSEA) )  
+!/SMC                           DCXDY(IY,IX), DCYDX(IY,IX), DCYDY(IY,IX), &
+!/SMC                           DCDX(:,IY,IX), DCDY(:,IY,IX), VA(:,JSEA) )
 !
                     END IF
                   END DO
@@ -1678,8 +1678,8 @@
 !
         IF (GTYPE .EQ. UNGTYPE) THEN
           IF (FLAGLL) THEN
-            FACX   =  1./(DERA * RADIUS) 
-          ELSE 
+            FACX   =  1./(DERA * RADIUS)
+          ELSE
             FACX   =  1.
           END IF
         END IF
@@ -1704,7 +1704,7 @@
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.4A'
 !/DEBUGRUN        WRITE(*,*), 'W3WAVE, step 6.12.4A'
 !/DEBUGRUN        FLUSH(740+IAPROC)
-!/PDLIB       ELSE IF(FSTOTALEXP .and. (IT .ne. 0)) THEN 
+!/PDLIB       ELSE IF(FSTOTALEXP .and. (IT .ne. 0)) THEN
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.3B'
 !/DEBUGRUN        WRITE(*,*), 'W3WAVE, step 6.12.3B'
 !/DEBUGRUN        FLUSH(740+IAPROC)
@@ -1795,19 +1795,19 @@
 !/ARC           IF( IK .LE. (NBAC-NBGL) ) THEN
 !/ARC                   IY = ICLBAC(IK)
 !/ARC           ELSE
-!/ARC                   IY = NGLO + IK 
-!/ARC           ENDIF 
+!/ARC                   IY = NGLO + IK
+!/ARC           ENDIF
 !/ARC
-!/ARC  !Li    Work out root PE (ISPEC) and JSEA numbers for IY 
+!/ARC  !Li    Work out root PE (ISPEC) and JSEA numbers for IY
 !
           IF( ARCTIC ) THEN
-!/DIST            ISPEC = MOD( IY-1, NAPROC ) 
+!/DIST            ISPEC = MOD( IY-1, NAPROC )
 !/DIST             JSEA = 1 + (IY - ISPEC - 1)/NAPROC
-!/SHRD            ISPEC = 0 
-!/SHRD             JSEA = IY 
+!/SHRD            ISPEC = 0
+!/SHRD             JSEA = IY
           ENDIF
 !
-!/ARC !!Li   Assign boundary cell spectra. 
+!/ARC !!Li   Assign boundary cell spectra.
 !/ARC              IF( IAPROC .EQ. ISPEC+1 ) THEN
 !/ARC                   SPCBAC(:,IK)=VA(:,JSEA)
 !/ARC              ENDIF
@@ -1825,29 +1825,29 @@
 !/ARC           ALLOCATE ( BACSPEC(NSPEC) )
 !/ARC        DO IK = 1, NBAC
 !/ARC           IF( IK .LE. (NBAC-NBGL) ) THEN
-!/ARC                   IX = NGLO + IK 
+!/ARC                   IX = NGLO + IK
 !/ARC                   BACANGL = ANGARC(IK)
 !/ARC           ELSE
 !/ARC                   IX = ICLBAC(IK)
 !/ARC                   BACANGL = - ANGARC(IK)
-!/ARC           ENDIF 
+!/ARC           ENDIF
 !/ARC
-!/ARC  !Li    Work out boundary PE (ISPEC) and JSEA numbers for IX 
+!/ARC  !Li    Work out boundary PE (ISPEC) and JSEA numbers for IX
 
           IF( ARCTIC ) THEN
-!/DIST            ISPEC = MOD( IX-1, NAPROC ) 
+!/DIST            ISPEC = MOD( IX-1, NAPROC )
 !/DIST             JSEA = 1 + (IX - ISPEC - 1)/NAPROC
-!/SHRD            ISPEC = 0 
-!/SHRD             JSEA = IX 
+!/SHRD            ISPEC = 0
+!/SHRD             JSEA = IX
           ENDIF
 !
 !/ARC              IF( IAPROC .EQ. ISPEC+1 ) THEN
 !/ARC                   BACSPEC = SPCBAC(:,IK)
-!/ARC                  
+!/ARC
 !/ARC                   CALL w3acturn( NTH, NK, BACANGL, BACSPEC )
 !/ARC
-!/ARC                   VA(:,JSEA) = BACSPEC 
-!/ARC  !Li              WRITE(NDSE,*) "IAPROC, IX, JSEAx, IK=", IAPROC, IX, JSEA, IK 
+!/ARC                   VA(:,JSEA) = BACSPEC
+!/ARC  !Li              WRITE(NDSE,*) "IAPROC, IX, JSEAx, IK=", IAPROC, IX, JSEA, IK
 !/ARC              ENDIF
 !/ARC
 !/ARC  !!Li   Boundary cell loop IK ends.
@@ -1884,7 +1884,7 @@
 !/DEBUGRUN                  IF (JSEA == DEBUG_NODE) WRITE(*,*) 'W3WAVE TEST', SUM(VA(:,JSEA))
                   DEPTH  = MAX ( DMIN , DW(ISEA) )
 
-                  IF ( GTYPE .EQ. UNGTYPE ) THEN 
+                  IF ( GTYPE .EQ. UNGTYPE ) THEN
                     IF (IOBP(ISEA) .NE. 1) CYCLE
                   ENDIF
 
@@ -1920,8 +1920,8 @@
 !/SMC                           CG(:,ISEA), WN(:,ISEA), DEPTH,            &
 !/SMC                           DHDX(ISEA), DHDY(ISEA), DHLMT(:,ISEA),    &
 !/SMC                           CX(ISEA), CY(ISEA), DCXDX(IY,IX),         &
-!/SMC                           DCXDY(IY,IX), DCYDX(IY,IX), DCYDY(IY,IX), & 
-!/SMC                           DCDX(:,IY,IX), DCDY(:,IY,IX), VA(:,JSEA) )  
+!/SMC                           DCXDY(IY,IX), DCYDX(IY,IX), DCYDY(IY,IX), &
+!/SMC                           DCDX(:,IY,IX), DCDY(:,IY,IX), VA(:,JSEA) )
 !
                     END IF
                   END DO
@@ -1938,7 +1938,7 @@
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'W3WAVE, step 6.17'
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'FSSOURCE=', FSSOURCE
 !/DEBUGRUN        FLUSH(740+IAPROC)
-! 
+!
 ! 3.6 End propapgation  = = = = = = = = = = = = = = = = = = = = = = = =
 
 ! 3.7 Calculate and integrate source terms.
@@ -1969,18 +1969,18 @@
                 CALL INIT_GET_ISEA(ISEA, JSEA)
                 IX     = MAPSF(ISEA,1)
                 IY     = MAPSF(ISEA,2)
-                DELA=1. 
-                DELX=1. 
-                DELY=1. 
-!/REF1                IF (GTYPE.EQ.RLGTYPE) THEN 
+                DELA=1.
+                DELX=1.
+                DELY=1.
+!/REF1                IF (GTYPE.EQ.RLGTYPE) THEN
 !/REF1                  DELX=SX*CLATS(ISEA)/FACX
 !/REF1                  DELY=SY/FACX
 !/REF1                  DELA=DELX*DELY
 !/REF1                END IF
-!/REF1                IF (GTYPE.EQ.CLGTYPE) THEN 
+!/REF1                IF (GTYPE.EQ.CLGTYPE) THEN
 !/REF1! Maybe what follows works also for RLGTYPE ... to be verified
 !/REF1                  DELX=HPFAC(IY,IX)/ FACX
-!/REF1                  DELY=HQFAC(IY,IX)/ FACX 
+!/REF1                  DELY=HQFAC(IY,IX)/ FACX
 !/REF1                  DELA=DELX*DELY
 !/REF1                END IF
 !
@@ -2465,7 +2465,7 @@
 ! This barrier is from older code versions. It has been removed in 3.11
 ! to optimize IO2/3 settings. May be needed on some systems still
 !
-!!/MPI            IF (FLDRY) CALL MPI_BARRIER (MPI_COMM_WAVE,IERR_MPI) 
+!!/MPI            IF (FLDRY) CALL MPI_BARRIER (MPI_COMM_WAVE,IERR_MPI)
 !
           END IF
 !/TIMINGS         CALL PRINT_MY_TIME("Before update log file")
@@ -2503,7 +2503,7 @@
                 WRITE (NDSO,900) ITIME, IPASS, IDTIME(1:19),          &
                                  IDACT, OUTID
                 IDLAST = TIME(1)
-              ELSE 
+              ELSE
                 WRITE (NDSO,901) ITIME, IPASS, IDTIME(12:19),         &
                                  IDACT, OUTID
               END IF
@@ -2954,7 +2954,7 @@
       IMPLICIT NONE
 !
 !/MPI      INCLUDE "mpif.h"
-!/ 
+!/
 !/ ------------------------------------------------------------------- /
 !/ Parameter list
 !/
@@ -3203,7 +3203,7 @@
           END IF
         END DO
 !/SMC !!Li   For SMC grid, local sea points are equally NSEA/NAPROC
-!/SMC !!Li   so the NLOC is overwirte by a constant.  
+!/SMC !!Li   so the NLOC is overwirte by a constant.
 !/SMC        NLOC = NSEA/NAPROC
 !
 !/T        WRITE (NDST,9000) IPROC, NLOC

--- a/model/ftn/w3wavset.ftn
+++ b/model/ftn/w3wavset.ftn
@@ -1,7 +1,7 @@
       MODULE W3WAVSET
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -11,8 +11,8 @@
 !/
 !/    01-June-2016 : Origination                        ( version 6.04 )
 !/
-!  1. Purpose : Implicit solution of wave setup problem following 
-!               Dingemans for structured and unstructured grids 
+!  1. Purpose : Implicit solution of wave setup problem following
+!               Dingemans for structured and unstructured grids
 !
 !  2. Method :  To be described
 !
@@ -77,7 +77,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -88,7 +88,7 @@
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : differentiate xy
-!  2. Method : linear shape function 
+!  2. Method : linear shape function
 !  3. Parameters :
 !
 !     Parameter list
@@ -180,7 +180,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -190,8 +190,8 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : differentiate xy based on mapsta 
-!  2. Method : linear shape function 
+!  1. Purpose : differentiate xy based on mapsta
+!  2. Method : linear shape function
 !  3. Parameters :
 !
 !     Parameter list
@@ -286,7 +286,7 @@
         ELSE
           DVDX(IP)=0.
           DVDY(IP)=0.
-        ENDIF 
+        ENDIF
       END DO
       DO IP=1,npa
         IX=iplg(IP)
@@ -303,7 +303,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                        FORTRAN 90 |
@@ -371,7 +371,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -381,7 +381,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Setup boundary pointer 
+!  1. Purpose : Setup boundary pointer
 !  2. Method :
 !  3. Parameters :
 !
@@ -495,7 +495,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -579,7 +579,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -738,7 +738,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -748,7 +748,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : preconditioner 
+!  1. Purpose : preconditioner
 !  2. Method :
 !  3. Parameters :
 !
@@ -853,7 +853,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -863,7 +863,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : compute off diagonal contr. 
+!  1. Purpose : compute off diagonal contr.
 !  2. Method :
 !  3. Parameters :
 !
@@ -937,7 +937,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -947,7 +947,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : scalar prod. + exchange 
+!  1. Purpose : scalar prod. + exchange
 !  2. Method :
 !  3. Parameters :
 !
@@ -1031,7 +1031,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1041,7 +1041,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : poisson eq. solver 
+!  1. Purpose : poisson eq. solver
 !  2. Method :
 !  3. Parameters :
 !
@@ -1172,7 +1172,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1182,7 +1182,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : set. mean value 
+!  1. Purpose : set. mean value
 !  2. Method :
 !  3. Parameters :
 !
@@ -1277,7 +1277,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -1361,7 +1361,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1490,7 +1490,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1500,7 +1500,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Wave setup for FD grids 
+!  1. Purpose : Wave setup for FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -1642,7 +1642,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1652,7 +1652,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : comp. off diagonal for FD grids 
+!  1. Purpose : comp. off diagonal for FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -1720,7 +1720,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1730,7 +1730,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Precond. for FD grids 
+!  1. Purpose : Precond. for FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -1805,7 +1805,7 @@
         END DO
       END IF
       IF (ThePrecond .eq. 2) THEN
-        
+
         DO IP=1,NSEA
           J=PDLIB_I_DIAG(IP)
           TheOut(IP)=TheIn(IP)/ASPAR(J)
@@ -1817,7 +1817,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1827,7 +1827,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Rad. stresses for FD grids 
+!  1. Purpose : Rad. stresses for FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -1928,7 +1928,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -1938,7 +1938,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : setup fluxes 
+!  1. Purpose : setup fluxes
 !  2. Method :
 !  3. Parameters :
 !
@@ -2062,7 +2062,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2072,7 +2072,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : differences on FD grids 
+!  1. Purpose : differences on FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -2151,7 +2151,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2161,7 +2161,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : Setup matrix on FD grids 
+!  1. Purpose : Setup matrix on FD grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -2251,7 +2251,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2322,7 +2322,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2332,7 +2332,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : possoin solver on fd grids 
+!  1. Purpose : possoin solver on fd grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -2429,7 +2429,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2439,7 +2439,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : set meanvalue 
+!  1. Purpose : set meanvalue
 !  2. Method :
 !  3. Parameters :
 !
@@ -2506,7 +2506,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  |                                   |
@@ -2516,7 +2516,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : wave setup comp. on fd grids 
+!  1. Purpose : wave setup comp. on fd grids
 !  2. Method :
 !  3. Parameters :
 !
@@ -2600,7 +2600,7 @@
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
-!/                  |                                   |  
+!/                  |                                   |
 !/                  | Aron Roland (BGS IT&E GmbH)       |
 !/                  | Mathieu Dutour-Sikiric (IRB)      |
 !/                  |                                   |
@@ -2610,7 +2610,7 @@
 !/
 !/    01-Mai-2018 : Origination.                        ( version 6.04 )
 !/
-!  1. Purpose : general driver 
+!  1. Purpose : general driver
 !  2. Method :
 !  3. Parameters :
 !

--- a/model/ftn/w3wdasmd.ftn
+++ b/model/ftn/w3wdasmd.ftn
@@ -18,7 +18,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -35,7 +35,7 @@
 !
 !     A three tier data structure is used with three separate data
 !     sets. Tentatively, they are intended for mean wave parameters,
-!     1-D and 2-D spectral data. This separation is made only for 
+!     1-D and 2-D spectral data. This separation is made only for
 !     economy in file and menory usage. All three data sets are defined
 !     here onlt by a record length and a number of records. All data are
 !     treated as real numbers, but the meaing of all record components
@@ -68,7 +68,7 @@
 !  5. Remarks :
 !
 !     - This module still requires an OpenMP or  MPI setup to be made
-!       compatible with WAVEWATCH III inside the user supplied 
+!       compatible with WAVEWATCH III inside the user supplied
 !       routines.
 !
 !  6. Switches :
@@ -213,9 +213,9 @@
 !
 !     User-defined data assimilation routines to be plugged in here.
 !     All that could be needed is avainalble in this subroutine,
-!     including the grid definition from W3GDATMD. All 
+!     including the grid definition from W3GDATMD. All
 !     can thus be included in the parameter list, and no explcit links
-!     to other WAVEWATCH III routines will be needed within the 
+!     to other WAVEWATCH III routines will be needed within the
 !     data assimilation routines ( with the possible exception of the
 !     CONSTANTS module ), If there is a reason to terminate the code,
 !     pass an error code out of the routine and use EXTCDE to stop

--- a/model/ftn/w3wdatmd.ftn
+++ b/model/ftn/w3wdatmd.ftn
@@ -22,7 +22,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -47,17 +47,17 @@
 !     ----------------------------------------------------------------
 !      TIME      I.A.  Public   Valid time for spectra.
 !      TIME00    I.A.  Public   Initial time
-!      TIMEEND   I.A.  Public   Final time 
+!      TIMEEND   I.A.  Public   Final time
 !      TLEV      I.A.  Public   Valid time for water levels.
 !      TICE      I.A.  Public   Valid time for ice concentration
 !      TIC1      I.A.  Public   Valid time for ice thickness
 !      TIC5      I.A.  Public   Valid time for ice floe
 !      VA        R.A.  Public   Storage array for spectra.
-!      WLV       R.A.  Public   Water levels.  
-!      ICE       R.A.  Public   Ice coverage.  
+!      WLV       R.A.  Public   Water levels.
+!      ICE       R.A.  Public   Ice coverage.
 !      ICEH      R.A.  Public   Ice thickness.
-!      ICEF      R.A.  Public   Ice flow maximum diameter. 
-!      ICEDMAX   R.A.  Public   Ice flow maximum diameter for updates. 
+!      ICEF      R.A.  Public   Ice flow maximum diameter.
+!      ICEDMAX   R.A.  Public   Ice flow maximum diameter for updates.
 !      BERG      R.A.  Public   Iceberg damping.
 !      UST       R.A.  Public   Friction velocity (absolute).
 !      USTDIR    R.A.  Public   Friction velocity direction.
@@ -317,7 +317,7 @@
 !
 !  7. Remarks :
 !
-!     - W3SETW needs to be called after allocation to point to 
+!     - W3SETW needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -615,7 +615,7 @@
       IF ( NWDATA .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
-        END IF   
+        END IF
 !
       IF ( IMOD.LT.0 .OR. IMOD.GT.NWDATA ) THEN
           WRITE (NDSE,1002) IMOD, NWDATA

--- a/model/ftn/wmesmfmd.ftn
+++ b/model/ftn/wmesmfmd.ftn
@@ -51,11 +51,11 @@
 !/
 !/    20-Jan-2017 : Origination.                        ( version 6.02 )
 !/    09-Aug-2017 : Add ocean forcing export fields     ( version 6.03 )
-!/    28-Feb-2018 : Modifications for unstruc meshes    ( version 6.06 ) 
+!/    28-Feb-2018 : Modifications for unstruc meshes    ( version 6.06 )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -405,7 +405,7 @@
       call NUOPC_CompSpecialize(gcomp, specLabel=label_CheckImport, &
         specRoutine=NUOPC_NoOp, rc=rc)
       if (ESMF_LogFoundError(rc, PASSTHRU)) return
-      
+
 ! --- Model advance method
 
       call NUOPC_CompSpecialize(gcomp, specLabel=label_Advance, &
@@ -778,7 +778,7 @@
 ! 2.  Initialization of all wave models / grids
 !
 ! 2.a Call into WMINIT
-!     
+!
       if ( .not.lsep_ss ) idss = stdo
       if ( .not.lsep_st ) idst = stdo
       if ( .not.lsep_se ) idse = stdo
@@ -830,7 +830,7 @@
 ! 3.  Initialize import field list
 !
       istep_import: do istep = 1, 2
-      
+
       if ( istep.eq.2 ) then
         allocate ( impFieldName(numImpFields), &
                    impFieldStdName(numImpFields), &
@@ -924,7 +924,7 @@
 ! 4.  Initialize export field list
 !
       istep_export: do istep = 1, 2
-      
+
       if ( istep.eq.2 ) then
         allocate ( expFieldName(numExpFields), &
                    expFieldStdName(numExpFields), &
@@ -1112,7 +1112,7 @@
 !/
 !/    20-Jan-2017 : Origination.                        ( version 6.02 )
 !/    09-Aug-2017 : Update 3D export field setup        ( version 6.03 )
-!/    28-Feb-2018 : Modifications for unstruc meshes    ( version 6.06 )  
+!/    28-Feb-2018 : Modifications for unstruc meshes    ( version 6.06 )
 !/
 !  1. Purpose :
 !
@@ -2395,7 +2395,7 @@
       endif
 !
 ! -------------------------------------------------------------------- /
-! Surface Roughness 
+! Surface Roughness
 !
       i1 = FieldIndex( expFieldName, 'z0rlen', rc )
       if (ESMF_LogFoundError(rc, PASSTHRU)) return
@@ -3241,7 +3241,7 @@
 !
 ! 5.b Store route handle
 !
-      call ESMF_FieldRedistStore( nField, eField, n2eRH, rc=rc ) 
+      call ESMF_FieldRedistStore( nField, eField, n2eRH, rc=rc )
       if (ESMF_LogFoundError(rc, PASSTHRU)) return
 !
 ! 5.c Clean up
@@ -3372,9 +3372,9 @@
 !
 !  2. Method :
 !
-!     Create an ESMF Mesh for import using the unstructured mesh description 
-!     in W3GDATMD. At present, this import mesh is not domain decomposed, 
-!     but instead is defined on PET 0 only. (In future, when the unstructured 
+!     Create an ESMF Mesh for import using the unstructured mesh description
+!     in W3GDATMD. At present, this import mesh is not domain decomposed,
+!     but instead is defined on PET 0 only. (In future, when the unstructured
 !     mesh will run on domain decomposition, we will use that decomposition.)
 !
 !  3. Parameters :
@@ -3487,7 +3487,7 @@
 !/PDLIB!        -------------------------------------------------------------------
 !/PDLIB!        ESMF Definition: The global id's of the nodes resident on this processor
 !/PDLIB!        -------------------------------------------------------------------
-!/PDLIB!        Allocate global node ids, including ghost nodes (npa=np+ng) 
+!/PDLIB!        Allocate global node ids, including ghost nodes (npa=np+ng)
 !/PDLIB         allocate(nodeIds(npa))
 !/PDLIB         do i = 1,npa
 !/PDLIB            nodeIds(i)=iplg(i)
@@ -3654,9 +3654,9 @@
          enddo
 !/PDLIB      else
 !/PDLIB!        -------------------------------------------------------------------
-!/PDLIB!        ESMF Definition: Connectivity table. The number of entries should 
-!/PDLIB!        be equal to the number of nodes in the given topology. The indices 
-!/PDLIB!        should be the local index (1 based) into the array of nodes that 
+!/PDLIB!        ESMF Definition: Connectivity table. The number of entries should
+!/PDLIB!        be equal to the number of nodes in the given topology. The indices
+!/PDLIB!        should be the local index (1 based) into the array of nodes that
 !/PDLIB!        was declared with MeshAddNodes.
 !/PDLIB!        -------------------------------------------------------------------
 !/PDLIB!        > INE is local element array. it stores the local node IDs
@@ -3731,16 +3731,16 @@
 !
 !  2. Method :
 !
-!     Create an ESMF Mesh for export using the unstructured mesh description 
-!     in W3GDATMD. At present, this export mesh is not domain decomposed, 
-!     but instead is defined on PET 0 only. (In future, when the unstructured 
+!     Create an ESMF Mesh for export using the unstructured mesh description
+!     in W3GDATMD. At present, this export mesh is not domain decomposed,
+!     but instead is defined on PET 0 only. (In future, when the unstructured
 !     mesh will run on domain decomposition, we will use that decomposition.)
 !
-!     Since the internal parallel data is currently stored accross grid points 
+!     Since the internal parallel data is currently stored accross grid points
 !     in a "card deck" fashion, we will define an intermediate native grid, as
 !     is done for regular/curvilinear grids, and perform an ESMF regrid to the
-!     export mesh. This code segment is taken from T. J. Campbell, and 
-!     modified to 1D, because the internal data structure for unstructred 
+!     export mesh. This code segment is taken from T. J. Campbell, and
+!     modified to 1D, because the internal data structure for unstructred
 !     meshes is an array with dimensions [NX,NY=1].
 !
 !  3. Parameters :
@@ -3848,7 +3848,7 @@
       natIndexFlag = ESMF_INDEX_DELOCAL
 !
 ! -------------------------------------------------------------------- /
-! 2.  Create ESMF mesh for export 
+! 2.  Create ESMF mesh for export
 !
 ! 2.a Create ESMF export mesh
 !
@@ -3862,7 +3862,7 @@
 !/PDLIB!        -------------------------------------------------------------------
 !/PDLIB!        ESMF Definition: The global id's of the nodes resident on this processor
 !/PDLIB!        -------------------------------------------------------------------
-!/PDLIB!        Allocate global node ids, including ghost nodes (npa=np+ng) 
+!/PDLIB!        Allocate global node ids, including ghost nodes (npa=np+ng)
 !/PDLIB         allocate(nodeIds(npa))
 !/PDLIB         do i = 1,npa
 !/PDLIB            nodeIds(i)=iplg(i)
@@ -4028,9 +4028,9 @@
          enddo
 !/PDLIB      else
 !/PDLIB!        -------------------------------------------------------------------
-!/PDLIB!        ESMF Definition: Connectivity table. The number of entries should 
-!/PDLIB!        be equal to the number of nodes in the given topology. The indices 
-!/PDLIB!        should be the local index (1 based) into the array of nodes that 
+!/PDLIB!        ESMF Definition: Connectivity table. The number of entries should
+!/PDLIB!        be equal to the number of nodes in the given topology. The indices
+!/PDLIB!        should be the local index (1 based) into the array of nodes that
 !/PDLIB!        was declared with MeshAddNodes.
 !/PDLIB!        -------------------------------------------------------------------
 !/PDLIB!        > INE is local element array. it stores the local node IDs
@@ -4155,7 +4155,7 @@
 !
 ! 4.b Store route handle
 !
-      call ESMF_FieldRedistStore( nField, eField, n2eRH, rc=rc ) 
+      call ESMF_FieldRedistStore( nField, eField, n2eRH, rc=rc )
       if (ESMF_LogFoundError(rc, PASSTHRU)) return
 !
 ! 4.c Clean up
@@ -5643,7 +5643,7 @@
             enddo ith_loop
             fack = dden(ik)/cg(ik,isea)
             kd = max(kdmin,min(kdmax,wn(ik,isea)*depth))
-            fkd = fack/sinh(kd)**2 
+            fkd = fack/sinh(kd)**2
             abr = abr + aka*fkd
             ubr = ubr + aka*sig2(ik)*fkd
             ubx = ubx + akx*sig2(ik)*fkd
@@ -5888,7 +5888,7 @@
 #endif
         enddo jsea_loop
 !/PDLIB      else
-!/PDLIB        jsea_loop2: do jsea = 1,np 
+!/PDLIB        jsea_loop2: do jsea = 1,np
 !/PDLIB          isea = iplg(jsea)
 !/PDLIB!          if ( dw(isea).le.zero ) cycle jsea_loop
 !/PDLIB          sxxn(jsea) = sxx(jsea)

--- a/model/ftn/wmfinlmd.ftn
+++ b/model/ftn/wmfinlmd.ftn
@@ -14,11 +14,11 @@
 !/    03-Sep-2012 : Output of initilization time.       ( version 4.10 )
 !/    28-Jan-2014 : Add memory hwm to profiling.        ( version 5.00 )
 !/    04-Feb-2014 : Switched clock to DATE_AND_TIME     ( version 4.18 )
-!/                  (A. Chawla and Mark Szyszka) 
+!/                  (A. Chawla and Mark Szyszka)
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -110,7 +110,7 @@
 !       !/MPI   MPI routines.
 !
 !       !/O10   Enable output identifying start and end of routine
-!      
+!
 !       !/F90   FORTRAN 90 specific extensions.
 !
 !       !/S     Enable subroutine tracing.

--- a/model/ftn/wmgridmd.ftn
+++ b/model/ftn/wmgridmd.ftn
@@ -45,12 +45,12 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Routines to determine and process grid dependencies in the 
+!     Routines to determine and process grid dependencies in the
 !     multi-grid wave model.
 !
 !  2. Variables and types :
@@ -62,7 +62,7 @@
 !      WMGLOW    Subr. Public   Dependencies to lower ranked grids.
 !      WMGHGH    Subr. Public   Dependencies to higher ranked grids.
 !      WMGEQL    Subr. Public   Dependencies to same ranked grids.
-!      WMRSPC    Subr. Public   Make map of flags for spectral 
+!      WMRSPC    Subr. Public   Make map of flags for spectral
 !                               conversion between grids.
 !     ----------------------------------------------------------------
 !
@@ -235,8 +235,8 @@
       LOGICAL                 :: RFILE(NRGRD),  FLAGOK
       LOGICAL                 :: INGRID ! indicates whether boundary point
                                ! is in lower rank grid
-      INTEGER                 :: IVER(4),JVER(4) ! (I,J) indices of vertices 
-                               ! of cell (in lower rank grid J) enclosing 
+      INTEGER                 :: IVER(4),JVER(4) ! (I,J) indices of vertices
+                               ! of cell (in lower rank grid J) enclosing
                                ! boundary point (in higher rank grid I)
       REAL                    :: RW(4) ! Array of interpolation weights.
       INTEGER                 :: KVER ! counter for 4 vertices
@@ -313,7 +313,7 @@
           ALLOCATE ( NBI2G(NRGRD,NRGRD), STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
         END IF
-      NBI2G  = 0 
+      NBI2G  = 0
 !
 !/T      WRITE (MDST,9020)
 !
@@ -360,7 +360,7 @@
                 XA     = XGRD(IY,IX) !old code: X0 + REAL(IX-1)*SX
                 YA     = YGRD(IY,IX) !old code: Y0 + REAL(IY-1)*SY
 !
-! ... Loop over previous (lower ranked) grids, going in order from highest 
+! ... Loop over previous (lower ranked) grids, going in order from highest
 !          of lower ranked grids (I-1) to lowest of lower ranked grids (1)
 !
                 JS     = 0
@@ -371,10 +371,10 @@
 !
 ! ... Check if in grid
 
-! notes: 
+! notes:
 ! old version (v4.00):
 !        if in grid, return location in grid: a) JX, JY
-!                                   (lower left indices of cell), 
+!                                   (lower left indices of cell),
 !                                             b) RX, RY
 !                                   (normalized location in cell)
 !        in not in grid, cycle (search next grid)
@@ -472,7 +472,7 @@
                                  RW(4)   .LT.0.05 ) .AND.      &
 ! point 3:
                            ( ABS(GRIDS(J)%MAPSTA(JVER(3),IVER(3))).GE.1 .OR.  &
-                                    RW(3)   .LT.0.05 ) 
+                                    RW(3)   .LT.0.05 )
 !
                   IF ( .NOT.FLAGOK ) CYCLE
 !
@@ -499,7 +499,7 @@
 !   I have no reason to believe that the ordering in RDBPI, TSTORE is important.
 !   I have gone through test case mww3_test_02 for gridsets a,b,c,d and found
 !      no change in result vs v4.00.
-                  
+
                   DO KVER=1,4
                     IF (KVER .LE. NbRelevant) THEN
                       IF ( ABS(GRIDS(J)%MAPSTA(JVER(KVER),IVER(KVER))).GE.1 &
@@ -656,10 +656,10 @@
 ! 3.a Get size of array and dimension
 !
 
-! notes: 
+! notes:
 !    GRIDD(I,J) indicates whether grid I is dependent on lower ranked grid J
-!    JS counts the number of grids J that grid I is dependent on      
-!    GRDLOW is sized to accomodate the grid with the largest JS   
+!    JS counts the number of grids J that grid I is dependent on
+!    GRDLOW is sized to accomodate the grid with the largest JS
 
       JTOT   = 0
       DO I=1, NRGRD
@@ -690,18 +690,18 @@
           IF ( GRIDD(I,J) ) THEN
             JTOT   = JTOT + 1
             GRDLOW(I,JTOT) = J
-! ... error checking: catch situation where ranks are inconsistent with 
+! ... error checking: catch situation where ranks are inconsistent with
 !                     resolution
 
 ! notes:
-! old code:   SXJ=GRIDS(J)%SX 
+! old code:   SXJ=GRIDS(J)%SX
 !             SXI=GRIDS(I)%SX
 !             SYJ=GRIDS(J)%SY
 !             SYI=GRIDS(I)%SY
-!             also, old code did not need to check both min and max, 
+!             also, old code did not need to check both min and max,
 !             since they were the same
 ! new code:
-!       SXI(:,:) ==> GRIDS(I)%HPFAC ! resolution in higher rank grid I 
+!       SXI(:,:) ==> GRIDS(I)%HPFAC ! resolution in higher rank grid I
 !                    (approximate in case of irregular grids)
 !       SYI(:,:) ==> GRIDS(I)%HQFAC ! viz.
 !       SXJ(:,:) ==> GRIDS(J)%HPFAC ! resolution in lower rank grid J
@@ -718,9 +718,9 @@
 !     making 4 checks total.
 ! This is strict, and may generate "false positives" in error checking
 !     here. In this case, the user may wish to disable this error checking.
-! For case of regular grids, we cannot use HPFAC, since it goes to zero 
+! For case of regular grids, we cannot use HPFAC, since it goes to zero
 !     at pole. We instead use good ol' SX and SY
-           
+
             IF ( GRIDS(I)%GTYPE .EQ. CLGTYPE ) THEN
                DX_MIN_GRIDI=MINVAL(GRIDS(I)%HPFAC)
                DY_MIN_GRIDI=MINVAL(GRIDS(I)%HQFAC)
@@ -834,9 +834,9 @@
                  FLAGOK = .FALSE.
               END IF
            END IF
-              
+
           END IF ! IF ( GRIDD(I,J) ) THEN
-            
+
         END DO ! DO J=...
         GRDLOW(I,0) = JTOT
       END DO ! DO I=...
@@ -878,7 +878,7 @@
         DO J=1, NRGRD
           IF ( GRIDD(J,I) ) THEN ! grid j is of higher rank than grid i
                                  ! *and* there is dependency
-              JTOT   = JTOT + 1  ! count the number of grids of higher 
+              JTOT   = JTOT + 1  ! count the number of grids of higher
                                  ! rank than grid i
               GRDHGH(I,JTOT) = J ! save the grid number of the higher rank grid
             END IF
@@ -1016,31 +1016,31 @@
 !  7. Remarks :
 !
 !     Regarding the map of distances to the boundary :
-!      - v4.00 : the map of distances to the boundary was intentionally 
-!                not an accurate characteristic distance. It was felt that 
-!                it was more important that it be 'safe' and quick to compute. 
-!                An iterative method was used to compute distance by starting 
-!                at boundary and working inwards one grid row layer at a time, 
+!      - v4.00 : the map of distances to the boundary was intentionally
+!                not an accurate characteristic distance. It was felt that
+!                it was more important that it be 'safe' and quick to compute.
+!                An iterative method was used to compute distance by starting
+!                at boundary and working inwards one grid row layer at a time,
 !                incrementing distance by dx etc. until the distance map was
 !                filled in. This was characterized as "local increment solution
 !                only."
 !      - v4.01 : conversion to work with irregular grids. Author could not
 !                think of any way to retain "local increment solution" method
 !                for situation of irregular grids. Therefore method has been
-!                changed to compute accurate distances. New method is also 
-!                more transparent and simpler with much less code, thus 
-!                easier to modify or debug. It is expected that this method 
-!                could be more expensive to compute. Isolated timings were 
-!                not performed. Since the iteration step has been removed, 
+!                changed to compute accurate distances. New method is also
+!                more transparent and simpler with much less code, thus
+!                easier to modify or debug. It is expected that this method
+!                could be more expensive to compute. Isolated timings were
+!                not performed. Since the iteration step has been removed,
 !                it is hoped that the expense is at least offset somewhat.
 !
 !     Regarding method of calculating weights :
-!              o If SCRIP software is not compiled into WW3 by user 
+!              o If SCRIP software is not compiled into WW3 by user
 !                (i.e. if SCRIP switch is not set, then original method
 !                (denoted "_OM") will be used.
-!              o If SCRIP is activated by user, and all grids are 
-!                regular and specified in terms of meters (cartesian), 
-!                then WMGHGH will calculate weights using both methods, 
+!              o If SCRIP is activated by user, and all grids are
+!                regular and specified in terms of meters (cartesian),
+!                then WMGHGH will calculate weights using both methods,
 !                and then compare the two, producing an error message
 !                if they do not match (built-in regression testing)
 !                For more info, see Section 0a below.
@@ -1060,7 +1060,7 @@
 !           * grid rank > 1 and NBI=0 : do nothing w/ warning message
 !           * grid rank = 1 and NBI>0 : do nothing
 !           * grid rank = 1 and NBI=0 : do nothing
-!         
+!
 !  8. Structure :
 !
 !     See source code.
@@ -1106,7 +1106,7 @@
 !/ Local parameters
 !/
 
-! notes re: variable names: During the extension for irregular grids, 
+! notes re: variable names: During the extension for irregular grids,
 !    some variable were renamed to make the code more readable:
 !         JX==> ISRC
 !         JY==> JSRC
@@ -1137,7 +1137,7 @@
       INTEGER, ALLOCATABLE    :: TMPINT_OM(:,:),TMPINT(:,:)
       REAL, ALLOCATABLE       :: TMPRL_OM(:,:) ,TMPRL(:,:)
       REAL, ALLOCATABLE       :: BDIST_OM(:)   ,BDIST(:)
-      INTEGER                 :: NR0   , NR1   , NR2   , NRL   , NLOC   
+      INTEGER                 :: NR0   , NR1   , NR2   , NRL   , NLOC
       INTEGER                 :: NR0_OM, NR1_OM, NR2_OM, NRL_OM, NLOC_OM
 
 !/DIST      INTEGER, ALLOCATABLE    :: LTAG(:)
@@ -1167,7 +1167,7 @@
 
 !/SCRIP      TYPE ALLWGT
 !/SCRIP        TYPE(WEIGHT_DATA), POINTER :: WGTDATA(:)
-!/SCRIP      END TYPE ALLWGT      
+!/SCRIP      END TYPE ALLWGT
 !/SCRIP      TYPE(ALLWGT), ALLOCATABLE :: ALLWGTS(:)
 !/SCRIP      LOGICAL              :: L_MASTER = .TRUE.
 !/SCRIP      LOGICAL              :: L_READ   = .FALSE.
@@ -1181,32 +1181,32 @@
 
       LOGICAL                 :: LSCRIP=.FALSE.      ! true if SCRIP switch is set,
                                                      ! indicates that SCRIP code has
-                                                     ! been compiled into WW3 
+                                                     ! been compiled into WW3
       LOGICAL                 :: LSCRIPNC=.FALSE.    ! true if SCRIPNC switch is set,
                                                      ! indicates that SCRIP code has
-                                                     ! been compiled with netCDF 
-                                                     ! into WW3 
+                                                     ! been compiled with netCDF
+                                                     ! into WW3
       LOGICAL                 :: L_STOP = .FALSE.    ! true if SCRIPNC switch is set
                                                      ! and STOP_SCRIP file exists
-      LOGICAL                 :: T38=.FALSE.         ! true if T38 switch is set. 
-                                                     ! This logical is necessary 
-                                                     ! since it isn't possible to 
-                                                     ! have two switches disabling 
+      LOGICAL                 :: T38=.FALSE.         ! true if T38 switch is set.
+                                                     ! This logical is necessary
+                                                     ! since it isn't possible to
+                                                     ! have two switches disabling
                                                      ! the same line of code.
-      LOGICAL                 :: ALL_REGULAR=.TRUE.  ! true if all grids are 
+      LOGICAL                 :: ALL_REGULAR=.TRUE.  ! true if all grids are
                                                      ! regular grids
-      LOGICAL                 :: DO_CHECKING=.FALSE. ! true if we will be 
+      LOGICAL                 :: DO_CHECKING=.FALSE. ! true if we will be
                                                      ! checking "old method" of
-                                                     ! computing weights vs. 
+                                                     ! computing weights vs.
                                                      ! SCRIP method of computing
                                                      ! weights.
       LOGICAL                 :: OLD_METHOD=.FALSE.  ! true if we will compute
                                                      ! using "old method" (does
-                                                     ! not necessarily mean 
+                                                     ! not necessarily mean
                                                      ! that this solution is
                                                      ! utilized)
       LOGICAL                 :: LMPIBDI=.FALSE.     ! true if MPIBDI switch is set
-      LOGICAL                 :: CALLED_SCRIP=.FALSE.! true if SCRIP has been 
+      LOGICAL                 :: CALLED_SCRIP=.FALSE.! true if SCRIP has been
                                                      ! called for this processor
 
 
@@ -1302,8 +1302,8 @@
 ! -------------------------------------------------------------------- /
 ! 0.a Plan future behavior by setting logical variables.
 
-!/SCRIP LSCRIP=.TRUE. 
-!/SCRIPNC LSCRIPNC=.TRUE. 
+!/SCRIP LSCRIP=.TRUE.
+!/SCRIPNC LSCRIPNC=.TRUE.
 !/T38   T38=.TRUE.
 
       DO GDST=1, NRGRD
@@ -1314,12 +1314,12 @@
 
 ! Notes re: FLAGLL case: Old method calculates overlap area based on deg lat
 !       and deg lon. New method (SCRIP) calculates overlap area based on real
-!       distances. Therefore weights will not match for FLAGLL case, so we 
-!       do not perform checking for FLAGLL case. 
+!       distances. Therefore weights will not match for FLAGLL case, so we
+!       do not perform checking for FLAGLL case.
 
       IF ( (.NOT.FLAGLL) .AND. ALL_REGULAR .AND. LSCRIP ) THEN
          IF ( IMPROC.EQ.NMPERR ) &
-         WRITE (MDSE,'(/2A)')'We will check SCRIP calculations ', & 
+         WRITE (MDSE,'(/2A)')'We will check SCRIP calculations ', &
                     'against old method of calculating weights.'
          DO_CHECKING=.TRUE.
       END IF
@@ -1337,14 +1337,14 @@
               'SCRIP switch.'
          CALL EXTCDE ( 999 )
       END IF
-      
+
 !
 ! -------------------------------------------------------------------- /
 ! 1.  Set boundary distance maps
 ! 1.a Check if needed
 !
 !!HT: FLGBDI is a flag set in WMMDATMD to .FALSE. and is used to identify
-!!HT:        if the boundary distance maps have been initialized 
+!!HT:        if the boundary distance maps have been initialized
 !!HT:
 !!HT: For each individual grid a map is generated identifying the distance
 !!HT: to open boundaries (MAPBDI, saved in structure MDATA in WMMDATMD).
@@ -1391,7 +1391,7 @@
 ! -------------------------------------------------------------------- /
 ! Inconsistent RANK vs NBI (warning message)
 !   This was an error, now changed to a warning (see notes section)
-            IF ( (GRANK(GDST).NE.1) .AND. (NBI.EQ.0) ) THEN 
+            IF ( (GRANK(GDST).NE.1) .AND. (NBI.EQ.0) ) THEN
                IF ( IMPROC.EQ.NMPERR ) &
                   WRITE (MDSE,'(/2A)') ' WARNING in WMGHGH:   ', &
                   'NBI=0 AND RANK > 1 '
@@ -1466,7 +1466,7 @@
                   DO JDST=1, NY
                      IF ( MAPSTA(JDST,IDST) .EQ. 0 ) THEN ! (excluded point)
                         MAPBDI(JDST,IDST) = -1. / SIG(1) * DTMAX ! new (bug fix)
-                     ELSE IF ( ABS(MAPSTA(JDST,IDST)) .EQ. 2 ) THEN 
+                     ELSE IF ( ABS(MAPSTA(JDST,IDST)) .EQ. 2 ) THEN
                         ! (boundary point)
                         MAPBDI(JDST,IDST) =  0.
                      ELSE ! ABS(MAPSTA)=1 (sea point)
@@ -1499,10 +1499,10 @@
 
 ! Notes: The origin of "0.58 * GRAV" is to translate from distance (in meters)
 ! to time (in seconds) required for a wave to travel from the boundary to point
-! JDST,IDST based on a specific group velocity 0.58*grav would be the group  
+! JDST,IDST based on a specific group velocity 0.58*grav would be the group
 ! velocity of a 7.3 s wave in deep water. Significance of T=7.3 s is explained
 ! in notes by HT below.
-                                 
+
                                  DD=DD/ ( 0.58 * GRAV )
                                  MAPBDI(JDST,IDST)=MIN(MAPBDI(JDST,IDST),DD)
                               ENDIF
@@ -1549,7 +1549,7 @@
 !!HT: (1)
 !!HT:
 !!HT: CHANGE array is used to identify grid points that still need to
-!!HT: be processed, and that are adjacent to points that have been 
+!!HT: be processed, and that are adjacent to points that have been
 !!HT: processed. Only those points can be updated in this step of the
 !!HT: loop started above here. The two loops below set the CHANGE array.
 !!HT:
@@ -1567,7 +1567,7 @@
 !!HT: This defines MAPBDI similar to an inverse CFL number.
 !!HT:
 !!HT: (3)
-!!HT: 
+!!HT:
 !!HT: ERROR : Should be CLAT(JDST), not CLATI(JDST) : "STX    = FACTOR * SX * CLATI(JDST) / ( 0.58 * GRAV )"
 
 ! 1.e Test output
@@ -1608,7 +1608,7 @@
 !/SCRIPNC      ALLOCATE(LGRDWRITE(NGRDRANK(1)-1, NGRDRANK(2)), STAT=ISTAT )
 !/SCRIPNC      CHECK_ALLOC_STATUS ( ISTAT )
 !/SCRIPNC      DO GDST=1, NRGRD
-!/SCRIPNC         DO JJ = 1, GRDHGH(GDST,0) 
+!/SCRIPNC         DO JJ = 1, GRDHGH(GDST,0)
 !/SCRIPNC            IF ( GRDHGH(GDST,0) .EQ. 0 ) THEN
 !/SCRIPNC !             If no remap, then no file
 !/SCRIPNC               LGRDREAD(GDST,JJ)  = .FALSE.
@@ -1661,14 +1661,14 @@
 !  W3SETG set ICLOSE for us, and we have determined that there is
 !   interaction between high and low rank. So this is a good point
 !   to check the closure type.
- 
+
             IF ( ICLOSE .EQ. ICLOSE_TRPL ) THEN
               IF ( IMPROC.EQ.NMPERR ) &
               WRITE(MDSE,*)'SUBROUTINE WMGHGH IS'// &
               ' NOT YET ADAPTED FOR TRIPOLE GRIDS. STOPPING NOW.'
               CALL EXTCDE ( 1 )
             END IF
-            
+
             ALLOCATE ( MAPTST(NY,NX), INFLND(NY,NX), STAT=ISTAT )
             CHECK_ALLOC_STATUS ( ISTAT )
             MAPTST = 0
@@ -1689,13 +1689,13 @@
 !   First, we ALLOCATE ALLWGTS from 1 up to the largest value of all
 !      the possible source grids. This will be referenced as "GSRC"
 !      Not every value of GSRC will be filled (e.g. "1" usually isn't filled)
-!      but since we are doing this as a derived data type, we are still 
+!      but since we are doing this as a derived data type, we are still
 !      efficient in terms of memory usage.
 !   Inside SCRIP interface, we have:
 !      type weight_data
 !         integer (kind=int_kind)              :: n    ! number of weights for
 !                                               dst cell, formerly npnts(:)
-!         real    (kind=dbl_kind), allocatable :: w(:) ! weights, sized by n, 
+!         real    (kind=dbl_kind), allocatable :: w(:) ! weights, sized by n,
 !                                               formerly wxwy(:,:)
 !         integer (kind=int_kind), allocatable :: k(:) ! source grid cells,
 !                                               sized by n, formerly KSRC(:,:)
@@ -1708,11 +1708,11 @@
 
 !/SCRIP            NJDST=NY
 !/SCRIP            NIDST=NX
-!/SCRIP            ALLOCATE ( ALLWGTS(MAXVAL(GRDHGH)), STAT=ISTAT ) 
+!/SCRIP            ALLOCATE ( ALLWGTS(MAXVAL(GRDHGH)), STAT=ISTAT )
 !/SCRIP            CHECK_ALLOC_STATUS ( ISTAT )
 
 ! Next, we loop through the src grids for the dst grid that we are working on.
-!/SCRIP            DO JJ=1, GRDHGH(GDST,0) 
+!/SCRIP            DO JJ=1, GRDHGH(GDST,0)
 !/T38                      CALL DATE_AND_TIME ( CDATE_TIME(1), CDATE_TIME(2), CDATE_TIME(3), DATE_TIME)
 !/T38                      BEG_TIME(3) = ((DATE_TIME(5)*60 + DATE_TIME(6))*60 + DATE_TIME(7))*1000 + DATE_TIME(8)
 !/T38                      ELAPSED_TIME = BEG_TIME(3) - BEG_TIME(1)
@@ -1727,9 +1727,9 @@
 ! 1) Not using L_STOP: in this case, all processes need all the weight
 !    information, so all processes need to call SCRIP for all grid pairs
 ! OR
-! 2) Using L_STOP, writing .nc files and not reading .nc files. With 
+! 2) Using L_STOP, writing .nc files and not reading .nc files. With
 !    L_STOP, different processors are doing different things, and so
-!    have different settings for L_WRITE. L_READ is the same for all 
+!    have different settings for L_WRITE. L_READ is the same for all
 !    processors, since it is simply based on whether the file already
 !    exists.
 
@@ -1754,7 +1754,7 @@
 
 !/SCRIP      CALLED_SCRIP=.FALSE. ! initialize
 
-!/SCRIPNC               IF ((.NOT. L_STOP) .OR. ((.NOT. L_READ) .AND. L_WRITE)) THEN 
+!/SCRIPNC               IF ((.NOT. L_STOP) .OR. ((.NOT. L_READ) .AND. L_WRITE)) THEN
 !/SCRIP                   IF (L_STOP) THEN ! we are sending different grids to different processors
 !/SCRIP                     WRITE(MDSE,'(A,2(I5),A,I5)')'Calling SCRIP for GSRC,GDST = ', &
 !/SCRIP                          GSRC,GDST,' on processor ',IMPROC
@@ -1772,8 +1772,8 @@
 !/SCRIPNC                  IF (.NOT. L_READ) THEN
 !/SCRIPNC                     IMPROC_ASSIGN = IMPROC_ASSIGN + 1
 !/SCRIPNC                     IF (IMPROC_ASSIGN .GT. NMPROC) IMPROC_ASSIGN = 1
-!/SCRIPNC                     IF(CALLED_SCRIP)THEN ! we called scrip_wrapper, so we need  
-!/SCRIPNC                                          ! to deallocate before leaving               
+!/SCRIPNC                     IF(CALLED_SCRIP)THEN ! we called scrip_wrapper, so we need
+!/SCRIPNC                                          ! to deallocate before leaving
 !/SCRIPNC                       DST_GRID_SIZE=NIDST*NJDST
 !/SCRIPNC                       DO KDST=1,DST_GRID_SIZE
 !/SCRIPNC                         DEALLOCATE(WGTDATA(KDST)%W, STAT=ISTAT )
@@ -1784,7 +1784,7 @@
 !/SCRIPNC                       DEALLOCATE(WGTDATA, STAT=ISTAT )
 !/SCRIPNC                       CHECK_DEALLOC_STATUS ( ISTAT )
 !/SCRIPNC                     END IF
-!/SCRIPNC                     CYCLE ! cycle out of this loop :  DO JJ=1, GRDHGH(GDST,0) 
+!/SCRIPNC                     CYCLE ! cycle out of this loop :  DO JJ=1, GRDHGH(GDST,0)
 !/SCRIPNC                  END IF
 !/SCRIPNC               END IF
 !/T38                      CALL DATE_AND_TIME (CDATE_TIME(1), CDATE_TIME(2), CDATE_TIME(3), DATE_TIME)
@@ -1799,7 +1799,7 @@
 !/SCRIP    CALL EXTCDE (506)
 !/SCRIP    ENDIF
 
-! SCRIP has now created the data strucure "WGTDATA" and stored the weights 
+! SCRIP has now created the data strucure "WGTDATA" and stored the weights
 ! in it. However, this is only for the present src grid. We want to store the
 ! data for all the src grids. Thus, we use a new data structure of type
 ! "ALLWGT" to store this data. First though, we need to ALLOCATE it:
@@ -1821,7 +1821,7 @@
 
 ! Notes re: short and long way to do this:
 ! pgf90 on IBM Opteron, gfortran, g95, xlf, all tested ok with "short method"
-! pgf90 on our linux workstations (Intel) requires the "long method" 
+! pgf90 on our linux workstations (Intel) requires the "long method"
 ! (possible compiler bug)
 ! ALLWGTS(GSRC)%WGTDATA = WGTDATA                               !short method
 
@@ -1859,7 +1859,7 @@
 ! (again note that "k" is equivalent to isea, but includes *all* points)
 
 !/SCRIP               IF(T38)THEN
-!/SCRIP                  WRITE(MDST,'(/2A)')'      XDST       YDST     ', & 
+!/SCRIP                  WRITE(MDST,'(/2A)')'      XDST       YDST     ', &
 !/SCRIP                  '     XSRC          YSRC          WXWY'
 !/SCRIP                  DO JDST=1,NJDST
 !/SCRIP                     DO IDST=1,NIDST
@@ -1885,7 +1885,7 @@
 !/T38                      ELAPSED_TIME = END_TIME - BEG_TIME(3)
 !/T38                      WRITE(NMYOUT,*) "WMGHGH, LOOP JJ, GSRC= ", GSRC, " TOOK ", ELAPSED_TIME, " MSEC"
 
-!/SCRIP            END DO ! DO JJ=1, GRDHGH(GDST,0) 
+!/SCRIP            END DO ! DO JJ=1, GRDHGH(GDST,0)
 !/SCRIP            GSRC = -999 ! unset grid
 
 ! If SCRIPNC and L_STOP, then cycle LOWRANK_GRID loop and deallocate
@@ -1901,7 +1901,7 @@
 !/SCRIPNC                    CHECK_DEALLOC_STATUS ( ISTAT )
 !/SCRIPNC                  END IF
 !/SCRIPNC                IF ( ALLOCATED(ALLWGTS) ) THEN
-!/SCRIPNC                    DO JJ=1, GRDHGH(GDST,0) 
+!/SCRIPNC                    DO JJ=1, GRDHGH(GDST,0)
 !/SCRIPNC                        GSRC = GRDHGH(GDST,JJ)
 !/SCRIPNC                        IF ( ASSOCIATED(ALLWGTS(GSRC)%WGTDATA) ) THEN
 !/SCRIPNC                            DO KDST=1, DST_GRID_SIZE
@@ -1936,21 +1936,21 @@
 ! 2.b.2 Find points used for boundary data in higher ranked grids
 !
 !!HT: These points are marked in MAPTST as negative values to assure
-!!HT: that the grid poits used for boundary data are not getting 
+!!HT: that the grid poits used for boundary data are not getting
 !!HT: averaged values from high-reswolution grids as that will result
 !!HT: in cyclic, possibly non-conservative updating.
 !!HT:
 !!HT: NBI2S has all necessary data set in WMGLOW as called before WMGHGH.
 !!HT:
-!!HT: JJ loop goes over grids that reviously have been identified as 
+!!HT: JJ loop goes over grids that reviously have been identified as
 !!HT: getting data from the grid presently cousidered.
 !
 ! notes: The purpose of this is to identify points
-!        that should not be used in the averaging procedure. It is 
-!        related to statement in Tolman (OM, 2008):  "Second, Eq (7) is not 
-!        applied to grid points in the low resolution grid that contribute 
+!        that should not be used in the averaging procedure. It is
+!        related to statement in Tolman (OM, 2008):  "Second, Eq (7) is not
+!        applied to grid points in the low resolution grid that contribute
 !        to boundary data for the high resolution grid. This avoids cyclic
-!        updating of data between grids. 
+!        updating of data between grids.
 
 ! notes:   GRDHGH(GDST,0) is number of grids of higher rank than the present
 !                         grid (GDST)
@@ -1961,7 +1961,7 @@
 !        we would need a new variable to use in its place, since we need
 !        to mark the point for use in STMASK determination.
 
-            DO JJ=1, GRDHGH(GDST,0) 
+            DO JJ=1, GRDHGH(GDST,0)
                GSRC   = GRDHGH(GDST,JJ)
                DO IB=1, SIZE(MDATAS(GSRC)%NBI2S(:,1))
                   IF ( MDATAS(GSRC)%NBI2S(IB,1) .EQ. GDST ) THEN
@@ -1993,7 +1993,7 @@
 
 !
 !       Notes: For case of lower ranked grid GDST being irregular, grid indices
-!              i and j do not correspond to x and y, so optimization 
+!              i and j do not correspond to x and y, so optimization
 !              by limiting search in manner of pre-curvilinear versions of
 !              WW3 is not appropriate.
 !
@@ -2006,7 +2006,7 @@
 
             ELSE
 
-! loop through higher ranked grids GSRC 
+! loop through higher ranked grids GSRC
 
                DO JJ=1, GRDHGH(GDST,0)
                   GSRC   = GRDHGH(GDST,JJ)
@@ -2024,8 +2024,8 @@
 !              will not work in a simple way for spherical grids,
 !              so we don't even try ....
 !
-!       Notes: SX and SY are only used in cases where GTYPE .NE. CLGTYPE, 
-!              i.e. regular grids. In case of regular grids, SX and SY 
+!       Notes: SX and SY are only used in cases where GTYPE .NE. CLGTYPE,
+!              i.e. regular grids. In case of regular grids, SX and SY
 !              can be replaced with HPFAC HQFAC, if desired.
 !
 ! find upper and lower bounds of higher ranks grids
@@ -2033,7 +2033,7 @@
                   IF ( (GRIDS(GSRC)%GTYPE .EQ. CLGTYPE) .OR. &
                      (GRIDS(GSRC)%GTYPE .EQ. UNGTYPE) ) THEN
 
-!       Notes: in case of irregular grids, there is no obvious way to 
+!       Notes: in case of irregular grids, there is no obvious way to
 !              offset by dx/2 dy/2, so we omit that sliver (thus we increase
 !              search area slightly).
 
@@ -2051,11 +2051,11 @@
                      YH     = GRIDS(GSRC)%Y0 + ( REAL(GRIDS(GSRC)%NY) - 1.5 ) &
                             * GRIDS(GSRC)%SY
 
-                  ENDIF ! IF ( GRIDS(GSRC)%GTYPE .EQ. CLGTYPE ) 
+                  ENDIF ! IF ( GRIDS(GSRC)%GTYPE .EQ. CLGTYPE )
 
 !
 ! find where this falls in the current (low) ranked grid
-                  
+
                   IF ( FLAGLL ) THEN
                      IDSTL(JJ) = 1
                      IDSTH(JJ) = NX
@@ -2096,7 +2096,7 @@
 !
 ! 2.b.4 Point by point check
 !
-! Notes: We loop through all grids of higher rank 
+! Notes: We loop through all grids of higher rank
 !        GSRC=the grid number of the higher rank grid.
 !        NLMAX is used for dimensioning purposes.
 !        It is apparently using the ratio between the resolution
@@ -2110,7 +2110,7 @@
 
 ! Notes: NLMAX is used to dimension TMPINT,TMPRL, and to set ITAG and LTAG
 !        (MPI case).
-!        As we remove more of the older code, it may turn out that 
+!        As we remove more of the older code, it may turn out that
 !        NLMAX is no longer needed, in which case we can remove this
 !        block of code. For example, the weights data structure is introduced
 !        to WW3 already dimensioned.
@@ -2195,7 +2195,7 @@
                  DY_MIN_GSRC=DIST_MIN
                END IF
 
-! notes: original code was much simpler: 
+! notes: original code was much simpler:
 !              NLMAX  = MAX ( NLMAX , (2+INT(SX/GRIDS(J)%SX+0.001)) *  &
 !                                     (2+INT(SY/GRIDS(J)%SY+0.001)) )
 
@@ -2205,7 +2205,7 @@
 
 !/T38          WRITE(MDST,*)'ratio 1 = ',(DX_MAX_GDST/DX_MIN_GSRC), &
 !/T38          DX_MAX_GDST,DX_MIN_GSRC
-!/T38          WRITE(MDST,*)'ratio 2 = ',(DY_MAX_GDST/DY_MIN_GSRC), & 
+!/T38          WRITE(MDST,*)'ratio 2 = ',(DY_MAX_GDST/DY_MIN_GSRC), &
 !/T38          DY_MAX_GDST,DY_MIN_GSRC
 !/T38          WRITE(MDSE,*)'GSRC, NLMAX = ',GSRC,NLMAX
 
@@ -2221,20 +2221,20 @@
             GSRC=-999 ! unset grid
 
 ! Notes regarding 3 possible scenarios:
-!        If only using SCRIP, then 
+!        If only using SCRIP, then
 !            * set NLMAX=NLMAX_SCRIP here.
 !            * TMPRL_OM will not be created
 !            * TMPRL will be calculated using SCRIP
 !        If only using old method
 !            * NLMAX is already set, and SCRIP switch does not exist, so
 !               nothing is done here
-!            * both TMPRL and TMPRL_OM will be dimensioned 
+!            * both TMPRL and TMPRL_OM will be dimensioned
 !            * TMPRL_OM will be calculated
-!            * TMPRL_OM will be copied to TMPRL for use 
+!            * TMPRL_OM will be copied to TMPRL for use
 !        If using both methods ("DO_CHECKING")
 !            * set NLMAX=MAX(NLMAX, NLMAX_SCRIP) here.
 !            * both TMPRL_OM and TMPRL will be created
-!            * both will be calculated using the 2 methods, and 
+!            * both will be calculated using the 2 methods, and
 !               checked against each other
 !            * the SCRIP version of weights (TMPRL) will be the ones used.
 
@@ -2280,10 +2280,10 @@
 !!HT: grid. Necxt two loops over all relevant point in target grid.
 !!HT:
 
-! Notes: This is the start of the large loop through the individual 
+! Notes: This is the start of the large loop through the individual
 !        grid points of the low-rank grid.
 !        The checks below for JDST.LT.JDSTLA , IDST.LT.IDSTLA etc are to save
-!        time but will only be useful for the case of regular grids. 
+!        time but will only be useful for the case of regular grids.
 
             LOWRANK_J : DO JDST=1, NY
                IF ( JDST.LT.JDSTLA .OR. JDST.GT.JDSTHA ) CYCLE
@@ -2295,7 +2295,7 @@
  ! MAPTST: see Section 2.b.2 above
                   IF ( MAPTST(JDST,IDST) .LT. 0 ) CYCLE
                   XA     = XGRD(JDST,IDST) ! old code: X0 + REAL(IDST-1)*SX
-                  YA     = YGRD(JDST,IDST) ! old code: Y0 + REAL(JDST-1)*SY 
+                  YA     = YGRD(JDST,IDST) ! old code: Y0 + REAL(JDST-1)*SY
 
 !!HT: For each point in the target grid, loop over all relevant high-res
 !!HT: grid (JJ loop).
@@ -2316,15 +2316,15 @@
 !       Note for LLG: Assumption is made that the higher ranked grid
 !                     cannot be global.
 !
-!!HT: Set search range in [candidate] high-res grid. 
+!!HT: Set search range in [candidate] high-res grid.
 
-! Notes: The quantities XL YL XH YH apear to be a bounding box in 
-!        index space for later searching within the high rank grid (or 
-!        otherwise making computations from the high rank grid). They 
-!        are the distance from the coarse grid point to the origin of 
-!        the high rank grid, measured in grid cells of the high rank 
-!        grid. So, they are the i and j values in the high rank  
-!        bounding the low rank grid cell. 
+! Notes: The quantities XL YL XH YH apear to be a bounding box in
+!        index space for later searching within the high rank grid (or
+!        otherwise making computations from the high rank grid). They
+!        are the distance from the coarse grid point to the origin of
+!        the high rank grid, measured in grid cells of the high rank
+!        grid. So, they are the i and j values in the high rank
+!        bounding the low rank grid cell.
 
                      IF (OLD_METHOD)THEN
  ! ...then  we do the counting using the old method
@@ -2365,14 +2365,14 @@
 !        Purpose of counting is unknown (for dimensioning?)
 
 ! Initialize
-                        NR0_OM    = 0 ! counter of MAPSTA=0 (indicates 
+                        NR0_OM    = 0 ! counter of MAPSTA=0 (indicates
                                       ! excluded point)
-                        NRL_OM    = 0 ! counter of MAPSTA=0 (indicates 
-                                      ! excluded point) and MAPST2=0 
+                        NRL_OM    = 0 ! counter of MAPSTA=0 (indicates
+                                      ! excluded point) and MAPST2=0
                                       ! (indicates land)
-                        NR1_OM    = 0 ! counter of |MAPSTA|=1 
+                        NR1_OM    = 0 ! counter of |MAPSTA|=1
                                       ! (indicates sea point)
-                        NR2_OM    = 0 ! counter of |MAPSTA|=2 
+                        NR2_OM    = 0 ! counter of |MAPSTA|=2
                                       ! (indicates boundary point)
                         BDIST_OM(JJ) = 9.99E33
 
@@ -2382,9 +2382,9 @@
                                  ! excluded point
                                  NR0_OM    = NR0_OM + 1
 
-! Notes: Q: What does MAPST2=0 indicate? 
+! Notes: Q: What does MAPST2=0 indicate?
 !        A: MAPST2 is the "second grid status map"
-!           For disabled points (MAPSTA=0) , MAPST2 indicates land (0) or 
+!           For disabled points (MAPSTA=0) , MAPST2 indicates land (0) or
 !           excluded (1). For sea and active boundary points, MAPST2 indicates
 !           a) ice coverage b) drying out of points c) land in moving grid or
 !           inferred land in nesting and d) masked in two-way nesting
@@ -2396,7 +2396,7 @@
                                  NR1_OM    = NR1_OM + 1
 
 ! Notes: check against stored "distance to boundary point"
-!        This BDIST_OM array will be used later, when we select 
+!        This BDIST_OM array will be used later, when we select
 !        the high rank grid to average from.
 
                                  BDIST_OM(JJ) = MIN ( BDIST_OM(JJ) ,     &
@@ -2422,7 +2422,7 @@
 
 !/SCRIP                     BDIST(JJ) = 9.99E33
 
-! Notes on variables used here:  
+! Notes on variables used here:
 ! IDST, JDST given by loop, NIDST set above, the rest we need to set here
 
 !/SCRIP                     NISRC=GRIDS(GSRC)%NX
@@ -2445,10 +2445,10 @@
 !/SCRIP                     END DO
 
 ! Pull NR0, etc. from storage...
-!/SCRIP                     NR0 = ALLWGTS(GSRC)%WGTDATA(KDST)%NR0 
+!/SCRIP                     NR0 = ALLWGTS(GSRC)%WGTDATA(KDST)%NR0
 !                             counter of MAPSTA=0 (indicates excluded point)
 !/SCRIP                     NRL = ALLWGTS(GSRC)%WGTDATA(KDST)%NRL
-!                             counter of MAPSTA=0 (indicates excluded point) 
+!                             counter of MAPSTA=0 (indicates excluded point)
 !                             and MAPST2=0 (indicates land)
 !/SCRIP                     NR1 = ALLWGTS(GSRC)%WGTDATA(KDST)%N
 !                             counter of |MAPSTA|=1 (indicates sea point)
@@ -2486,7 +2486,7 @@
                         IF(BDIST_OM(JJ).NE.BDIST(JJ))THEN
                            IF ( IMPROC.EQ.NMPERR ) &
                                 WRITE (MDSE,'(/2A,2(F12.5))') &
-                                ' *** ERROR WMGHGH: ', & 
+                                ' *** ERROR WMGHGH: ', &
                                 ' BDIST_OM(JJ),BDIST(JJ) = ', &
                                 BDIST_OM(JJ),BDIST(JJ)
                            CALL EXTCDE ( 999 )
@@ -2506,13 +2506,13 @@
                      END IF
 
 ! Notes: Potential future improvement: for irregular grids, it would make
-! more sense to use the overlapped area, rather than simply counting cells 
-! to decide on "inferred land". However, since grid cell size it typically 
+! more sense to use the overlapped area, rather than simply counting cells
+! to decide on "inferred land". However, since grid cell size it typically
 ! fairly uniform locally, the current approach will suffice for now.
 
-! Notes: This is the only place that the "NRL" "NR0" "NR1" and "NR2" variables 
+! Notes: This is the only place that the "NRL" "NR0" "NR1" and "NR2" variables
 !        are used directly. They affect MAPST2 indirectly below.
-!        The calculation itself is essentially "50% or more of the grid 
+!        The calculation itself is essentially "50% or more of the grid
 !        cells are land".
 
                      IF ( NRL .GT. (NR0+NR1+NR2)/2 ) THEN
@@ -2526,7 +2526,7 @@
 
 ! Notes: for a grid cell to be considered "OK", we require that there is
 ! at least one sea point being used, and no boundary points being used
-                   
+
                         IF ( GRIDOK(JJ) ) NROK = NROK + 1
                      END IF
 
@@ -2537,32 +2537,32 @@
 
 ! Notes:  exit IDST loop since there are no "OK" source grid cells for this
 ! dst point. At this point, INFLND could be 1, but isn't necessarily 1
-                     
+
                      CYCLE
 
                   ELSE
 
 ! Notes: If any grids are OK for this dst point, then we override any prior
 ! setting of INFLD=1. Apparently this is for the situation of having some src
-! grids giving INFLD=1 and another giving INFLD=0 for the same dst point. 
+! grids giving INFLD=1 and another giving INFLD=0 for the same dst point.
 ! I wouldn't expect this to happen very often.
-                     
+
                      INFLND(JDST,IDST) = 0
 
                   END IF
 !
 ! 2.b.5 Select source grid
 !
-! Notes: It appears that we are selecting the high rank grid from 
+! Notes: It appears that we are selecting the high rank grid from
 !        which we will perform the averaging.
-!        The code is written such that the first higher rank 
+!        The code is written such that the first higher rank
 !        grid that we find has the rank that we want, but isn't necessarily the
-!        grid that we want. 
+!        grid that we want.
 !        Are grids necessarily in order of rank? If so, then we want the grid
 !        that is higher rank but of nearest rank to the present grid.
 !        Anyway, once we have decided on the grid rank that we want, we select
 !        the specific grid according to criterion: larger distance to
-!        boundary = better 
+!        boundary = better
 !        Keep in mind that this grid is selected for *this* (IDST,JDST) and not
 !        necesssarily for the next...
 
@@ -2573,22 +2573,22 @@
 !!HT: the boundary distance in the high-res grid, stored in BDIST is
 !!HT: used to make the choice.
 
-!!ER: Old logic was to select a grid that is of the "next rank up, 
-!!ER: for which data is available". This was done by searching 
+!!ER: Old logic was to select a grid that is of the "next rank up,
+!!ER: for which data is available". This was done by searching
 !!ER: from 1 to GRDHGH (remember that the available source grids
 !!ER: are in order of rank), and exiting when the rank increased.
 !!ER: The problem with selecting the "lowest rank grid with rank
-!!ER: greater than that of GDST" is that at this point, we have 
+!!ER: greater than that of GDST" is that at this point, we have
 !!ER: no knowledge of what will be masked in that SRC grid, since
 !!ER: we haven't updated MAPSTA for that GSRC yet, based on what
 !!ER: points are covered by higher rank grids (in case of masking
-!!ER: computations). We can avoid this problem by reversing the 
+!!ER: computations). We can avoid this problem by reversing the
 !!ER: order of GSRC search (from highest rank to lowest rank of
-!!ER: higher rank). For example, grid 1 wants data from grid 2, 
+!!ER: higher rank). For example, grid 1 wants data from grid 2,
 !!ER: but just gets zeros because grid 2 is masked there, because
 !!ER: grid 2 is masked by grid 3 in Section 2.3.2 below. Going
-!!ER: directly to GSRC=3 for GDST=1 (skipping GSRC=2) avoids 
-!!ER: this: the highest rank at that location will never be 
+!!ER: directly to GSRC=3 for GDST=1 (skipping GSRC=2) avoids
+!!ER: this: the highest rank at that location will never be
 !!ER: masked by a higher rank grid.
 
                   DO JJ=GRDHGH(GDST,0),1,-1
@@ -2598,7 +2598,7 @@
 
                      IF ( GRIDOK(JJ) ) THEN
                         IF ( JF .EQ. 0 ) THEN ! we haven't already found a grid
-                           JF     = GSRC ! now we have found a grid. 
+                           JF     = GSRC ! now we have found a grid.
                            JR     = GRANK(GSRC)
 ! this is the rank that we want....the rank of the first grid that we find
                            JD     = BDIST(JJ) ! larger distance = better
@@ -2606,7 +2606,7 @@
 ! we already found a grid, but maybe this one is better
                            IF ( GRANK(GSRC) .NE. JR ) EXIT
 ! this is not the rank that we want
-                           IF ( BDIST(JJ) .GT. JD ) THEN 
+                           IF ( BDIST(JJ) .GT. JD ) THEN
 ! we like this grid better
                               JF     = GSRC
                               JD     = BDIST(JJ)
@@ -2635,14 +2635,14 @@
                   TMPRL (NRTOT, 0) = JD * SIG(1) / DTMAX
 
 ! Notes: Calculation for XL YL XH YH is same as it was in section 2.b.4, so
-!        see notes in that section. 
+!        see notes in that section.
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !...Begin block of code for computing weights using old method
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-                  
+
                   IF (OLD_METHOD)THEN
-! it is OK to do the counting using the old method 
+! it is OK to do the counting using the old method
 ! (These variables are saved with "_OM" suffix)
 
                      DO ITMP=-4,-1
@@ -2706,7 +2706,7 @@
 !...Begin block of code for "computing" weights using new method
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-! Notes: Weights have already been computed by SCRIP. 
+! Notes: Weights have already been computed by SCRIP.
 !        We just need to transfer them to TMPINT and TMPRL
 
 !/SCRIP                  KDST=(JDST-1)*NIDST+IDST
@@ -2724,7 +2724,7 @@
 !/SCRIP                  IF ( NLOC .GT. NLMAX ) THEN
 !/SCRIP                     IF ( IMPROC.EQ.NMPERR ) THEN
 !/SCRIP                        WRITE (MDSE,'(/2A,4(1x,I8))') &
-!/SCRIP                        ' *** ERROR WMGHGH: ', & 
+!/SCRIP                        ' *** ERROR WMGHGH: ', &
 !/SCRIP                        ' IDST,JDST,NLOC,NLMAX = ', &
 !/SCRIP                        IDST,JDST,NLOC,NLMAX
 !/SCRIP                        WRITE(MDSE,1021)
@@ -2745,7 +2745,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-!...Begin block of code that is just for testing 
+!...Begin block of code that is just for testing
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
                   IF (DO_CHECKING)THEN
@@ -2786,7 +2786,7 @@
 !/T38                WRITE(MDST,*)'PASSED TEST 2'
 
                   END IF ! (if both grids are regular grids)
-                  
+
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !...End block of code that is just for testing
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -2798,7 +2798,7 @@
 
 !/T38       WRITE(MDST,*)'WMGHGH Section 2.b.6 completed.'
 
-! Notes: We are done with the counting. If we didn't use SCRIP to get 
+! Notes: We are done with the counting. If we didn't use SCRIP to get
 !     TMPINT, TMPRL, then we need to set them using the _OM variables.
 
             IF(.NOT.LSCRIP)THEN
@@ -2848,8 +2848,8 @@
 !!HT:        MAPTST that have been marked as used for boundary points in
 !!HT:        the corrsponding high-res grids.
 !!HT: NIT sets the stencil width of the propagation scheme, used to see
-!!HT:        how far we need to move in from the boundary points of 
-!!HT:        the high-res grid to reach the area in the low-res grid 
+!!HT:        how far we need to move in from the boundary points of
+!!HT:        the high-res grid to reach the area in the low-res grid
 !!HT:        where we do not need to compute.
 
             STMASK(:,1:NX) = MAPTST .LT. 0
@@ -2864,7 +2864,7 @@
             IDSTLA=2
             IDSTHA=NX-1
 
-! notes....bug fix: in official release 3.14, the if-then below 
+! notes....bug fix: in official release 3.14, the if-then below
 !  was missing. This would produce incorrect results for a global grid that
 !  had a higher rank grid on the branch cut (180 to -180 or 360 to 0). See
 !  treatment of STMASK after the if-then statement. There, it is clear that
@@ -3160,7 +3160,7 @@
 !        This is important because ALLWGTS will be allocated again for the next
 !        dst grid.
 
-!/SCRIP            DO JJ=1, GRDHGH(GDST,0) 
+!/SCRIP            DO JJ=1, GRDHGH(GDST,0)
 !/SCRIP               GSRC   = GRDHGH(GDST,JJ)
 !/SCRIP               DO KDST=1,DST_GRID_SIZE
 !/SCRIP                  DEALLOCATE ( ALLWGTS(GSRC)%WGTDATA(KDST)%W, STAT=ISTAT )
@@ -3488,10 +3488,10 @@
         END IF
 
 ! Unresolved bug: this triggers even for 2 irregular grids that are not overlapping!
-!   We should only be checking for cases of 2 irregular grids of equal rank that 
+!   We should only be checking for cases of 2 irregular grids of equal rank that
 !   are overlapping. Unfortunately, at this point in the routine, we don't know
 !   whether they are overlapping...requires more code to do this, since all code
-!   in this routine is for regular grids. Fortunately, there is really no 
+!   in this routine is for regular grids. Fortunately, there is really no
 !   disadvantage to making the two irregular grids to be different rank using
 !   ww3_multi.inp
 
@@ -3714,7 +3714,7 @@
             IY     = STORES(I,J)%IY(JJ)
             IF ( IX.EQ.1 .OR. IX.EQ.NX .OR. IY.EQ.1 .OR. IY.EQ.NY ) THEN
                 MASKA(IY,IX) = STORES(I,J)%FLA(JJ) .OR.               &
-                               STORES(I,J)%NAV(JJ).EQ.0 
+                               STORES(I,J)%NAV(JJ).EQ.0
                 IF ( ABS(MAPSTA(IY,IX)).EQ.2 .AND.                    &
                      .NOT.STORES(I,J)%FLA(JJ) .AND.                   &
                      STORES(I,J)%NAV(JJ).GT.0 ) THEN
@@ -3969,8 +3969,8 @@
         CHECK_ALLOC_STATUS ( ISTAT )
         MAP3D  = 0
         WGT3D  = 0.
-        NREC   = 0 
-        NSND   = 0 
+        NREC   = 0
+        NSND   = 0
 !
 ! 3.b Filling MAP3D and WGT3D, as well as NREC and NSND
 !
@@ -4269,7 +4269,7 @@
 !
 ! 4.b.2 All other grids, info for receiving
 !
-        DO J=1, NRGRD 
+        DO J=1, NRGRD
           IF ( .NOT. SHRANK(I,J) ) CYCLE
           IF ( EQSTGE(I,J)%NREC .EQ. 0 ) CYCLE
           NTL    = 0
@@ -4294,7 +4294,7 @@
 !
 ! 4.b.3 All other grids, info for sending
 !
-        DO J=1, NRGRD 
+        DO J=1, NRGRD
           IF ( .NOT. SHRANK(I,J) ) CYCLE
           IF ( EQSTGE(I,J)%NSND .EQ. 0 ) CYCLE
           NTPP   = 0
@@ -4445,9 +4445,9 @@
 !
 ! notes: This resolution test, with FACMAX=2, is pretty strict, so
 !        it is not going to be appropriate for irregular grids.
-!        We'll just have to trust the judgement of the user in the 
-!        case of irregular grids. But if we change our minds and do 
-!        some kind of check for irregular grids, we could make 
+!        We'll just have to trust the judgement of the user in the
+!        case of irregular grids. But if we change our minds and do
+!        some kind of check for irregular grids, we could make
 !        a check against median(HPFAC) and median(HQFAC).
 
       DO I=1, NRGRD
@@ -4611,7 +4611,7 @@
 !/
 !  1. Purpose :
 !
-!     Generate map with flogs for need of spectral grid conversion 
+!     Generate map with flogs for need of spectral grid conversion
 !     between models.
 !
 !  2. Method :

--- a/model/ftn/wminiomd.ftn
+++ b/model/ftn/wminiomd.ftn
@@ -18,7 +18,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -270,7 +270,7 @@
 !/MPI            ITAG   = MTAG0 + IMOD + (J-1)*NRGRD
 !/MPI            IF ( ITAG .GT. MTAG1 ) THEN
 !/MPI                WRITE (MDSE,1001)
-!/MPI                CALL EXTCDE (1001) 
+!/MPI                CALL EXTCDE (1001)
 !/MPI              END IF
 !/MPI            DO IP=1, NMPROC
 !/MPI              IF ( ALLPRC(IP,J) .NE. 0 .AND.                 &
@@ -303,13 +303,13 @@
             END DO
 !
 !/MPI          DO IP=1, NMPROC
-!/MPI            IF ( ALLPRC(IP,J) .NE. 0 .AND.                   &    
+!/MPI            IF ( ALLPRC(IP,J) .NE. 0 .AND.                   &
 !/MPI                 ALLPRC(IP,J) .LE. OUTPTS(J)%NAPROC ) THEN
 !/MPI                NRQ    = NRQ + 1
 !/MPI                ITAG   = IT0 + I
 !/MPI                IF ( ITAG .GT. MTAG1 ) THEN
 !/MPI                    WRITE (MDSE,1001)
-!/MPI                    CALL EXTCDE (1001) 
+!/MPI                    CALL EXTCDE (1001)
 !/MPI                  END IF
 !/MPI                CALL MPI_ISEND ( SBPI(1,I), NSPEC, MPI_REAL, &
 !/MPI                                 IP-1, ITAG, MPI_COMM_MWAVE, &
@@ -379,7 +379,7 @@
 !/
       END SUBROUTINE WMIOBS
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE WMIOBG ( IMOD, DONE ) 
+      SUBROUTINE WMIOBG ( IMOD, DONE )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -548,7 +548,7 @@
         END IF
 !
 ! -------------------------------------------------------------------- /
-! 1.  Testing / gathering data in staging arrays 
+! 1.  Testing / gathering data in staging arrays
 !
 !/T      WRITE (MDST,9010)
 !
@@ -572,7 +572,7 @@
 ! 1.b Distributed memory version - - - - - - - - - - - - - - - - - - - /
 !
 !/MPIT        WRITE (MDST,9011) NBISTA(IMOD)
-! 
+!
 ! 1.b.1 NBISTA = 0
 !       Check if staging arrays are initialized.
 !       Post the proper receives.
@@ -602,7 +602,7 @@
 !/MPI                         SIZE(BPSTGE(IMOD,J)%SBPI(1,:)) .NE.     &
 !/MPI                                             NBI2G(IMOD,J) ) THEN
 !/MPI                        IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1003)
-!/MPI                        CALL EXTCDE (1003) 
+!/MPI                        CALL EXTCDE (1003)
 !/MPI                      END IF
 !/MPIT                    WRITE (MDST,9012) J, 'TESTED'
 !/MPI                  END IF
@@ -694,7 +694,7 @@
 ! ..... End IF in 1.b.1
 !
 !/MPI        END IF
-! 
+!
 ! 1.b.2 NBISTA = 1
 !       Wait for communication to finish.
 !       If DONE defined, check if done, otherwise wait.
@@ -741,7 +741,7 @@
 !
 !/MPI          NBISTA(IMOD) = 2
 !/MPIT          WRITE (MDST,9011) NBISTA(IMOD)
-! 
+!
 ! 1.b.3 Convert spectra if needed
 !
 !/MPI          DO J=1, NRGRD
@@ -1157,7 +1157,7 @@
 !
 ! -------------------------------------------------------------------- /
 ! 0.  Initializations
-! 
+!
 !/T      WRITE (MDST,9000) IMOD, FLGHG1
 !
       IF ( .NOT. FLGHG1 ) THEN
@@ -1172,7 +1172,7 @@
       CALL W3SETG ( IMOD, MDSE, MDST )
       CALL W3SETW ( IMOD, MDSE, MDST )
       CALL W3SETA ( IMOD, MDSE, MDST )
-! 
+!
 ! -------------------------------------------------------------------- /
 ! 1.  Loop over grids
 !
@@ -1248,7 +1248,7 @@
 !/MPI          ITAG   = HGSTGE(J,IMOD)%ISEND(I,5) + IT0
 !/MPI          IF ( ITAG .GT. MTAG2 ) THEN
 !/MPI              WRITE (MDSE,1001)
-!/MPI              CALL EXTCDE (1001) 
+!/MPI              CALL EXTCDE (1001)
 !/MPI            END IF
 !
           DO IS=1, NSPEC
@@ -1308,7 +1308,7 @@
 !/
       END SUBROUTINE WMIOHS
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE WMIOHG ( IMOD, DONE ) 
+      SUBROUTINE WMIOHG ( IMOD, DONE )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -1469,12 +1469,12 @@
       CALL W3SETA ( IMOD, MDSE, MDST )
 !
 ! -------------------------------------------------------------------- /
-! 1.  Testing / gathering data in staging arrays 
-! 
+! 1.  Testing / gathering data in staging arrays
+!
 !/T      WRITE (MDST,9010) TIME
 !
 ! 1.a Shared memory version, test valid times. - - - - - - - - - - - - /
-! 
+!
 !/SHRD      DO J=1, NRGRD
 !
 !/SHRD        IF ( FLGALL ) THEN
@@ -1538,7 +1538,7 @@
 ! ..... Spectra
 !
 !/MPI                IT0 = MTAG1 + 1
-!/MPI                SHGH  => HGSTGE(IMOD,J)%SHGH 
+!/MPI                SHGH  => HGSTGE(IMOD,J)%SHGH
 !
 !/MPI                IF ( FLGALL ) THEN
 !/MPI                    NTOT   = HGSTGE(IMOD,J)%NREC
@@ -1566,7 +1566,7 @@
 !
 ! ..... End IF for posting receives 1.b.1
 !
-!/MPIT                WRITE (MDST,9017) 
+!/MPIT                WRITE (MDST,9017)
 !/MPI              END IF
 !
 ! ..... End grid loop J in 1.b.1
@@ -1579,7 +1579,7 @@
 !/MPI          DEALLOCATE ( IRQ )
 !
 ! ..... Reset status
-! 
+!
 !/MPI          IF ( NRQ .GT. 0 ) THEN
 !/MPI              HGHSTA(IMOD) = 1
 !/MPIT              WRITE (MDST,9011) HGHSTA(IMOD)
@@ -1654,7 +1654,7 @@
 !
 ! -------------------------------------------------------------------- /
 ! 2.  Data available, process grid by grid
-! 
+!
 !/T      WRITE (MDST,9020)
 !
 ! 2.a Loop over grids
@@ -1726,7 +1726,7 @@
 !
 ! -------------------------------------------------------------------- /
 ! 3.  Set flag if reqeusted
-! 
+!
       IF ( PRESENT(DONE) ) DONE = .TRUE.
 !
 !/PDLIB      CALL PDLIB_exchange2Dreal(VA(:,1:NPA))
@@ -1999,7 +1999,7 @@
 !
 ! -------------------------------------------------------------------- /
 ! 0.  Initializations
-! 
+!
 !/T      WRITE (MDST,9000) IMOD
 !/T      WRITE (MDST,9001) EQSTGE(:,IMOD)%NSND
 !
@@ -2007,7 +2007,7 @@
       CALL W3SETG ( IMOD, MDSE, MDST )
       CALL W3SETW ( IMOD, MDSE, MDST )
       CALL W3SETA ( IMOD, MDSE, MDST )
-! 
+!
 ! -------------------------------------------------------------------- /
 ! 1.  Loop over grids
 !
@@ -2068,7 +2068,7 @@
 !/MPI          ITAG   = EQSTGE(J,IMOD)%STG(I) + IT0
 !/MPI          IF ( ITAG .GT. MTAG_UB ) THEN
 !/MPI              WRITE (MDSE,1001)
-!/MPI              CALL EXTCDE (1001) 
+!/MPI              CALL EXTCDE (1001)
 !/MPI            END IF
 !
           DO IS=1, NSPEC
@@ -2084,7 +2084,7 @@
 !/MPI                       ITAG, MPI_COMM_MWAVE, IRQ(NRQ), IERR_MPI )
 !/MPIT              WRITE (MDST,9082) NRQ, JSEA, IP, ITAG-MTAG2,      &
 !/MPIT                                IRQ(NRQ), IERR_MPI
-!/MPI            ELSE 
+!/MPI            ELSE
 !/MPI              NRQOUT = NRQOUT + 1
 !/MPI              OUTDAT(NRQOUT,1) = I
 !/MPI              OUTDAT(NRQOUT,2) = I1
@@ -2127,7 +2127,7 @@
 !/
       END SUBROUTINE WMIOES
 !/ ------------------------------------------------------------------- /
-      SUBROUTINE WMIOEG ( IMOD, DONE ) 
+      SUBROUTINE WMIOEG ( IMOD, DONE )
 !/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
@@ -2318,12 +2318,12 @@
 !/MPIT            WRITE (MDST,9013) VTIME, DTTST
 !
 ! ..... Post receives for data gather
-! 
+!
 !/MPI            IF ( DTTST .NE. 0. ) THEN
 !/MPIT                WRITE (MDST,9014) J
 !
 ! ..... Spectra
-! 
+!
 !/MPI                IT0 = MTAG2 + 1
 !/MPI                SEQL  => EQSTGE(IMOD,J)%SEQL
 !
@@ -2363,7 +2363,7 @@
 !/MPI          DEALLOCATE ( IRQ )
 !
 ! ..... Reset status
-! 
+!
 !/MPI          IF ( NRQ .GT. 0 ) THEN
 !/MPI              EQLSTA(IMOD) = 1
 !/MPIT              WRITE (MDST,9011) EQLSTA(IMOD)
@@ -2509,7 +2509,7 @@
 ! 3.  Set flag if requested
 !
       IF ( PRESENT(DONE) ) DONE = .TRUE.
-!       
+!
 !/PDLIB  CALL PDLIB_exchange2Dreal(VA(:,1:NPA))
 !
 ! Formats

--- a/model/ftn/wminitmd.ftn
+++ b/model/ftn/wminitmd.ftn
@@ -36,7 +36,7 @@
 !/    18-Dec-2013 : Adding error checking for FLAGLL    ( version 4.16 )
 !/    28-Jan-2014 : Add memory hwm to profiling.        ( version 5.00 )
 !/    04-Feb-2014 : Switched clock to DATE_AND_TIME     ( version 4.18 )
-!/                  (A. Chawla and Mark Szyszka) 
+!/                  (A. Chawla and Mark Szyszka)
 !/    27-May-2014 : Bug fix prf file name.              ( version 5.02 )
 !/    20-Jan-2017 : Update to new W3GSRUMD APIs         ( version 6.02 )
 !/    20-Jan-2017 : Modify input forcing flags to support coupler input.
@@ -46,13 +46,13 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
 !     Initialization of the multi-grid wave model. As a preparation
-!     for coupled modeling, all initialization, including the 
+!     for coupled modeling, all initialization, including the
 !     processing of the input file has ben included in the routine.
 !
 !  2. Variables and types :
@@ -130,7 +130,7 @@
 !/                  required for regridding.            ( version 4.08 )
 !/                  (T. J. Campbell, NRL)
 !/    15-Apr-2013 : Changes the reading of output fields( version 4.10 )
-!/                  (F. Ardhuin) 
+!/                  (F. Ardhuin)
 !/    28-Jan-2014 : Add memory hwm to profiling.        ( version 5.00 )
 !/    27-May-2014 : Bug fix prf file name.              ( version 5.02 )
 !/    17-Sep-2014 : Read mod_def before inp file        ( version 5.03 )
@@ -229,12 +229,12 @@
 !
 !  7. Remarks :
 !
-!     - When running regtests in cases where disk is non-local 
+!     - When running regtests in cases where disk is non-local
 !       (i.e. NFS used), there can be a huge improvment in compute
-!       time by using /var/tmp/ for log files. 
+!       time by using /var/tmp/ for log files.
 !       See commented line at "OPEN (MDSO,FILE=..."
 !
-!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where lowest possible 
+!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where lowest possible
 !       value of JFIRST is JFIRST=-7
 !
 !  8. Structure :
@@ -309,12 +309,12 @@
 !       !/SHRD  Switch for shared / distributed memory architecture.
 !       !/DIST  Id.
 !       !/MPI   Id.
-!                            
+!
 !       !/MGW   Moving grid wind correction.
 !       !/MGP   Moving grid propagation correction.
 !
 !       !/O10   Enable output identifying start and end of routine
-!      
+!
 !       !/F90  FORTRAN 90 specific extensions.
 !
 !       !/S     Enable subroutine tracing.
@@ -334,7 +334,7 @@
       USE WMMDATMD, ONLY: WMNDAT, WMSETM, WMDIMD
 !
       USE W3FLDSMD, ONLY: W3FLDO
-      USE W3IOGOMD, ONLY: W3READFLGRD 
+      USE W3IOGOMD, ONLY: W3READFLGRD
       USE W3IOGRMD, ONLY: W3IOGR
       USE W3INITMD, ONLY: W3INIT
       USE WMGRIDMD, ONLY: WMRSPC, WMGLOW, WMGEQL, WMGHGH
@@ -548,7 +548,7 @@
 !
       LFILE  = 'log.mww3'
       IW     = 1 + INT ( LOG10 ( REAL(NMPROC) + 0.5 ) )
-      IW     = MAX ( 3 , MIN ( 9 , IW ) ) 
+      IW     = MAX ( 3 , MIN ( 9 , IW ) )
       WRITE (FORMAT,'(A5,I1.1,A1,I1.1,A4)') '(A4,I',IW,'.',IW,',A5)'
 !/SHRD       TFILE  = 'test.mww3'
 !/DIST       WRITE (TFILE,FORMAT) 'test', IMPROC, '.mww3'
@@ -639,8 +639,8 @@
       CALL W3NDAT (        MDSE2, MDST )
       CALL W3NAUX (        MDSE2, MDST )
       CALL W3NOUT (        MDSE2, MDST )
-      CALL W3NINP (        MDSE2, MDST ) 
-      CALL WMNDAT (        MDSE2, MDST ) 
+      CALL W3NINP (        MDSE2, MDST )
+      CALL WMNDAT (        MDSE2, MDST )
 !
 ! 2.c Set up I/O for individual models (initial)
 !
@@ -655,7 +655,7 @@
       FLGR2  = .FALSE.
       IPRT   = 0
 !
-! ... Fixed and recycleable unit numbers.      
+! ... Fixed and recycleable unit numbers.
 !
       CALL WMUGET ( MDSE, MDST, NDSREC, 'INP' )
       CALL WMUSET ( MDSE, MDST, NDSREC, .TRUE., 'I/O', NAME='...',    &
@@ -825,7 +825,7 @@
                     USEINP(INPMAP(I,J)) = .TRUE.
                   END IF
               END IF
-!        INFLAGS2 is initial value of INFLAGS1. Unlike INFLAGS1, 
+!        INFLAGS2 is initial value of INFLAGS1. Unlike INFLAGS1,
 !           it does not change during the simulation
          IF(.NOT. INFLAGS2(J)) INFLAGS2(J)=INFLAGS1(J)
          END DO !         DO J=JFIRST, 7
@@ -903,7 +903,7 @@
           DO I=1, NRGRD
             IF ( GRANK(I).EQ.RNKTMP .AND. GRPMIN.EQ.TMPGRP(I) ) THEN
                 GRGRP(I)  = NRGRP
-                TMPGRP(I) = GRPMAX 
+                TMPGRP(I) = GRPMAX
                 NINGRP(NRGRP) = NINGRP(NRGRP) + 1
               END IF
             END DO
@@ -1035,7 +1035,7 @@
               IF ( NMPLOG .EQ. IMPROC ) WRITE (MDSO,934) LINE(1:JJJ)
               LINE(1:6) = '      '
               JJJ       = 6
-            END IF 
+            END IF
           WRITE (LINE(JJJ+1:JJJ+3),'(I3)') INGRP(J,JJ)
 !
           LINE(JJJ+4:JJJ+5) = ' ('
@@ -1075,10 +1075,10 @@
       DO I=1, NRGRD
         CALL W3SETW ( I, MDSE, MDST )
         TIME   = STIME
-        END DO 
+        END DO
 !
       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) WRITE (MDSS,943)
-!              
+!
       CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
       READ (MDSI,*,END=2001,ERR=2002) FLGHG1, FLGHG2
       FLGHG2 = FLGHG1 .AND. FLGHG2
@@ -1112,7 +1112,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
         READ (MDSI,*,END=2001,ERR=2002) (ODAT(I,1),I=5*(J-1)+1,5*J)
         ODAT(5*(J-1)+3,1) = MAX ( 0 , ODAT(5*(J-1)+3,1) )
-!                 
+!
         IF ( ODAT(5*(J-1)+3,1) .NE. 0 ) THEN
             IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC )                &
                 WRITE (MDSS,951) J, IDOTYP(J)
@@ -1147,7 +1147,7 @@
 !
 ! 5.c Type 1: fields of mean wave parameters
 !
-              FLGRD(:,:,:)=.FALSE. ! Initialize FLGRD 
+              FLGRD(:,:,:)=.FALSE. ! Initialize FLGRD
               CALL W3READFLGRD ( MDSI, MDSS, MDSO, MDSE2, COMSTR, FLG1D,    &
                                  FLG2D, IMPROC, NMPSCR, IERR )
               FLGRD(:,:,1)=FLG2D
@@ -1357,7 +1357,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
         READ (MDSI,*,END=2001,ERR=2002) (ODAT(II,I),II=5*(J-1)+1,5*J)
         ODAT(5*(J-1)+3,I) = MAX ( 0 , ODAT(5*(J-1)+3,I) )
-! 
+!
         IF ( ODAT(5*(J-1)+3,I) .NE. 0 ) THEN
             TTIME(1) = ODAT(5*(J-1)+1,I)
             TTIME(2) = ODAT(5*(J-1)+2,I)
@@ -1520,7 +1520,7 @@
 ! 6.  Read moving grid data ------------------------------------------ /
 !
 !     Only a single set of data are provided to be applied to all
-!     the grids, because this is only intended for test cases. 
+!     the grids, because this is only intended for test cases.
 !     For true implementations, the jumping grid will be used.
 !
       IF ( INFLAGS1(8) ) THEN
@@ -1894,13 +1894,13 @@
       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) THEN
           WRITE (MDSS,976)
           IF ( UNIPTS ) WRITE (MDSS,977) NMPUPT
-          WRITE (MDSS,*) 
+          WRITE (MDSS,*)
         END IF
 !
       IF ( NMPLOG .EQ. IMPROC ) THEN
           WRITE (MDSO,1976)
           IF ( UNIPTS ) WRITE (MDSO,1977) NMPUPT
-          WRITE (MDSO,*) 
+          WRITE (MDSO,*)
         END IF
 !
       DEALLOCATE ( TMPRNK, NDPOUT )
@@ -2439,8 +2439,8 @@
 !/MPI      DO I=1, NRGRD
 !/MPI        CALL WMSETM ( I, MDSE, MDST )
 !/MPI        CALL W3SETG ( I, MDSE, MDST )
-! the next line (with the W3GSUD call) removed Jan 8 2013. 
-! ...ref: personal communication, 
+! the next line (with the W3GSUD call) removed Jan 8 2013.
+! ...ref: personal communication,
 ! ...email from Rogers to Alves, Campbell, Tolman, Chawla Dec 13 2012.
 ! REMOVED  !/MPI        IF ( MPI_COMM_GRD .EQ. MPI_COMM_NULL ) CALL W3GSUD( GSU )
 !/MPI        END DO
@@ -2718,12 +2718,12 @@
       RETURN
 !
  2020 CONTINUE
-      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1020) 
+      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1020)
       CALL EXTCDE ( 2020 )
       RETURN
 !
  2021 CONTINUE
-      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1021) 
+      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1021)
       CALL EXTCDE ( 2021 )
       RETURN
 !
@@ -2850,7 +2850,7 @@
   954 FORMAT ( '            Interval : ',A/)
   955 FORMAT ( '            Fields   : ',A)
   956 FORMAT ( '                       ',A)
-  957 FORMAT ( '            Point  1 : ',2E14.6,2X,A)             
+  957 FORMAT ( '            Point  1 : ',2E14.6,2X,A)
   958 FORMAT ( '              ',I6,' : ',2E14.6,2X,A)
   959 FORMAT ( '            No points defined')
   960 FORMAT ( '            The file with ',A,' data is ',A,'.')
@@ -2913,7 +2913,7 @@
 !
  1001 FORMAT (/' *** WAVEWATCH III ERROR IN WMINIT : *** '/           &
                '     PREMATURE END OF INPUT FILE'/)
-! 
+!
  1002 FORMAT (/' *** WAVEWATCH III ERROR IN WMINIT : *** '/           &
                '     ERROR IN READING FROM INPUT FILE'/               &
                '     IOSTAT =',I5/)
@@ -3051,7 +3051,7 @@
 !/                  required for regridding.            ( version 4.08 )
 !/                  (T. J. Campbell, NRL)
 !/    15-Apr-2013 : Changes the reading of output fields( version 4.10 )
-!/                  (F. Ardhuin) 
+!/                  (F. Ardhuin)
 !/    28-Jan-2014 : Add memory hwm to profiling.        ( version 5.00 )
 !/    27-May-2014 : Bug fix prf file name.              ( version 5.02 )
 !/    17-Sep-2014 : Read mod_def before inp file        ( version 5.03 )
@@ -3151,12 +3151,12 @@
 !
 !  7. Remarks :
 !
-!     - When running regtests in cases where disk is non-local 
+!     - When running regtests in cases where disk is non-local
 !       (i.e. NFS used), there can be a huge improvment in compute
-!       time by using /var/tmp/ for log files. 
+!       time by using /var/tmp/ for log files.
 !       See commented line at "OPEN (MDSO,FILE=..."
 !
-!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where lowest possible 
+!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where lowest possible
 !       value of JFIRST is JFIRST=-7
 !
 !  8. Structure :
@@ -3231,12 +3231,12 @@
 !       !/SHRD  Switch for shared / distributed memory architecture.
 !       !/DIST  Id.
 !       !/MPI   Id.
-!                            
+!
 !       !/MGW   Moving grid wind correction.
 !       !/MGP   Moving grid propagation correction.
 !
 !       !/O10   Enable output identifying start and end of routine
-!      
+!
 !       !/F90  FORTRAN 90 specific extensions.
 !
 !       !/S     Enable subroutine tracing.
@@ -3317,8 +3317,8 @@
 !/ Local parameters
 !/
       TYPE(NML_DOMAIN_T)                      :: NML_DOMAIN
-      TYPE(NML_INPUT_GRID_T), ALLOCATABLE     :: NML_INPUT_GRID(:) 
-      TYPE(NML_MODEL_GRID_T), ALLOCATABLE     :: NML_MODEL_GRID(:) 
+      TYPE(NML_INPUT_GRID_T), ALLOCATABLE     :: NML_INPUT_GRID(:)
+      TYPE(NML_MODEL_GRID_T), ALLOCATABLE     :: NML_MODEL_GRID(:)
       TYPE(NML_OUTPUT_TYPE_T), ALLOCATABLE    :: NML_OUTPUT_TYPE(:)
       TYPE(NML_OUTPUT_DATE_T), ALLOCATABLE    :: NML_OUTPUT_DATE(:)
       TYPE(NML_HOMOG_COUNT_T)                 :: NML_HOMOG_COUNT
@@ -3483,13 +3483,13 @@
       ! process ww3_multi namelist input
       CALL W3NMLMULTIDEF (MPI_COMM, MDSI, TRIM(FNMPRE)//IFNAME, NML_DOMAIN, IERR)
       ALLOCATE(NML_INPUT_GRID(NML_DOMAIN%NRINP))
-      ALLOCATE(NML_MODEL_GRID(NML_DOMAIN%NRGRD)) 
+      ALLOCATE(NML_MODEL_GRID(NML_DOMAIN%NRGRD))
       ALLOCATE(NML_OUTPUT_TYPE(NML_DOMAIN%NRGRD))
       ALLOCATE(NML_OUTPUT_DATE(NML_DOMAIN%NRGRD))
 !
       CALL W3NMLMULTICONF (MPI_COMM, MDSI, TRIM(FNMPRE)//IFNAME, &
                           NML_DOMAIN, NML_INPUT_GRID, NML_MODEL_GRID, NML_OUTPUT_TYPE, &
-                          NML_OUTPUT_DATE, NML_HOMOG_COUNT, NML_HOMOG_INPUT, IERR) 
+                          NML_OUTPUT_DATE, NML_HOMOG_COUNT, NML_HOMOG_INPUT, IERR)
       IF (IERR.NE.0) THEN
         WRITE (*,'(2A)') 'ERROR: error occured while processing ', IFNAME
         CALL EXIT (IERR)
@@ -3503,7 +3503,7 @@
 !
       LFILE  = 'log.mww3'
       IW     = 1 + INT ( LOG10 ( REAL(NMPROC) + 0.5 ) )
-      IW     = MAX ( 3 , MIN ( 9 , IW ) ) 
+      IW     = MAX ( 3 , MIN ( 9 , IW ) )
       WRITE (FORMAT,'(A5,I1.1,A1,I1.1,A4)') '(A4,I',IW,'.',IW,',A5)'
 !/SHRD       TFILE  = 'test.mww3'
 !/DIST       WRITE (TFILE,FORMAT) 'test', IMPROC, '.mww3'
@@ -3596,8 +3596,8 @@
       CALL W3NDAT (        MDSE2, MDST )
       CALL W3NAUX (        MDSE2, MDST )
       CALL W3NOUT (        MDSE2, MDST )
-      CALL W3NINP (        MDSE2, MDST ) 
-      CALL WMNDAT (        MDSE2, MDST ) 
+      CALL W3NINP (        MDSE2, MDST )
+      CALL WMNDAT (        MDSE2, MDST )
 !
 ! 2.c Set up I/O for individual models (initial)
 !
@@ -3612,7 +3612,7 @@
       FLGR2  = .FALSE.
       IPRT   = 0
 !
-! ... Fixed and recycleable unit numbers.      
+! ... Fixed and recycleable unit numbers.
 !
       CALL WMUGET ( MDSE, MDST, NDSREC, 'INP' )
       CALL WMUSET ( MDSE, MDST, NDSREC, .TRUE., 'I/O', NAME='...',    &
@@ -3671,7 +3671,7 @@
 !
         CALL W3SETI ( -I, MDSE, MDST )
         INFLAGS1 = .FALSE.
-        MNAMES(-I) = NML_INPUT_GRID(I)%NAME 
+        MNAMES(-I) = NML_INPUT_GRID(I)%NAME
         INFLAGS1(-7) = NML_INPUT_GRID(I)%FORCING%ICE_PARAM1
         INFLAGS1(-6) = NML_INPUT_GRID(I)%FORCING%ICE_PARAM2
         INFLAGS1(-5) = NML_INPUT_GRID(I)%FORCING%ICE_PARAM3
@@ -3812,7 +3812,7 @@
                     USEINP(INPMAP(I,J)) = .TRUE.
                   END IF
               END IF
-!        INFLAGS2 is initial value of INFLAGS1. Unlike INFLAGS1, 
+!        INFLAGS2 is initial value of INFLAGS1. Unlike INFLAGS1,
 !           it does not change during the simulation
          IF(.NOT. INFLAGS2(J)) INFLAGS2(J)=INFLAGS1(J)
          END DO !         DO J=JFIRST, 7
@@ -3890,7 +3890,7 @@
           DO I=1, NRGRD
             IF ( GRANK(I).EQ.RNKTMP .AND. GRPMIN.EQ.TMPGRP(I) ) THEN
                 GRGRP(I)  = NRGRP
-                TMPGRP(I) = GRPMAX 
+                TMPGRP(I) = GRPMAX
                 NINGRP(NRGRP) = NINGRP(NRGRP) + 1
               END IF
             END DO
@@ -4023,7 +4023,7 @@
               IF ( NMPLOG .EQ. IMPROC ) WRITE (MDSO,934) LINE(1:JJJ)
               LINE(1:6) = '      '
               JJJ       = 6
-            END IF 
+            END IF
           WRITE (LINE(JJJ+1:JJJ+3),'(I3)') INGRP(J,JJ)
 !
           LINE(JJJ+4:JJJ+5) = ' ('
@@ -4048,12 +4048,12 @@
 !     in WMESMFMD from the external clock.
 !
       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) WRITE (MDSS,940)
-!              
+!
       IF (IS_ESMF_COMPONENT) THEN
-          READ(NML_DOMAIN%START, *) STMPT 
+          READ(NML_DOMAIN%START, *) STMPT
           READ(NML_DOMAIN%STOP, *) ETMPT
         ELSE
-          READ(NML_DOMAIN%START, *) STIME 
+          READ(NML_DOMAIN%START, *) STIME
           READ(NML_DOMAIN%STOP, *) ETIME
         END IF
       CALL STME21 ( STIME , DTME21 )
@@ -4064,10 +4064,10 @@
       DO I=1, NRGRD
         CALL W3SETW ( I, MDSE, MDST )
         TIME   = STIME
-        END DO 
+        END DO
 !
       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) WRITE (MDSS,943)
-!              
+!
       FLGHG1 = NML_DOMAIN%FLGHG1
       FLGHG2 = NML_DOMAIN%FLGHG2
       FLGHG2 = FLGHG1 .AND. FLGHG2
@@ -4255,7 +4255,7 @@
                     IF ( ILOOP .EQ. 2 ) THEN
                       OT2(I)%X(OT2(I)%NPTS)      = XX
                       OT2(I)%Y(OT2(I)%NPTS)      = YY
-                      OT2(I)%PNAMES(OT2(I)%NPTS) = PN 
+                      OT2(I)%PNAMES(OT2(I)%NPTS) = PN
                       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) THEN
                         IF ( OT2(I)%NPTS .EQ. 1 ) THEN
                           WRITE (MDSS,957)              XX, YY, PN
@@ -4264,7 +4264,7 @@
                         END IF
                       END IF
                     END IF ! ILOOP.EQ.2
-                  END DO ! end of file                      
+                  END DO ! end of file
                 END DO ! ILOOP
                 CLOSE(MDSI)
 !
@@ -4365,7 +4365,7 @@
 ! 6.  Read moving grid data ------------------------------------------ /
 !
 !     Only a single set of data are provided to be applied to all
-!     the grids, because this is only intended for test cases. 
+!     the grids, because this is only intended for test cases.
 !     For true implementations, the jumping grid will be used.
 !
       IF ( INFLAGS1(8) ) THEN
@@ -4701,13 +4701,13 @@
       IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) THEN
           WRITE (MDSS,976)
           IF ( UNIPTS ) WRITE (MDSS,977) NMPUPT
-          WRITE (MDSS,*) 
+          WRITE (MDSS,*)
         END IF
 !
       IF ( NMPLOG .EQ. IMPROC ) THEN
           WRITE (MDSO,1976)
           IF ( UNIPTS ) WRITE (MDSO,1977) NMPUPT
-          WRITE (MDSO,*) 
+          WRITE (MDSO,*)
         END IF
 !
       DEALLOCATE ( TMPRNK, NDPOUT )
@@ -5245,8 +5245,8 @@
 !/MPI      DO I=1, NRGRD
 !/MPI        CALL WMSETM ( I, MDSE, MDST )
 !/MPI        CALL W3SETG ( I, MDSE, MDST )
-! the next line (with the W3GSUD call) removed Jan 8 2013. 
-! ...ref: personal communication, 
+! the next line (with the W3GSUD call) removed Jan 8 2013.
+! ...ref: personal communication,
 ! ...email from Rogers to Alves, Campbell, Tolman, Chawla Dec 13 2012.
 ! REMOVED  !/MPI        IF ( MPI_COMM_GRD .EQ. MPI_COMM_NULL ) CALL W3GSUD( GSU )
 !/MPI        END DO
@@ -5524,12 +5524,12 @@
       RETURN
 !
  2020 CONTINUE
-      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1020) 
+      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1020)
       CALL EXTCDE ( 2020 )
       RETURN
 !
  2021 CONTINUE
-      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1021) 
+      IF ( IMPROC .EQ. NMPERR ) WRITE (MDSE,1021)
       CALL EXTCDE ( 2021 )
       RETURN
 !
@@ -5671,7 +5671,7 @@
   954 FORMAT ( '            Interval : ',A/)
   955 FORMAT ( '            Fields   : ',A)
   956 FORMAT ( '                       ',A)
-  957 FORMAT ( '            Point  1 : ',2E14.6,2X,A)             
+  957 FORMAT ( '            Point  1 : ',2E14.6,2X,A)
   958 FORMAT ( '              ',I6,' : ',2E14.6,2X,A)
   959 FORMAT ( '            No points defined')
   960 FORMAT ( '            The file with ',A,' data is ',A,'.')

--- a/model/ftn/wmiopomd.ftn
+++ b/model/ftn/wmiopomd.ftn
@@ -23,7 +23,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -73,7 +73,7 @@
 !
 !       !/S    Enable subroutine tracing.
 !       !/T    Enable test output
-!       !/MPIT 
+!       !/MPIT
 !
 !  7. Source code :
 !
@@ -291,9 +291,9 @@
 ! ..........in w3iopomd.ftn, it is "DO IPT=1, NPT" but otherwise very similar
         DO IPT=1, NOPTS
 !
-!     Check if point within grid 
+!     Check if point within grid
 !
-          IF (GTYPE .NE. UNGTYPE) THEN 
+          IF (GTYPE .NE. UNGTYPE) THEN
             INGRID(J,IPT) = W3GRMP( GSU, XPT(IPT), YPT(IPT), IX, IY, RD )
             IF ( .NOT.INGRID(J,IPT) ) THEN
               CYCLE
@@ -315,8 +315,8 @@
               CYCLE
               END IF
 
-!.........If we've gotten to this point, then we are satisfied that 
-!................the point is in this grid. 
+!.........If we've gotten to this point, then we are satisfied that
+!................the point is in this grid.
 
         END DO !        DO IPT=1, NOPTS
 !
@@ -343,7 +343,7 @@
 ! 2.c Diagnostic output
 !
 !/O7b      IF ( IMPROC .EQ. NMPSCR ) THEN
-!/O7b          WRITE (MDSS,920) 
+!/O7b          WRITE (MDSS,920)
 !/O7b          DO IPT=1, NOPTS
 !/O7b            DO J=1, NRGRD
 !/O7b              IF ( GRIDS(J)%FILEXT .EQ. GRDID(IPT) ) EXIT
@@ -355,7 +355,7 @@
 !/O7b                                 GRIDS(J)%FILEXT
 !/O7b              END IF
 !/O7b            END DO
-!/O7b          WRITE (MDSS,929) 
+!/O7b          WRITE (MDSS,929)
 !/O7b        END IF
 !
 ! 2.d Test output
@@ -401,7 +401,7 @@
           MDATAS(J)%UPTMAP(IPT) = II
           XP(IPT)  = PTLOC(1,II)
           YP(IPT)  = PTLOC(2,II)
-          PN(IPT)  = PTNME(II) 
+          PN(IPT)  = PTNME(II)
           END DO
 !
 !/T        DO IPT=1, MDATAS(J)%NRUPTS
@@ -591,7 +591,7 @@
 !
 !       !/S    Enable subroutine tracing.
 !       !/T    Enable test output
-!       !/MPIT 
+!       !/MPIT
 !
 ! 10. Source code :
 !
@@ -655,8 +655,8 @@
           OUTPTS(0)%OUT2%CAO   = 0.
           OUTPTS(0)%OUT2%CDO   = 0.
           OUTPTS(0)%OUT2%ICEO  = 0.
-          OUTPTS(0)%OUT2%ICEFO = 0. 
-          OUTPTS(0)%OUT2%ICEHO = 0.   
+          OUTPTS(0)%OUT2%ICEFO = 0.
+          OUTPTS(0)%OUT2%ICEHO = 0.
         END IF
 !
 ! -------------------------------------------------------------------- /
@@ -769,10 +769,10 @@
 !/MPI            CALL MPI_SEND ( CDO(1), NOPTS, MPI_REAL, ITARG, IT,  &
 !/MPI                            MPI_COMM_MWAVE, IERR_MPI )
 !/MPIT            WRITE (MDST,9019) IT-IT0, 'CURRENT DIRECTION'
-!JDM: The below should be added for points using partitioned processors 
-! for multigrid, however I am unsure if the IT0 (7 to 10?) should be changed so 
-! this is being left here commented out for now.  
-! There is a corresponding section to this below 
+!JDM: The below should be added for points using partitioned processors
+! for multigrid, however I am unsure if the IT0 (7 to 10?) should be changed so
+! this is being left here commented out for now.
+! There is a corresponding section to this below
 !!/MPI            IT     = IT + 1
 !!/MPI            CALL MPI_SEND ( ICEO(1), NOPTS, MPI_REAL, ITARG, IT,  &
 !!/MPI                            MPI_COMM_MWAVE, IERR_MPI )
@@ -828,7 +828,7 @@
 !/MPI        IFROM  = NMPPNT - 1
 !/MPI        ALLOCATE ( SPCR(NSPEC,NOPTS), STATUS(MPI_STATUS_SIZE,1),  &
 !/MPI                   DPR(NOPTS), WAR(NOPTS), WDR(NOPTS), ASR(NOPTS),&
-!/MPI                   CAR(NOPTS), CDR(NOPTS), ICRO(NOPTS),           & 
+!/MPI                   CAR(NOPTS), CDR(NOPTS), ICRO(NOPTS),           &
 !/MPI                   ICRFO(NOPTS), ICRHO(NOPTS) )
 !
 !/MPI        IT     = IT + 1
@@ -859,9 +859,9 @@
 !/MPI        CALL MPI_RECV ( CDR(1), NSPEC*NOPTS, MPI_REAL, IFROM,     &
 !/MPI                        IT, MPI_COMM_MWAVE, STATUS, IERR_MPI )
 !/MPIT        WRITE (MDST,9019) IT-IT0, 'CURRENT DIRECTION'
-!JDM: The below should be added for points using partitioned processors 
-! for multigrid, however I am unsure if the IT0 (7 to 10?) should be changed so 
-! this is being left here commented out for now.  
+!JDM: The below should be added for points using partitioned processors
+! for multigrid, however I am unsure if the IT0 (7 to 10?) should be changed so
+! this is being left here commented out for now.
 ! There is a corresponding section to this above
 !!/MPI         IT     = IT + 1
 !!/MPI         CALL MPI_RECV ( ICRO(1), NSPEC*NOPTS, MPI_REAL, IFROM,   &
@@ -872,7 +872,7 @@
 !!/MPI                        IT, MPI_COMM_MWAVE, STATUS, IERR_MPI )
 !!/MPIT         WRITE (MDST,9019) IT-IT0, 'ICEFO'
 !!/MPI         IT     = IT + 1
-!!/MPI         CALL MPI_SEND (ICRHO(1), NSPEC*NOPTS, MPI_REAL, IFROM,   & 
+!!/MPI         CALL MPI_SEND (ICRHO(1), NSPEC*NOPTS, MPI_REAL, IFROM,   &
 !!/MPI                        IT, MPI_COMM_MWAVE, STATUS, IERR_MPI )
 !!/MPIT            WRITE (MDST,9019) IT-IT0, 'ICEHO'
 !
@@ -903,15 +903,15 @@
 !/MPI          OUTPTS(0)%OUT2%ASO(II)     = ASR(I)
 !/MPI          OUTPTS(0)%OUT2%CAO(II)     = CAR(I)
 !/MPI          OUTPTS(0)%OUT2%CDO(II)     = CDR(I)
-!/MPI          OUTPTS(0)%OUT2%ICEO(II)    = ICEO(I)   
-!/MPI          OUTPTS(0)%OUT2%ICEFO(II)    = ICEFO(I)   
-!/MPI          OUTPTS(0)%OUT2%ICEHO(II)    = ICEHO(I)   
+!/MPI          OUTPTS(0)%OUT2%ICEO(II)    = ICEO(I)
+!/MPI          OUTPTS(0)%OUT2%ICEFO(II)    = ICEFO(I)
+!/MPI          OUTPTS(0)%OUT2%ICEHO(II)    = ICEHO(I)
 !/MPI        END DO
 !
 !/MPI        IF ( RESPEC(0,J) ) DEALLOCATE ( SPEC )
 !/MPI        DEALLOCATE ( SPCR, DPR, WAR, WDR, ASR, CAR, CDR, STATUS )
 !        !JDM add deallocates here and check the itag stuff.. really not
-!        sure aabout that 
+!        sure aabout that
 !/MPI        DEALLOCATE (ICRO, ICRFO, ICRHO)
 !/MPI        END DO
 !

--- a/model/ftn/wmmdatmd.ftn
+++ b/model/ftn/wmmdatmd.ftn
@@ -29,12 +29,12 @@
 !/    10-Dec-2014 : Add checks for allocate status     ( version 5.04 )
 !/    28-Sep-2016 : Adjust MTAG? values so that MPI tags used fit
 !/                  within allowed bounds.             ( version 5.15 )
-!/    06-Jun-2018 : add subroutine INIT_GET_JSEA_ISPROC_GLOB/add PDLIB 
+!/    06-Jun-2018 : add subroutine INIT_GET_JSEA_ISPROC_GLOB/add PDLIB
 !/                                                     ( version 6.04 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -55,7 +55,7 @@
 !      MDST      Int.  Public   Unit number for test output.
 !      MDSE      Int.  Public   Unit number for error output.
 !                               These outputs correspond to similar
-!                               unit numbers as defined per grid, but 
+!                               unit numbers as defined per grid, but
 !                               are used for multi-grid routines
 !                               only.
 !      MDSP      Int.  Public   Unit number for profiling.
@@ -112,10 +112,10 @@
 !                               data.                         ( !/MPI )
 !      HGHSTA    I.A.  Public   Status for gathering high resolution
 !                               data.                         ( !/MPI )
-!      EQLSTA    I.A.  Public   Status for gathering data fro equally 
+!      EQLSTA    I.A.  Public   Status for gathering data fro equally
 !                               ranked grids.                 ( !/MPI )
 !
-!      FLGBDI    Log.  Public   Flag for intitialization of boundry 
+!      FLGBDI    Log.  Public   Flag for intitialization of boundry
 !                               distance maps.
 !      FLGHGn    Log.  Public   Flags for using mask for computations
 !                               and output for areas of grid overlap.
@@ -201,7 +201,7 @@
 !      NRQOUT    Int.  Public   Number of local spectra.     ( !/MPI )
 !      OUTDAT    I.A.  Public   Corresponding data.          ( !/MPI )
 !      NTOT, NREC, NRC1, NSND, NSN1, NSMX
-!                Int.  Public   Counters for total data, send and 
+!                Int.  Public   Counters for total data, send and
 !                               received data with and without
 !                               masking.
 !      VTIME     I.A.  Public   Valid time of data.
@@ -212,7 +212,7 @@
 !      ISEND     I.A.  Public   Composite of all deta needed for send.
 !      WGHT      R.A.  Public   Weihts in averaging.
 !      SHGH      R.A.  Public   Staging area for spectra.
-!      TSTORE    R.A.  Public   Staging area for spectra to be send 
+!      TSTORE    R.A.  Public   Staging area for spectra to be send
 !                               out                         ( !/MPI )
 !      INIT      Log.  Public   Flag for array allocation.
 !     ----------------------------------------------------------------
@@ -226,7 +226,7 @@
 !      NRQOUT    Int.  Public   Number of local spectra.     ( !/MPI )
 !      OUTDAT    I.A.  Public   Corresponding data.          ( !/MPI )
 !      NTOT, NREC, NSND, NAVMAX
-!                Int.  Public   Counters for total data, send and 
+!                Int.  Public   Counters for total data, send and
 !                               received data.
 !      VTIME     I.A.  Public   Valid time of data.
 !      I/JSEA    I.A.  Public   Sea point counters.
@@ -240,7 +240,7 @@
 !      SEQL      R.A.  Public   Staging array.
 !      WGHT      R.A.  Public   Weight between grids.
 !      WAVG      R.A.  Public   Weight within grid.
-!      TSTORE    R.A.  Public   Staging area for spectra to be send 
+!      TSTORE    R.A.  Public   Staging area for spectra to be send
 !                               out                         ( !/MPI )
 !      INIT      Log.  Public   Flag for array allocation.
 !     ----------------------------------------------------------------
@@ -604,7 +604,7 @@
 !
 !  7. Remarks :
 !
-!     - WMSETM needs to be called after allocation to point to 
+!     - WMSETM needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -779,7 +779,7 @@
 !
 !  7. Remarks :
 !
-!     - WMSETM needs to be called after allocation to point to 
+!     - WMSETM needs to be called after allocation to point to
 !       proper allocated arrays.
 !
 !  8. Structure :
@@ -960,7 +960,7 @@
       IF ( NMDATA .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
-        END IF   
+        END IF
 !
       IF ( IMOD.LT.1 .OR. IMOD.GT.NMDATA ) THEN
           WRITE (NDSE,1002) IMOD, NMDATA
@@ -1033,8 +1033,8 @@
 !/    06-Jun-2018 : Origination.                        ( version 6.04 )
 !/
 !  1. Purpose : Introduce mapping for ISPROC and JSEA when using PDLIB
-!               in the Multigrid approach 
-!             
+!               in the Multigrid approach
+!
 !  2. Method :
 !  3. Parameters :
 !
@@ -1091,7 +1091,7 @@
         ISPROC=1
 !/DIST        ISPROC = MDATAS(J)%CROOT - 1 + ISEA - (JSEA-1)*nb
       ELSE
-!/PDLIB      IF (GRIDS(J)%GTYPE .ne. UNGTYPE) THEN       
+!/PDLIB      IF (GRIDS(J)%GTYPE .ne. UNGTYPE) THEN
 !/PDLIB        nb=OUTPTS(J)%NAPROC
 !/PDLIB        JSEA   = 1 + (ISEA-1)/nb
 !/PDLIB        ISPROC = MDATAS(J)%CROOT - 1 + ISEA - (JSEA-1)*nb

--- a/model/ftn/wmscrpmd.ftn
+++ b/model/ftn/wmscrpmd.ftn
@@ -15,12 +15,12 @@
 !/
 !/    Copyright 2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Routines to determine and process grid dependencies in the 
+!     Routines to determine and process grid dependencies in the
 !     multi-grid wave model.
 !
 !  2. Variables and types :
@@ -29,14 +29,14 @@
 !
 !      Name                          Type  Scope      Description
 !     ----------------------------------------------------------------
-!      scrip_wrapper                  Subr. Public   as the name says ... 
-!      get_scrip_info_structured      Subr. Public   as the name says ... 
-!      get_scrip_info_unstructured    Subr. Public   as the name says ... 
-!      get_scrip_info                 Subr. Public   as the name says ... 
-!      scrip_info_renormalization     Subr. Public   as the name says ... 
-!      TRIANG_INDEXES                 Subr. Public   as the name says ... 
-!      get_unstructured_vertex_degree Subr. Public   as the name says ... 
-!      GET_BOUNDARY                   Subr. Public   as the name says ... 
+!      scrip_wrapper                  Subr. Public   as the name says ...
+!      get_scrip_info_structured      Subr. Public   as the name says ...
+!      get_scrip_info_unstructured    Subr. Public   as the name says ...
+!      get_scrip_info                 Subr. Public   as the name says ...
+!      scrip_info_renormalization     Subr. Public   as the name says ...
+!      TRIANG_INDEXES                 Subr. Public   as the name says ...
+!      get_unstructured_vertex_degree Subr. Public   as the name says ...
+!      GET_BOUNDARY                   Subr. Public   as the name says ...
 !     ----------------------------------------------------------------
 !
 !  4. Subroutines and functions used :
@@ -47,8 +47,8 @@
 !     ----------------------------------------------------------------
 !
 !  5. Remarks :
-!     
-!     - The subroutines TRIANG_INDEXES, get_unstructured_vertex_degree, and 
+!
+!     - The subroutines TRIANG_INDEXES, get_unstructured_vertex_degree, and
 !       GET_BOUNDARY should probably be renamed and moved to the module w3triamd
 !
 !  6. Switches :
@@ -104,15 +104,15 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     Compute grid information required by SCRIP
 !
 !  6. Method :
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine WMGHGH
 !
@@ -120,7 +120,7 @@
 !
 !     Subroutine SCRIP
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
@@ -169,29 +169,29 @@
 !/T38      if(l_master)write(*,*)'flagll = ',flagll
 !/T38      if(l_master)write(*,*)'gridshift = ',gridshift
 
-! 
+!
 ! START: universal settings
-! 
+!
 
 !     Set variables for converting to degrees
 !     notes: SCRIP only operates on spherical coordinates, so for the case
-!         where the problem is specified by the user as in a 
-!         meters/cartesian coordinate system, it is necessary to make 
-!         a temporary conversion to a "fake" spherical coordinate grid, 
-!         to keep SCRIP happy. The good news here is that multi-grid 
-!         meters-grid simulations will be very rare: we will probably only 
-!         encounter them in the context of simple test cases. Strictly 
-!         speaking, this conversion does not even need to be physically 
-!         correct, e.g. we could say that 1000 km is 1 deg....as long as 
+!         where the problem is specified by the user as in a
+!         meters/cartesian coordinate system, it is necessary to make
+!         a temporary conversion to a "fake" spherical coordinate grid,
+!         to keep SCRIP happy. The good news here is that multi-grid
+!         meters-grid simulations will be very rare: we will probably only
+!         encounter them in the context of simple test cases. Strictly
+!         speaking, this conversion does not even need to be physically
+!         correct, e.g. we could say that 1000 km is 1 deg....as long as
 !         we are consistent between grids.
-!     Potential future improvement: make conv_dy and offset such that dst grid 
+!     Potential future improvement: make conv_dy and offset such that dst grid
 !         covers a specific longitude range, e.g. 1 deg east to 2 deg east
-     
-! 
-! START: set up src grid
-! 
 
-!notes: when we work out how to interface with an unstructured grid, 
+!
+! START: set up src grid
+!
+
+!notes: when we work out how to interface with an unstructured grid,
 !       we will need to revisit this issue of how to set grid1_rank, etc.
 !       strategy: declare variables in grid module, but allocate them here.
 !
@@ -220,7 +220,7 @@
 !           conv_dy=92.6*1200.0 ! physical, =92.6/(3/3600)=111000 m = 111 km
          CONV_DY=1.0E+6_SCRIP_R8 ! non-physical, 1e+6=1 deg
          CONV_DX=COS(LAT_CONVERSION)*CONV_DY
-! notes:    offset (in meters), is necessary so that our grid does 
+! notes:    offset (in meters), is necessary so that our grid does
 !           not lie on the branch cut
          OFFSET=75000.0_SCRIP_R8-MIN(MINVAL(GRID1_CENTER_LON),          &
      &                               MINVAL(GRID2_CENTER_LON))
@@ -274,20 +274,20 @@
 !/T38      if(l_master)write(*,*)'new maxval(grid1_center_lon) = ',maxval(grid1_center_lon)
 
 !.....notes: at this point we have the following useful variables:
-!       num_wts, e.g. num_wts=3....for first order conservative remapping, 
+!       num_wts, e.g. num_wts=3....for first order conservative remapping,
 !       only the first one is relevant, the other two are for second-order
 !       remapping.
-!       max_links_map1, e.g. max_links_map1=1369, 
-!       grid2_size, e.g. grid2_size=1849, 
-!       wts_map1(num_wts,max_links_map1), e.g. wts_map1(3,1369), 
+!       max_links_map1, e.g. max_links_map1=1369,
+!       grid2_size, e.g. grid2_size=1849,
+!       wts_map1(num_wts,max_links_map1), e.g. wts_map1(3,1369),
 !       grid1_add_map1(max_links_map1),  e.g. grid1_add_map1(1369),
-!       grid2_add_map1(max_links_map1), e.g. grid2_add_map1(1369), 
-!       grid2_frac(grid2_size), e.g. grid2_frac(1849), 
+!       grid2_add_map1(max_links_map1), e.g. grid2_add_map1(1369),
+!       grid2_frac(grid2_size), e.g. grid2_frac(1849),
 !       (see earlier versions for notes re: equivalency in netcdf/matlab)
-! 
+!
 !.....test output (optional)
-! 
-!.....note re: notation: I use k for the combined i/j array, similar to isea, 
+!
+!.....note re: notation: I use k for the combined i/j array, similar to isea,
 !            but not necessarily the same as isea since some points may
 !            be land etc.
 !/T38     if(l_master)then
@@ -300,7 +300,7 @@
 !/T38     do ilink=1,max_links_map1
 !/T38        write(406,'(i20)')grid1_add_map1(ilink) ! equivalent to
 !/T38                                                ! my "src_address"
-!/T38        write(407,'(i20)')grid2_add_map1(ilink) ! equivalent to 
+!/T38        write(407,'(i20)')grid2_add_map1(ilink) ! equivalent to
 !/T38                                                ! my "dst_address"
 !/T38     end do
 !/T38     endif
@@ -308,8 +308,8 @@
 !.....organize results and return to wmghgh.
 
 ! what we need, for purpose of feeding back to ww3, for each dst grid node:
-!        a) the set of src grid nodes, in terms of isea, for which 
-!           weights are available  
+!        a) the set of src grid nodes, in terms of isea, for which
+!           weights are available
 !        b) the corresponding set of weights
 
       ALLOCATE ( WGTDATA(GRID2_SIZE), STAT=ISTAT )
@@ -317,13 +317,13 @@
 
 !.....step 1: count up NR0, NR1, NR2, NRL, NLOC (NR1 and NLOC are denoted
 !             "n" here)
-!     It is especially important to determine how large npnts gets, 
+!     It is especially important to determine how large npnts gets,
 !              so that we can allocate arrays properly
       WGTDATA%NR0=0
       WGTDATA%NR2=0
       WGTDATA%NRL=0
       WGTDATA%N=0
-      
+
       NI_SRC=GRID1_DIMS(1)
       NGOODPNTS=0
       NBADPNTS=0
@@ -361,7 +361,7 @@
             ELSEIF ( (GRID1_FRAC(GRID1_ADD_MAP1(ILINK))>FRAC_LOWEST)   &
                  .AND. (GRID1_FRAC(GRID1_ADD_MAP1(ILINK))<FRAC_HIGHEST)&
                  ) THEN
-               ! note that we don't bother giving a warning for the 
+               ! note that we don't bother giving a warning for the
                ! cases where grid1_frac is strange.
                NBADPNTS=NBADPNTS+1
                ! we also don't bother giving a warning if we've already
@@ -384,7 +384,7 @@
                   'grid2_frac(grid2_add_map1(ilink)) = ',              &
                   grid2_frac(grid2_add_map1(ilink))
                   WRITE(*,'(4x,A,F10.5)')'grid1_center_lat = ',        &
-                  grid1_center_lat(grid1_add_map1(ilink)) 
+                  grid1_center_lat(grid1_add_map1(ilink))
                   WRITE(*,'(4x,A,F10.5)')'grid1_center_lon = ',        &
                   grid1_center_lon(grid1_add_map1(ilink))
                   WRITE(*,'(4x,A,F10.5)')'grid2_center_lat = ',        &
@@ -484,7 +484,7 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     Compute grid arrays for scrip for a specific unstructured grid
 !     For interior vertices, we select for every triangle the barycenter
@@ -504,14 +504,14 @@
 !  6. Method :
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine get_scrip_info
 !
 !  9. Subroutines and functions used :
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
@@ -706,7 +706,7 @@
         IF (DODEBUG.EQ.1) THEN
           print *, 'nbplus=', nbplus, ' nbminus=', nbminus
         END IF
-        
+
         STATUS(:) = 0
         NEXTVERT(:) = 0
         PREVVERT(:) = 0
@@ -850,7 +850,7 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     Compute grid arrays needed for scrip for a specific structured grid.
 !     This is adapted from Erick Rogers original code by splitting
@@ -859,14 +859,14 @@
 !  6. Method :
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine get_scrip_info
 !
 !  9. Subroutines and functions used :
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
@@ -927,7 +927,7 @@
       GRID_CORNERS=4  ! hardwired: each cell has 4 corners
 
 !.....notes: unfortunately, scrip only works for spherical coordinates.
-!         thus, if we want to have a multi-grid case in meters, we have to 
+!         thus, if we want to have a multi-grid case in meters, we have to
 !         fake it. fortunately, it should be pretty rare to have a multi-grid
 !         case in meters.
 
@@ -943,7 +943,7 @@
       CHECK_ALLOC_STATUS ( ISTAT )
 
 !.....notes: this "gridshift" variable is included because SCRIP sometimes
-!            has trouble when grids cell locations are identical between 
+!            has trouble when grids cell locations are identical between
 !            the two grids. Thus we apply this to one of the two grids.
 
 !.....notes: The following block of code could be converted to a subroutine.
@@ -957,14 +957,14 @@
             GRID_MASK(IREC)=.TRUE.
 
 !..notes: normally, we'd apply the mask like this:
-!           if(abs(mapsta_src(j,i)).eq.1)then 
+!           if(abs(mapsta_src(j,i)).eq.1)then
 !              grid1_mask(irec)=.true.
 !           else
 !              grid1_mask(irec)=.false.
 !           endif
 !..but unfortunately, WMGHGH needs information about the overlaying high-res
-!           cells, even those that are masked, for calculating 
-!           NRL, NR0, NR1, NR2. 
+!           cells, even those that are masked, for calculating
+!           NRL, NR0, NR1, NR2.
 
 !...........corner 1 : halfway to i-1,j-1
             GRID_CORNER_LON(1,IREC)=GRID_CENTER_LON(IREC)-              &
@@ -972,7 +972,7 @@
             GRID_CORNER_LAT(1,IREC)=GRID_CENTER_LAT(IREC)-              &
      &        HALF*DYDP_GRD(J,I)-HALF*DYDQ_GRD(J,I)
 
-!...........corner 2: halfway to i+1,j-1 
+!...........corner 2: halfway to i+1,j-1
             GRID_CORNER_LON(2,IREC)=GRID_CENTER_LON(IREC)+              &
      &        HALF*DXDP_GRD(J,I)-HALF*DXDQ_GRD(J,I)
             GRID_CORNER_LAT(2,IREC)=GRID_CENTER_LAT(IREC)+              &
@@ -1013,7 +1013,7 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     Compute grid for scrip for a specific structured grid.
 !     This is adapted from Erick Rogers code by making it cleaner.
@@ -1021,14 +1021,14 @@
 !  6. Method :
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine scrip_wrapper
 !
 !  9. Subroutines and functions used :
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
@@ -1114,7 +1114,7 @@
 !
 !  4. Copyright :
 !
-!  5. Purpose : 
+!  5. Purpose :
 !
 !     This is adapted from Erick Rogers scrip_wrapper
 !     Purpose is to rescale according to whether the grid is spherical
@@ -1128,14 +1128,14 @@
 !    finite difference meshes.
 !
 !  7. Parameters, Variables and types :
-!  
-!  8. Called by : 
+!
+!  8. Called by :
 !
 !     Subroutine WMGHGH
 !
 !  9. Subroutines and functions used :
 !
-! 10. Error messages: 
+! 10. Error messages:
 !
 ! 11. Remarks :
 !
@@ -1227,7 +1227,7 @@
 !
 !  Description:
 !    this function returns the list of incidences
-!    
+!
       IMPLICIT NONE
       INTEGER, INTENT(IN) :: MNP, MNE
       INTEGER, INTENT(IN) :: TRIGP(:,:)
@@ -1273,24 +1273,24 @@
 !    if a node belong to a boundary, the function
 !    returns the neighbor of this point on one side.
 !    if the point is interior then the value 0 is set.
-!    
+!
         USE W3SERVMD, ONLY: EXTCDE
         IMPLICIT NONE
-               
+
         INTEGER, INTENT(IN)             :: MNP, MNE, TRIGP(MNE,3)
         INTEGER, INTENT(INOUT)          :: IOBP(MNP)
         INTEGER, INTENT(INOUT)          :: NEIGHBOR_PREV(MNP)
         INTEGER, INTENT(INOUT)          :: NEIGHBOR_NEXT(MNP)
-        
+
         INTEGER, POINTER :: STATUS(:)
         INTEGER, POINTER :: COLLECTED(:)
         INTEGER, POINTER :: NEXTVERT(:)
         INTEGER, POINTER :: PREVVERT(:)
-        
+
         INTEGER :: IE, I, IP, IP2, IP3
         INTEGER :: ISFINISHED, INEXT, IPREV
         INTEGER :: IPNEXT, IPPREV, ZNEXT, ZPREV
-        
+
         ALLOCATE(STATUS(MNP), STAT=ISTAT)
         CHECK_ALLOC_STATUS ( ISTAT )
         ALLOCATE(COLLECTED(MNP), STAT=ISTAT)
@@ -1302,7 +1302,7 @@
         IOBP = 0
         NEIGHBOR_NEXT = 0
         NEIGHBOR_PREV = 0
-        
+
 !  Now computing the next items
         STATUS = 0
         NEXTVERT = 0
@@ -1437,7 +1437,7 @@
         CHECK_DEALLOC_STATUS ( ISTAT )
         DEALLOCATE(PREVVERT, STAT=ISTAT)
         CHECK_DEALLOC_STATUS ( ISTAT )
-        
+
       END SUBROUTINE
 !/
 !/ End of module WMSCRPMD -------------------------------------------- /

--- a/model/ftn/wmunitmd.ftn
+++ b/model/ftn/wmunitmd.ftn
@@ -14,7 +14,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -31,7 +31,7 @@
 !      UNITLW    I.P.  Private  Lowest unit number.
 !      UNITHG    I.P.  Private  Highest unit number.
 !      INPLOW, INPHGH, OUTLOW, OUTHGH, SCRLOW, SCRHGH
-!                I.P.  Private  Low and high for input, output and 
+!                I.P.  Private  Low and high for input, output and
 !                               scratch files.
 !      FLINIT    Log.  Private  Flag for intialization.
 !
@@ -402,11 +402,11 @@
   930 FORMAT (/' WMUDMP: Unit information '//                         &
                '    Nr Flg Type  Name                  Description '/ &
                '  -------------------------------------------------', &
-               '---------------------') 
+               '---------------------')
   931 FORMAT (/' WMUDMP: Unit information (assigned only)'//          &
                '    Nr Flg Type  Name                  Description '/ &
                '  -------------------------------------------------', &
-               '---------------------') 
+               '---------------------')
   932 FORMAT ( 2X,I4,L4,2X,A3,2X,A20,2X,A)
 !
  1000 FORMAT (/' *** ERROR WMUDMP: DATA STRUCTURE READY ***'/         &
@@ -651,7 +651,7 @@
         END IF
 !
       IF ( PRESENT(NR) ) THEN
-          NRC    = MAX ( 1 , NR ) 
+          NRC    = MAX ( 1 , NR )
         ELSE
           NRC    = 1
         END IF
@@ -702,7 +702,7 @@
  1010 FORMAT (/' *** ERROR WMUGET: INITIALIZE FIRST !!! ***')
  1020 FORMAT (/' *** ERROR WMUGET: CANNOT FIND FREE UNIT FOR TYPE ',  &
                A,' ***'/)
-!  
+!
 !/T 9010 FORMAT ( ' TEST WMUGET: LOOKING FOR UNIT FOR TYPE ',A,' [',  &
 !/T                I2,']')
 !/T 9020 FORMAT ( ' TEST WMUGET: UNIT NUMBER SET TO',I4)

--- a/model/ftn/wmupdtmd.ftn
+++ b/model/ftn/wmupdtmd.ftn
@@ -24,7 +24,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -132,7 +132,7 @@
 !
 !  7. Remarks :
 !
-!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where  
+!     - IDFLDS dimensioning is hardwired as IDFLDS(-7:7) where
 !       lowest possible value of JFIRST is JFIRST=-7
 !
 !  8. Structure :
@@ -401,7 +401,7 @@
 !/T      WRITE (MDST,9072) 8, 'MOV'        , INFLAGS1(8), TG0, TGN
 !
       RETURN
-!       
+!
 ! Error escape locations
 !
  2000 CONTINUE
@@ -700,8 +700,8 @@
 ! 8. Moving grid data ----------------------------------------------- /
 !
         CASE ( 8 )
-! notes: 
-! SUBROUTINE W3FLDM in w3fldsmd.ftn : 
+! notes:
+! SUBROUTINE W3FLDM in w3fldsmd.ftn :
 !<       INTEGER, INTENT(INOUT)  :: NH, THO(2,4,NHM), TF0(2), TFN(2)
 !>       INTEGER, INTENT(INOUT)  :: NH, THO(2,-7:4,NHM), TF0(2), TFN(2)
 !<       REAL, INTENT(INOUT)     :: HA(NHM,4), HD(NHM,4), A0, AN, D0, DN
@@ -1013,7 +1013,7 @@
 ! 4. End of routine -------------------------------------------------- /
 !
       RETURN
-!       
+!
 ! Error escape locations
 !
  2999 CONTINUE
@@ -1100,7 +1100,7 @@
 !  7. Remarks :
 !
 !     - Grid pointers for output grid need to be set externally.
-!     - If input grid does not cover point of target grid, target grid 
+!     - If input grid does not cover point of target grid, target grid
 !       values are set to UNDEF.
 !
 !  8. Structure :
@@ -1650,7 +1650,7 @@
 !  7. Remarks :
 !
 !     - Grid pointers for output grid need to be set externally.
-!     - If input grid does not cover point of target grid, target grid 
+!     - If input grid does not cover point of target grid, target grid
 !       values are set to UNDEF.
 !
 !  8. Structure :

--- a/model/ftn/wmwavemd.ftn
+++ b/model/ftn/wmwavemd.ftn
@@ -27,7 +27,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -129,7 +129,7 @@
 !      WWTIME    Subr    Id.    System time in readable format.
 !      PRTIME    Subr    Id.    Profiling routine ( !/MPRF )
 !      STME21    Subr  W3TIMEMD Print date and time readable.
-!      DSEC21    Func    Id.    Difference between times.             
+!      DSEC21    Func    Id.    Difference between times.
 !      TICK21    Subr    Id.    Advance time.
 !      WMSETM    Subr  WMMDATMD Point to grid/model.
 !      WMUPDT    Subr  WMUPDTMD Update input fields at driver level.
@@ -160,7 +160,7 @@
 !
 !  7. Remarks :
 !
-!     - If no action is taken in the endless loop, an error is 
+!     - If no action is taken in the endless loop, an error is
 !       assumed (code 2099). This should never take place in the
 !       default driver, but may be a problem in a coupled model.
 !     - If output is requested for the initial model time, TSYNC
@@ -256,7 +256,7 @@
 !/S      CALL STRACE (IENT, 'WMWAVE')
 !
 !/MPRF      CALL PRTIME ( PRFT0 )
-!              
+!
 !/O10      IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC ) WRITE (MDSS,900)
 !
 ! 0.  Initializations ------------------------------------------------ /
@@ -350,7 +350,7 @@
 !
         IF ( MDSS.NE.MDSO .AND. NMPSCR.EQ.IMPROC .AND.                &
              DSEC21(TPRNT,TSYNC(:,0)).NE.0. ) THEN
-            IF ( .NOT. TSTAMP ) WRITE (MDSS,*) 
+            IF ( .NOT. TSTAMP ) WRITE (MDSS,*)
             CALL WMPRNT ( MDSO, NRGRD, TSYNC(:,0), GRSTAT )
             CALL STME21 ( TSYNC(:,0), MTIME )
             CALL WWTIME ( WTIME )
@@ -401,11 +401,11 @@
 !/T                WRITE (MDST,9002) I, GRSTAT(I), ' '
 !
                 IF ( TDATA(1,I) .EQ. -1 ) THEN
-                    DTTST  = 0.  
-                  ELSE 
+                    DTTST  = 0.
+                  ELSE
                     CALL W3SETW ( I, MDSE, MDST )
-                    DTTST  = DSEC21 ( TIME , TDATA(:,I) ) 
-                  END IF         
+                    DTTST  = DSEC21 ( TIME , TDATA(:,I) )
+                  END IF
 !/T                WRITE (MDST,9020) DTTST
 !
                 IF ( DTTST .GT. 0. ) THEN
@@ -759,7 +759,7 @@
 !/MPI                CALL WMIOEF ( I )
                 CALL WMIOES ( I )
 !
-! 5.c Finish up 
+! 5.c Finish up
 !
                 GRSTAT(I) = 4
                 DONE      = .TRUE.
@@ -957,11 +957,11 @@
 !/T                WRITE (MDST,9002) I, GRSTAT(I), ' '
 !
                 IF ( TOUTP(1,I) .EQ. -1 ) THEN
-                    DTTST  = 1.  
-                  ELSE 
+                    DTTST  = 1.
+                  ELSE
                     CALL W3SETW ( I, MDSE, MDST )
-                    DTTST  = DSEC21 ( TIME , TOUTP(:,I) ) 
-                  END IF         
+                    DTTST  = DSEC21 ( TIME , TOUTP(:,I) )
+                  END IF
 !/T                WRITE (MDST,9090) DTTST
                 FLG_O1 = DTTST .EQ. 0.
 !
@@ -1090,7 +1090,7 @@
 !/MPI                TIME       = TOUTP(:,I)
 !/MPI                TOUTP(1,I) = -1
 !/MPI                TOUTP(2,I) =  0
-! 
+!
 !/MPI                DO JO=1, NOTYPE
 !
 !/MPI                  IF ( FLOUT(JO) ) THEN
@@ -1244,7 +1244,7 @@
            CALL WWTIME ( WTIME )
            WRITE (MDSS,902) WTIME
         ENDIF
-!              
+!
 !/MPI      DO I=1, NRGRD
 !/MPI        CALL WMSETM ( I, MDSE, MDST )
 !/MPI        IF ( MPI_COMM_GRD .NE. MPI_COMM_NULL ) THEN
@@ -1529,8 +1529,8 @@
 !  1. Purpose :
 !
 !     Non-blocking broadcast, initially for times only, but made for
-!     any integer array. Sending data from first process in the 
-!     model cummunicator to all processes that are in the overall 
+!     any integer array. Sending data from first process in the
+!     model cummunicator to all processes that are in the overall
 !     communicator but not in the model communicator.
 !
 !  2. Method :

--- a/model/ftn/ww3_bounc.ftn
+++ b/model/ftn/ww3_bounc.ftn
@@ -13,14 +13,14 @@
 !/    24-May-2013 : Adaptation from ww3_bound.ftn       ( version 4.08 )
 !/     1-Apr-2015 : Add checks on lat lon xfr           ( version 5.05 )
 !/    11-May-2015 : Allow use of cartesian grids        ( version 5.08 )
-!/    17-Aug-2016 : Bug correction on RDBPO             ( version 5.10 ) 
+!/    17-Aug-2016 : Bug correction on RDBPO             ( version 5.10 )
 !/    20-Oct-2016 : Error statement updates             ( version 5.15 )
 !/    20-Mar-2018 : Improve netcdf file reading         ( version 6.02 )
 !/    15-May-2018 : Add namelist feature                ( version 6.05 )
 !/
 !/    Copyright 2012-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -69,7 +69,7 @@
 !
 !     ----------------------------------------------------
 !        1.a  Set up data structures.
-!                            ( W3NMOD , W3NDAT , W3NOUT 
+!                            ( W3NMOD , W3NDAT , W3NOUT
 !                              W3SETG , W3SETW , W3SETO )
 !          b  I-O setup.
 !        ....
@@ -205,7 +205,7 @@
 !
 ! process ww3_bounc namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_bounc.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_bounc.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         ! Read namelist
         CALL W3NMLBOUNC (NDSI, TRIM(FNMPRE)//'ww3_bounc.nml', NML_BOUND, IERR)
@@ -215,7 +215,7 @@
         VERBOSE = NML_BOUND%VERBOSE
         FILE = NML_BOUND%FILE
 
-        NBO2 = 0          
+        NBO2 = 0
         OPEN(NDSL,FILE=TRIM(FILE),STATUS='OLD',ERR=809,IOSTAT=IERR)
         REWIND (NDSL)
         DO
@@ -251,7 +251,7 @@
         READ (NDSI,*,END=801,ERR=802) VERBOSE
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !
-        NBO2 = 0          
+        NBO2 = 0
 !
 !       ILOOP = 1 to count NBO2
 !       ILOOP = 2 to read the file names
@@ -266,10 +266,10 @@
             ALLOCATE(SPECFILES(NBO2))
             NBO2=0
           ENDIF
- 
+
           NBO2=0
 !         Read input file names
-          DO 
+          DO
             CALL NEXTLN ( COMSTR , NDSI2 , NDSE )
             READ (NDSI2,'(A512)') FILENAME
             JJ     = LEN_TRIM(FILENAME)
@@ -278,13 +278,13 @@
               READ (NDSI,'(A)') LINE
               WRITE (NDSS,'(A)') LINE
             END IF
-            IF (FILENAME(:JJ).EQ."'STOPSTRING'") EXIT 
+            IF (FILENAME(:JJ).EQ."'STOPSTRING'") EXIT
             NBO2=NBO2+1
-            IF (ILOOP.EQ.1) CYCLE 
+            IF (ILOOP.EQ.1) CYCLE
             SPECFILES(NBO2)=FILENAME
-          END DO 
+          END DO
 !
-          IF ( ILOOP .EQ. 1 ) CLOSE ( NDSS) 
+          IF ( ILOOP .EQ. 1 ) CLOSE ( NDSS)
 !
           IF ( ILOOP .EQ. 2 ) CLOSE ( NDSS, STATUS='DELETE' )
         END DO ! ILOOP = 1, 2
@@ -298,15 +298,15 @@
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 4. Tests the reading of the file
 !
-      IF ( INXOUT.EQ.'READ') THEN 
+      IF ( INXOUT.EQ.'READ') THEN
         OPEN(NDSB,FILE='nest.ww3',FORM='UNFORMATTED',status='old')
         READ(NDSB) IDTST, VERTEST, NK1, NTH1, XFR, FR1I, TH1I, NBI
         NSPEC1  = NK1 * NTH1
         IF ( IDTST .NE. IDSTRBC ) GOTO 803
         WRITE(NDSO,940) VERTEST
         WRITE(NDSO,941) IDTST
-        IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,2I5,3F12.6,I5)') 'NK,NTH,XFR, FR1I, TH1I, NBI :', & 
-                    NK1,NTH1,XFR, FR1I, TH1I, NBI 
+        IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,2I5,3F12.6,I5)') 'NK,NTH,XFR, FR1I, TH1I, NBI :', &
+                    NK1,NTH1,XFR, FR1I, TH1I, NBI
         ALLOCATE (XBPI(NBI),YBPI(NBI))
         ALLOCATE (IPBPI(NBI,4),RDBPI(NBI,4))
         READ(NDSB) (XBPI(I),I=1,NBI),                                 &
@@ -327,8 +327,8 @@
         IERR=0
         DO WHILE (IERR.EQ.0)
           READ (NDSB,IOSTAT=IERR) TIME2, NBI2
-          IF (IERR.EQ.0) THEN 
-            IF (VERBOSE.EQ.1) WRITE(NDSO,*)      'TIME2,NBI2:',TIME2, NBI2,IERR      
+          IF (IERR.EQ.0) THEN
+            IF (VERBOSE.EQ.1) WRITE(NDSO,*)      'TIME2,NBI2:',TIME2, NBI2,IERR
             DO IP=1, NBI2
               READ (NDSB,END=803,ERR=804) ABPIN(:,IP)
             END DO
@@ -338,7 +338,7 @@
       END IF ! INXOUT.EQ.'READ'
 !
 !
-      IF ( INXOUT.EQ.'WRITE') THEN 
+      IF ( INXOUT.EQ.'WRITE') THEN
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 5. Defines position of active boundary points
@@ -346,8 +346,8 @@
         NBO = 0
         DO ISEA=1,NSEA
           IX     = MAPSF(ISEA,1)
-          IY     = MAPSF(ISEA,2) 
-          IF (MAPSTA(IY,IX).EQ.2) THEN 
+          IY     = MAPSF(ISEA,2)
+          IF (MAPSTA(IY,IX).EQ.2) THEN
             NBO=NBO+1
           END IF
         END DO
@@ -357,7 +357,7 @@
         DO ISEA=1,NSEA
           IX     = MAPSF(ISEA,1)
           IY     = MAPSF(ISEA,2)
-          IF (MAPSTA(IY,IX).EQ.2) THEN 
+          IF (MAPSTA(IY,IX).EQ.2) THEN
             IBO=IBO+1
             SELECT CASE ( GTYPE )
             CASE ( RLGTYPE )
@@ -366,7 +366,7 @@
             CASE ( CLGTYPE )
               XBPO(IBO)= XGRD(IY,IX)
               YBPO(IBO)= YGRD(IY,IX)
-            CASE (UNGTYPE) 
+            CASE (UNGTYPE)
               XBPO(IBO)= XYB(IX,1)
               YBPO(IBO)= XYB(IX,2)
             END SELECT !GTYPE
@@ -382,17 +382,17 @@
           ! open file
           OPEN(NDSC,FILE=TRIM(SPECFILES(IP)),FORM='UNFORMATTED',      &
                status='old',iostat=ICODE)
-          IF (ICODE.NE.0) THEN 
+          IF (ICODE.NE.0) THEN
             LONS(IP)=-999.
             LATS(IP)=-999.
             WRITE (NDSE,1010) TRIM(SPECFILES(IP))
             CALL EXTCDE ( 70 )
           END IF
- 
+
           IRET=NF90_OPEN(TRIM(SPECFILES(IP)),NF90_NOWRITE,NCID(IP))
           WRITE(6,*) 'Opening file:',TRIM(SPECFILES(IP))
           CALL CHECK_ERR(IRET)
-          
+
           ! dimensions
           IRET=NF90_INQ_DIMID(NCID(IP),'time',DIMID(IP,1))
           CALL CHECK_ERR(IRET)
@@ -428,7 +428,7 @@
             IRET=NF90_GET_VAR(NCID(IP), VARID(1), TIMES(:))
             CALL CHECK_ERR(IRET)
             IRET=NF90_GET_ATT(NCID(IP),VARID(1),"calendar",CALENDAR)
-            IF ( IRET/=NF90_NOERR ) THEN 
+            IF ( IRET/=NF90_NOERR ) THEN
               WRITE(NDSE,951)
             ELSE IF ((INDEX(CALENDAR, "standard").EQ.0) .AND. &
                      (INDEX(CALENDAR, "gregorian").EQ.0)) THEN
@@ -438,7 +438,7 @@
             CALL U2D(TIMEUNITS,REFDATE,IERR)
             CALL D2J(REFDATE,REFJULDAY,IERR)
 
-          ELSE 
+          ELSE
             IF (NKI.NE.NK1.OR.NTHI.NE.NTH1) GOTO 805
           END IF
 
@@ -448,16 +448,16 @@
             CALL CHECK_ERR(IRET)
             IRET=NF90_GET_VAR(NCID(IP), VARID(2), LATS(IP))
             CALL CHECK_ERR(IRET)
-            IRET=NF90_INQ_VARID(NCID(IP), 'longitude', VARID(3))        
+            IRET=NF90_INQ_VARID(NCID(IP), 'longitude', VARID(3))
             CALL CHECK_ERR(IRET)
             IRET=NF90_GET_VAR(NCID(IP), VARID(3), LONS(IP))
             CALL CHECK_ERR(IRET)
           ELSE
-            IRET=NF90_INQ_VARID(NCID(IP), 'y', VARID(2))        
+            IRET=NF90_INQ_VARID(NCID(IP), 'y', VARID(2))
             CALL CHECK_ERR(IRET)
             IRET=NF90_GET_VAR(NCID(IP), VARID(2), LATS(IP))
             CALL CHECK_ERR(IRET)
-            IRET=NF90_INQ_VARID(NCID(IP), 'x', VARID(3))        
+            IRET=NF90_INQ_VARID(NCID(IP), 'x', VARID(3))
             CALL CHECK_ERR(IRET)
             IRET=NF90_GET_VAR(NCID(IP), VARID(3), LONS(IP))
             CALL CHECK_ERR(IRET)
@@ -474,7 +474,7 @@
           CALL CHECK_ERR(IRET)
           THETA=(PI/180)*THETA
 
-          ! 2D spectra depending on station name or lat/lon 
+          ! 2D spectra depending on station name or lat/lon
           IRET=NF90_INQ_VARID(NCID(IP),"efth",VARID(7))
           IF (IRET.NE.0) IRET=NF90_INQ_VARID(NCID(IP),"Efth",VARID(7))
           CALL CHECK_ERR(IRET)
@@ -482,7 +482,7 @@
           IF (IRET.NE.0) FACTOR=1.
           IRET=NF90_GET_ATT(NCID(IP),VARID(7),"add_offset",OFFSET)
           IF (IRET.NE.0) OFFSET=0.
-          IRET = NF90_INQ_VARID(NCID(IP), 'station_name', VARID(6)) 
+          IRET = NF90_INQ_VARID(NCID(IP), 'station_name', VARID(6))
           IF (IRET.NE.0) THEN
             ! efth(time, frequency, direction, latitude, longitude)
             IRET=NF90_GET_VAR(NCID(IP),VARID(7),SPEC2D(:,:,:,IP),       &
@@ -496,7 +496,7 @@
           END IF
           ! apply scale_factor and add_offset
           SPEC2D(:,:,:,IP)=(SPEC2D(:,:,:,IP)*FACTOR)+OFFSET
-         
+
           ! close spectra file
           IRET=NF90_CLOSE(NCID(IP))
           CALL CHECK_ERR(IRET)
@@ -526,36 +526,36 @@
         IF (ABS((FREQ(IFMIN+1)/FREQ(IFMIN))-XFR).GT.0.005) GOTO 807
 !
         ! Checks consistency of NTH
-        ! WARNING: check is only done on number of directions, no check 
-        ! is done on the relative offset of first direction in terms of 
-        ! the directional increment [-0.5,0.5] (last parameter of the 
-        ! spectral definition in ww3_grid.inp, on second active line) 
+        ! WARNING: check is only done on number of directions, no check
+        ! is done on the relative offset of first direction in terms of
+        ! the directional increment [-0.5,0.5] (last parameter of the
+        ! spectral definition in ww3_grid.inp, on second active line)
         IF (NTHI.NE.NTH) GOTO 808
 !
-        IF ((FR1-FREQ(1))/FR1.GT. 0.03) THEN 
+        IF ((FR1-FREQ(1))/FR1.GT. 0.03) THEN
           DO J=1,MIN(NK1,NK)
-            IF (ABS(FREQ(J)-FR1) .LT. ABS(FREQ(IFMIN)-FR1)) THEN 
+            IF (ABS(FREQ(J)-FR1) .LT. ABS(FREQ(IFMIN)-FR1)) THEN
               IFMIN=J
             END IF
-          END DO  
-        END IF
-!     
-        IF ((FREQ(1)-FR1)/FR1.GT. 0.03) THEN 
-          DO J=1,MIN(NK,NK1)
-            IF (ABS(FREQ(J)-FR1*XFR**(J-1)) .LT. ABS(FREQ(IFMIN2)-FR1)) THEN 
-              IFMIN2=J
-            END IF
-          END DO  
+          END DO
         END IF
 !
-        IF ((FREQ(NK1)-FR1*XFR**(NK-1))/FREQ(NK1) .GT.0.03) THEN 
+        IF ((FREQ(1)-FR1)/FR1.GT. 0.03) THEN
+          DO J=1,MIN(NK,NK1)
+            IF (ABS(FREQ(J)-FR1*XFR**(J-1)) .LT. ABS(FREQ(IFMIN2)-FR1)) THEN
+              IFMIN2=J
+            END IF
+          END DO
+        END IF
+!
+        IF ((FREQ(NK1)-FR1*XFR**(NK-1))/FREQ(NK1) .GT.0.03) THEN
           DO J=1,NK
             IF (ABS(FREQ(J)-FR1*XFR**(NK1-1)) .LT. &
-                ABS(FREQ(IFMAX)-FR1*XFR**(NK1-1))) THEN 
+                ABS(FREQ(IFMAX)-FR1*XFR**(NK1-1))) THEN
               IFMAX=J
             END IF
-          END DO 
-        END IF 
+          END DO
+        END IF
 
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -563,7 +563,7 @@
 !
         DO IP=1,NBO2
 !         Fills in the low frequency end of the spectrum
-          IF (IFMIN2.GT.1) THEN 
+          IF (IFMIN2.GT.1) THEN
             ABPIN2(1:(IFMIN2-1)*NTH,:,IP)=0.
           END IF
 
@@ -574,18 +574,18 @@
             END DO
           END DO
 
-!         Fills tail of spectrum            
-          IF (IFMAX-IFMIN+IFMIN2.LT.NK1) THEN 
+!         Fills tail of spectrum
+          IF (IFMAX-IFMIN+IFMIN2.LT.NK1) THEN
             IF (VERBOSE.GE.2) WRITE(NDSO,*) 'FILLING TAIL',IFMAX-IFMIN,NK1,IFMAX-IFMIN+(IFMIN2-1)
             ABPIN2((IFMAX-IFMIN+IFMIN2)*NTH+1:NK1*NTH,:,IP)=0.
-          END IF 
+          END IF
         END DO ! IP=1,NBO2
 
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 8. Writes header
 !
-!       Writes header in nest.ww3 file 
+!       Writes header in nest.ww3 file
         WRITE(NDSB) IDSTRBC, VERBPTBC, NK1, NTH1, XFR, FREQ(1),       &
         MOD(2.5*PI-THETA(1),TPI), NBO
         IPBPO(:,:)=1
@@ -599,19 +599,19 @@
 !         Loops on files
           DO IP=1,NBO2
 !           Searches for the nearest 2 points where spectra are available
-            IF (FLAGLL)  THEN 
+            IF (FLAGLL)  THEN
               DIST=DIST_SPHERE ( LONS(IP),LATS(IP),XBPO(IP1),YBPO(IP1) )
-            ELSE 
+            ELSE
               DIST=SQRT((LONS(IP)-XBPO(IP1))**2+(LATS(IP)-YBPO(IP1))**2)
               END IF
-            IF (DMIN.EQ.(360.+180.)) THEN 
-              IF(DIST.LT.DMIN) THEN 
+            IF (DMIN.EQ.(360.+180.)) THEN
+              IF(DIST.LT.DMIN) THEN
                 IPBPO(IP1,1)=IP
                 DMIN=DIST
               END IF
             ELSE
-              IF(DIST.LT.DMIN2) THEN 
-                IF(DIST.LT.DMIN) THEN 
+              IF(DIST.LT.DMIN2) THEN
+                IF(DIST.LT.DMIN) THEN
                   IPBPO(IP1,2)=IPBPO(IP1,1)
                   DMIN2=DMIN
                   IPBPO(IP1,1)=IP
@@ -632,8 +632,8 @@
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 9. Computes linear interpolation coefficient between the nearest 2 points
 !
-          IF (INTERP.GT.1.AND.NBO2.GT.1) THEN 
-            IF (FLAGLL) THEN 
+          IF (INTERP.GT.1.AND.NBO2.GT.1) THEN
+            IF (FLAGLL) THEN
               DLON=LONS(IPBPO(IP1,2))-LONS(IPBPO(IP1,1))
               DLAT=LATS(IPBPO(IP1,2))-LATS(IPBPO(IP1,1))
               DLO=XBPO(IP1)-LONS(IPBPO(IP1,1))
@@ -641,11 +641,11 @@
               IF (DLON.LT.-180.) DLON=DLON+360
               IF (DLO.GT.180.) DLO=DLO-360
               IF (DLO.LT.-180.) DLO=DLO+360
-              DIST=SQRT(DLON**2+DLAT**2) 
+              DIST=SQRT(DLON**2+DLAT**2)
               COS1=( DLO*DLON &
                   + (YBPO(IP1)-LATS(IPBPO(IP1,1)))  &
                   *DLAT )/(DIST**2)
-            ELSE 
+            ELSE
               DIST=SQRT((LONS(IPBPO(IP1,1))-LONS(IPBPO(IP1,2)))**2   &
                +(LATS(IPBPO(IP1,1))-LATS(IPBPO(IP1,2)))**2)
               COS1=( (XBPO(IP1)-LONS(IPBPO(IP1,1)))  &
@@ -659,7 +659,7 @@
             !      *(LATS(IPBPO(IP1,1))-LATS(IPBPO(IP1,2))))/(DIST**2)
             RDBPO(IP1,1)=1-MIN(1.,MAX(0.,COS1))
             RDBPO(IP1,2)=MIN(1.,MAX(0.,COS1))
-          ELSE 
+          ELSE
             ! in this case: nearest point
             RDBPO(IP1,1)=1.
             RDBPO(IP1,2:4)=0.
@@ -678,12 +678,12 @@
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 10. Loops on times and files and write to nest.ww3
-!          
+!
         DO IT=1,NT1
           CURJULDAY=TIMES(IT)
           IF (INDEX(TIMEUNITS, "seconds").NE.0)   CURJULDAY=CURJULDAY/86400.
           IF (INDEX(TIMEUNITS, "minutes").NE.0)   CURJULDAY=CURJULDAY/1440.
-          IF (INDEX(TIMEUNITS, "hours").NE.0)     CURJULDAY=CURJULDAY/24. 
+          IF (INDEX(TIMEUNITS, "hours").NE.0)     CURJULDAY=CURJULDAY/24.
           CURJULDAY=REFJULDAY+CURJULDAY
 
           ! convert julday to date and time

--- a/model/ftn/ww3_bound.ftn
+++ b/model/ftn/ww3_bound.ftn
@@ -11,11 +11,11 @@
 !/
 !/    28-Aug-2012 : adaptation from SHOM/Ifremer code   ( version 4.08 )
 !/    01-Nov-2012 : Bug correction for NKI != NK        ( version 4.08 )
-!/    20-Oct-2016 : Error statement updates             ( version 5.15 ) 
+!/    20-Oct-2016 : Error statement updates             ( version 5.15 )
 !/
 !/    Copyright 2012-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -64,7 +64,7 @@
 !
 !     ----------------------------------------------------
 !        1.a  Set up data structures.
-!                            ( W3NMOD , W3NDAT , W3NOUT 
+!                            ( W3NMOD , W3NDAT , W3NOUT
 !                              W3SETG , W3SETW , W3SETO )
 !          b  I-O setup.
 !        ....
@@ -96,7 +96,7 @@
 
       USE W3GDATMD, ONLY: NK, NTH, XFR, FR1, GNAME, W3NMOD, W3SETG, &
                           NSEA, MAPSTA, XYB, GTYPE, XGRD, YGRD, X0, Y0, &
-                          SX, SY, MAPSF, UNGTYPE, CLGTYPE, RLGTYPE 
+                          SX, SY, MAPSF, UNGTYPE, CLGTYPE, RLGTYPE
       USE W3ODATMD, ONLY: NDSO, NDSE
       USE W3IOBCMD, ONLY: VERBPTBC, IDSTRBC
       USE W3IOGRMD, ONLY: W3IOGR
@@ -133,8 +133,8 @@
       REAL   FR1I, TH1I
       REAL, ALLOCATABLE     :: XBPI(:), YBPI(:), RDBPI(:,:),        &
                                XBPO(:), YBPO(:), RDBPO(:,:),        &
-                               ABPIN(:,:) 
-             
+                               ABPIN(:,:)
+
       INTEGER,  ALLOCATABLE :: IPBPI(:,:),   IPBPO(:,:)
 
       CHARACTER(120) string1,buoyname
@@ -188,7 +188,7 @@
       READ (NDSI,*) VERBOSE
       CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !
-      NBO2 = 0          
+      NBO2 = 0
 !
 !     ILOOP = 1 to count NBO2
 !     ILOOP = 2 to read the file names
@@ -203,10 +203,10 @@
           ALLOCATE(SPECFILES(NBO2))
           NBO2=0
           ENDIF
- 
+
         NBO2=0
 ! Read input file names
-        DO 
+        DO
           CALL NEXTLN ( COMSTR , NDSI2 , NDSE )
           READ (NDSI2,'(A120)') FILENAME
           JJ     = LEN_TRIM(FILENAME)
@@ -215,15 +215,15 @@
               READ (NDSI,'(A)') LINE
               WRITE (NDSS,'(A)') LINE
             END IF
-          IF (FILENAME(:JJ).EQ."'STOPSTRING'") EXIT 
+          IF (FILENAME(:JJ).EQ."'STOPSTRING'") EXIT
           NBO2=NBO2+1
-          IF (ILOOP.EQ.1) CYCLE 
+          IF (ILOOP.EQ.1) CYCLE
           SPECFILES(NBO2)=FILENAME
-          END DO 
+          END DO
 !
 ! ... End of ILOOP loop
 !
-        IF ( ILOOP .EQ. 1 ) CLOSE ( NDSS) 
+        IF ( ILOOP .EQ. 1 ) CLOSE ( NDSS)
 
         IF ( ILOOP .EQ. 2 ) CLOSE ( NDSS, STATUS='DELETE' )
        END DO
@@ -232,7 +232,7 @@
 !
 ! 3. Tests the reading of the file
 !
-      IF ( INXOUT.EQ.'READ') THEN 
+      IF ( INXOUT.EQ.'READ') THEN
         OPEN(NDSB,FILE='nest.ww3',FORM='UNFORMATTED',status='old')
         READ(NDSB) IDTST, VERTEST, NK1, NTH1, XFR, FR1I, TH1I, NBI
         NSPEC1  = NK1 * NTH1
@@ -240,9 +240,9 @@
           WRITE (NDSO,901) IDTST, IDSTRBC
           END IF
         WRITE(NDSO,*) "FORMAT VERSION: '",VERTEST,"'"
-        WRITE(NDSO,*) "FILE TYPE: '",IDTST,"'"  
-        IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,2I5,3F12.6,I5)') 'NK,NTH,XFR, FR1I, TH1I, NBI :', & 
-                    NK1,NTH1,XFR, FR1I, TH1I, NBI 
+        WRITE(NDSO,*) "FILE TYPE: '",IDTST,"'"
+        IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,2I5,3F12.6,I5)') 'NK,NTH,XFR, FR1I, TH1I, NBI :', &
+                    NK1,NTH1,XFR, FR1I, TH1I, NBI
         ALLOCATE (XBPI(NBI),YBPI(NBI))
         ALLOCATE (IPBPI(NBI,4),RDBPI(NBI,4))
         READ(NDSB) (XBPI(I),I=1,NBI),           &
@@ -263,8 +263,8 @@
         IERR=0
         DO WHILE (IERR.EQ.0)
           READ (NDSB,IOSTAT=IERR) TIME2, NBI2
-          IF (IERR.EQ.0) THEN 
-          IF (VERBOSE.EQ.1) WRITE(NDSO,*)      'TIME2,NBI2:',TIME2, NBI2,IERR      
+          IF (IERR.EQ.0) THEN
+          IF (VERBOSE.EQ.1) WRITE(NDSO,*)      'TIME2,NBI2:',TIME2, NBI2,IERR
           DO IP=1, NBI2
             READ (NDSB,IOSTAT=IERR) ABPIN(:,IP)
             END DO
@@ -274,16 +274,16 @@
         END IF
 !
 !
-      IF ( INXOUT.EQ.'WRITE') THEN 
-        IF ( FLBPI) THEN 
+      IF ( INXOUT.EQ.'WRITE') THEN
+        IF ( FLBPI) THEN
 !
 !  Defines position of active boundary points
 !
         NBO = 0
         DO ISEA=1,NSEA
           IX     = MAPSF(ISEA,1)
-          IY     = MAPSF(ISEA,2) 
-          IF (MAPSTA(IY,IX).EQ.2) THEN 
+          IY     = MAPSF(ISEA,2)
+          IF (MAPSTA(IY,IX).EQ.2) THEN
             NBO=NBO+1
             END IF
           END DO
@@ -293,7 +293,7 @@
         DO ISEA=1,NSEA
           IX     = MAPSF(ISEA,1)
           IY     = MAPSF(ISEA,2)
-          IF (MAPSTA(IY,IX).EQ.2) THEN 
+          IF (MAPSTA(IY,IX).EQ.2) THEN
             IBO=IBO+1
             SELECT CASE ( GTYPE )
             CASE ( RLGTYPE )
@@ -302,7 +302,7 @@
             CASE ( CLGTYPE )
               XBPO(IBO)= XGRD(IY,IX)
               YBPO(IBO)= YGRD(IY,IX)
-            CASE (UNGTYPE) 
+            CASE (UNGTYPE)
               XBPO(IBO)= XYB(IX,1)
               YBPO(IBO)= XYB(IX,2)
               END SELECT !GTYPE
@@ -319,7 +319,7 @@
           READ(200+IP,'(A1,A22,A1,X,2I6)',iostat=IERR)  &
              space,string1,space,NKI,NTHI
           IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,3I5)') 'IP and spectral dimensions:',IP, NKI,NTHI
-          IF (IP.EQ.1) THEN 
+          IF (IP.EQ.1) THEN
             NK1=NKI
             NTH1=NTHI
             NSPEC1  = NK1 * NTH1
@@ -328,9 +328,9 @@
             ALLOCATE (ABPIN(NK*NTH1,NBO2))
           ELSE
 !
-!  To be cleaned up later ... 
+!  To be cleaned up later ...
 !
-            IF (NK1.NE.NKI.OR.NTH1.NE.NTHI) THEN 
+            IF (NK1.NE.NKI.OR.NTH1.NE.NTHI) THEN
               WRITE(NDSE,'(A,A,4I5)') 'ERROR, SPECTRAL GRID IN FILE:',     &
                          TRIM(SPECFILES(IP)),NK1,NKI,NTH1,NTHI
               STOP
@@ -361,36 +361,36 @@
       IF (ABS((FREQ(IFMIN+1)/FREQ(IFMIN))-XFR).GT.0.005) GOTO 2006
 !
       ! Checks consistency of NTH
-      ! WARNING: check is only done on number of directions, no check 
-      ! is done on the relative offset of first direction in terms of 
-      ! the directional increment [-0.5,0.5] (last parameter of the 
-      ! spectral definition in ww3_grid.inp, on second active line) 
+      ! WARNING: check is only done on number of directions, no check
+      ! is done on the relative offset of first direction in terms of
+      ! the directional increment [-0.5,0.5] (last parameter of the
+      ! spectral definition in ww3_grid.inp, on second active line)
       IF (NTHI.NE.NTH) GOTO 2007
 
-      IF ((FR1-FREQ(1))/FR1.GT. 0.03) THEN 
+      IF ((FR1-FREQ(1))/FR1.GT. 0.03) THEN
         DO J=1,MIN(NK1,NK)
-          IF (ABS(FREQ(J)-FR1) .LT. ABS(FREQ(IFMIN)-FR1)) THEN 
+          IF (ABS(FREQ(J)-FR1) .LT. ABS(FREQ(IFMIN)-FR1)) THEN
             IFMIN=J
             END IF
-          END DO  
-        END IF
-!     
-      IF ((FREQ(1)-FR1)/FR1.GT. 0.03) THEN 
-        DO J=1,MIN(NK,NK1)
-          IF (ABS(FREQ(J)-FR1*XFR**(J-1)) .LT. ABS(FREQ(IFMIN2)-FR1)) THEN 
-            IFMIN2=J
-            END IF
-          END DO  
+          END DO
         END IF
 !
-      IF ((FREQ(NK1)-FR1*XFR**(NK-1))/FREQ(NK1) .GT.0.03) THEN 
+      IF ((FREQ(1)-FR1)/FR1.GT. 0.03) THEN
+        DO J=1,MIN(NK,NK1)
+          IF (ABS(FREQ(J)-FR1*XFR**(J-1)) .LT. ABS(FREQ(IFMIN2)-FR1)) THEN
+            IFMIN2=J
+            END IF
+          END DO
+        END IF
+!
+      IF ((FREQ(NK1)-FR1*XFR**(NK-1))/FREQ(NK1) .GT.0.03) THEN
         DO J=1,NK
-            IF (ABS(FREQ(J)-FR1*XFR**(NK1-1)) .LT. ABS(FREQ(IFMAX)-FR1*XFR**(NK1-1))) THEN 
+            IF (ABS(FREQ(J)-FR1*XFR**(NK1-1)) .LT. ABS(FREQ(IFMAX)-FR1*XFR**(NK1-1))) THEN
             IFMAX=J
             END IF
-          END DO 
-        END IF 
-! 
+          END DO
+        END IF
+!
       IERR=0
       ITIME=0
 !
@@ -399,20 +399,20 @@
       DO WHILE (IERR.EQ.0)
         DO IP=1,NBO2
           READ(200+IP,*,IOSTAT=IERR) TIME2
-          IF (IERR.EQ.0) THEN 
+          IF (IERR.EQ.0) THEN
 !
               IF (IP.EQ.1) THEN
               TIME1=TIME2
             ELSE
-                IF (TIME1(1).NE.TIME2(1).OR.TIME1(2).NE.TIME2(2)) THEN 
+                IF (TIME1(1).NE.TIME2(1).OR.TIME1(2).NE.TIME2(2)) THEN
                   WRITE(NDSE,*) 'AT POINT ',IP,', BAD TIMES:',TIME1, TIME2
                 END IF
-              END IF 
+              END IF
 !
             READ(200+IP,'(A1,A10,A1,2F7.2,F10.1,F7.2,F6.1,F7.2,F6.1)') &
               space,buoyname,space,LATS(IP),LONS(IP),depth,U10,Udir,Curr,Currdir
-            READ(200+IP,*,IOSTAT=IERR) SPEC2D 
-              IF (IFMIN2.GT.1) THEN 
+            READ(200+IP,*,IOSTAT=IERR) SPEC2D
+              IF (IFMIN2.GT.1) THEN
 !
 !  Fills in the low frequency end of the spectrum
 !
@@ -423,26 +423,26 @@
                 ABPIN((I-IFMIN+(IFMIN2-1))*NTH+J,IP)=SPEC2D(I,J)*tpiinv
                 END DO
               END DO
-           IF (IFMAX-IFMIN+IFMIN2.LT.NK1) THEN 
+           IF (IFMAX-IFMIN+IFMIN2.LT.NK1) THEN
         !IF (VERBOSE.EQ.1) WRITE(NDSO,*) 'FILLING TAIL',IFMAX-IFMIN,NK1,IFMAX-IFMIN+(IFMIN2-1)
              ABPIN((IFMAX-IFMIN+IFMIN2)*NTH+1:NK1*NTH,IP)=0.
-             END IF 
+             END IF
            END IF  ! ned of test on IERR
          END DO
 !
 ! Writes header
 !
-       IF (IERR.EQ.0) THEN 
-         IF (ITIME.EQ.0) THEN 
-! Correction for rounding error in ASCII files ... 
+       IF (IERR.EQ.0) THEN
+         IF (ITIME.EQ.0) THEN
+! Correction for rounding error in ASCII files ...
            IF (ABS(THETA(1)-0.5*PI).LT.0.01) THETA(1)=0.5*PI
-! Writes header in nest.ww3 file 
+! Writes header in nest.ww3 file
            WRITE(NDSB) IDSTRBC, VERBPTBC, NK1, NTH, XFR, FREQ(1), &
                        MOD(2.5*PI-THETA(1),TPI), NBO
              IPBPO(:,:)=1
              RDBPO(:,1)=1.
              RDBPO(:,2:4)=0.
-!     
+!
            DO IP1=1,NBO
              DMIN=360.+180.
              DMIN2=360.+180.
@@ -451,14 +451,14 @@
 ! Searches for the nearest 2 points where spectra are available
 !
           DIST=SQRT((LONS(IP)-XBPO(IP1))**2+(LATS(IP)-YBPO(IP1))**2)
-          IF (DMIN.EQ.(360.+180.)) THEN 
-            IF(DIST.LT.DMIN) THEN 
+          IF (DMIN.EQ.(360.+180.)) THEN
+            IF(DIST.LT.DMIN) THEN
               IPBPO(IP1,1)=IP
               DMIN=DIST
               END IF
           ELSE
-            IF(DIST.LT.DMIN2) THEN 
-              IF(DIST.LT.DMIN) THEN 
+            IF(DIST.LT.DMIN2) THEN
+              IF(DIST.LT.DMIN) THEN
              IPBPO(IP1,2)=IPBPO(IP1,1)
              DMIN2=DMIN
                 IPBPO(IP1,1)=IP
@@ -476,7 +476,7 @@
 !
 !  Computes linear interpolation coefficient between the nearest 2 points
 !
-          IF (INTERP.GT.1.AND.NBO2.GT.1) THEN 
+          IF (INTERP.GT.1.AND.NBO2.GT.1) THEN
                 DIST=SQRT((LONS(IPBPO(IP1,1))-LONS(IPBPO(IP1,2)))**2   &
                    +(LATS(IPBPO(IP1,1))-LATS(IPBPO(IP1,2)))**2)
           COS1=( (XBPO(IP1)-LONS(IPBPO(IP1,1)))  &
@@ -493,14 +493,14 @@
 !
           IF (VERBOSE.EQ.1) WRITE(NDSO,*) 'IPBP:',IP1,(IPBPO(IP1,J),J=1,4)
           IF (VERBOSE.EQ.1) WRITE(NDSO,*) 'RDBP:',IP1,(RDBPO(IP1,J),J=1,4)
-!          
+!
         END DO
       WRITE(NDSB) (XBPO(I),I=1,NBO),           &
                   (YBPO(I),I=1,NBO),           &
                   ((IPBPO(I,J),I=1,NBO),J=1,4),&
                   ((RDBPO(I,J),I=1,NBO),J=1,4)
          END IF
-      
+
        WRITE(NDSO,*) 'Writing boundary data for time:', TIME2, NBO2
        WRITE(NDSB,IOSTAT=IERR) TIME2, NBO2
        DO IP=1, NBO2
@@ -508,7 +508,7 @@
          END DO
 
        ITIME=ITIME+1
-       END IF      
+       END IF
        END DO
        CLOSE(NDSB)
      END IF

--- a/model/ftn/ww3_gint.ftn
+++ b/model/ftn/ww3_gint.ftn
@@ -20,23 +20,23 @@
 !/                  (F.Ardhuin, M.Accensi, J.H.Alves)   ( version 6.05 )
 !/    31-Aug-2018 : Update groups 2,4,6,8 (S. Zieger)   ( version 6.05 )
 !/
-!   1. Purpose : 
+!   1. Purpose :
 !
-!   Re-gridding binary output (out_grd.* files) to another grid 
+!   Re-gridding binary output (out_grd.* files) to another grid
 !
 !   2. Method :
 !
 !   Data is interpolated from a combination of base grids to the target
 !   grid. For each grid, if resolution is coarser or similar to target
 !   grid then a linear interpolation approach is used. On the other hand
-!   if resolution is much higher then an averaging technique based on 
-!   cell areas. 
+!   if resolution is much higher then an averaging technique based on
+!   cell areas.
 !   Total number of base grids to be used for interpolation together with
-!   their (and target grid) file extns are read from 'ww3_gint.inp'. 
-!   Base grids can be arranged in any order but the target grid should 
-!       always be the last grid. 
+!   their (and target grid) file extns are read from 'ww3_gint.inp'.
+!   Base grids can be arranged in any order but the target grid should
+!       always be the last grid.
 !
-!   3. Parameters : 
+!   3. Parameters :
 !
 !   4. Subroutines used :
 !
@@ -57,10 +57,10 @@
 !      W3SETA    Subr.   Id.    Point to selected model for aux data.
 !      W3DIMA      Subr.   Id.    Assign memory for aux data.
 !      W3GRMP    Func. W3GSRUMD Compute interpolation coeff. from grid.
-!      W3CKCL    Func.   Id.    Check if point lies within grid cell. 
+!      W3CKCL    Func.   Id.    Check if point lies within grid cell.
 !      W3IOGO    Subr. W3IOGOMD Reading/writing raw gridded data file.
 !     ----------------------------------------------------------------
-!  
+!
 !  5. Called by :
 !
 !     None, stand-alone program.
@@ -185,7 +185,7 @@
         WRITE (NDSO,902) IDTIME, DTREQ, NOUT
 !
 ! 3.c Read number of grids and allocate memory
-!   
+!
         CALL NEXTLN ( COMSTR, NDSI, NDSE )
         READ (NDSI,*,END=2001,ERR=2002) NG
         WRITE (NDSO,903) NG
@@ -196,7 +196,7 @@
         CALL W3NINP (    6, 6)
         CALL W3NOUT(     6, 6)
 !
-! 3.d Read file extensions for each of the grids and 
+! 3.d Read file extensions for each of the grids and
 !     the grid information from the corresponding mod_def files
 !
         NOSWLL_MIN = 9999999
@@ -211,7 +211,7 @@
           CALL W3SETW( IG, 6, 6)
           CALL W3SETG( IG, 6, 6)
           CALL W3IOGR ('READ', NDSM, IG, GRIDS(IG)%FILEXT)
-          WRITE (NDSO,905) NX, NY, GTYPE, ICLOSE 
+          WRITE (NDSO,905) NX, NY, GTYPE, ICLOSE
 
           IF ( ICLOSE .EQ. ICLOSE_TRPL ) THEN
              WRITE(NDSE,*)'PROGRAM W3GRID_INTERP HAS NOT BEEN '//  &
@@ -260,7 +260,7 @@
 !
         IF ( FLAGLL ) THEN
           IF ( MINVAL ( XGRD ) .LT. 0 .OR.                                     &
-               MAXVAL ( XGRD ) .GT. 180.0 ) L360 = .TRUE. 
+               MAXVAL ( XGRD ) .GT. 180.0 ) L360 = .TRUE.
         END IF
 !
 ! 4.b Check if weight files exist or create it
@@ -268,11 +268,11 @@
         FNAMEWHT='WHTGRIDINT.bin'
         OPEN (994,FILE=FNMPRE(:J)//TRIM(FNAMEWHT),FORM='UNFORMATTED',IOSTAT=IERR,STATUS='OLD')
         NSEA_FILE = 0
-        IF (IERR.EQ.0) READ(994) NSEA_FILE ! basic security check ... 
-        IF (NSEA_FILE.EQ.NSEA) THEN 
+        IF (IERR.EQ.0) READ(994) NSEA_FILE ! basic security check ...
+        IF (NSEA_FILE.EQ.NSEA) THEN
           DO ISEA = 1, NSEA
             READ(994) COUNTG
-            ALLOCATE ( GR_INTS(ISEA)%IND_WTS(COUNTG),GR_INTS(ISEA)%GDID(COUNTG) ) 
+            ALLOCATE ( GR_INTS(ISEA)%IND_WTS(COUNTG),GR_INTS(ISEA)%GDID(COUNTG) )
             DO IG = 1,COUNTG
               READ(994) GR_INTS(ISEA)%IND_WTS(IG)%AR
               READ(994) GR_INTS(ISEA)%GDID(IG)
@@ -310,7 +310,7 @@
 !
           COUNTG = 0
           DO IG = 1,NG-1
-!       
+!
 ! 4.b.ii Check if point is enclosed in grid domain
 !
             INGRID=.FALSE.
@@ -319,16 +319,16 @@
               CALL IS_IN_UNGRID(IG, XGRD(IY,IX), YGRD(IY,IX),  &
                                                  ITOUT, IS, JS, RW)
               IF (ITOUT.GT.0) INGRID=.TRUE.
-!              ! If extrapolation activated, force to find if a triangles is inside 
+!              ! If extrapolation activated, force to find if a triangles is inside
 !              ! the coarse grid cell even if there is no triangle in the cell center
               IF (EXTRA.GT.0) THEN
                 WRITE(991,'(2I6,2F9.4,I8,3I8,3F5.3)') IX,IY,XGRD(IY,IX), YGRD(IY,IX), ITOUT, IS(1:3), RW(1:3)
                 IF (ITOUT.EQ.0)  WRITE(992,*) IX,IY,ISEA,XGRD(IY,IX), YGRD(IY,IX)
-                IF (ITOUT.EQ.0) THEN 
+                IF (ITOUT.EQ.0) THEN
                    CALL IS_IN_UNGRID2(IG, XGRD(IY,IX), YGRD(IY,IX), EXTRA,  &
                                                  ITOUT, IS, JS, RW)
                    WRITE(993,'(2I6,2F9.4,I8,3I8,3F6.3)') IX,IY,XGRD(IY,IX), YGRD(IY,IX), ITOUT, IS(1:3), RW(1:3)
-                ENDIF  
+                ENDIF
                 !IF (ITOUT.EQ.0) CALL IS_IN_UNGRID(IG, XGRD(IY,IX)+DX, YGRD(IY,IX), ITOUT, IS, JS, RW)
                 !IF (ITOUT.GT.0) INGRID=.TRUE.
                 !IF (ITOUT.EQ.0) CALL IS_IN_UNGRID(IG, XGRD(IY,IX)-DX, YGRD(IY,IX), ITOUT, IS, JS, RW)
@@ -337,19 +337,19 @@
                 !IF (ITOUT.GT.0) INGRID=.TRUE.
                 !IF (ITOUT.EQ.0) CALL IS_IN_UNGRID(IG, XGRD(IY,IX), YGRD(IY,IX)-DY, ITOUT, IS, JS, RW)
                 !IF (ITOUT.GT.0) INGRID=.TRUE.
-              END IF           
+              END IF
             ELSE
               IF ( W3GRMP ( GRIDS(IG)%GSU, XGRD(IY,IX), YGRD(IY,IX), IS,        &
                    JS, RW ) ) INGRID=.TRUE.
               END IF
-           IF (INGRID) THEN 
+           IF (INGRID) THEN
 !
-! 4.b.iii Check source grid resolution vs target grid resolution 
+! 4.b.iii Check source grid resolution vs target grid resolution
 !         (averaging used for finer resolution source grids)
 !
-             IF (GRIDS(IG)%GTYPE .EQ. UNGTYPE) THEN 
+             IF (GRIDS(IG)%GTYPE .EQ. UNGTYPE) THEN
                 SAREA = GRIDS(IG)%TRIA(ITOUT)
-             ELSE 
+             ELSE
                DO I = 1,4
                  XCRNR(I) = GRIDS(IG)%XGRD(JS(I),IS(I))
                  YCRNR(I) = GRIDS(IG)%YGRD(JS(I),IS(I))
@@ -373,33 +373,33 @@
              NS = NINT(DAREA/SAREA)
 !
              IF ( NS .LE. 2 .OR. GRIDS(IG)%GTYPE .EQ. UNGTYPE ) THEN
-! FA: Quick fix for UNST type grids: always perform interpolation 
-!     To be updated later ... 
+! FA: Quick fix for UNST type grids: always perform interpolation
+!     To be updated later ...
 !
 ! 4.b.iv Counting the contributing nodes to re-normalize the weights RW
-! 
+!
                 ALLOCATE ( TMP_INDX(4) )
                 COUNTF = 0
                 SUMWT = 0.0
-                DO I = 1,4 
+                DO I = 1,4
 ! The following two IF tests are separated because for triangles, JS(4)=IS(4)=0
-                  IF ( RW(I) .GT. 0.0 ) THEN 
+                  IF ( RW(I) .GT. 0.0 ) THEN
                     IF ( GRIDS(IG)%MAPSTA(JS(I),IS(I)) .NE. 0) THEN
                       COUNTF = COUNTF+1
                       TMP_INDX(COUNTF) = I
                       SUMWT = SUMWT + RW(I)
-                    END IF 
+                    END IF
                   END IF
                 END DO
 !
 ! 4.b.v  Interpolating to target grid
-! 
-                IF ( COUNTF .GT. 0 ) THEN                
-! Should use SAREA info to prevent the increment of COUNTG ... 
-! what about islands / land in triangle meshes? they are not part of the triangles... 
+!
+                IF ( COUNTF .GT. 0 ) THEN
+! Should use SAREA info to prevent the increment of COUNTG ...
+! what about islands / land in triangle meshes? they are not part of the triangles...
                   COUNTG = COUNTG + 1
-                  IF (COUNTG.GT.1) THEN 
-                    IF (SAREA.LT.0.5*GR_INTS(ISEA)%IND_WTS(COUNTG-1)%AR) THEN 
+                  IF (COUNTG.GT.1) THEN
+                    IF (SAREA.LT.0.5*GR_INTS(ISEA)%IND_WTS(COUNTG-1)%AR) THEN
                        DO JG=1,COUNTG-1
                          DEALLOCATE (GR_INTS(ISEA)%IND_WTS(JG)%IP)
                          DEALLOCATE (GR_INTS(ISEA)%IND_WTS(JG)%JP)
@@ -426,7 +426,7 @@
                 DEALLOCATE ( TMP_INDX )
 !
               ELSE
-! 
+!
 ! 4.b.vi Find the averaging points for higher resolution grid
 !        Step 1 : Compute the corners of the cell
 !
@@ -464,8 +464,8 @@
                   YCRNR(4) = 0.5*(YT+Y0)
                 ELSEIF ( IX .EQ. 1 ) THEN
                   IF ( IY .EQ. 1 ) THEN
-                    XT = XGRD(IY+1,IX+1)     
-                    YT = YGRD(IY+1,IX+1)     
+                    XT = XGRD(IY+1,IX+1)
+                    YT = YGRD(IY+1,IX+1)
                     IF ( ABS(XT-X0) .GT. 270 ) THEN
                       XT = XT - SIGN(360.,XT-X0)
                       END IF
@@ -473,13 +473,13 @@
                     YCRNR(2) = 0.5*(YT+Y0)
                     XCRNR(4) = 2*X0 - XCRNR(2)
                     YCRNR(4) = 2*Y0 - YCRNR(2)
-                    XCRNR(3) = X0 - (YCRNR(2)-Y0) 
-                    YCRNR(3) = Y0 + (XCRNR(2)-X0) 
+                    XCRNR(3) = X0 - (YCRNR(2)-Y0)
+                    YCRNR(3) = Y0 + (XCRNR(2)-X0)
                     XCRNR(1) = 2*X0 - XCRNR(3)
                     YCRNR(1) = 2*Y0 - YCRNR(3)
                   ELSEIF ( IY .EQ. NY ) THEN
-                    XT = XGRD(IY-1,IX+1)     
-                    YT = YGRD(IY-1,IX+1)     
+                    XT = XGRD(IY-1,IX+1)
+                    YT = YGRD(IY-1,IX+1)
                     IF ( ABS(XT-X0) .GT. 270 ) THEN
                       XT = XT - SIGN(360.,XT-X0)
                     END IF
@@ -487,8 +487,8 @@
                     YCRNR(1) = 0.5*(YT+Y0)
                     XCRNR(3) = 2*X0 - XCRNR(1)
                     YCRNR(3) = 2*Y0 - YCRNR(1)
-                    XCRNR(2) = X0 - (Y0-YCRNR(1)) 
-                    YCRNR(2) = Y0 + (X0-XCRNR(1)) 
+                    XCRNR(2) = X0 - (Y0-YCRNR(1))
+                    YCRNR(2) = Y0 + (X0-XCRNR(1))
                     XCRNR(4) = 2*X0 - XCRNR(2)
                     YCRNR(4) = 2*Y0 - YCRNR(2)
                   ELSE
@@ -513,29 +513,29 @@
                   ENDIF
                 ELSEIF ( IX .EQ. NX ) THEN
                   IF ( IY .EQ. 1 ) THEN
-                    XT = XGRD(IY+1,IX-1)     
-                    YT = YGRD(IY+1,IX-1)     
+                    XT = XGRD(IY+1,IX-1)
+                    YT = YGRD(IY+1,IX-1)
                     IF ( ABS(XT-X0) .GT. 270 ) THEN
                       XT = XT - SIGN(360.,XT-X0)
                     END IF
                     XCRNR(3) = 0.5*(XT+X0)
                     YCRNR(3) = 0.5*(YT+Y0)
-                    XCRNR(2) = X0 - (YCRNR(3)-Y0) 
-                    YCRNR(2) = Y0 + (XCRNR(3)-X0) 
+                    XCRNR(2) = X0 - (YCRNR(3)-Y0)
+                    YCRNR(2) = Y0 + (XCRNR(3)-X0)
                     XCRNR(1) = 2*X0 - XCRNR(3)
                     YCRNR(1) = 2*Y0 - YCRNR(3)
                     XCRNR(4) = 2*X0 - XCRNR(2)
                     YCRNR(4) = 2*Y0 - YCRNR(2)
                   ELSEIF ( IY .EQ. NY ) THEN
-                    XT = XGRD(IY-1,IX-1)     
-                    YT = YGRD(IY-1,IX-1)     
+                    XT = XGRD(IY-1,IX-1)
+                    YT = YGRD(IY-1,IX-1)
                     IF ( ABS(XT-X0) .GT. 270 ) THEN
                       XT = XT - SIGN(360.,XT-X0)
                     END IF
                     XCRNR(4) = 0.5*(XT+X0)
                     YCRNR(4) = 0.5*(YT+Y0)
-                    XCRNR(3) = X0 - (YCRNR(4)-Y0) 
-                    YCRNR(3) = Y0 + (XCRNR(4)-X0) 
+                    XCRNR(3) = X0 - (YCRNR(4)-Y0)
+                    YCRNR(3) = Y0 + (XCRNR(4)-X0)
                     XCRNR(1) = 2*X0 - XCRNR(3)
                     YCRNR(1) = 2*Y0 - YCRNR(3)
                     XCRNR(2) = 2*X0 - XCRNR(4)
@@ -601,22 +601,22 @@
                     YCRNR(3) = 2*Y0 - YCRNR(1)
                   END IF
                 END IF
-                BRNCHCL = .FALSE. 
-                BRNCHCR = .FALSE. 
+                BRNCHCL = .FALSE.
+                BRNCHCR = .FALSE.
                 IF ( FLAGLL .AND. ICLOSE .EQ. ICLOSE_SMPL ) THEN
                   IF ( L360 ) THEN
-                    IF ( MINVAL ( XCRNR(1:4) ) .LT.   0.0 ) BRNCHCL = .TRUE. 
-                    IF ( MAXVAL ( XCRNR(1:4) ) .GT. 360.0 ) BRNCHCR = .TRUE. 
+                    IF ( MINVAL ( XCRNR(1:4) ) .LT.   0.0 ) BRNCHCL = .TRUE.
+                    IF ( MAXVAL ( XCRNR(1:4) ) .GT. 360.0 ) BRNCHCR = .TRUE.
                   ELSE
-                    IF ( MINVAL ( XCRNR(1:4) ) .LT. -180.0 ) BRNCHCL = .TRUE. 
-                    IF ( MAXVAL ( XCRNR(1:4) ) .GT.  180.0 ) BRNCHCR = .TRUE. 
+                    IF ( MINVAL ( XCRNR(1:4) ) .LT. -180.0 ) BRNCHCL = .TRUE.
+                    IF ( MAXVAL ( XCRNR(1:4) ) .GT.  180.0 ) BRNCHCR = .TRUE.
                   END IF
                 END IF
 !
 !        Step 2 : Loop through source grid to find all active points in cell
 !
-!FA : why only *5 ???... 
-! 
+!FA : why only *5 ???...
+!
                 ALLOCATE ( TMP_INDX(NS*5) )
                 COUNTF = 0
                 DO I = 1, GRIDS(IG)%NSEA
@@ -672,7 +672,7 @@
                     GR_INTS(ISEA)%IND_WTS(COUNTG)%WT(I) = 1./( REAL(COUNTF) )
                   END DO
                   GR_INTS(ISEA)%IND_WTS(COUNTG)%NP = COUNTF
-                END IF   
+                END IF
                 DEALLOCATE ( TMP_INDX )
 !
               END IF  ! End of check for grid resolution
@@ -682,15 +682,15 @@
           END DO      ! End of loop through all input grids
 !
           GR_INTS(ISEA)%NGRDS = COUNTG
-! 
-! 4.b.vii Check to see if interpolation weights found.  
+!
+! 4.b.vii Check to see if interpolation weights found.
 !        Status of output points with / without weights set in MAPST2
 !        using the next available bit
 !
           IF ( GR_INTS(ISEA)%NGRDS .EQ. 0 ) THEN
 !/T            WRITE (NDSO,909)IX, IY
             MAPINT = 1
-            MAPST2(IY,IX) = MAPST2(IY,IX) + MAPINT*16 
+            MAPST2(IY,IX) = MAPST2(IY,IX) + MAPINT*16
             MAPSTA(IY,IX) = -ABS ( MAPSTA(IY,IX) )
           END IF
 !
@@ -700,8 +700,8 @@
         WRITE(994) NSEA
         DO ISEA = 1, NSEA
           COUNTG = GR_INTS(ISEA)%NGRDS
-          WRITE(994) COUNTG              
-          DO IG = 1,COUNTG                   
+          WRITE(994) COUNTG
+          DO IG = 1,COUNTG
             WRITE(994) GR_INTS(ISEA)%IND_WTS(IG)%AR
             WRITE(994) GR_INTS(ISEA)%GDID(IG)
             COUNTF = GR_INTS(ISEA)%IND_WTS(IG)%NP
@@ -715,7 +715,7 @@
           END DO ! IG
           WRITE(994) GR_INTS(ISEA)%NGRDS
         END DO ! ISEA
-        END IF ! NSEA.EQ.NSEA_FILE	
+        END IF ! NSEA.EQ.NSEA_FILE
         CLOSE(994)
 !
 ! 4.c Print Interpolation grids map
@@ -783,8 +783,8 @@
         END DO
         WRITE (NDSO, 915)
 !
-! 5.d Carry out interpolation in an infinite loop till appropriate 
-!     time steps are interpolated 
+! 5.d Carry out interpolation in an infinite loop till appropriate
+!     time steps are interpolated
 !
         IOUT = 0
 !
@@ -890,7 +890,7 @@
                  '     IOSTAT =',I5/)
 !
 !/
-!/ Internal Subroutine 
+!/ Internal Subroutine
 !/
 !/ Internal Subroutine W3EXGI ----------------------------------------------/
 !/
@@ -911,34 +911,34 @@
 !/
 !   1. Purpose :
 !
-!      Perform actual output of interpolated data. 
+!      Perform actual output of interpolated data.
 !
-!   3. Parameters : 
+!   3. Parameters :
 !
-!   4. Subroutines used : 
+!   4. Subroutines used :
 !
 !      Name      Type  Module   Description
 !     ----------------------------------------------------------------
 !        W3IOGO    Subr. W3IOGOMD Reading/writing raw gridded data file.
 !     ----------------------------------------------------------------
 !
-!   5. Called by : 
+!   5. Called by :
 !
 !      Subroutine it resides in
 !
-!   6. Error messages : 
+!   6. Error messages :
 !
 !      None.
 !
-!   7. Remarks : 
+!   7. Remarks :
 !
-!   8. Structure : 
+!   8. Structure :
 !
 !      See source code.
 !
-!   9. Switches : 
+!   9. Switches :
 !
-!      10. Source code : 
+!      10. Source code :
 !
 !/ -------------------------------------------------------------------------/
         USE W3ADATMD
@@ -1156,11 +1156,11 @@
 !
           IX = MAPSF(ISEA,1)
           IY = MAPSF(ISEA,2)
-          MAPICE = MOD(MAPST2(IY,IX),2) 
-          MAPDRY = MOD(MAPST2(IY,IX)/2,2) 
-          MAPLND = MOD(MAPST2(IY,IX)/4,2) 
-          MAPMSK = MOD(MAPST2(IY,IX)/8,2) 
-          MAPINT = MOD(MAPST2(IY,IX)/16,2) 
+          MAPICE = MOD(MAPST2(IY,IX),2)
+          MAPDRY = MOD(MAPST2(IY,IX)/2,2)
+          MAPLND = MOD(MAPST2(IY,IX)/4,2)
+          MAPMSK = MOD(MAPST2(IY,IX)/8,2)
+          MAPINT = MOD(MAPST2(IY,IX)/16,2)
           MAPST2(IY,IX) = MAPST2(IY,IX) - MAPICE - 2*MAPDRY - 4*MAPLND         &
                           - 8*MAPMSK
           ACTIVE =  (MAPICE .NE. 1 .AND. MAPDRY .NE. 1)
@@ -1198,7 +1198,7 @@
                 IF ( LMAPDRY .EQ. 1 ) NMAPDRY = NMAPDRY + 1
                 IF ( LMAPLND .EQ. 1 ) NMAPLND = NMAPLND + 1
                 IF ( LMAPMSK .EQ. 1 ) NMAPMSK = NMAPMSK + 1
-              END DO 
+              END DO
               NMAPICE = NMAPICE*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
               NMAPDRY = NMAPDRY*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
               NMAPLND = NMAPLND*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
@@ -1495,7 +1495,7 @@
 !/IS2                      SUMWT1(9) = SUMWT1(9) + WT
 !/IS2                      IF (ICEHAUX .EQ. UNDEF) THEN
 !/IS2                        ICEHAUX = WDATAS(IGRID)%ICEH(GSEA)*WT
-!/IS2                      ELSE 
+!/IS2                      ELSE
 !/IS2                        ICEHAUX = ICEHAUX + WDATAS(IGRID)%ICEH(GSEA)*WT
 !/IS2                      END IF
 !/IS2                    END IF
@@ -1506,7 +1506,7 @@
 !/IS2                      SUMWT1(10) = SUMWT1(10) + WT
 !/IS2                      IF (ICEFAUX .EQ. UNDEF) THEN
 !/IS2                        ICEFAUX = WDATAS(IGRID)%ICEF(GSEA)*WT
-!/IS2                      ELSE 
+!/IS2                      ELSE
 !/IS2                        ICEFAUX = ICEFAUX + WDATAS(IGRID)%ICEF(GSEA)*WT
 !/IS2                      END IF
 !/IS2                    END IF
@@ -2342,7 +2342,7 @@
                     CX(ISEA) = CXAUX / REAL( SUMGRD )
                     CY(ISEA) = CYAUX / REAL( SUMGRD )
                   ELSE
-                    CX(ISEA) = CX(ISEA) + CXAUX / REAL( SUMGRD ) 
+                    CX(ISEA) = CX(ISEA) + CXAUX / REAL( SUMGRD )
                     CY(ISEA) = CY(ISEA) + CYAUX / REAL( SUMGRD )
                   END IF
                 END IF
@@ -2351,10 +2351,10 @@
                   UAAUX = UAAUX / SUMWT1(3)
                   UDAUX = UDAUX / SUMWT1(3)
                   IF ( UA(ISEA) .EQ. UNDEF )  THEN
-                    UA(ISEA) = UAAUX / REAL( SUMGRD ) 
+                    UA(ISEA) = UAAUX / REAL( SUMGRD )
                     UD(ISEA) = UDAUX / REAL( SUMGRD )
                   ELSE
-                    UA(ISEA) = UA(ISEA) + UAAUX / REAL( SUMGRD ) 
+                    UA(ISEA) = UA(ISEA) + UAAUX / REAL( SUMGRD )
                     UD(ISEA) = UD(ISEA) + UDAUX / REAL( SUMGRD )
                   END IF
                 END IF
@@ -2364,7 +2364,7 @@
                   IF ( AS(ISEA) .EQ. UNDEF )  THEN
                     AS(ISEA) = ASAUX / REAL( SUMGRD )
                   ELSE
-                    AS(ISEA) = AS(ISEA) + ASAUX / REAL( SUMGRD ) 
+                    AS(ISEA) = AS(ISEA) + ASAUX / REAL( SUMGRD )
                   END IF
                 END IF
 !
@@ -2869,7 +2869,7 @@
                   IF ( WHITECAPAUX(ICAP) .NE. UNDEF ) THEN
                     WHITECAPAUX(ICAP) = WHITECAPAUX(ICAP) / SUMWTC(ICAP)
                     IF ( WHITECAP(ISEA,ICAP) .EQ. UNDEF )  THEN
-                      WHITECAP(ISEA,ICAP) = WHITECAPAUX(ICAP) / REAL( SUMGRD ) 
+                      WHITECAP(ISEA,ICAP) = WHITECAPAUX(ICAP) / REAL( SUMGRD )
                     ELSE
                       WHITECAP(ISEA,ICAP) = WHITECAP(ISEA,ICAP) +              &
                                WHITECAPAUX(ICAP) / REAL( SUMGRD )
@@ -3135,7 +3135,7 @@
             END DO !/ IG = 1, GR_INTS
 !
 ! Convert select variables back to polar notation. This is done because just
-! prior to writing to file the w3iogo routine converts these variables 
+! prior to writing to file the w3iogo routine converts these variables
 ! from polar to cartesian coordinates
 !
             IF ( UA(ISEA) .NE. UNDEF ) THEN
@@ -3143,7 +3143,7 @@
               VAR2 = UD(ISEA)
               UA(ISEA) = SQRT ( VAR1**2 + VAR2**2 )
               UD(ISEA) = ATAN2 ( VAR2, VAR1 )
-            END IF 
+            END IF
 !
             IF ( UST(ISEA) .NE. UNDEF ) THEN
               VAR1 = UST(ISEA)

--- a/model/ftn/ww3_grib.ftn
+++ b/model/ftn/ww3_grib.ftn
@@ -31,14 +31,14 @@
 !/                  (Arun Chawla)
 !/    01-Mar-2013 : Adding double-index output fields   ( version 4.11 )
 !/                  (J-Henrique Alves)
-!/    01-Dec-2016 : Adding lambert conformal grid       ( version 6.01 ) 
+!/    01-Dec-2016 : Adding lambert conformal grid       ( version 6.01 )
 !/                  (J.H. Alves)
-!/    26-Jul-2018 : Adding polar stereographic grid     ( version 6.05 ) 
+!/    26-Jul-2018 : Adding polar stereographic grid     ( version 6.05 )
 !/                  (J.H. Alves)
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -77,7 +77,7 @@
 !      DSEC21    Func.   Id.    Difference between times.
 !      W3IOGR    Subr. W3IOGRMD Reading/writing model definition file.
 !      W3IOGO    Subr. W3IOGOMD Reading/writing raw gridded data file.
-!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags. 
+!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags.
 !      W3EXGB    Subr. Internal Execute grib output.
 !      BAOPEN    Subr.          NCEP library routine.
 !      BAOPENW    Subr.          NCEP library routine.
@@ -142,7 +142,7 @@
                                  ISEA, IX, IY, TOUT(2), NOUT, TDUM(2),&
                                  FTIME(2), CID, PID, GID, GDS, IOUT,  &
                                  GDTN
-      INTEGER, ALLOCATABLE    :: IFIA(:),IFJA(:) 
+      INTEGER, ALLOCATABLE    :: IFIA(:),IFJA(:)
 ! GRIB1 specific variables
 !/NOGRB      INTEGER                 :: KPDS(1), KGDS(1)
 !/NCEP1      INTEGER                 :: KPDS(25), KGDS(22)
@@ -153,10 +153,10 @@
 !/NCEP2      INTEGER                 :: IBMP, LCGRIB, LENGRIB, IDRSNUM
 !/NCEP2      REAL                    :: COORDLIST, XN
 !/NCEP2      CHARACTER(LEN=1), ALLOCATABLE  :: CGRIB(:)
-!/NCEP2      INTEGER                 :: LATAN1, LONV, SCNMOD, LATIN1, & 
-!/NCEP2                                 LATIN2, LATSP, LONSP  
-!/NCEP2      REAL                    :: DSX, DSY 
-!/NCEP2      REAL                    :: YN, X0N, Y0N 
+!/NCEP2      INTEGER                 :: LATAN1, LONV, SCNMOD, LATIN1, &
+!/NCEP2                                 LATIN2, LATSP, LONSP
+!/NCEP2      REAL                    :: DSX, DSY
+!/NCEP2      REAL                    :: YN, X0N, Y0N
 !/S      INTEGER, SAVE           :: IENT = 0
       REAL                    :: DTREQ, DTEST, RFTIME
       LOGICAL                 :: FLREQ(NOGRP,NGRPP), FLGRIB(NOGRP,NGRPP)
@@ -246,9 +246,9 @@
       IDTIME(21:23) = '   '
       WRITE (NDSO,941) IDTIME, NOUT
 !
-! ... Initialize FLGRD array 
+! ... Initialize FLGRD array
 !
-      FLREQ(:,:)=.FALSE. 
+      FLREQ(:,:)=.FALSE.
 !
 ! ... Call to interface for reading flags or namelists
 !
@@ -261,10 +261,10 @@
 !
       WRITE (NDSO,944)
 ! Reset flags for variables not yet implemented in grib output
-! interface 
+! interface
 !
 !
-      IFI = 3 ! Entire group Frequency-dependent parameters 
+      IFI = 3 ! Entire group Frequency-dependent parameters
       DO IFJ = 1,NOGE(IFI)
         IF ( FLREQ(IFI,IFJ) ) THEN
           WRITE (NDSO,946) IDOUT(IFI,IFJ),                           &
@@ -272,7 +272,7 @@
           FLREQ(IFI,IFJ) = .FALSE.
         END IF
       END DO
-! 
+!
       IFI = 5 ! Atm-waves layer, all except for friction velocity
       DO IFJ = 2,10
         IF ( FLREQ(IFI,IFJ) ) THEN
@@ -310,13 +310,13 @@
 !
 ! Chage this as parameters become available in grib2 tables
 !
-      ALLOCATE ( IFIA (16), IFJA(16) ) 
+      ALLOCATE ( IFIA (16), IFJA(16) )
 
       IFIA = (/ 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 5, 9, 9, 9, 9 /)
       IFJA = (/ 1, 4, 2 ,3, 5, 8, 3, 5, 6, 7, 8, 1, 1, 2, 3, 4 /)
-      DO I = 1, 16 
+      DO I = 1, 16
         IF ( FLREQ(IFIA(I),IFJA(I)) ) THEN
-          FLREQ(IFIA(I),IFJA(I)) = .FALSE. 
+          FLREQ(IFIA(I),IFJA(I)) = .FALSE.
           WRITE(NDSO,946) IDOUT(IFIA(I),IFJA(I)),                      &
                         '*** EXCLUDED FROM GRIB OUTPUT ***'
         END IF
@@ -337,72 +337,72 @@
 !
       CALL NEXTLN ( COMSTR , NDSI , NDSE )
       READ (NDSI,*,END=801,ERR=802) FTIME, CID, PID, GID, GDS, GDTN
-! 
-! Check if grid type is curvilinear, and only go on if Lambert conformal 
+!
+! Check if grid type is curvilinear, and only go on if Lambert conformal
 ! or PolarStereo
-! 
-      IF ( GTYPE .EQ. CLGTYPE ) THEN 
-!/NCEP2! Allowing code to work with Lambert conformal grids 
-!/NCEP2      IF ( GDTN .NE. 30 .AND. GDTN .NE. 20 ) THEN 
-        WRITE(NDSE,*)'PROGRAM W3GRIB: CURVILINEAR GRID SUPPORT '// & 
-        'FOR GRIB OUTPUT IS NOT YET IMPLEMENTED. NOW STOPPING' 
-        CALL EXTCDE ( 1 ) 
-!/NCEP2      ENDIF 
-      END IF 
-! 
-! 
-! Coded up to now only for Lamber conformal grids (GDTN=30) or 
-! PolarStereo (GDTN=20). For regular grids use GDTN=0 
-! 
-!/NCEP2      IF ( GDTN .EQ. 30 ) THEN 
-!/NCEP2! This is a Lambert conformal grid, read projection parameters 
-!/NCEP2        CALL NEXTLN ( COMSTR , NDSI , NDSE ) 
-!/NCEP2        READ (NDSI,*,END=801,ERR=802) LATAN1, LONV, DSX, DSY,          & 
-!/NCEP2                                SCNMOD, LATIN1, LATIN2, LATSP, LONSP 
+!
+      IF ( GTYPE .EQ. CLGTYPE ) THEN
+!/NCEP2! Allowing code to work with Lambert conformal grids
+!/NCEP2      IF ( GDTN .NE. 30 .AND. GDTN .NE. 20 ) THEN
+        WRITE(NDSE,*)'PROGRAM W3GRIB: CURVILINEAR GRID SUPPORT '// &
+        'FOR GRIB OUTPUT IS NOT YET IMPLEMENTED. NOW STOPPING'
+        CALL EXTCDE ( 1 )
+!/NCEP2      ENDIF
+      END IF
+!
+!
+! Coded up to now only for Lamber conformal grids (GDTN=30) or
+! PolarStereo (GDTN=20). For regular grids use GDTN=0
+!
+!/NCEP2      IF ( GDTN .EQ. 30 ) THEN
+!/NCEP2! This is a Lambert conformal grid, read projection parameters
+!/NCEP2        CALL NEXTLN ( COMSTR , NDSI , NDSE )
+!/NCEP2        READ (NDSI,*,END=801,ERR=802) LATAN1, LONV, DSX, DSY,          &
+!/NCEP2                                SCNMOD, LATIN1, LATIN2, LATSP, LONSP
 !/NCEP2             ELSEIF ( GDTN .EQ. 20 ) THEN
 !/NCEP2               CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/NCEP2               READ (NDSI,*,END=801,ERR=802) LATAN1, LONV, DSX, DSY,   &
 !/NCEP2                                             SCNMOD
 
-!/NCEP2      ENDIF 
+!/NCEP2      ENDIF
 !
       CALL STME21 ( FTIME , IDTIME )
       WRITE (NDSO,948) IDTIME, CID, PID, GID, GDS
-! 
-! 
-!--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-! 4.  Read general data and first fields from file 
-! 4.a Read file. 
-! 
-      CALL W3IOGO ( 'READ', NDSOG, IOTEST ) 
-! 
-! 4.b Output fields in file 
-! 
-! 
-      WRITE (NDSO,930) 
-      DO I=1, NOGRP 
-       DO J=1, NGRPP 
-        IF ( FLOGRD(I,J) ) WRITE (NDSO,931) IDOUT(I,J) 
-        END DO 
-        END DO 
-! 
-!/NCEP2! 
-!/NCEP2      IF ( GDTN .EQ. 0 ) THEN 
-!/NCEP2! 
-! 4.c Flip MAPSF for REGULAR/RECTILINEAR grids 
-! 
-      DO ISEA=1, NSEA 
-        IX            = MAPSF(ISEA,1) 
-        IY            = MAPSF(ISEA,2) 
-        MAPSF(ISEA,2) = NY + 1 - IY 
-        MAPSF(ISEA,3) = IY +( IX-1)*NY 
-        END DO 
-!/NCEP2! 
-!/NCEP2      ENDIF 
 !
-!--- - - - - - - - - - - - - - - - - - - - - - - - - -  
-! 5. Set grib encoding parameter Sections 
-! 
+!
+!--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+! 4.  Read general data and first fields from file
+! 4.a Read file.
+!
+      CALL W3IOGO ( 'READ', NDSOG, IOTEST )
+!
+! 4.b Output fields in file
+!
+!
+      WRITE (NDSO,930)
+      DO I=1, NOGRP
+       DO J=1, NGRPP
+        IF ( FLOGRD(I,J) ) WRITE (NDSO,931) IDOUT(I,J)
+        END DO
+        END DO
+!
+!/NCEP2!
+!/NCEP2      IF ( GDTN .EQ. 0 ) THEN
+!/NCEP2!
+! 4.c Flip MAPSF for REGULAR/RECTILINEAR grids
+!
+      DO ISEA=1, NSEA
+        IX            = MAPSF(ISEA,1)
+        IY            = MAPSF(ISEA,2)
+        MAPSF(ISEA,2) = NY + 1 - IY
+        MAPSF(ISEA,3) = IY +( IX-1)*NY
+        END DO
+!/NCEP2!
+!/NCEP2      ENDIF
+!
+!--- - - - - - - - - - - - - - - - - - - - - - - - - -
+! 5. Set grib encoding parameter Sections
+!
 ! ... Initialize KPDS and KGDS (for both NCEP1 and NCEP2)
 !
       KPDS     =   0
@@ -491,8 +491,8 @@
 !      ( 2)  GRIB Edition Number
 !      ( 3)
 !/NCEP2       LISTSEC0      =   0
-!/NCEP2       LISTSEC0(1)   =   10      
-!/NCEP2       LISTSEC0(2)   =   2       
+!/NCEP2       LISTSEC0(1)   =   10
+!/NCEP2       LISTSEC0(2)   =   2
 !
 ! ... Set GRIB2 Identification Section
 !       ( 1) ID OF CENTER
@@ -545,9 +545,9 @@
 !
 ! General parameters for all grids
 !       ( 1) Coordinate system (6 = spherical coordinate system with radius of 6,371,229 m)
-!       ( 2) 
+!       ( 2)
 !       ( 3)
-!       ( 4) 
+!       ( 4)
 !       ( 5)
 !       ( 6)
 !       ( 7)
@@ -562,14 +562,14 @@
 ! Lambert Conformal grid
 !       (10) Latitude of first grid point
 !       (11) Longitude of first grid point
-!       (12) Resolution and component flags 
+!       (12) Resolution and component flags
 !       (13) Latitude where DX and DY are specified
 !       (14) Longitude of orientation
 !       (15) Increment of longitude
 !       (16) Increment of latitude
 !       (17) Projection center flag
 !       (18) Scanning mode
-!       (19) First latitude of secant cone 
+!       (19) First latitude of secant cone
 !       (20) Second latitude of secant cone
 !       (21) Latitude of southern pole
 !       (22) Longitude of southern pole
@@ -663,7 +663,7 @@
 !     ( 9) Time range
 !     (10) Type of level (Code Table 4.5) 1st level
 !     (11) Scaled factor of (10)
-!     (12) Scaled value of (10) 
+!     (12) Scaled value of (10)
 !     (13) Type of level (Code Table 4.5) 2nd level
 !     (14) Scaled factor of (13)
 !     (15) Scaled value of (13)
@@ -677,7 +677,7 @@
 !/NCEP2       KPDS(12) = 1
 !/NCEP2       KPDS(13) = 255
 !
-! ... Set GRIB2 vertical layer information 
+! ... Set GRIB2 vertical layer information
 !
 !/NCEP2       NUMCOORD  = 0
 !/NCEP2       COORDLIST = 0.0
@@ -906,7 +906,7 @@
 !     ----------------------------------------------------------------
 !      STRACE     Subr. W3SERVMD Subroutine tracing.
 !      EXTCDE     Subr.   Id.    Abort program as graceful as possible.
-!      W3S2XY     Subr.   Id.    Convert from storage to spatial grid. 
+!      W3S2XY     Subr.   Id.    Convert from storage to spatial grid.
 !      PUTGB      Subr.          NCEP GRIB1 library routine.
 !      GRIBCREATE Subr.          NCEP GRIB2 library routine.
 !      ADDGRID    Subr.          NCEP GRIB2 library routine.
@@ -1006,8 +1006,8 @@
             IF ( IFI .EQ. 1 .AND. IFJ .EQ.  1 ) THEN
                 FLONE = .TRUE.
 !/NCEP1                KPDS(5) = -1
-!/NCEP2                KPDS(2) = 14 
-!/NCEP2                KPDS(1) = 4  
+!/NCEP2                KPDS(2) = 14
+!/NCEP2                KPDS(1) = 4
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, DW(1:NSEA)          &
                                                         , MAPSF, X1 )
 !
@@ -1016,8 +1016,8 @@
               ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ.  2 ) THEN
                 FLTWO = .TRUE.
 !/NCEP1                KPDS(5) = -1
-!/NCEP2                KPDS(2) = 1 
-!/NCEP2                KPDS(1) = 1 
+!/NCEP2                KPDS(2) = 1
+!/NCEP2                KPDS(1) = 1
 !/RTD                ! Rotate x,y vector back to standard pole
 !/RTD                IF ( FLAGUNR ) CALL W3XYRTN(NSEA, CX, CY, AnglD)
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, CX(1:NSEA)          &
@@ -1083,8 +1083,8 @@
               ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ.  4 ) THEN
                 FLONE = .TRUE.
 !/NCEP1                KPDS(5) = -1
-!/NCEP2                KPDS(2) = 255 
-!/NCEP2                KPDS(1) = 3   
+!/NCEP2                KPDS(2) = 255
+!/NCEP2                KPDS(1) = 3
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, AS(1:NSEA)          &
                                                         , MAPSF, X1 )
 !
@@ -1092,9 +1092,9 @@
 !
               ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 5 ) THEN
                 FLONE = .TRUE.
-!/NCEP1                KPDS(5) = -1 
-!/NCEP2                KPDS(2) = 1 
-!/NCEP2                KPDS(1) = 3 
+!/NCEP1                KPDS(5) = -1
+!/NCEP2                KPDS(2) = 1
+!/NCEP2                KPDS(1) = 3
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, WLV   , MAPSF, X1 )
 !
 !     Ice concentration
@@ -1126,7 +1126,7 @@
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ.  3 ) THEN
                 FLONE = .TRUE.
-!/NCEP1                KPDS(5) = -1 
+!/NCEP1                KPDS(5) = -1
 !/NCEP2                KPDS(2) = 28
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, T02   , MAPSF, X1 )
 !
@@ -1142,7 +1142,7 @@
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ.  5 ) THEN
                 FLONE = .TRUE.
-!/NCEP1                KPDS(5) = -1 
+!/NCEP1                KPDS(5) = -1
 !/NCEP2                KPDS(2) = 25
                 CALL W3S2XY ( NSEA, NSEA, NX, NY, T01   , MAPSF, X1 )
 !
@@ -1274,8 +1274,8 @@
                 FLPRT = .TRUE.
 !/NCEP1                KPDS5A  =  -1
 !/NCEP1                KPDS5B  =  -1
-!/NCEP2                KPDS5A  =  32 
-!/NCEP2                KPDS5B  =  33 
+!/NCEP2                KPDS5A  =  32
+!/NCEP2                KPDS5B  =  33
                 CALL W3S2XY                                           &
                         ( NSEA, NSEA, NX, NY, PSI(:,0), MAPSF, YY(:,0) )
                 DO I=1, NOSWLL
@@ -1319,7 +1319,7 @@
               ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ.  1 ) THEN
                 FLTWO = .TRUE.
 !/NCEP1                KPDS(5) = -1
-!/NCEP2                KPDS(2) = 17 
+!/NCEP2                KPDS(2) = 17
 !/NCEP2                KPDS(1) = 1
 !/RTD                ! Rotate x,y vector back to standard pole
 !/RTD                IF ( FLAGUNR ) CALL W3XYRTN(NSEA, UST, USTDIR, AnglD)

--- a/model/ftn/ww3_grid.ftn
+++ b/model/ftn/ww3_grid.ftn
@@ -64,7 +64,7 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Clean up of unstructured grids      ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid. Change GLOBAL
 !/                  input in ww3_grid.inp to CSTRG.     ( version 3.14 )
@@ -73,7 +73,7 @@
 !/    16-Sep-2011 : Clean up.                           ( version 4.05 )
 !/    01-Dec-2011 : New namelist for reflection         ( version 4.05 )
 !/    01-Mar-2012 : Bug correction for NLPROP in ST2    ( version 4.05 )
-!/    12-Jun-2012 : Add /RTD rotated grid option. JGLi  ( version 4.06 ) 
+!/    12-Jun-2012 : Add /RTD rotated grid option. JGLi  ( version 4.06 )
 !/    13-Jul-2012 : Move data structures GMD (SNL3) and nonlinear
 !/                  filter (SNLS) from 3.15 (HLT).      ( version 4.07 )
 !/    02-Sep-2012 : Clean up of reflection and UG grids ( version 4.08 )
@@ -106,7 +106,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -275,29 +275,29 @@
 !
 ! (Begin SMC description)
 !
-!      Spherical Multiple-Cell (SMC) grid 
+!      Spherical Multiple-Cell (SMC) grid
 !     -----------------------------------
 !
-!     SMC grid is a multi-resolution grid using cells of multiple times 
-!     of each other.  It is similar to the lat-lon grid using rectangular 
-!     cells but only cells at sea points are retained.  All land points 
-!     have been removed from the model.  At high latitudes, cells are 
-!     merged longitudinally to relax the CFL resctiction on time steps. 
-!     Near coastlines, cells are divided into quarters in a few steps so 
-!     that high resolution is achieved to refine coastlines and resolve 
+!     SMC grid is a multi-resolution grid using cells of multiple times
+!     of each other.  It is similar to the lat-lon grid using rectangular
+!     cells but only cells at sea points are retained.  All land points
+!     have been removed from the model.  At high latitudes, cells are
+!     merged longitudinally to relax the CFL resctiction on time steps.
+!     Near coastlines, cells are divided into quarters in a few steps so
+!     that high resolution is achieved to refine coastlines and resolve
 !     small islands.  At present, three tiers of quarter cells are used.
-!     For locating purpose, a usual x-y counter is setup by the smallest 
-!     cell size and starting from the south-west corner of the usual 
-!     rectuangular domain.  Each sea cell is then given a pair of x-y 
-!     index, plus a pair of increments.  These four index are stored in 
+!     For locating purpose, a usual x-y counter is setup by the smallest
+!     cell size and starting from the south-west corner of the usual
+!     rectuangular domain.  Each sea cell is then given a pair of x-y
+!     index, plus a pair of increments.  These four index are stored in
 !     the cell array IJKCel(NCel, 5), each row holds i, j, di, dj, ndps
 !     where ndps is an integer depth in metre.  If precision higher than
 !     a metre is required, it may use other unit (cm for instance) with a
-!     conversion factor.  
-!    
-!     For transport calculation, two face arrays, IJKUFc(NUFc, 7) and 
-!     IJKVFc(NVFc,8), are also created to store the neighbouring cell 
-!     sequential numbers and the face location and size.  The 3 arrays 
+!     conversion factor.
+!
+!     For transport calculation, two face arrays, IJKUFc(NUFc, 7) and
+!     IJKVFc(NVFc,8), are also created to store the neighbouring cell
+!     sequential numbers and the face location and size.  The 3 arrays
 !     are calculated outside the wave model and input from text files.
 !
 !     Boundary condition is added for SMC grid so that it can be used for
@@ -308,15 +308,15 @@
 !     reset with an input value because the NX-Y double loop overcount
 !     the boundary cells for merged cells in the SMC grid.  ISBPI
 !     boundary cell mapping array is fine as MAPFS uses duplicated cell
-!     number in any merged cell.  From there, all original NBI loops are 
-!     reusable. 
+!     number in any merged cell.  From there, all original NBI loops are
+!     reusable.
 !
 !     The whole Arctic can be included in the SMC grid if another option
 !     ARC is activated along with the SMC option.  ARC option appends
 !     the polar Arctic part above 86N to the existing SMC grid and uses
 !     a map-east reference direction for this extra polar region.
 !     Because the map-east direction changes with latitude and longitude
-!     the wave spectra defined to the map-east direction could not be 
+!     the wave spectra defined to the map-east direction could not be
 !     mixed up with the conventional spectra defined to the local east
 !     direction.  A rotation sub is provided for convertion from one to
 !     another.  Propagation part will be calculated together, including
@@ -331,17 +331,17 @@
 !     are required for a Arctic regional model, users may consider use
 !     the rotated SMC grid options (RTD and SMC).
 !
-!     For more information about the SMC grid, please refer to  
+!     For more information about the SMC grid, please refer to
 !     Li, J.G. (2012) Propagation of Ocean Surface Waves on a Spherical
 !     Multiple-Cell Grid.  J. Comput. Phys., 231, 8262-8277.  online at
 !     http://dx.doi.org/10.1016/j.jcp.2012.08.007
 !
 ! (End SMC description)
 !
-!     ICEWIND is the scale factor for reduction of wind input by ice 
-!     concentration. Value specified corresponds to the fractional 
+!     ICEWIND is the scale factor for reduction of wind input by ice
+!     concentration. Value specified corresponds to the fractional
 !     input for 100% ice concentration. Default is 1.0, meaning that
-!     100% ice concentration result in zero wind input. 
+!     100% ice concentration result in zero wind input.
 !     Sin_in_ice=Sin_in_open_water * (1-ICE*ICEWIND)
 
 !     -----------------------------------------------------------------*
@@ -423,7 +423,7 @@
 !     !/ST1   WAM-3 physics package.
 !     !/ST2   Tolman and Chalikov (1996) physics package.
 !     !/ST3   WAM 4+ source terms from P.A.E.M. Janssen and J-R. Bidlot
-!     !/ST4   Ardhuin et al. (2009,2010) input and dissipation 
+!     !/ST4   Ardhuin et al. (2009,2010) input and dissipation
 !     !/ST6   BYDRZ source term package featuring Donelan et al.
 !             (2006) input and Babanin et al. (2001,2010) dissipation.
 !     !/STX   Open slot.
@@ -438,12 +438,12 @@
 !
 !     !/BT0   No bottom friction included.
 !     !/BT1   JONSWAP bottom friction package.
-!     !/BT4   SHOWEX bottom friction using movable bed roughness 
+!     !/BT4   SHOWEX bottom friction using movable bed roughness
 !                  (Tolman 1994, Ardhuin & al. 2003)
 !     !/BTX   Open slot.
 !
 !     !/IC1   Sink term for interaction with ice (uniform k_i)
-!     !/IC2   Sink term for under-ice boundary layer friction 
+!     !/IC2   Sink term for under-ice boundary layer friction
 !                  (Liu et al.    1991: JGR 96 (C3), 4605-4621)
 !                  (Liu and Mollo 1988: JPO 18       1720-1712)
 !     !/IC3   Sink term for interaction with ice (Wang and Shen method)
@@ -475,8 +475,8 @@
 !             correction for swell dispersion.
 !     !/PR3   Averaging ULTIMATE QUICKEST scheme.
 !
-!     !/RTD   Rotated regular lat-lon grid. 
-!     !/SMC   UNO2 scheme on Spherical Multiple-Cell grid.   
+!     !/RTD   Rotated regular lat-lon grid.
+!     !/SMC   UNO2 scheme on Spherical Multiple-Cell grid.
 !     !/ARC   Append the Arctic part to the SMC grid.
 !
 !     !/MGG   GSE correction for moving grid.
@@ -502,8 +502,8 @@
       USE W3ODATMD, ONLY: W3NOUT, W3SETO, W3DMO5
       USE W3IOGRMD, ONLY: W3IOGR
       USE W3SERVMD, ONLY: ITRACE, NEXTLN, EXTCDE
-!/RTD      USE W3SERVMD, ONLY: W3EQTOLL 
-!/ARC      USE W3SERVMD, ONLY: W3LLTOEQ 
+!/RTD      USE W3SERVMD, ONLY: W3EQTOLL
+!/ARC      USE W3SERVMD, ONLY: W3LLTOEQ
 !/S      USE W3SERVMD, ONLY: STRACE
       USE W3ARRYMD, ONLY: INA2R, INA2I
 !/T      USE W3ARRYMD, ONLY: PRTBLK
@@ -562,9 +562,9 @@
 !/O1      INTEGER             :: IBI, IP0, IPN, IPH, IPI
       INTEGER                 :: NCOL =  78
 !/SMC !!Li     Offset to change Equator index = 0 to regular index JEQT
-!/SMC !!Li     LvSMC  levels of refinded resolutions for SMC grid.  
-!/SMC !!Li     NBISMC number of boundary point for regional SMC grid.  
-!/SMC !!Li     ISHFT for SMC i-index from smc origin to regular grid west edge. 
+!/SMC !!Li     LvSMC  levels of refinded resolutions for SMC grid.
+!/SMC !!Li     NBISMC number of boundary point for regional SMC grid.
+!/SMC !!Li     ISHFT for SMC i-index from smc origin to regular grid west edge.
 !/SMC !!Li     SMC cell only subgrid obstruction array dimensions NCObst, JObs.
 !/SMC      INTEGER      :: JEQT, LvSMC, NBISMC, JS, NCObst, JObs, ISHFT
 !/SMC      INTEGER      :: NGUI, NGVJ
@@ -622,7 +622,7 @@
 !/SMC      INTEGER, ALLOCATABLE    :: NBICelin(:),  IJKObstr(:,:)
 !/ARC      REAL                    :: PoLonAC, PoLatAC
 !/ARC      INTEGER, ALLOCATABLE    :: IJKCelAC(:,:),IJKUFcAC(:,:),IJKVFcAC(:,:)
-!/ARC      REAL,    ALLOCATABLE    :: XLONAC(:),YLATAC(:),ELONAC(:),ELATAC(:) 
+!/ARC      REAL,    ALLOCATABLE    :: XLONAC(:),YLATAC(:),ELONAC(:),ELATAC(:)
 !
 !/RTD      REAL, ALLOCATABLE       :: AnglDin(:,:),StdLon(:,:),StdLat(:,:)
       REAL, ALLOCATABLE       :: XGRDIN(:,:), YGRDIN(:,:)
@@ -737,7 +737,7 @@
 !/ST4                                 SDSSTRAIN, SDSSTRAINA, SDSSTRAIN2,   &
 !/ST4                                 SDSBR, SDSP,                         &
 !/ST4                                 SDSCOS, SDSDTH, SDSBCK, SDSABK,      &
-!/ST4                                 SDSPBK, SDSBINT, SDSHCK,             &               
+!/ST4                                 SDSPBK, SDSBINT, SDSHCK,             &
 !/ST4                                 SDSBR2, SDSBRF1,                     &
 !/ST4                                 SDSBM0, SDSBM1, SDSBM2, SDSBM3,      &
 !/ST4                                 SDSBM4, SDSLFGEN, SDSHFGEN
@@ -759,7 +759,7 @@
 !/PR2      REAL                    :: DTIME
 !
 !/SMC      REAL                    :: DTIME, RFMAXD, SYMR, YJ0R
-!/SMC      LOGICAL                 :: UNO3, AVERG, SEAWND 
+!/SMC      LOGICAL                 :: UNO3, AVERG, SEAWND
 !
 !/PR3      REAL                    :: WDTHCG, WDTHTH
            LOGICAL :: JGS_TERMINATE_MAXITER = .TRUE.
@@ -792,7 +792,7 @@
            REAL*8  :: CRIT_DEP_SETUP = 0.
 !
            CHARACTER               :: UGOBCFILE*60
-           REAL                    :: UGOBCDEPTH 
+           REAL                    :: UGOBCDEPTH
            LOGICAL                 :: UGOBCOK
 
 !/RTD      REAL                    :: PLAT, PLON
@@ -814,7 +814,7 @@
 !/IC5                       IC5KFILTER
 !/IG1      NAMELIST /SIG1/  IGMETHOD, IGADDOUTP, IGSOURCE, IGBCOVERWRITE,   &
 !/IG1                      IGMAXFREQ, IGSTERMS, IGSWELLMAX,                &
-!/IG1                      IGSOURCEATBP, IGKDMIN, IGFIXEDDEPTH, IGEMPIRICAL 
+!/IG1                      IGSOURCEATBP, IGKDMIN, IGFIXEDDEPTH, IGEMPIRICAL
 !/LN1      NAMELIST /SLN1/ CLIN, RFPM, RFHF
 !/ST1      NAMELIST /SIN1/ CINP
 !/ST2      NAMELIST /SIN2/ ZWND, SWELLF, STABSH, STABOF, CNEG, CPOS, FNEG
@@ -858,8 +858,8 @@
 !/PR1      NAMELIST /PRO1/ CFLTM
 !/PR2      NAMELIST /PRO2/ CFLTM, DTIME, LATMIN
 !/SMC      NAMELIST /PSMC/ CFLTM, DTIME, LATMIN, RFMAXD, UNO3, AVERG, &
-!/SMC                      LvSMC, ISHFT, JEQT,   NBISMC, SEAWND 
-! 
+!/SMC                      LvSMC, ISHFT, JEQT,   NBISMC, SEAWND
+!
 !/PR3      NAMELIST /PRO3/ CFLTM, WDTHCG, WDTHTH
            NAMELIST /UNST/ UGOBCAUTO, UGOBCDEPTH, UGOBCFILE,          &
                            EXPFSN, EXPFSPSI, EXPFSFCT,                &
@@ -880,7 +880,7 @@
                            JGS_SOURCE_NONLINEAR,                      &
                            SETUP_APPLY_WLV, SOLVERTHR_SETUP,          &
                            CRIT_DEP_SETUP
-           NAMELIST /MISC/ CICE0, CICEN, LICE, XSEED, FLAGTR, XP, XR, & 
+           NAMELIST /MISC/ CICE0, CICEN, LICE, XSEED, FLAGTR, XP, XR, &
                       XFILT, PMOVE, IHM, HSPM, WSM, WSC, FLC, FMICHE, &
                       RWNDC, FACBERG, NOSW, GSHIFT, WCOR1, WCOR2,     &
                       STDX, STDY, STDT, ICEHMIN, ICEHINIT, ICEDISP,   &
@@ -934,14 +934,14 @@
       NDSS   = 99
       NDSM   = 20
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_grid.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_grid.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
          ! Read namelist
          CALL W3NMLGRID (NDSI, TRIM(FNMPRE)//'ww3_grid.nml', NML_SPECTRUM, NML_RUN,  &
                          NML_TIMESTEPS, NML_GRID, NML_RECT, NML_CURV,   &
                          NML_UNST, NML_SMC, NML_DEPTH, NML_MASK,        &
                          NML_OBST, NML_SLOPE, NML_SED, NML_INBND_COUNT, &
-                         NML_INBND_POINT, NML_EXCL_COUNT,               &                  
+                         NML_INBND_POINT, NML_EXCL_COUNT,               &
                          NML_EXCL_POINT, NML_EXCL_BODY,                 &
                          NML_OUTBND_COUNT, NML_OUTBND_LINE, IERR)
       ELSE
@@ -1121,10 +1121,10 @@
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
         READ (NDSI,*,END=2001,ERR=2002) DTMAX, DTCFL, DTCFLI, DTMIN
       END IF
-!/SEC1      IF (DTMAX.LT.1.) THEN 
+!/SEC1      IF (DTMAX.LT.1.) THEN
 !/SEC1        NITERSEC1=CEILING(1./DTMAX)
 !/SEC1        WRITE (NDSO,913) NITERSEC1
-!/SEC1      ELSE 
+!/SEC1      ELSE
 !/SEC1        NITERSEC1=1
 !/SEC1        END IF
 
@@ -1386,26 +1386,26 @@
 !
 !/ST3      ZWND   =   10.
 !/ST3      ALPHA0 = 0.0095
-!/ST3      Z0MAX = 0.0    
+!/ST3      Z0MAX = 0.0
 !/ST3      BETAMAX  = 1.2       !  default WAM4 / WAM4 + is 1.2 with rhow=1000
-!/ST3      SINTHP   = 2.     
-!/ST3      SWELLF = 0.         
+!/ST3      SINTHP   = 2.
+!/ST3      SWELLF = 0.
 !/ST3      ZALP   = 0.0110
 !
 !/ST4      ZWND   =   10.
 !/ST4      ALPHA0 = 0.0095
-!/ST4      Z0MAX = 0.0    
-!/ST4      Z0RAT = 0.04 
-!/ST4      BETAMAX   = 1.43     
-!/ST4      SINTHP    = 2.     
-!/ST4      SWELLF    = 0.66     
+!/ST4      Z0MAX = 0.0
+!/ST4      Z0RAT = 0.04
+!/ST4      BETAMAX   = 1.43
+!/ST4      SINTHP    = 2.
+!/ST4      SWELLF    = 0.66
 !/ST4      SWELLFPAR = 1
 !/ST4      SWELLF2 = -0.018
 !/ST4      SWELLF3 = 0.022
 !/ST4      SWELLF4 = 1.5E5
 !/ST4      SWELLF5 = 1.2
 !/ST4      SWELLF6 = 0.
-!/ST4      SWELLF7 = 360000. 
+!/ST4      SWELLF7 = 360000.
 !/ST4      TAUWSHELTER = 0.3
 !/ST4      ZALP   = 0.006
 !/ST4      SINBR   = 0.
@@ -1669,29 +1669,29 @@
 !/ST2      FPIMIN =  0.009
 !/ST3      SDSC1  = -2.1 !! This is Bidlot et al. 2005,  Otherwise WAM4 uses -4.5
 !/ST3      WNMEANP = 0.5 !! This is Bidlot et al. 2005,  Otherwise WAM4 uses -0.5
-!/ST3      FXFM3 = 2.5 
+!/ST3      FXFM3 = 2.5
 !/ST3      FXPM3 = 4.
-!/ST3      WNMEANPTAIL = 0.5 
+!/ST3      WNMEANPTAIL = 0.5
 !/ST3      SDSDELTA1 = 0.4 !! This is Bidlot et al. 2005,  Otherwise WAM4 uses 0.5
 !/ST3      SDSDELTA2 = 0.6 !! This is Bidlot et al. 2005,  Otherwise WAM4 uses 0.5
 !
-!/ST4      SDSC1  = 0.0     ! not used in ST4, should be cleaned up                                                             
+!/ST4      SDSC1  = 0.0     ! not used in ST4, should be cleaned up
 !/ST4      WNMEANP = 0.5    ! taken from Bidlot et al. 2005
-!/ST4      FXFM3 = 2.5 
-!/ST4      FXFMAGE = 0. 
-!/ST4      FXINCUT = 0. 
-!/ST4      FXDSCUT = 0. 
+!/ST4      FXFM3 = 2.5
+!/ST4      FXFMAGE = 0.
+!/ST4      FXINCUT = 0.
+!/ST4      FXDSCUT = 0.
 !/ST4      FXPM3 = 4.
-!/ST4      WNMEANPTAIL = -0.5 
+!/ST4      WNMEANPTAIL = -0.5
 !/ST4      SDSC2     = -2.2E-5
 !/ST4      SDSCUM     = -0.40344
 !/ST4      SDSC4     = 1.
-!/ST4      SDSC5     = 0. 
+!/ST4      SDSC5     = 0.
 !/ST4      SDSC6     = 0.3
-!/ST4      SDSBR     = 0.90E-3                                     
+!/ST4      SDSBR     = 0.90E-3
 !/ST4      SDSBRFDF  = 0
 !/ST4      SDSBRF1   = 0.5
-!/ST4      SDSP      = 2.   ! this is now fixed in w3sds4, should be cleaned up 
+!/ST4      SDSP      = 2.   ! this is now fixed in w3sds4, should be cleaned up
 !/ST4      SDSDTH    = 80.
 !/ST4      SDSCOS    = 2.
 !/ST4      SDSISO    = 2
@@ -1769,7 +1769,7 @@
 !
 !/ST4      CALL READNL ( NDSS, 'SDS4', STATUS )
 !/ST4      WRITE (NDSO,924) STATUS
-!/ST4      WRITE (NDSO,925) SDSC2, SDSBCK, SDSCUM, WNMEANP 
+!/ST4      WRITE (NDSO,925) SDSC2, SDSBCK, SDSCUM, WNMEANP
 !/ST4      SSDSC(1)   = SDSLFGEN
 !/ST4      SSDSC(2)   = SDSC2
 !/ST4      SSDSC(3)   = SDSCUM
@@ -1777,10 +1777,10 @@
 !/ST4      SSDSC(5)   = SDSC5
 !/ST4      SSDSC(6)   = SDSC6
 !/ST4      SSDSC(7)   = WHITECAPWIDTH
-!/ST4      SSDSC(8)   = SDSSTRAIN ! Straining constant ... 
+!/ST4      SSDSC(8)   = SDSSTRAIN ! Straining constant ...
 !/ST4      SSDSC(9)   = SDSHFGEN
 !/ST4      SSDSC(10)   = SDSSTRAINA*NTH/360. ! angle for enhanced straining
-!/ST4      SSDSC(11)   = SDSSTRAIN2 ! enhanced straining constant ... 
+!/ST4      SSDSC(11)   = SDSSTRAIN2 ! enhanced straining constant ...
 !/ST4      SSDSBR   = SDSBR
 !/ST4      SSDSBRF1 = SDSBRF1
 !/ST4      SSDSBRFDF= SDSBRFDF
@@ -1865,7 +1865,7 @@
 !/BT4      SBTCX(5)=SIGDEPTH
 !/BT4      SBTCX(6)=BOTROUGHMIN
 !/BT4      SBTCX(7)=BOTROUGHFAC
-!        
+!
 !
 ! 6.h Define Sdb.
 !
@@ -1943,7 +1943,7 @@
 !/IC5            //'Mosig et al. method.','        '&
 !/IC5            //'Required field input: ice parameters 1, 2, 3 and 4.'
 !
-! 6.l Read unstructured data 
+! 6.l Read unstructured data
 ! initialisation of logical related to unstructured grid
        UGOBCAUTO = .TRUE.
        UGOBCDEPTH= -10.
@@ -1954,7 +1954,7 @@
        EXPFSFCT  = .FALSE.
        IMPFSN    = .FALSE.
        IMPTOTAL  = .FALSE.
-       EXPTOTAL  = .FALSE. 
+       EXPTOTAL  = .FALSE.
        IMPREFRACTION = .FALSE.
        IMPFREQSHIFT = .FALSE.
        IMPSOURCE = .FALSE.
@@ -2122,7 +2122,7 @@
 !/SMC          WRITE (NDSO,954) CFLTM, DTIME/3600., LATMIN, RFMAXD
 !/SMC        END IF
 !/SMC      DTME   = DTIME
-!/SMC      Refran = RFMAXD * DERA 
+!/SMC      Refran = RFMAXD * DERA
 !/SMC      FUNO3  = UNO3
 !/SMC      FVERG  = AVERG
 !/SMC      FSWND  = SEAWND
@@ -2130,9 +2130,9 @@
 !/SMC        " Advection use 3rd order UNO3 instead of UNO2 scheme."
 !/SMC      IF( AVERG ) WRITE (NDSO,*)                 &
 !/SMC        " Extra 1-2-1 average smoothing activated on SMC grid."
-!/SMC      IF( SEAWND ) WRITE (NDSO,*)                & 
+!/SMC      IF( SEAWND ) WRITE (NDSO,*)                &
 !/SMC        " Sea-point only wind input is required for SMC grid. "
-!/SMC      NRLv = LvSMC 
+!/SMC      NRLv = LvSMC
 !/SMC      WRITE (NDSO,4001) NRLv
 !/SMC      WRITE (NDSO,4002) JEQT
 !/SMC      WRITE (NDSO,4302) ISHFT
@@ -2166,9 +2166,9 @@
       CICE0  = 0.5
       CICEN  = 0.5
       LICE   = 0.
-      ICEHFAC= 1.0  
+      ICEHFAC= 1.0
       ICEHMIN= 0.2  ! the 0.2 value is arbitrary and needs to be tuned.
-      ICEHINIT= 0.5  
+      ICEHINIT= 0.5
       ICESLN = 1.0
       ICEWIND= 1.0
       ICESNL = 1.0
@@ -2194,41 +2194,41 @@
       PTFC   = 0.1  ! Part. method 5 cutoff freq default. C. Bunney
       FMICHE = 1.6
       RWNDC  = 1.
-      WCOR1  = 99. 
+      WCOR1  = 99.
       WCOR2  = 0.
       BTBET  = 1.2 ! β for c / [U cos(θ - φ)] < β
 ! Variables for Space-Time Extremes
 !  Default negative values make w3iogomd switch off space-time extremes
 !  forces user to provide NAMELIST if wanting to compute STE parameters
-      STDX = -1. 
-      STDY = -1. 
-      STDT = -1. 
+      STDX = -1.
+      STDY = -1.
+      STDT = -1.
       ICEDISP = .FALSE.
       NOLEAP = .FALSE.
 ! Variables for 3D array output
-      E3D=0 
+      E3D=0
       I1E3D=1
       I2E3D=NK
       P2SF   = 0
       I1P2SF = 1
       I2P2SF = 15
-      US3D=0 
+      US3D=0
       I1US3D=1
       I2US3D=NK
       USSP=0
       IUSSP=1
       STK_WN(:)=0.0
       STK_WN(1)=TPI/100. !Set default decay of 100 m for Stokes drift
-      TH1MF=0 
+      TH1MF=0
       I1TH1M=1
       I2TH1M=NK
-      STH1MF=0 
+      STH1MF=0
       I1STH1M=1
       I2STH1M=NK
       TH2MF=0
       I1TH2M=1
       I2TH2M=NK
-      STH2MF=0 
+      STH2MF=0
       I1STH2M=1
       I2STH2M=NK
 !
@@ -2244,11 +2244,11 @@
 !/IS2      ISC1 = 1.
 !/IS2      IS2C2 = 0.   ! 0.025
 !/IS2      IS2C3 = 0.   ! 2.4253
-!/IS2      IS2CONC = 0.   
+!/IS2      IS2CONC = 0.
 !/IS2      IS2BACKSCAT = 1.
 !/IS2      IS2BREAK = .FALSE.
 !/IS2      IS2BREAKF = 3.6
-!/IS2      IS2FLEXSTR=2.7414E+05  ! value used in Boutin et al. JGR 2018. 
+!/IS2      IS2FLEXSTR=2.7414E+05  ! value used in Boutin et al. JGR 2018.
 !/IS2      IS2ISOSCAT=.TRUE.     ! uses isotropic back-scatter
 !/IS2      IS2DISP=.FALSE. !not dispersion only attenuation following Liu disp. eq.
 !/IS2      IS2DUPDATE=.TRUE.
@@ -2288,7 +2288,7 @@
 !/REF1      WRITE (NDSO,969) STATUS
 !
 !/IG1       IGMETHOD = 2
-!/IG1       IGADDOUTP= 0 
+!/IG1       IGADDOUTP= 0
 !/IG1       IGSOURCE = 2
 !/IG1       IGSTERMS = 0
 !/IG1       IGMAXFREQ=0.03
@@ -2302,10 +2302,10 @@
 !/IG1      CALL READNL ( NDSS, 'SIG1 ', STATUS )
 !/IG1      WRITE (NDSO,970) STATUS
 !
-!/IC2       IC2DISPER = .FALSE. 
+!/IC2       IC2DISPER = .FALSE.
 !/IC2       IC2TURB = 1.
 !/IC2       IC2TURBS = 0.
-!/IC2       IC2ROUGH = 0.01 
+!/IC2       IC2ROUGH = 0.01
 !/IC2       IC2REYNOLDS = 1.5E5
 !/IC2       IC2SMOOTH = 2E5
 !/IC2       IC2VISC = 1.
@@ -2361,7 +2361,7 @@
       WRITE (NDSO,4970) STATUS
 !
 !
-! output of frequency spectra, th1m ... 
+! output of frequency spectra, th1m ...
 !
       E3DF(1,1) = E3D
       E3DF(2,1) = MIN(MAX(1,I1E3D),NK)
@@ -2401,13 +2401,13 @@
          WRITE(NDSE,*) "   intended for use with more than 25   "
          WRITE(NDSE,*) "   partitions.  Please reduce IUSSP     "
          WRITE(NDSE,*) "   specified in ww3_grid.inp to proceed "
-         CALL EXTCDE( 31) 
+         CALL EXTCDE( 31)
       ENDIF
 
       DO J=1,USSPF(2)
          USSP_WN(j) = STK_WN(J)
       ENDDO
-      
+
 !
       WRITE (NDSO,4971) P2MSF(1:3)
       WRITE (NDSO,4972) US3DF(1:3)
@@ -2428,7 +2428,7 @@
       ICESNL  = MIN ( 1. , MAX ( 0. , ICESNL ) )
       FICEN  = CICEN
       GRIDSHIFT=GSHIFT
-      ICESCALES(1)=ICESLN 
+      ICESCALES(1)=ICESLN
       ICESCALES(2)=ICEWIND
       ICESCALES(3)=ICESNL
       ICESCALES(4)=ICESDS
@@ -2473,7 +2473,7 @@
          WRITE (NDSO,1042)
       END IF
       IF ( STDT .GT. 0 ) THEN
-         WRITE (NDSO,1043) STDT 
+         WRITE (NDSO,1043) STDT
       ELSE
          WRITE (NDSO,1044)
       END IF
@@ -2484,9 +2484,9 @@
 !/SCRIP     WRITE (NDSO,963) GSHIFT
       WRITE (NDSO,1972) TRCKCMPR
       FACSD  = XSEED
-!/RWND RWINDC = RWNDC 
-!/WCOR WWCOR(1) = WCOR1 
-!/WCOR WWCOR(2) = WCOR2 
+!/RWND RWINDC = RWNDC
+!/WCOR WWCOR(1) = WCOR1
+!/WCOR WWCOR(2) = WCOR2
 !
       XP     = MAX ( 1.E-6 , XP )
       XR     = MAX ( 1.E-6 , XR )
@@ -2647,7 +2647,7 @@
 !/PR1          WRITE (NDSO,2953) CFLTM
 !/PR2          WRITE (NDSO,2953) CFLTM, DTIME, LATMIN
 !/SMC          WRITE (NDSO,2953) CFLTM, DTIME, LATMIN, RFMAXD, UNO3, &
-!/SMC                      AVERG, LvSMC, NBISMC, ISHFT, JEQT, SEAWND 
+!/SMC                      AVERG, LvSMC, NBISMC, ISHFT, JEQT, SEAWND
 !/PR3          WRITE (NDSO,2953) CFLTM, WDTHCG, WDTHTH
 !
         WRITE (NDSO,2956) UGOBCAUTO, UGOBCDEPTH, TRIM(UGOBCFILE),     &
@@ -2668,7 +2668,7 @@
                           JGS_SOURCE_NONLINEAR
 !
         WRITE (NDSO,2976)    P2SF, I1P2SF, I2P2SF,                    &
-                             US3D, I1US3D, I2US3D,                    & 
+                             US3D, I1US3D, I2US3D,                    &
                              USSP, IUSSP,                             &
                              E3D, I1E3D, I2E3D,                       &
                              TH1MF, I1TH1M, I2TH1M,                   &
@@ -2683,7 +2683,7 @@
 !/IG1         WRITE(NDSO,2977) IGMETHOD, IGADDOUTP, IGSOURCE,         &
 !/IG1                    IGSTERMS, IGBCOVERWRITE, IGSWELLMAX,         &
 !/IG1                    IGMAXFREQ, IGSOURCEATBP, IGKDMIN,            &
-!/IG1                    IGFIXEDDEPTH, IGEMPIRICAL 
+!/IG1                    IGFIXEDDEPTH, IGEMPIRICAL
 !
 !/IC2         WRITE(NDSO,2978) IC2DISPER, IC2TURB, IC2ROUGH,          &
 !/IC2                    IC2REYNOLDS,  IC2SMOOTH, IC2VISC, IC2TURBS,  &
@@ -2819,7 +2819,7 @@
         CASE DEFAULT
           WRITE (NDSE,1007) TRIM(GSTRG)
           CALL EXTCDE ( 25 )
-        END SELECT      
+        END SELECT
 !
       IF ( FLAGLL ) THEN
           FACTOR = 1.
@@ -2891,21 +2891,21 @@
           NY=1
         END SELECT
       ELSE
-        IF ( GTYPE.NE.UNGTYPE) THEN 
+        IF ( GTYPE.NE.UNGTYPE) THEN
           CALL NEXTLN ( COMSTR , NDSI , NDSE )
           READ (NDSI,*,END=2001,ERR=2002) NX, NY
           NX     = MAX ( 3 , NX )
           NY     = MAX ( 3 , NY )
           WRITE (NDSO,3003) NX, NY
-        ELSE 
-          NY =1 
+        ELSE
+          NY =1
         END IF
       END IF
 !
 ! Propagation specific to unstructured grids
 !
       DO_CHANGE_WLV=.FALSE.
-      IF ( GTYPE.EQ.UNGTYPE) THEN 
+      IF ( GTYPE.EQ.UNGTYPE) THEN
         UNSTSCHEMES(:)=0
         IF (EXPFSN)   UNSTSCHEMES(1)=1
         IF (EXPFSPSI) UNSTSCHEMES(2)=1
@@ -2913,24 +2913,24 @@
         IF (IMPFSN)   UNSTSCHEMES(4)=1
         UNSTSCHEME=-1
         DO IX=1,4
-          IF (UNSTSCHEMES(IX).EQ.1) THEN 
+          IF (UNSTSCHEMES(IX).EQ.1) THEN
             UNSTSCHEME=IX
             EXIT
           END IF
         END DO
- 
+
         SELECT CASE (UNSTSCHEME)
-        CASE (1) 
+        CASE (1)
           FSN = EXPFSN
           PNAME2 = 'N Explicit (Fluctuation Splitting) '
-        CASE (2) 
+        CASE (2)
           FSPSI = EXPFSPSI
           PNAME2 = 'PSI Explicit (Fluctuation Splitting)  '
-        CASE (3) 
+        CASE (3)
           FSFCT = EXPFSFCT
           PNAME2 = ' Flux Corrected Transport Explicit'
-        CASE (4) 
-          FSNIMP = IMPFSN 
+        CASE (4)
+          FSNIMP = IMPFSN
           PNAME2 = 'N Implicit (Fluctuation Splitting) '
           END SELECT
 !
@@ -2941,7 +2941,7 @@
           PNAME2 = 'N Implicit (Fluctuation Splitting) for total implicit'
         END IF
         IF (EXPTOTAL) THEN
-          FSTOTALEXP = EXPTOTAL 
+          FSTOTALEXP = EXPTOTAL
           PNAME2 = 'N Explicit (Fluctuation Splitting) for one exchange explicit DC HPCF '
         END IF
         IF (IMPREFRACTION .and. IMPTOTAL .AND. FLCTH) THEN
@@ -2985,7 +2985,7 @@
         CASE ( RLGTYPE )
 !
           IF (FLGNML) THEN
-            SX = NML_RECT%SX 
+            SX = NML_RECT%SX
             SY = NML_RECT%SY
             VSC = NML_RECT%SF
             X0 = NML_RECT%X0
@@ -3220,9 +3220,9 @@
 !
 ! 7.e Read bottom depths
 !
-      IF ( GTYPE.NE.UNGTYPE ) THEN 
+      IF ( GTYPE.NE.UNGTYPE ) THEN
 !
-! Reading depths on structured grid 
+! Reading depths on structured grid
 !
 !Li Suspended for SMC grid, which uses depth stored in its cell array.
 !Li               JGLi15Oct2014
@@ -3254,11 +3254,11 @@
                             STATUS='OLD',ERR=2000,IOSTAT=IERR)
                     END IF
                 END IF
-            END IF  !( NDSG .EQ. NDSI ) 
+            END IF  !( NDSG .EQ. NDSI )
 !
 !Li     End of RGLGRD block
         ENDIF
-!Li 
+!Li
 !
         ALLOCATE ( ZBIN(NX,NY), OBSX(NX,NY), OBSY(NX,NY) )
 !
@@ -3274,7 +3274,7 @@
                        IDFM, RFORM, IDLA, VSC, 0.0)
 !Li     End of RGLGRD block
         ENDIF
-!Li 
+!Li
 !
       ELSE
 !
@@ -3419,7 +3419,7 @@
 !
 !Li     End of RGLGRD block
       END IF
-!Li 
+!Li
 !
 !/RTD ! 7.h Calculate rotation angles for configs with rotated pole
 !/RTD !     Check that pole lat/lon values have been read in
@@ -3442,7 +3442,7 @@
 !/RTD
 !/RTD !     Write out rotation information
 !/RTD       WRITE (NDSO,4203)   PoLat, PoLon
-!/RTD       WRITE (NDSO,4200) 
+!/RTD       WRITE (NDSO,4200)
 !/RTD       WRITE (NDSO,4201)    (        IX,     IX=1,NX,NX/3)
 !/RTD       WRITE (NDSO,4202)    1,(AnglDin(IX, 1), IX=1,NX,NX/3)
 !/RTD       WRITE (NDSO,4202)   NY,(AnglDin(IX,NY), IX=1,NX,NX/3)
@@ -3459,7 +3459,7 @@
 !/SMC         IDFM = NML_SMC%MCELS%IDFM
 !/SMC         RFORM = TRIM(NML_SMC%MCELS%FORMAT)
 !/SMC         TNAME = TRIM(NML_SMC%MCELS%FILENAME)
-!/SMC       ELSE  
+!/SMC       ELSE
 !/SMC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/SMC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/SMC       END IF
@@ -3476,7 +3476,7 @@
 !/SMC                    IDFM, RFORM, IDLA, 1, 0)
 !/SMC       CLOSE(NDSTR)
 !/SMC !!Li     Offset to change Equator index = 0 to regular grid index JEQT
-!/SMC       IJKCelin( 2, :) = IJKCelin( 2, :) + JEQT 
+!/SMC       IJKCelin( 2, :) = IJKCelin( 2, :) + JEQT
 !/SMC !!Li     Offset to change i-index = 0 to regular grid index ISHFT
 !/SMC       IJKCelin( 1, :) = IJKCelin( 1, :) + ISHFT
 !/SMC
@@ -3491,7 +3491,7 @@
 !/SMC         IDFM = NML_SMC%ISIDE%IDFM
 !/SMC         RFORM = TRIM(NML_SMC%ISIDE%FORMAT)
 !/SMC         TNAME = TRIM(NML_SMC%ISIDE%FILENAME)
-!/SMC       ELSE  
+!/SMC       ELSE
 !/SMC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/SMC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/SMC       END IF
@@ -3500,7 +3500,7 @@
 !/SMC       ALLOCATE (  NLvUFcsk( 0:NRLv ) )
 !/SMC       READ (NDSTR,*)  NLvUFcsk
 !/SMC       NUFc = NLvUFcsk(0)
-!/SMC       NGUI = NUFc 
+!/SMC       NGUI = NUFc
 !/SMC       WRITE (NDSO,4007)   NUFc, NLvUFcsk
 !/SMC
 !/SMC       ALLOCATE (   IJKUFcin( 7, NUFc) )
@@ -3508,7 +3508,7 @@
 !/SMC                    IDFM, RFORM, IDLA, 1, 0)
 !/SMC       CLOSE(NDSTR)
 !/SMC !!Li     Offset to change Equator index = 0 to regular grid index
-!/SMC       IJKUFcin( 2, :) = IJKUFcin( 2, :) + JEQT 
+!/SMC       IJKUFcin( 2, :) = IJKUFcin( 2, :) + JEQT
 !/SMC       IJKUFcin( 1, :) = IJKUFcin( 1, :) + ISHFT
 !/SMC
 !/SMC       WRITE (NDSO,4008) TNAME
@@ -3522,7 +3522,7 @@
 !/SMC         IDFM = NML_SMC%JSIDE%IDFM
 !/SMC         RFORM = TRIM(NML_SMC%JSIDE%FORMAT)
 !/SMC         TNAME = TRIM(NML_SMC%JSIDE%FILENAME)
-!/SMC       ELSE  
+!/SMC       ELSE
 !/SMC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/SMC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/SMC       END IF
@@ -3539,7 +3539,7 @@
 !/SMC                    IDFM, RFORM, IDLA, 1, 0)
 !/SMC       CLOSE(NDSTR)
 !/SMC !!Li     Offset to change Equator index = 0 to regular grid index
-!/SMC       IJKVFcin( 2, :) = IJKVFcin( 2, :) + JEQT 
+!/SMC       IJKVFcin( 2, :) = IJKVFcin( 2, :) + JEQT
 !/SMC       IJKVFcin( 1, :) = IJKVFcin( 1, :) + ISHFT
 !/SMC
 !/SMC       WRITE (NDSO,4011) TNAME
@@ -3554,7 +3554,7 @@
 !/SMC         IDFM = NML_SMC%SUBTR%IDFM
 !/SMC         RFORM = TRIM(NML_SMC%SUBTR%FORMAT)
 !/SMC         TNAME = TRIM(NML_SMC%SUBTR%FILENAME)
-!/SMC       ELSE  
+!/SMC       ELSE
 !/SMC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/SMC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/SMC       END IF
@@ -3581,7 +3581,7 @@
 !/SMC         IDFM = NML_SMC%BUNDY%IDFM
 !/SMC         RFORM = TRIM(NML_SMC%BUNDY%FORMAT)
 !/SMC         TNAME = TRIM(NML_SMC%BUNDY%FILENAME)
-!/SMC       ELSE  
+!/SMC       ELSE
 !/SMC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/SMC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/SMC       END IF
@@ -3599,14 +3599,14 @@
 !/SMC       ENDIF
 !/SMC
 !
-!/ARC !! 7.j  Read Arctic grid cell and boundary cell integer arrays.  
+!/ARC !! 7.j  Read Arctic grid cell and boundary cell integer arrays.
 !/ARC       IF (FLGNML) THEN
 !/ARC         NDSTR = NML_SMC%MBARC%IDF
 !/ARC         IDLA = NML_SMC%MBARC%IDLA
 !/ARC         IDFM = NML_SMC%MBARC%IDFM
 !/ARC         RFORM = TRIM(NML_SMC%MBARC%FORMAT)
 !/ARC         TNAME = TRIM(NML_SMC%MBARC%FILENAME)
-!/ARC       ELSE  
+!/ARC       ELSE
 !/ARC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/ARC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/ARC       END IF
@@ -3620,7 +3620,7 @@
 !/ARC                    IDFM, RFORM, IDLA, 1, 0)
 !/ARC       CLOSE(NDSTR)
 !/ARC !!Li     Offset to change Equator index = 0 to regular grid index JEQT
-!/ARC       IJKCelAC( 2, :) = IJKCelAC( 2, :) + JEQT 
+!/ARC       IJKCelAC( 2, :) = IJKCelAC( 2, :) + JEQT
 !/ARC       IJKCelAC( 1, :) = IJKCelAC( 1, :) + ISHFT
 !/ARC
 !/ARC       WRITE (NDSO,4016) TNAME
@@ -3634,7 +3634,7 @@
 !/ARC         IDFM = NML_SMC%AISID%IDFM
 !/ARC         RFORM = TRIM(NML_SMC%AISID%FORMAT)
 !/ARC         TNAME = TRIM(NML_SMC%AISID%FILENAME)
-!/ARC       ELSE  
+!/ARC       ELSE
 !/ARC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/ARC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/ARC       END IF
@@ -3648,7 +3648,7 @@
 !/ARC                    IDFM, RFORM, IDLA, 1, 0)
 !/ARC       CLOSE(NDSTR)
 !/ARC !!Li     Offset to change Equator index = 0 to regular grid index
-!/ARC       IJKUFcAC( 2, :) = IJKUFcAC( 2, :) + JEQT 
+!/ARC       IJKUFcAC( 2, :) = IJKUFcAC( 2, :) + JEQT
 !/ARC       IJKUFcAC( 1, :) = IJKUFcAC( 1, :) + ISHFT
 !/ARC !!Li     Offset Arctic cell sequential numbers by global cell number NGLO
 !/ARC       DO  IP=1, NAUI
@@ -3668,13 +3668,13 @@
 !/ARC         IDFM = NML_SMC%AJSID%IDFM
 !/ARC         RFORM = TRIM(NML_SMC%AJSID%FORMAT)
 !/ARC         TNAME = TRIM(NML_SMC%AJSID%FILENAME)
-!/ARC       ELSE  
+!/ARC       ELSE
 !/ARC         CALL NEXTLN ( COMSTR , NDSI , NDSE )
 !/ARC         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFM, RFORM, TNAME
 !/ARC       END IF
 !/ARC       OPEN (NDSTR,FILE=TRIM(FNMPRE)//TNAME,             &
 !/ARC                   FORM='FORMATTED',STATUS='OLD',ERR=2000)
-!/ARC       READ (NDSTR,*) NAVJ 
+!/ARC       READ (NDSTR,*) NAVJ
 !/ARC       WRITE (NDSO,4019)   NAVJ
 !/ARC
 !/ARC       ALLOCATE (   IJKVFcAC( 8, NAVJ) )
@@ -3682,7 +3682,7 @@
 !/ARC                    IDFM, RFORM, IDLA, 1, 0)
 !/ARC       CLOSE(NDSTR)
 !/ARC !!Li     Offset to change Equator index = 0 to regular grid index
-!/ARC       IJKVFcAC( 2, :) = IJKVFcAC( 2, :) + JEQT 
+!/ARC       IJKVFcAC( 2, :) = IJKVFcAC( 2, :) + JEQT
 !/ARC       IJKVFcAC( 1, :) = IJKVFcAC( 1, :) + ISHFT
 !/ARC !!Li     Offset Arctic cell sequential numbers by global cell number NGLO
 !/ARC       DO  IP=1, NAVJ
@@ -3701,9 +3701,9 @@
 !/ARC       NUFc = NGUI + NAUI
 !/ARC       NVFc = NGVJ + NAVJ
 !/ARC !!Li  Also append Arctic part into base level sub-loops
-!/ARC       NLvCelsk(NRLv)=NLvCelsk(NRLv)+NARC 
-!/ARC       NLvUFcsk(NRLv)=NLvUFcsk(NRLv)+NAUI 
-!/ARC       NLvVFcsk(NRLv)=NLvVFcsk(NRLv)+NAVJ 
+!/ARC       NLvCelsk(NRLv)=NLvCelsk(NRLv)+NARC
+!/ARC       NLvUFcsk(NRLv)=NLvUFcsk(NRLv)+NAUI
+!/ARC       NLvVFcsk(NRLv)=NLvVFcsk(NRLv)+NAVJ
 !/ARC !!Li  Reset NBAC to total number of boundary cells.
 !/ARC       NBAC = NBGL + NBAC
 !/ARC
@@ -3731,7 +3731,7 @@
         FROM = TRIM(NML_MASK%FROM)
         TNAME = TRIM(NML_MASK%FILENAME)
         IF (TNAME.EQ.'unset' .OR. TNAME.EQ.'UNSET') FROM='PART'
-      ELSE  
+      ELSE
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
         READ (NDSI,*,END=2001,ERR=2002) NDSTR, IDLA, IDFT, RFORM,     &
                                         FROM, TNAME
@@ -3775,7 +3775,7 @@
             IF (FLGNML) THEN
               ! inbound points
               IF (ILOOP.EQ.1) THEN
-                IF (NML_INBND_COUNT%N_POINT.GT.0 .AND. I.LE.NML_INBND_COUNT%N_POINT) THEN 
+                IF (NML_INBND_COUNT%N_POINT.GT.0 .AND. I.LE.NML_INBND_COUNT%N_POINT) THEN
                   IX = NML_INBND_POINT(I)%X_INDEX
                   IY = NML_INBND_POINT(I)%Y_INDEX
                   CONNCT = NML_INBND_POINT(I)%CONNECT
@@ -3785,7 +3785,7 @@
                 END IF
               ! excluded points
               ELSE IF (ILOOP.EQ.2) THEN
-                IF (NML_EXCL_COUNT%N_POINT.GT.0 .AND. I.LE.NML_EXCL_COUNT%N_POINT) THEN 
+                IF (NML_EXCL_COUNT%N_POINT.GT.0 .AND. I.LE.NML_EXCL_COUNT%N_POINT) THEN
                   IX = NML_EXCL_POINT(I)%X_INDEX
                   IY = NML_EXCL_POINT(I)%Y_INDEX
                   CONNCT = NML_EXCL_POINT(I)%CONNECT
@@ -3806,7 +3806,7 @@
 ! ... Check if last point reached.
 !
             IF (IX.EQ.0 .AND. IY.EQ.0) EXIT
-!           
+!
 ! ... Check if point in grid.
 !
             IF (GTYPE.EQ.UNGTYPE.AND.(UGOBCAUTO.OR.UGOBCOK)) CYCLE
@@ -3835,7 +3835,7 @@
                       IY     = IY + IDY
                       IF ( TMPSTA(IY,IX).EQ.1 .OR. J.EQ.2 ) THEN
                         TMPSTA(IY,IX) = NSTAT
-                      ELSE 
+                      ELSE
                         WRITE(NDSO,*) 'WARNING: POINT (',IX,',',IY,  &
                                    ') CANNOT BE GIVEN THE STATUS ',NSTAT
                       END IF
@@ -3874,7 +3874,7 @@
             DO
               IF (FLGNML) THEN
                 ! excluded bodies
-                IF (NML_EXCL_COUNT%N_BODY.GT.0 .AND. I.LE.NML_EXCL_COUNT%N_BODY) THEN 
+                IF (NML_EXCL_COUNT%N_BODY.GT.0 .AND. I.LE.NML_EXCL_COUNT%N_BODY) THEN
                   IX = NML_EXCL_BODY(I)%X_INDEX
                   IY = NML_EXCL_BODY(I)%Y_INDEX
                   I=I+1
@@ -3964,7 +3964,7 @@
 !
 ! ... Outer boundary excluded points
 !
-            IF ( GTYPE.NE.UNGTYPE ) THEN    
+            IF ( GTYPE.NE.UNGTYPE ) THEN
 
               DO IX=1, NX
                 IF ( TMPSTA( 1,IX) .EQ. 1 ) TMPSTA( 1,IX) = NSTAT
@@ -4017,8 +4017,8 @@
           IF (IDLA.LT.1 .OR. IDLA.GT.4) IDLA   = 1
           IF (IDFT.LT.1 .OR. IDFT.GT.3) IDFT   = 1
 
-!!Li  Suspended for SMC grid though the file input line in  ww3_grid.inp 
-!!Li  is kept to divert the program into this block.  JGLi15Oct2014 
+!!Li  Suspended for SMC grid though the file input line in  ww3_grid.inp
+!!Li  is kept to divert the program into this block.  JGLi15Oct2014
 !!Li
           IF( RGLGRD ) THEN
 !!Li
@@ -4107,12 +4107,12 @@
         END DO
 !
 !/SMC !Li   Moved before FLBPI is defined with NBI value.  JGLi05Jun2015
-!/SMC !Li   Overwrite NSEA with NCel for SMC grid. 
+!/SMC !Li   Overwrite NSEA with NCel for SMC grid.
 !/SMC        NSEA = NCel
 !/SMC !Li   Use input NBI number for SMC grid because merged
-!/SMC !Li   cells are over-counted by model.   
+!/SMC !Li   cells are over-counted by model.
 !/SMC        NBI = NBISMC
-!/SMC !Li   No land points are used in SMC grid.   JGLi26Feb2016 
+!/SMC !Li   No land points are used in SMC grid.   JGLi26Feb2016
 !/SMC        NLAND = 0
 !
       WRITE (NDSO,980)
@@ -4164,7 +4164,7 @@
                   )
 !/SMC       WRITE (NDSO,4021)   NCel
 !
-! 8.g Activation of reflections and scattering 
+! 8.g Activation of reflections and scattering
       FFACBERG=FACBERG
 !/REF1      REFPARS(1)=REFCOAST
 !/REF1      REFPARS(2)=REFSUBGRID
@@ -4176,7 +4176,7 @@
 !/REF1      REFPARS(9)=REFRMAX
 !/REF1      REFPARS(10)=REFFREQPOW
 !/REF1      IF (GTYPE.EQ.UNGTYPE) REFPARS(2:5)=0.
-!/REF1      IF (REFMAP.EQ.0) THEN 
+!/REF1      IF (REFMAP.EQ.0) THEN
 !/REF1        REFLC(3,:)=REFPARS(7)
 !/REF1        END IF
 
@@ -4188,9 +4188,9 @@
             YGRD(IY,IX) = YGRDIN(IX,IY)
             END DO
           END DO
-          DEALLOCATE ( XGRDIN, YGRDIN )   
-          CALL W3GNTX ( 1, 6, 6 )  
-      ELSE 
+          DEALLOCATE ( XGRDIN, YGRDIN )
+          CALL W3GNTX ( 1, 6, 6 )
+      ELSE
 !
 !FA:  This distinction  between structured and unstructured
 ! should be removed when XYB is replaced by XGRD and YGRD
@@ -4200,7 +4200,7 @@
           YGRD(:,IX) = XYB(IX,2)
           END DO
         END IF   ! GTYPE
-!      
+!
 !
 !!Li  MAPSTA = TMPSTA
 !!Li  Shelter MAPSTA LLG definition for SMC by RGLGRD.
@@ -4257,9 +4257,9 @@
 
 !/ ------------------------------------------------------------------- /
 
-! notes: Oct 22 2012: I moved the following "if-then" statement from 
+! notes: Oct 22 2012: I moved the following "if-then" statement from
 ! inside the  "IF ( MAPSTA(IY,IX) .NE. 0 )" statement to outside that
-! statement. This is needed since later on, ATRNX is computed from 
+! statement. This is needed since later on, ATRNX is computed from
 ! TRNX(ix-1) , TRNX(ix) etc. which causes boundary effects if the
 ! MAPSTA=0 values are set to TRNX=0
 
@@ -4308,17 +4308,17 @@
 !/ARC       IJKUFc(:, NGUI+1:NUFc)=IJKUFcAC(:, 1:NAUI)
 !/ARC       IJKVFc(:, NGVJ+1:NVFc)=IJKVFcAC(:, 1:NAVJ)
 !/SMC
-!/SMC       WRITE (NDSO,4026) 
+!/SMC       WRITE (NDSO,4026)
 !/SMC       WRITE (NDSO,4006)    1,(IJKCel(ix,    1), ix=1,5)
 !/SMC       JJ=NCel
 !/SMC       WRITE (NDSO,4006) JJ,(IJKCel(ix, JJ), ix=1,5)
 !/SMC       WRITE (NDSO,*) ' '
-!/SMC       WRITE (NDSO,4027) 
+!/SMC       WRITE (NDSO,4027)
 !/SMC       WRITE (NDSO,4009)    1,(IJKUFc(ix,    1), ix=1,7)
 !/SMC       JJ=NUFc
 !/SMC       WRITE (NDSO,4009) JJ,(IJKUFc(ix, JJ), ix=1,7)
 !/SMC       WRITE (NDSO,*) ' '
-!/SMC       WRITE (NDSO,4028) 
+!/SMC       WRITE (NDSO,4028)
 !/SMC       WRITE (NDSO,4012)    1,(IJKVFc(ix,    1), ix=1,8)
 !/SMC       JJ=NVFc
 !/SMC       WRITE (NDSO,4012) JJ,(IJKVFc(ix, JJ), ix=1,8)
@@ -4327,30 +4327,30 @@
 !/SMC !Li    Boundary -9 to 0 cells for cell x-size 2**n
 !/SMC !Li    Note the position indice for bounary cell are not used.
 !/SMC       IJKCel(1, -9:0)=0
-!/SMC !Li    Use Equator Y index for boundary cells.  JGLi04Apr2011 
-!/SMC !Li   IJKCel(2, -9:0)=0  
+!/SMC !Li    Use Equator Y index for boundary cells.  JGLi04Apr2011
+!/SMC !Li   IJKCel(2, -9:0)=0
 !/SMC       IJKCel(2, -9:0)=JEQT
 !/SMC       IJKCel(3,    0)=1
 !/SMC       IJKCel(4,    0)=1
-!/SMC !Li    Use minimum 10 m depth for boundary cells. 
-!/SMC !Li    Y-size is restricted below base-cell value. 
-!/SMC !Li    For refined boundary cells, its y-size is replaced with 
-!/SMC !Li    the inner cell y-size for flux gradient. 
+!/SMC !Li    Use minimum 10 m depth for boundary cells.
+!/SMC !Li    Y-size is restricted below base-cell value.
+!/SMC !Li    For refined boundary cells, its y-size is replaced with
+!/SMC !Li    the inner cell y-size for flux gradient.
 !/SMC       IJKCel(5,    0)=10
 !/SMC       DO ip=1,9
 !/SMC          IJKCel(3,-ip)=IJKCel(3,-ip+1)*2
-!/SMC          IK=MIN(ip, NRLv-1) 
-!/SMC          IJKCel(4,-ip)=2**IK 
+!/SMC          IK=MIN(ip, NRLv-1)
+!/SMC          IJKCel(4,-ip)=2**IK
 !/SMC          IJKCel(5,-ip)=10
 !/SMC       ENDDO
-!/SMC       WRITE (NDSO,4029) 
+!/SMC       WRITE (NDSO,4029)
 !/SMC       DO ip=0, -9, -1
 !/SMC       WRITE (NDSO,4030)  IJKCel(:,ip)
 !/SMC       ENDDO
 !/SMC
 !/SMC       WRITE (NDSO,4031)   NCel
 !/SMC !Li    Multi-resolution SMC grid requires rounding of x, y indices
-!/SMC !Li    by a factor MRFct. 
+!/SMC !Li    by a factor MRFct.
 !/SMC       MRFct = 2**(NRLv - 1)
 !/SMC       WRITE (NDSO,4032)   MRFct
 !/SMC
@@ -4373,7 +4373,7 @@
 !/SMC          JS=MAX(1, IJKCel(4,ISEA)/MRFct)
 !/ARC        ENDIF
 !/ARC
-!/SMC !!Li  Minimum DMIN depth is used as well for SMC. 
+!/SMC !!Li  Minimum DMIN depth is used as well for SMC.
 !/SMC          ZB(ISEA)= - MAX( DMIN, FLOAT( IJKCel(5, ISEA) ) )
 !/SMC          MAPFS(IY:IY+JS-1,IX:IX+IK-1)  = ISEA
 !/SMC         MAPSTA(IY:IY+JS-1,IX:IX+IK-1)  = 1
@@ -4383,9 +4383,9 @@
 !/SMC          MAPSF(ISEA,3)  = IY + (IX    -1)*NY
 !/SMC !Li   New variable CLATS to hold cosine latitude at cell centre.
 !/SMC !Li   Also added CLATIS and CTHG0S for version 4.08.
-!/SMC !        JJ=IJKCel(2,ISEA) - JEQT 
+!/SMC !        JJ=IJKCel(2,ISEA) - JEQT
 !/SMC !        Y = SYMR*( FLOAT(JJ)+0.5*FLOAT(IJKCel(4,ISEA)) )
-!/SMC !Li   Use adjusted j-index to calculate cell centre y from YJ0R.  
+!/SMC !Li   Use adjusted j-index to calculate cell centre y from YJ0R.
 !/SMC          Y = YJ0R + SYMR*( FLOAT(IJKCel(2,ISEA))+0.5*FLOAT(IJKCel(4,ISEA)) )
 !/ARC !Li   Arctic polar cell does not need COS(LAT), set 1 row down.
 !/ARC          IF(Y .GE. HPI-0.1*SYMR) Y=HPI - SYMR*0.5*FLOAT( MRFct )
@@ -4404,9 +4404,9 @@
 !/SMC !         ENDDO
 !/SMC !!Li  Sub-grid obstruction is set zero beyond NCObst cells.
 !/SMC         IF(ISEA .GT. NCObst) THEN
-!/SMC           TRNMX=1.0 
+!/SMC           TRNMX=1.0
 !/SMC           TRNMY=1.0
-!/SMC         ELSE 
+!/SMC         ELSE
 !/SMC !!Li    Present obstruction is isotropic and in percentage.
 !/SMC           TRNMX=1.0 - IJKObstr(1,    ISEA)*0.01
 !/SMC           TRNMY=1.0 - IJKObstr(JObs, ISEA)*0.01
@@ -4415,21 +4415,21 @@
 !/SMC           CTRNY(ISEA) = MAX(0.11, TRNMY)
 !/SMC       END DO
 !/SMC !!Li    Transparency for boundary cells are 1.0   JGLi16Jan2012
-!/SMC           CTRNX(-9:0) = 1.0 
-!/SMC           CTRNY(-9:0) = 1.0 
+!/SMC           CTRNX(-9:0) = 1.0
+!/SMC           CTRNY(-9:0) = 1.0
 !/SMC !!Li  Check range of MAPSF and MAPFS
 !/SMC       WRITE (NDSO,4033) MINVAL( MAPSF(:,1) ), MAXVAL( MAPSF(:,1) )
 !/SMC       WRITE (NDSO,4034) MINVAL( MAPSF(:,2) ), MAXVAL( MAPSF(:,2) )
 !/SMC       WRITE (NDSO,4035) MINVAL( MAPSF(:,3) ), MAXVAL( MAPSF(:,3) )
 !/SMC       WRITE (NDSO,4036) MINVAL( MAPFS(:,:) ), MAXVAL( MAPFS(:,:) )
-!/SMC 
+!/SMC
 !/SMC !Li   New variable CLATF to hold cosine latitude at cell V face.
 !/SMC       DO IP = 1, NVFC
 !/SMC !        CLATF(IP) = COS( SYMR*FLOAT(IJKVFc(2,IP) - JEQT) )
 !/SMC !Li   Use adjusted j-index to calculate cell face Y from YJ0R.
 !/SMC          CLATF(IP) = COS( SYMR*FLOAT(IJKVFc(2,IP)) + YJ0R )
 !/SMC       ENDDO
-!/SMC !Li   Reset MAPSTA for boundary cells if any.  
+!/SMC !Li   Reset MAPSTA for boundary cells if any.
 !/SMC       IF(NBISMC .GT. 0) THEN
 !/SMC       DO IP=1, NBISMC
 !/SMC          ISEA = NBICelin(IP)
@@ -4441,7 +4441,7 @@
 !/SMC          MAPST2(IY:IY+JS-1,IX:IX+IK-1)  = 0
 !/SMC       ENDDO
 !/SMC       ENDIF
-!/SMC 
+!/SMC
 !
 !/ARC !Li   Define rotation angle for Arctic cells.
 !/ARC       PoLonAC = 179.999
@@ -4462,36 +4462,36 @@
 !/ARC          ENDIF
 !/ARC          XLONAC(ISEA-NGLO)= X0 + REAL(IX-1+IK/2)*SX
 !/ARC          YLATAC(ISEA-NGLO)= Y0 + REAL(IY-1+JS/2)*SY
-!/ARC       ENDDO 
+!/ARC       ENDDO
 !/ARC
 !/ARC        CALL W3LLTOEQ ( YLATAC, XLONAC, ELATAC, ELONAC,   &
 !/ARC      &                 ANGARC, PoLatAC, PoLonAC, NARC  )
 !/ARC
-!/ARC       WRITE (NDSO,4037)  NARC 
+!/ARC       WRITE (NDSO,4037)  NARC
 !/ARC       WRITE (NDSO,4038) (ANGARC(ix), ix=1,NARC,NARC/8)
 !/ARC
 !
 !/ARC !Li   Mapping Arctic boundary cells with inner model cells
-!/ARC       DO IP=1, NBAC 
+!/ARC       DO IP=1, NBAC
 !/ARC             IX=IJKCel(1,IP+NGLO)
 !/ARC             IY=IJKCel(2,IP+NGLO)
-!/ARC          DO ISEA=1, NGLO 
+!/ARC          DO ISEA=1, NGLO
 !/ARC             IF( (IX .EQ. IJKCel(1,ISEA)) .AND.      &
-!/ARC      &          (IY .EQ. IJKCel(2,ISEA)) ) THEN 
+!/ARC      &          (IY .EQ. IJKCel(2,ISEA)) ) THEN
 !/ARC                 ICLBAC(IP) = ISEA
 !/ARC             ENDIF
 !/ARC          ENDDO
 !/ARC       ENDDO
-!/ARC       WRITE (NDSO,4039)  NBAC 
+!/ARC       WRITE (NDSO,4039)  NBAC
 !/ARC       WRITE (NDSO,4040) (ICLBAC(ix), ix=1,NBAC,NBAC/8)
 !/ARC
-!/ARC !Li   Redefine GCT term factor for Arctic part or the netative of 
+!/ARC !Li   Redefine GCT term factor for Arctic part or the netative of
 !/ARC !Li   tangient of rotated latitude divided by radius. JGLi14Sep2015
 !/ARC       DO ISEA=NGLO+1, NCel-1
 !/ARC          CTHG0S(ISEA)= - TAN( ELATAC(ISEA-NGLO)*DERA ) / RADIUS
-!/ARC       ENDDO 
+!/ARC       ENDDO
 !/ARC          CTHG0S(NCel)=0.0
-!/ARC       
+!/ARC
 !
 !/RTD !Li   Assign rotated grid angle for all sea points.  JGLi01Feb2016
 !/RTD       DO ISEA=1,NSEA
@@ -4574,7 +4574,7 @@
 !/IG1         END DO
 !/IG1       IGMINDEP=MINVAL(ZB*(-1.)-2)  ! -2 / +2 is there for water level changes
 !/IG1       IGMAXDEP=MAXVAL(ZB*(-1.)+2)
-!/IG1       IF (IGSOURCEATBP.EQ.1)  IGMINDEP=1.   ! should use true minimum depth ... 
+!/IG1       IF (IGSOURCEATBP.EQ.1)  IGMINDEP=1.   ! should use true minimum depth ...
 !/IG1       IGPARS(6)=1+NINT(LOG(MAX(IGMAXDEP,1.0)/MAX(IGMINDEP,1.0))/LOG(1.1))
 !/IG1       IGPARS(7)=MAX(IGMINDEP,1.0)
 !/IG1       IGPARS(8)=IGSOURCEATBP
@@ -4628,14 +4628,14 @@
 !/IS2      IS2PARS(1) = ISC1
 !/IS2      IS2PARS(2) = IS2BACKSCAT
 !/IS2      IS2PARS(3)=0.
-!/IS2      IF (IS2BREAK) IS2PARS(3)=1. 
+!/IS2      IF (IS2BREAK) IS2PARS(3)=1.
 !/IS2      IS2PARS(4)=IS2C2
 !/IS2      IS2PARS(5)=IS2C3
 !/IS2      IS2PARS(6)=0.
 !/IS2      IF (IS2DISP) IS2PARS(6)=1.
 !/IS2      IS2PARS(7)=IS2DAMP
 !/IS2      IS2PARS(8)=IS2FRAGILITY
-!/IS2      IS2PARS(9)=IS2DMIN 
+!/IS2      IS2PARS(9)=IS2DMIN
 !/IS2      IS2PARS(10)=0.
 !/IS2      IF (IS2DUPDATE) IS2PARS(10)=1.
 !/IS2      IS2PARS(11)=IS2CONC
@@ -4656,22 +4656,22 @@
 !/IS2      IS2PARS(24)=IS2ANDISE
 !
 ! 9.d Estimates shoreline direction for reflection
-!     and shoreline treatment in general for UNST grids. 
+!     and shoreline treatment in general for UNST grids.
 ! NB: this is updated with moving water levels in W3ULEV
 ! AR: this is not anymore needed and will be deleted ...
 !
-      IF (GTYPE.EQ.UNGTYPE) THEN 
-        CALL SETUGIOBP 
+      IF (GTYPE.EQ.UNGTYPE) THEN
+        CALL SETUGIOBP
 !/REF1      ELSE
 !/REF1        CALL W3SETREF
         END IF
-!/REF1! 
+!/REF1!
 !/REF1!  9.a Reads shoreline slope  (whith REF1 switch only)
 !/REF1!
 !/REF1      ALLOCATE ( REFD(NX,NY), REFD2(NX,NY), REFS(NX,NY) )
-!/REF1      IF (REFMAP.EQ.0) THEN 
+!/REF1      IF (REFMAP.EQ.0) THEN
 !/REF1        REFS(:,:)=1.
-!/REF1      ELSE 
+!/REF1      ELSE
 !/REF1!
 !/REF1!  9.b Info from input file
 !/REF1!
@@ -4793,10 +4793,10 @@
 !/BT4                                            FROM, TNAME
 !/BT4          END IF
 !/BT4!
-!/BT4          IF (   ABS(VSC) .LT. 1.E-7  ) THEN 
+!/BT4          IF (   ABS(VSC) .LT. 1.E-7  ) THEN
 !/BT4            VSC    = 1.
-!/BT4          ELSE 
-!/BT4! WARNING TO BE ADDED ... 
+!/BT4          ELSE
+!/BT4! WARNING TO BE ADDED ...
 !/BT4          END IF
 !/BT4          IF (IDLA.LT.1 .OR. IDLA.GT.4) IDLA   = 1
 !/BT4          IF (IDFT.LT.1 .OR. IDFT.GT.3) IDFT   = 1
@@ -4851,7 +4851,7 @@
 !/BT4          WRITE (NDSO,*) 'Min and Max values of grain sizes:',MINVAL(SED_D50FILE), MAXVAL(SED_D50FILE)
 !/BT4          WRITE (NDSO,*)
 !/BT4!
-!/BT4      ELSE 
+!/BT4      ELSE
 !/BT4        SED_D50FILE(:,:)=SED_D50_UNIFORM
 !/BT4        END IF
 !/BT4!
@@ -4859,12 +4859,12 @@
 !/BT4        DO IX=1, NX
 !/BT4          ISEA = MAPFS (IY,IX)
 !/BT4          SED_D50(ISEA)       = SED_D50FILE(IX,IY)
-!/BT4          SED_D50(ISEA)       = MAX(SED_D50(ISEA),1E-5)  
+!/BT4          SED_D50(ISEA)       = MAX(SED_D50(ISEA),1E-5)
 !/BT4   ! Critical Shields number, Soulsby, R.L. and R J S W Whitehouse
 !/BT4   ! Threshold of sed. motion in coastal environments, Proc. Pacific Coasts and
 !/BT4   ! ports, 1997 conference, Christchurch, p149-154, University of Cantebury, NZ
-!/BT4          SED_DSTAR=(GRAV*(SED_SG-1)/nu_water**2)**(0.333333)*SED_D50(ISEA)  
-!/BT4          SED_PSIC(ISEA)=0.3/(1+1.2*SED_DSTAR)+0.55*(1-exp(-0.02*SED_DSTAR)) 
+!/BT4          SED_DSTAR=(GRAV*(SED_SG-1)/nu_water**2)**(0.333333)*SED_D50(ISEA)
+!/BT4          SED_PSIC(ISEA)=0.3/(1+1.2*SED_DSTAR)+0.55*(1-exp(-0.02*SED_DSTAR))
 
 
 !/BT4          END DO
@@ -4898,7 +4898,7 @@
         DO
           IF (FLGNML) THEN
             ! outbound lines
-            IF (NML_OUTBND_COUNT%N_LINE.GT.0 .AND. I.LE.NML_OUTBND_COUNT%N_LINE) THEN 
+            IF (NML_OUTBND_COUNT%N_LINE.GT.0 .AND. I.LE.NML_OUTBND_COUNT%N_LINE) THEN
               XO0 = NML_OUTBND_LINE(I)%X0
               YO0 = NML_OUTBND_LINE(I)%Y0
               DXO = NML_OUTBND_LINE(I)%DX
@@ -5165,9 +5165,9 @@
               WRITE (NDSO,9998)  0,  0, NX*NY, NSEA, NBI, NLAND, NBT
             END IF
         ENDIF ! GTYPE .EQ. UNGTYPE
-              
-      WRITE (NDSO,9999)  
- 
+
+      WRITE (NDSO,9999)
+
 !
 ! Formats
 !
@@ -5263,7 +5263,7 @@
 !/ST3 2920 FORMAT ( '  &SIN3 ZWND =',F5.1,', ALPHA0 =',F8.5,', Z0MAX =',F8.5,', BETAMAX =', &
 !/ST3                  F8.5,','/                                           &
 !/ST3              '        SINTHP =',F8.5,', ZALP =',F8.5,','/            &
-!/ST3              '        SWELLF =',F8.5,'R /'/)                              
+!/ST3              '        SWELLF =',F8.5,'R /'/)
 !
 !/ST4  920 FORMAT (/'  Wind input (WAM 4+) ',A/                            &
 !/ST4        ' --------------------------------------------------')
@@ -5390,16 +5390,16 @@
 !/ST3        ' --------------------------------------------------')
 !/ST3  925 FORMAT ( '       SDSC1                       :',1E11.3/    &
 !/ST3               '       Power of k in mean k        :',F8.2/      &
-!/ST3               '       weights of k and k^2        :',F9.3,F6.3/)  
+!/ST3               '       weights of k and k^2        :',F9.3,F6.3/)
 !/ST3 2924 FORMAT ( '  &SDS3 SDSC1 =',E12.4,', WNMEANP =',F4.2,       &
-!/ST3               ', FXPM3 =', F4.2,',FXFM3 =',F4.2,', '/           &  
+!/ST3               ', FXPM3 =', F4.2,',FXFM3 =',F4.2,', '/           &
 !/ST3               '        SDSDELTA1 =', F5.2,', SDSDELTA2 =',F5.2, &
-!/ST3               ' /')                               
+!/ST3               ' /')
 !
 !/ST4  924 FORMAT (/' Dissipation (Ardhuin et al. 2010) ',A/          &
 !/ST4        ' --------------------------------------------------')
 !/ST4  925 FORMAT ( '       SDSC2, SDSBCK, SDSCUM       :',3E11.3/    &
-!/ST4               '       Power of k in mean k        :',F8.2/)      
+!/ST4               '       Power of k in mean k        :',F8.2/)
 !/ST4 2924 FORMAT ( '  &SDS4 SDSC1 =',E12.4,', SDSC2 =',E12.4,        &
 !/ST4               ', SDSCUM =',F6.2,', '/                           &
 !/ST4               '        SDSC4 =',F6.2,', SDSC5 =',E12.4,         &
@@ -5453,11 +5453,11 @@
 !/BT4               ' --------------------------------------------------')
 !/BT4  927 FORMAT ( '       SEDMAPD50, SED_D50_UNIFORM        :',L3,1X,F8.6/ &
 !/BT4               '       RIPFAC1,RIPFAC2,RIPFAC3,RIPFAC4   :',4F8.4/      &
-!/BT4               '       SIGDEPTH, BOTROUGHMIN, BOTROUGHFAC:',3F8.4/)          
+!/BT4               '       SIGDEPTH, BOTROUGHMIN, BOTROUGHFAC:',3F8.4/)
 !/BT4 2926 FORMAT ( '  &SBT4 SEDMAPD50 =',L3,', SED_D50_UNIFORM =',F8.6,','/ &
 !/BT4               '        RIPFAC1 =',F8.4,', RIPFAC2 =',F8.4,      &
 !/BT4               ', RIPFAC3 =',F8.4,', RIPFAC4 =',F8.4,','/        &
-!/BT4               '        SIGDEPTH =',F8.4,', BOTROUGHMIN =',F8.4, & 
+!/BT4               '        SIGDEPTH =',F8.4,', BOTROUGHMIN =',F8.4, &
 !/BT4               ', BOTROUGHFAC =',F4.1,' /')
 !/BTX  926 FORMAT (/'  Experimental bottom friction.'/)
 !
@@ -5581,7 +5581,7 @@
 !/SMC               '       Cut-off latitude    (degr.) :',F8.2/      &
 !/SMC               '       Maximum refraction  (degr.) :',F8.2/)
 !/SMC 2953 FORMAT ( '  &PSMC CFLTM  =',F5.2,', DTIME  =', F9.1/     &
-!/SMC               '        LATMIN =',F5.1,', RFMAXD =', F9.2/     & 
+!/SMC               '        LATMIN =',F5.1,', RFMAXD =', F9.2/     &
 !/SMC               '        UNO3   =',L5,  ', AVERG  =',L5/        &
 !/SMC               '        LvSMC  =',i5,  ', NBISMC =',i9/        &
 !/SMC               '        ISHFT  =',i5,  ', JEQT   =',i9/        &
@@ -5692,21 +5692,21 @@
  4981 FORMAT ( '       Coefficient for shorelines  :',F6.4)
  4989 FORMAT ( '          *** CURVLINEAR GRID: REFLECTION NOT IMPLEMENTED YET ***')
  2977 FORMAT ( '  &SIG1  IGMETHOD =',I2,', IGADDOUTP =',I2,', IGSOURCE =',I2, &
-               ', IGSTERMS = ',I2,', IGBCOVERWRITE =', L3,','/        & 
+               ', IGSTERMS = ',I2,', IGBCOVERWRITE =', L3,','/        &
                '        IGSWELLMAX =', L3,', IGMAXFREQ =',F6.4,       &
                ', IGSOURCEATBP = ',I2,', IGKDMIN = ',F6.4,','/        &
                '        IGFIXEDDEPTH = ',F6.2,', IGEMPIRICAL = ',F8.6,' /')
 !
  2978 FORMAT ( '  &SIC2  IC2DISPER =',L3,', IC2TURB =',F6.2,          &
                ', IC2ROUGH  =',F10.6,','/                             &
-               '        IC2REYNOLDS = ',F10.1,', IC2SMOOTH = ',F10.1, & 
+               '        IC2REYNOLDS = ',F10.1,', IC2SMOOTH = ',F10.1, &
                ', IC2VISC =',F6.3,','/                                &
                ',       IC2TURBS =',F8.2,', IC2DMAX =',F5.3,' /')
 !
  2979 FORMAT ( '  &SIC3 IC3MAXTHK =',F6.2, ', IC3MAXCNC =',F6.2,','/  &
                '        IC2TURB =',F8.2,                              &
                ', IC2ROUGH  =',F7.3,','/                              &
-               '        IC2REYNOLDS = ',F10.1,', IC2SMOOTH = ',F10.1, & 
+               '        IC2REYNOLDS = ',F10.1,', IC2SMOOTH = ',F10.1, &
                ', IC2VISC =',F10.3,','/                               &
                '        IC2TURBS =',F8.2,', IC3CHENG =',L3,           &
                ', USECGICE =',L3,', IC3HILIM = ',F6.2,','/            &
@@ -5740,17 +5740,17 @@
                      ', NOLEAP = ',L3,' , TRCKCMPR = ', L3,','/       &
                '        BTBET  = ', F6.2, ' /')
 !
- 2976 FORMAT ( '  &OUTS P2SF  =',I2,', I1P2SF =',I2,', I2P2SF =',I3,','/&    
-               '        US3D  =',I2,', I1US3D =',I3,', I2US3D =',I3,','/&  
+ 2976 FORMAT ( '  &OUTS P2SF  =',I2,', I1P2SF =',I2,', I2P2SF =',I3,','/&
+               '        US3D  =',I2,', I1US3D =',I3,', I2US3D =',I3,','/&
                '        USSP  =',I2,', IUSSP  =',I3,','/&
-               '        E3D   =',I2,', I1E3D  =',I3,', I2E3D  =',I3,','/&  
-               '        TH1MF =',I2,', I1TH1M =',I3,', I2TH1M =',I3,','/&  
-               '        STH1MF=',I2,', I1STH1M=',I3,', I2STH1M=',I3,','/&  
-               '        TH2MF =',I2,', I1TH2M =',I3,', I2TH2M =',I3,','/&  
+               '        E3D   =',I2,', I1E3D  =',I3,', I2E3D  =',I3,','/&
+               '        TH1MF =',I2,', I1TH1M =',I3,', I2TH1M =',I3,','/&
+               '        STH1MF=',I2,', I1STH1M=',I3,', I2STH1M=',I3,','/&
+               '        TH2MF =',I2,', I1TH2M =',I3,', I2TH2M =',I3,','/&
                '        STH2MF=',I2,', I1STH2M=',I3,', I2STH2M=',I3,' /')
 !
  2986 FORMAT ( '  &REF1 REFCOAST =',F5.2,', REFFREQ =',F5.2,', REFSLOPE =',F5.3, &
-               ', REFMAP =',F4.1, ', REFMAPD =',F4.1, ', REFSUBGRID =',F5.2,','/ &   
+               ', REFMAP =',F4.1, ', REFMAPD =',F4.1, ', REFSUBGRID =',F5.2,','/ &
                '        REFRMAX=',F5.2,', REFFREQPOW =',F5.2,                    &
                ', REFICEBERG =',F5.2,', REFCOSP_STRAIGHT =',F4.1,' /')
 !
@@ -5781,11 +5781,11 @@
                '       Format indicator            :',I6)
  3008 FORMAT ( '       Format                      : ',A)
  3009 FORMAT ( '       File name                   : ',A)
-!/SMC 4001 FORMAT ( '       SMC refined levels NRLv   = ',I8) 
-!/SMC 4002 FORMAT ( '       SMC Equator j shift no.   = ',I8) 
-!/SMC 4302 FORMAT ( '       SMC I-index shift number  = ',I8) 
+!/SMC 4001 FORMAT ( '       SMC refined levels NRLv   = ',I8)
+!/SMC 4002 FORMAT ( '       SMC Equator j shift no.   = ',I8)
+!/SMC 4302 FORMAT ( '       SMC I-index shift number  = ',I8)
 !/SMC 4003 FORMAT ( '       SMC input boundary  no.   = ',I8)
-!/SMC 4004 FORMAT ( '       SMC NCel   = ',6I9)  
+!/SMC 4004 FORMAT ( '       SMC NCel   = ',6I9)
 !/SMC 4005 FORMAT ( '       IJKCel(5,NCel) read from ', A)
 !/SMC 4006 FORMAT (6I8)
 !/SMC 4007 FORMAT ( '       SMC NUFc   = ',6I9)
@@ -6136,7 +6136,7 @@
 !
       DO
         READ (NDS,'(A)',END=800,ERR=800,IOSTAT=IERR) LINE
-        DO I=1, 70 
+        DO I=1, 70
           IF ( LINE(I:I) .NE. ' ' ) THEN
               IF ( LINE(I:I) .EQ. '&' ) THEN
                   IF ( LINE(I+1:I+4) .EQ. NAME ) THEN
@@ -6212,19 +6212,19 @@
 !/SMC                          READ (NDS,NML=PSMC,END=801,ERR=802,IOSTAT=J)
 !/PR3                        CASE('PRO3')
 !/PR3                          READ (NDS,NML=PRO3,END=801,ERR=802,IOSTAT=J)
-!/RTD                        CASE('ROTD') 
+!/RTD                        CASE('ROTD')
 !/RTD                          READ (NDS,NML=ROTD,END=801,ERR=802,IOSTAT=J)
-!/REF1                        CASE('REF1') 
+!/REF1                        CASE('REF1')
 !/REF1                         READ (NDS,NML=REF1,END=801,ERR=802,IOSTAT=J)
-!/IG1                        CASE('SIG1') 
+!/IG1                        CASE('SIG1')
 !/IG1                         READ (NDS,NML=SIG1,END=801,ERR=802,IOSTAT=J)
-!/IC2                        CASE('SIC2') 
+!/IC2                        CASE('SIC2')
 !/IC2                         READ (NDS,NML=SIC2,END=801,ERR=802,IOSTAT=J)
-!/IC3                        CASE('SIC3') 
+!/IC3                        CASE('SIC3')
 !/IC3                         READ (NDS,NML=SIC3,END=801,ERR=802,IOSTAT=J)
-!/IC4                        CASE('SIC4 ') 
+!/IC4                        CASE('SIC4 ')
 !/IC4                         READ (NDS,NML=SIC4,END=801,ERR=802,IOSTAT=J)
-!/IC5                        CASE('SIC5 ') 
+!/IC5                        CASE('SIC5 ')
 !/IC5                         READ (NDS,NML=SIC5,END=801,ERR=802,IOSTAT=J)
                         CASE('UNST')
                           READ (NDS,NML=UNST,END=801,ERR=802,IOSTAT=J)

--- a/model/ftn/ww3_gspl.ftn
+++ b/model/ftn/ww3_gspl.ftn
@@ -31,7 +31,7 @@
 !/
 !/    Copyright 2012-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -419,7 +419,7 @@
           IF ( IGY .EQ. NGY ) THEN
               IGYN   = NY
             ELSE
-              IGYN   = NINT ( REAL(NY*IGY) / REAL(NGY)  ) 
+              IGYN   = NINT ( REAL(NY*IGY) / REAL(NGY)  )
             END IF
           IGXN   = 0
 !
@@ -429,7 +429,7 @@
             IF ( IGX .EQ. NGX ) THEN
                 IGXN   = NX
               ELSE
-                IGXN   = NINT ( REAL(NX*IGX) / REAL(NGX)  ) 
+                IGXN   = NINT ( REAL(NX*IGX) / REAL(NGX)  )
               END IF
 !
             DO IX=IGX0, IGXN
@@ -723,7 +723,7 @@
         IF ( MSTATS%NMIN .GT. INGMIN ) THEN
             INGMIN = MSTATS%NMIN
             INGMNC = 0
-          ELSE 
+          ELSE
             INGMNC = INGMNC + 1
           END IF
 !
@@ -979,11 +979,11 @@
         WRITE (NDSM,980) MSPLIT(IY,:)
         END DO
 !
-!/O16      CLOSE ( NDSG ) 
+!/O16      CLOSE ( NDSG )
 !
 !/O16      OPEN ( NDSG,FILE='ww3.ctl')
 !/O16      WRITE (NDSG,985)  NX, X0, SX, NY, Y0, SY, NTGRDS
-!/O16      CLOSE ( NDSG ) 
+!/O16      CLOSE ( NDSG )
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 9.  End of program
@@ -1414,7 +1414,7 @@
         MY     = 1 + GSTATS(IG)%NYH - GSTATS(IG)%NYL
         MX     = 1 + GSTATS(IG)%NXH - GSTATS(IG)%NXL
         IF ( GSTATS(IG)%STRADLE ) MX     = MX + NX
-        ICIRC  = 2 * ( MX + MY ) 
+        ICIRC  = 2 * ( MX + MY )
 !
         NWDTH  = 1
 !
@@ -1785,7 +1785,7 @@
 !/
 !  1. Purpose :
 !
-!     Reassign unassigned grid points to gridsR. Dealing with lost 
+!     Reassign unassigned grid points to gridsR. Dealing with lost
 !     point by finding clostst grids.
 !
 ! 10. Source code :
@@ -2764,7 +2764,7 @@
 !
         IF ( NNEXT .GE. 1 ) THEN
             GSTATS(IG)%INSTAT = .FALSE.
-!/T6            WRITE (NDST,9032) 
+!/T6            WRITE (NDST,9032)
           ELSE
 !
 ! 3.c Biggest grid is isolated, should split

--- a/model/ftn/ww3_multi.ftn
+++ b/model/ftn/ww3_multi.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -128,7 +128,7 @@
 !
 ! ... Separate test output file
 !
-      INQUIRE(FILE="ww3_multi.nml", EXIST=FLGNML) 
+      INQUIRE(FILE="ww3_multi.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         CALL WMINITNML ( MDSI, MDSO, MDSS, 10, MDSE, 'ww3_multi.nml', MPI_COMM )
       ELSE

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -35,7 +35,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -47,7 +47,7 @@
 !     Data is read from the grid output file out_grd.ww3 (raw data)
 !     and from the file ww3_ounf.nml or ww3_ounf.inp (NDSI)
 !     Model definition and raw data files are read using WAVEWATCH III
-!     subroutines. Extra global NetCDF attributes may be read from 
+!     subroutines. Extra global NetCDF attributes may be read from
 !     ASCII file NC_globatt.inp.
 !
 !     Output types :
@@ -231,7 +231,7 @@
 !
 ! process ww3_ounf namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_ounf.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_ounf.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         ! Read namelist
         CALL W3NMLOUNF (NDSI, TRIM(FNMPRE)//'ww3_ounf.nml', NML_FIELD, &
@@ -246,7 +246,7 @@
         FLDOUT = NML_FIELD%LIST
         CALL W3FLGRDFLAG ( NDSO, SCREEN, NDSE, FLDOUT, FLG1D,       &
                            FLG2D, 1, 1, IERR )
-        IF (IERR.NE.0) GOTO 800 
+        IF (IERR.NE.0) GOTO 800
 
 ! 4.3 Output type
         NCTYPE = NML_FILE%NETCDF
@@ -265,8 +265,8 @@
 !/SMC          NOVAL = NML_SMC%NOVAL
         ELSE
           IX1 = NML_FILE%IX0
-          IXN = NML_FILE%IXN 
-          IY1 = NML_FILE%IY0 
+          IXN = NML_FILE%IXN
+          IY1 = NML_FILE%IY0
           IYN = NML_FILE%IYN
         ENDIF ! SMCGRD
       END IF ! FLGNML
@@ -289,7 +289,7 @@
 ! 4.2 Output fields
         CALL W3READFLGRD ( NDSI, NDSO, SCREEN, NDSE, COMSTR, FLG1D,      &
                            FLG2D, 1, 1, IERR )
-        IF (IERR.NE.0) GOTO 800 
+        IF (IERR.NE.0) GOTO 800
 
 ! 4.3 Output type
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
@@ -379,7 +379,7 @@
 !!        END IF
 !!      END DO
 
-      ! Alternative processing of TABIPART to capture requests 
+      ! Alternative processing of TABIPART to capture requests
       ! greater than NOSWLL (C.Bunney):
       ALLOCATE(TABIPART(NOSWLL + 1))
       ALLOCATE(NCIDS(NOGRP,NGRPP,NOSWLL + 1))
@@ -436,7 +436,7 @@
 !/SMC      IXN = NXO
 !/SMC      IY1 = 1
 !/SMC      IYN = NYO
-!/SMC     
+!/SMC
 !/SMC      ! Also store NXO and NYO in __local__ RTDNX and RTDNY variables.
 !/SMC      ! This avoids compilation errors when the RTD switch is enabled
 !/SMC      ! but the SMC switch is not. TODO: Remove this when C-preprocessor
@@ -494,7 +494,7 @@
 ! 5.1.3 Defines the stop date
         CALL T2D(TOUT,STOPDATE,IERR)
         WRITE(STRSTOPDATE,'(I4.4,A,4(I2.2,A),I2.2)') STOPDATE(1),'-',STOPDATE(2), &
-              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7) 
+              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7)
 
         CALL TICK21 ( TOUT , DTREQ )
         IF ( IOUT .GE. NOUT ) EXIT
@@ -675,7 +675,7 @@
 !/    17-Mar-2010 : Creation                            ( version 3.14_SHOM )
 !/    28-Feb-2013 : New option for float output         ( version 4.08 )
 !/    02-Apr-2013 : New structure of output fields.     ( version 4.09 )
-!/    12-Apr-2013 : Allows curvilinear grids            ( version 4.10 ) 
+!/    12-Apr-2013 : Allows curvilinear grids            ( version 4.10 )
 !/    30-Apr-2014 : Correct group3 freq dim.            ( version 5.00 )
 !/    23-May-2014 : Adding ice fluxes to W3SRCE         ( version 5.01 )
 !/    14-Oct-2014 : Keep the output files opened        ( version 5.01 )
@@ -752,7 +752,7 @@
 !/ Parameter list
 !/
       INTEGER, INTENT(IN)     :: NX, NY, IX1, IXN, IY1, IYN, NSEA,     &
-                                 E3DF(3,5), P2MSF(3), US3DF(3),        & 
+                                 E3DF(3,5), P2MSF(3), US3DF(3),        &
                                  USSPF(2), NCTYPE, NCVARTYPEI
       CHARACTER(30)           :: FILEPREFIX
       LOGICAL, INTENT(IN)     :: TOGETHER
@@ -765,7 +765,7 @@
 !/
       INTEGER                 :: IFI, IFJ, MFILL, I, J, ISEA, IX, IY,  &
                                  I1, J1, IPART, INDEXIPART, COORDTYPE
-      INTEGER                 :: S1, S2, S4, S5, NCID, OLDNCID,        & 
+      INTEGER                 :: S1, S2, S4, S5, NCID, OLDNCID,        &
                                  MAPSTAOUT, NDSDAT, VMIN, VMAX,        &
                                  NFIELD, N, IRET, IK, EXTRADIM, IVAR,  &
                                  IVAR1, IDVAROUT, NCVARTYPE
@@ -779,7 +779,7 @@
 !/S      INTEGER, SAVE           :: IENT   =   0
 !
       INTEGER, ALLOCATABLE    :: TRIGP2(:,:)
-      ! Make the below allocatable to avoid stack overflow on some machines 
+      ! Make the below allocatable to avoid stack overflow on some machines
       INTEGER(KIND=2), ALLOCATABLE    :: MX1(:,:), MXX(:,:), MYY(:,:), &
                                          MXY(:,:), MAPOUT(:,:)
 !
@@ -789,9 +789,9 @@
       REAL,DIMENSION(:),  ALLOCATABLE    :: LON, LAT, FREQ
       REAL,DIMENSION(:,:),  ALLOCATABLE  :: LON2D, LAT2D, ANGLD2D
 !/RTD      REAL,DIMENSION(:,:),  ALLOCATABLE  :: LON2DEQ, LAT2DEQ
-      ! Make the below allocatable to avoid stack overflow on some machines 
+      ! Make the below allocatable to avoid stack overflow on some machines
       REAL, ALLOCATABLE       :: X1(:,:), X2(:,:), XX(:,:), XY(:,:),   &
-                                 XK(:,:,:), XXK(:,:,:), XYK(:,:,:),    & 
+                                 XK(:,:,:), XXK(:,:,:), XYK(:,:,:),    &
                                  MX1R(:,:), MXXR(:,:), MYYR(:,:),      &
                                  MXYR(:,:)
 !
@@ -818,7 +818,7 @@
 !
 !/S      CALL STRACE (IENT, 'W3EXNC')
 !
-!/T      DO IFI=1, NOGRP 
+!/T      DO IFI=1, NOGRP
 !/T        LTEMP  = FLG2D(IFI,:)
 !/T        WRITE (NDST,9000) IFI, LTEMP
 !/T        END DO
@@ -872,12 +872,12 @@
         COORDTYPE=2
       ENDIF
 
-! 1.2 Sets the date as ISO8601 convention 
+! 1.2 Sets the date as ISO8601 convention
       ! S3 defines the number of characters in the date for the filename
       ! S3=0 -> field, S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
       ! Setups min and max date format
-      IF (S3.GT.0 .AND. S3.LT.4) S3=4 
-      IF (S3.GT.10) S3=10 
+      IF (S3.GT.0 .AND. S3.LT.4) S3=4
+      IF (S3.GT.10) S3=10
 !
       ! Defines the format of FILETIME
       S5=S3-8
@@ -888,7 +888,7 @@
         S4=5
         TIMEID="field"
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHZ'
-      ELSE IF (S3.EQ.10) THEN 
+      ELSE IF (S3.EQ.10) THEN
         S4=S4+2 ! add chars for ISO8601 : day T hours Z
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (TIMEID,FORMAT1) TIME(1), 'T', &
@@ -899,10 +899,10 @@
         WRITE (TIMEID,FORMAT1) TIME(1)
       ! if S3=>YYYYMM then filetime='YYYYMM'
       ! or S3=>YYYY then filetime='YYYY'
-      ELSE 
+      ELSE
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I',S3,'.',S3,')'
         WRITE (TIMEID,FORMAT1) FLOOR(REAL(TIME(1))/NINT(10.**(8-S3)))
-      END IF       
+      END IF
       ! redefines filename with updated date format
       S1=LEN_TRIM(FILEPREFIX)
       FNAMENC=''
@@ -989,7 +989,7 @@
               VARNG(1)='depth'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = -90000 
+              VMIN = -90000
               VMAX = 140000
 !
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 2 ) THEN
@@ -1056,7 +1056,7 @@
               !! Note - UA and UD read in from .ww3 file are UX,UY
 !/RTD              ! Rotate x,y vector back to standard pole
 !/RTD              IF ( FLAGUNR ) CALL W3XYRTN(NSEA, UA(1:NSEA), UD(1:NSEA), AnglD)
-              
+
               IF( SMCGRD ) THEN
 !/SMC                 CALL W3S2XY_SMC( UA(1:NSEA), XX )
 !/SMC                 CALL W3S2XY_SMC( UD(1:NSEA), XY )
@@ -1124,7 +1124,7 @@
               VARNG(1)='air_sea_temperature_difference'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0    
+              VMIN = 0
               VMAX = 4000
 !
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 5 ) THEN
@@ -1143,14 +1143,14 @@
               VARNG(1)='sea_surface_height_above_sea_level'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 10000
 !
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 6 ) THEN
               FSC    = 0.001
               UNITS  = '1'
               ENAME  = '.ice'
-              
+
               IF( SMCGRD ) THEN
 !/SMC                 CALL W3S2XY_SMC(ICE, X1)
               ELSE
@@ -1193,7 +1193,7 @@
 !/BT4              UNITS  = 'Krumbein phi scale'
 !/BT4              ENAME  = '.d50'
 !/BT4              CALL W3S2XY ( NSEA, NSEA, NX+1, NY, SED_D50   , MAPSF, X1 )
-!/BT4              WHERE ( X1.NE.UNDEF) X1 = -LOG(X1/0.001)/LOG2    
+!/BT4              WHERE ( X1.NE.UNDEF) X1 = -LOG(X1/0.001)/LOG2
 !/BT4              NFIELD=1
 !/BT4              VARNM(1)='d50'
 !/BT4              VARNL(1)='grain_size'
@@ -1250,11 +1250,11 @@
               NFIELD=1
               VARNM(1)='hs'
               VARNL(1)='significant height of wind and swell waves'
-              VARNS(1)='sea_surface_wave_significant_height' 
+              VARNS(1)='sea_surface_wave_significant_height'
               VARNG(1)='significant_wave_height'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 2 ) THEN
@@ -1270,11 +1270,11 @@
               NFIELD=1
               VARNM(1)='lm'
               VARNL(1)='mean wave length'
-              VARNS(1)='mean_wave_length' 
-              VARNG(1)='mean_wave_length' 
+              VARNS(1)='mean_wave_length'
+              VARNG(1)='mean_wave_length'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 3200
 !
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 3 ) THEN
@@ -1316,14 +1316,14 @@
               VARNG(1)='mean_period_t0m1'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 5000
 !
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 5 ) THEN
               FSC    = 0.01
               UNITS  = 's'
               ENAME  = '.t01'
-              
+
               IF( SMCGRD ) THEN
 !/SMC                CALL W3S2XY_SMC( T01, X1 )
               ELSE
@@ -1333,7 +1333,7 @@
               VARNM(1)='t01'
               VARNL(1)='mean period T01'
               VARNS(1)='sea_surface_wind_wave_mean_period_from_variance' // &
-                       '_spectral_density_first_frequency_moment' 
+                       '_spectral_density_first_frequency_moment'
               VARNG(1)='mean_period_t01'
               VARNC(1)=''
               VARND(1)=''
@@ -1357,7 +1357,7 @@
               VARNG(1)='dominant_wave_frequency'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 10000
 !
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 7 ) THEN
@@ -1443,7 +1443,7 @@
 !/RTD              ELSE IF ( .NOT. FLAGUNR ) THEN
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = 0 
+              VMIN = 0
               VMAX = 360
 !
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 10 ) THEN
@@ -1459,11 +1459,11 @@
               NFIELD=1
               VARNM(1)='hig'
               VARNL(1)='infragravity_wave_height'
-              VARNS(1)='sea_surface_wave_infragravity_significant_height' 
-              VARNG(1)='infragravity_significant_wave_height' 
+              VARNS(1)='sea_surface_wave_infragravity_significant_height'
+              VARNG(1)='infragravity_significant_wave_height'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 5000
 !
             ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 11 ) THEN
@@ -1608,7 +1608,7 @@
               VARNG(1)=VARNS(1)
               VARNC(1)=''
               VARND(1)=''
-              IF (NCVARTYPE.LE.3) THEN 
+              IF (NCVARTYPE.LE.3) THEN
                 UNITS  = 'log10(m2 s+1E-12)'
                 VARNS(1)='base_ten_logarithm_of_power_spectral_density_of_surface_elevation'
                 FSC     = 0.0004
@@ -1665,7 +1665,7 @@
                 ENDIF
                 XK(:,:,IK)=XX
                 END DO
-              VMIN = 0 
+              VMIN = 0
               VMAX = 3600
 !
             ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 3 ) THEN
@@ -1691,7 +1691,7 @@
                 ENDIF
                 XK(:,:,IK)=XX
                 END DO
-              VMIN = 0 
+              VMIN = 0
               VMAX = 9000
 !
             ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 4 ) THEN
@@ -1725,7 +1725,7 @@
                 ENDIF
                 XK(:,:,IK)=XX
                 END DO
-              VMIN = 0 
+              VMIN = 0
               VMAX = 3600
 !
             ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 5 ) THEN
@@ -1751,7 +1751,7 @@
                 ENDIF
                 XK(:,:,IK)=XX
                 END DO
-              VMIN = 0 
+              VMIN = 0
               VMAX = 9000
 !
             ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 6 ) THEN
@@ -1762,7 +1762,7 @@
               ENAME  = '.wn'
               I1F=1
               I2F=NK
-              DO IK=1,NK 
+              DO IK=1,NK
                 IF( SMCGRD ) THEN
 !/SMC                  CALL W3S2XY_SMC( WN(IK,:), XX )
                 ELSE
@@ -1777,7 +1777,7 @@
               VARNG(1)='wave_numbers'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 1 ) THEN
@@ -1792,13 +1792,13 @@
               ENDIF
 
               NFIELD=1
-              WRITE(VARNM(1),'(A3,I1)') 'phs',IPART 
-              WRITE(VARNL(1),'(A,I1)') 'wave significant height partition ',IPART 
-              WRITE(VARNS(1),'(A,I1)') 'sea_surface_wave_significant_height_partition_',IPART 
-              WRITE(VARNG(1),'(A,I1)') 'significant_wave_height_partition_',IPART 
+              WRITE(VARNM(1),'(A3,I1)') 'phs',IPART
+              WRITE(VARNL(1),'(A,I1)') 'wave significant height partition ',IPART
+              WRITE(VARNS(1),'(A,I1)') 'sea_surface_wave_significant_height_partition_',IPART
+              WRITE(VARNG(1),'(A,I1)') 'significant_wave_height_partition_',IPART
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 2 ) THEN
@@ -1813,14 +1813,14 @@
               ENDIF
 
               NFIELD=1
-              WRITE(VARNM(1),'(A3,I1)') 'ptp',IPART 
-              WRITE(VARNL(1),'(A,I1)') 'peak period partition ',IPART 
+              WRITE(VARNM(1),'(A3,I1)') 'ptp',IPART
+              WRITE(VARNL(1),'(A,I1)') 'peak period partition ',IPART
               WRITE(VARNS(1),'(A,I1)') 'sea_surface_wave_period_at_' // &
                                        'variance_spectral_density_maximum_partition_',IPART
               WRITE(VARNG(1),'(A,I1)') 'dominant_wave_period_partition_',IPART
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 10000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 3 ) THEN
@@ -1834,13 +1834,13 @@
               ENDIF
 
               NFIELD=1
-              WRITE(VARNM(1),'(A3,I1)') 'plp',IPART 
-              WRITE(VARNL(1),'(A,I1)') 'peak wave length partition ',IPART 
+              WRITE(VARNM(1),'(A3,I1)') 'plp',IPART
+              WRITE(VARNL(1),'(A,I1)') 'peak wave length partition ',IPART
               WRITE(VARNS(1),'(A,I1)') 'peak_wave_length_partition_',IPART
               WRITE(VARNG(1),'(A,I1)') 'peak_wave_length_partition_',IPART
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 10000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 4 ) THEN
@@ -1860,8 +1860,8 @@
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PDIR(:,IPART), MAPSF, X1 )
               ENDIF
               NFIELD=1
-              WRITE(VARNM(1),'(A4,I1)') 'pdir',IPART 
-              WRITE(VARNL(1),'(A,I1)') 'wave mean direction partition ',IPART 
+              WRITE(VARNM(1),'(A4,I1)') 'pdir',IPART
+              WRITE(VARNL(1),'(A,I1)') 'wave mean direction partition ',IPART
               WRITE(VARNS(1),'(A,I1)') 'sea_surface_wave_from_direction_partition_',IPART
               WRITE(VARNG(1),'(A,I1)') 'wave_from_direction_partition_',IPART
               VARNC(1)=PARTCOM
@@ -1879,7 +1879,7 @@
               FSC    = 0.1
               UNITS  = 'degree'
               WRITE(ENAME,'(A5,I1)') '.pspr',IPART
-              
+
               IF( SMCGRD ) THEN
 !/SMC                CALL W3S2XY_SMC( PSI(:,IPART), X1 )
               ELSE
@@ -1887,13 +1887,13 @@
               ENDIF
 
               NFIELD=1
-              WRITE(VARNM(1),'(A4,I1)') 'pspr',IPART 
-              WRITE(VARNL(1),'(A,I1)') 'directional spread partition ',IPART 
+              WRITE(VARNM(1),'(A4,I1)') 'pspr',IPART
+              WRITE(VARNL(1),'(A,I1)') 'directional spread partition ',IPART
               WRITE(VARNS(1),'(A,I1)') 'sea_surface_wave_directional_spread_partition_',IPART
               WRITE(VARNG(1),'(A,I1)') 'directional_spread_partition_',IPART
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 900
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 6 ) THEN
@@ -1909,12 +1909,12 @@
 
               NFIELD=1
               WRITE(VARNM(1),'(A3,I1)') 'pws',IPART
-              WRITE(VARNL(1),'(A,I1)') 'wind sea fraction in partition ',IPART 
-              WRITE(VARNS(1),'(A,I1)') 'wind_sea_fraction_in_partition_',IPART 
+              WRITE(VARNL(1),'(A,I1)') 'wind sea fraction in partition ',IPART
+              WRITE(VARNS(1),'(A,I1)') 'wind_sea_fraction_in_partition_',IPART
               WRITE(VARNG(1),'(A,I1)') 'wind_sea_fraction_in_partition_',IPART
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 1000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 7 ) THEN
@@ -2141,7 +2141,7 @@
               VARNG(1)='wind_sea_fraction'
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 1000
 !
             ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 17 ) THEN
@@ -2162,7 +2162,7 @@
               VARNG(1)='number_of_wave_partitions'
               VARNC(1)=PARTCOM
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 100
 !
             ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 1 ) THEN
@@ -2250,8 +2250,8 @@
             ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 3 ) THEN
               FSC    = 0.1           !0.01
               UNITS  = 'kW m-1'
-              ENAME  = '.cge' 
-              CGE=CGE*0.001  ! from W / m to kW / m 
+              ENAME  = '.cge'
+              CGE=CGE*0.001  ! from W / m to kW / m
               IF( SMCGRD ) THEN
 !/SMC                CALL W3S2XY_SMC( CGE(1:NSEA), X1 )
               ELSE
@@ -2392,9 +2392,9 @@
               ENDIF ! SMCGRD
               NFIELD=1
               VARNM(1)='wcc'
-              VARNL(1)='whitecap coverage'         
+              VARNL(1)='whitecap coverage'
               VARNS(1)='whitecap_coverage'
-              VARNG(1)='whitecap_coverage'            
+              VARNG(1)='whitecap_coverage'
               VARNC(1)=''
               VARND(1)=''
               VMIN = 0
@@ -2412,16 +2412,16 @@
               ENDIF
               NFIELD=1
               VARNM(1)='wcf'
-              VARNL(1)='whitecap foam thickness' 
+              VARNL(1)='whitecap foam thickness'
               VARNS(1)='whitecap_foam_thickness'
-              VARNG(1)='whitecap_foam_thickness' 
+              VARNG(1)='whitecap_foam_thickness'
               VARNC(1)=''
               VARND(1)=''
               VMIN = 0
               VMAX = 10000
 !
             ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 9 ) THEN
-              FSC    = 0.002 
+              FSC    = 0.002
               UNITS  = 'm'
               ENAME  = '.wch'
               IF( SMCGRD ) THEN
@@ -2452,8 +2452,8 @@
               ENDIF ! SMCGRD
               NFIELD=1
               VARNM(1)='wcm'
-              VARNL(1)='whitecap moment'  
-              VARNS(1)='whitecap_moment'   
+              VARNL(1)='whitecap moment'
+              VARNS(1)='whitecap_moment'
               VARNG(1)='whitecap_moment'
               VARNC(1)=''
               VARND(1)=''
@@ -2523,7 +2523,7 @@
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD                VARND(3) = 'Rotated Pole Grid North'
               VMIN = -3000
-              VMAX = 3000     
+              VMAX = 3000
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 2 ) THEN
               FSC    = 0.000001
@@ -2561,7 +2561,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -32000 
+              VMIN = -32000
               VMAX =  32000
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 3 ) THEN
@@ -2581,7 +2581,7 @@
               VARNG(1)='radiation_pressure'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 1000
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 4 ) THEN
@@ -2605,7 +2605,7 @@
               VARNG(1)='wave_to_ocean_energy_flux'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 9990
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 5 ) THEN
@@ -2661,7 +2661,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -9900 
+              VMIN = -9900
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 6 ) THEN
               FSC    = 0.0005
@@ -2718,7 +2718,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -9900 
+              VMIN = -9900
               VMAX =  9900
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 7 ) THEN
@@ -2739,7 +2739,7 @@
               VARNC(2)=''
               VARND(1)=''
               VARND(2)=''
-              VMIN = -15000 
+              VMIN = -15000
               VMAX = 32000
               IF( SMCGRD ) THEN
 !/SMC                CALL W3S2XY_SMC( PRMS(1:NSEA), XX )
@@ -2794,7 +2794,7 @@
               FSC    = 0.0005
               ENAME  = '.usf'
 
-              VMIN = -9900 
+              VMIN = -9900
               VMAX =  9900
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ.  9 ) THEN
@@ -2817,17 +2817,17 @@
                   ELSE
                     CALL W3S2XY ( NSEA, NSEA, NX+1,NY,P2SMS(:,IK),MAPSF, XX )
                   ENDIF ! SMCGRD
-                  IF (NCVARTYPE.EQ.2) THEN 
+                  IF (NCVARTYPE.EQ.2) THEN
                      WHERE ( XX.GE.0.) XX = ALOG10(XX*(DWAT*GRAV)**2+1E-12)
                      UNITS  = 'log10(Pa2 m2 s+1E-12)'
-                  ELSE 
+                  ELSE
                      WHERE ( XX.GE.0.) XX = XX*(DWAT*GRAV)**2
                      UNITS  = 'Pa2 m2 s'
                   END IF
-                
+
                   XK(:,:,IK)=XX
                   END DO
-              VMIN = -30000 
+              VMIN = -30000
               VMAX = 30000
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 10 ) THEN
@@ -2866,7 +2866,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -32000 
+              VMIN = -32000
               VMAX =  32000
 !
             ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 11 ) THEN
@@ -2890,7 +2890,7 @@
               VARNG(1)='wave_to_sea_ice_energy_flux'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 9990
 
            ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 12 ) THEN
@@ -3011,7 +3011,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -18000 
+              VMIN = -18000
               VMAX = 18000
 !
             ELSE IF ( IFI .EQ. 7 .AND. IFJ .EQ. 3 ) THEN
@@ -3105,7 +3105,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = -32000 
+              VMIN = -32000
               VMAX =  32000
 !
             ELSE IF ( IFI .EQ. 8 .AND. IFJ .EQ. 1 ) THEN
@@ -3137,11 +3137,11 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = 0 
+              VMIN = 0
               VMAX = 30000
 !
             ELSE IF ( IFI .EQ. 8 .AND. IFJ .EQ. 2 ) THEN
-              FSC    = 1E-7     
+              FSC    = 1E-7
               ENAME  = '.msc'
               UNITS  = '1'
 !/RTD              ! Rotate x,y vector back to standard pole
@@ -3169,7 +3169,7 @@
 !/RTD                VARND(1) = 'Rotated Pole Grid North'
 !/RTD                VARND(2) = 'Rotated Pole Grid North'
 !/RTD              END IF
-              VMIN = 0 
+              VMIN = 0
               VMAX = 30000
 !
             ELSE IF ( IFI .EQ. 8 .AND. IFJ .EQ. 3 ) THEN
@@ -3264,7 +3264,7 @@
               VARNG(1)='dynamic_time_step'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 9 .AND. IFJ .EQ. 2 ) THEN
@@ -3279,7 +3279,7 @@
               VARNG(1)='cut_off_frequency'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 8000
 !
             ELSE IF ( IFI .EQ. 9 .AND. IFJ .EQ. 3 ) THEN
@@ -3294,7 +3294,7 @@
               VARNG(1)='maximum_cfl_for_spatial_advection'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 9 .AND. IFJ .EQ. 4 ) THEN
@@ -3309,7 +3309,7 @@
               VARNG(1)='maximum_cfl_for_direction_advection'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 9 .AND. IFJ .EQ. 5 ) THEN
@@ -3324,7 +3324,7 @@
               VARNG(1)='maximum_cfl_for_frequency_advection'
               VARNC(1)=''
               VARND(1)=''
-              VMIN = 0 
+              VMIN = 0
               VMAX = 32000
 !
             ELSE IF ( IFI .EQ. 10 ) THEN
@@ -3391,7 +3391,7 @@
 
             ! If flag TOGETHER and not variable with freq dim &
             ! (ef, p2l, ...), no variable name in file name
-            IF (TOGETHER.AND.(.NOT.FLFRQ)) THEN 
+            IF (TOGETHER.AND.(.NOT.FLFRQ)) THEN
               S2=0
             ! If NOT flag TOGETHER or variable with freq dim &
             ! (ef, p2l, ...), add variable name in file name
@@ -3402,17 +3402,17 @@
             FNAMENC(S1+S2+1:S1+S2+3) = '.nc'
             FNAMENC(S1+S2+4:S1+S2+6) = '   '
             ! If the flag frequency is .TRUE., defines the fourth dimension
-            IF (FLFRQ) THEN 
+            IF (FLFRQ) THEN
               UNITVAR(:)=UNITS
               DIMLN(4)=I2F-I1F+1
               EXTRADIM=1
             ELSE
               DIMLN(4)=0
               EXTRADIM=0
-            END IF 
+            END IF
 
             ! If regular grid, initializes the lat/lon or x/y dimension lengths
-            IF (GTYPE.NE.UNGTYPE) THEN 
+            IF (GTYPE.NE.UNGTYPE) THEN
               IF( SMCGRD ) THEN
 !/SMC                IF( SMCTYPE .EQ. 1 ) THEN
 !/SMC                  ! Flat seapoints file
@@ -3471,7 +3471,7 @@
 
 ! 2.4.3 Finalize the previous file (if a new one will be created)
 
-            IF (.NOT.FEXIST) THEN 
+            IF (.NOT.FEXIST) THEN
               IF (INDEX('0000000000000000',OLDTIMEID).EQ.0 .AND. INDEX(TIMEID,OLDTIMEID).EQ.0) THEN
                 IRET = NF90_REDEF(OLDNCID)
                 CALL CHECK_ERR(IRET)
@@ -3485,15 +3485,15 @@
 
 ! 2.5 Creates the netcdf file
 
-            IF (.NOT.FEXIST) THEN 
+            IF (.NOT.FEXIST) THEN
 
               ! Initializes the time dimension length
               DIMLN(1)=1
 
               ! If NOT unstructure mesh (i.e. regular grid)
-              IF (GTYPE.NE.UNGTYPE) THEN      
+              IF (GTYPE.NE.UNGTYPE) THEN
                 ! If spherical coordinate
-                IF (FLAGLL) THEN 
+                IF (FLAGLL) THEN
                   VARNM(NFIELD+1)='Longitude'
                   VARNM(NFIELD+2)='Latitude'
                 ! If cartesian coordinate
@@ -3501,7 +3501,7 @@
                   VARNM(NFIELD+1)='x'
                   VARNM(NFIELD+2)='y'
                 END IF
-              END IF   
+              END IF
 
 
 
@@ -3510,7 +3510,7 @@
               ! Initializes the time iteration counter n
               N=1
 
-! 2.5.1 Creates the NetCDF file 
+! 2.5.1 Creates the NetCDF file
               CALL W3CRNC(FNAMENC,NCID,DIMID,DIMLN,VARID, &
                           EXTRADIM,NCTYPE,MAPSTAOUT)
 
@@ -3534,7 +3534,7 @@
                                      'longitude_resolution','n/a')
                 CALL CHECK_ERR(IRET)
               ! If NOT curvilinear grid,
-              ELSE 
+              ELSE
                 IF( SMCGRD ) THEN
 !/SMC                   IF(SMCTYPE .EQ. 1) THEN
 !/SMC                     ! Flat seapoints file
@@ -3571,16 +3571,16 @@
                   IF (.NOT.ALLOCATED(LON)) ALLOCATE(LON(NX))
 !/RTD                  ! 2d longitude array for standard grid coordinates
 !/RTD                  IF (.NOT.ALLOCATED(LON2D)) ALLOCATE(LON2D(NX,NY),LON2DEQ(NX,NY),ANGLD2D(NX,NY))
-                  IF (.NOT.ALLOCATED(LAT)) THEN 
+                  IF (.NOT.ALLOCATED(LAT)) THEN
                     ! If regular grid, instanciates lat with y/lat
-                    IF (GTYPE.EQ.RLGTYPE) THEN 
+                    IF (GTYPE.EQ.RLGTYPE) THEN
                       ALLOCATE(LAT(NY))
 !/RTD                      ! 2d latitude array for standard grid coordinates
 !/RTD                      IF (.NOT.ALLOCATED(LAT2D)) ALLOCATE(LAT2D(NX,NY),LAT2DEQ(NX,NY))
                     ! If unstructured mesh, instanciates lat with nodes
-                    ELSE 
+                    ELSE
                       ALLOCATE(LAT(NX))
-                    END IF 
+                    END IF
                   END IF
                 END IF ! SMCGRD
               END IF
@@ -3589,7 +3589,7 @@
 ! 2.5.2 Generates Lat-Lon arrays
 
               ! If regular grid
-              IF (GTYPE.EQ.RLGTYPE) THEN 
+              IF (GTYPE.EQ.RLGTYPE) THEN
                 IF( SMCGRD ) THEN
 !/SMC                  ! CB: Calculate lat/lons of SMC grid
 !/SMC                  IF( SMCTYPE .EQ. 1 ) THEN
@@ -3655,13 +3655,13 @@
 !/RTD                  DO I=1,NX
 !/RTD                    CALL W3EQTOLL(LAT2DEQ(I,1:NY), LON2DEQ(I,1:NY), LAT2D(I,1:NY), &
 !/RTD                                   LON2D(I,1:NY), ANGLD2D(I,1:NY), POLAT, POLON, NY)
-!/RTD                  END DO   
+!/RTD                  END DO
                   WRITE(STR2,'(F12.0)') SY
                   STR2=ADJUSTL(STR2)
                   IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,   &
                            'latitude_resolution', TRIM(STR2))
                   CALL CHECK_ERR(IRET)
-                  WRITE(STR2,'(F12.0)') SX 
+                  WRITE(STR2,'(F12.0)') SX
                   STR2=ADJUSTL(STR2)
                   IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,   &
                            'longitude_resolution',TRIM(STR2))
@@ -3670,8 +3670,8 @@
               END IF
 
               ! If unstructured mesh
-              IF (GTYPE.EQ.UNGTYPE) THEN 
-                LON(:)=XYB(:,1) 
+              IF (GTYPE.EQ.UNGTYPE) THEN
+                LON(:)=XYB(:,1)
                 LAT(:)=XYB(:,2)
                 IF (.NOT.ALLOCATED(TRIGP2)) ALLOCATE(TRIGP2(3,NTRI))
                 DIMLN(2)=NX
@@ -3752,7 +3752,7 @@
 ! 2.5.3 Writes longitudes, latitudes, triangles, frequency and status map (mapsta) to netcdf file
 
               ! If regular grid
-              IF (GTYPE.EQ.RLGTYPE) THEN 
+              IF (GTYPE.EQ.RLGTYPE) THEN
                 IF(SMCGRD) THEN ! CB: shelter original code from SMC grid
 !/SMC                  IRET=NF90_PUT_VAR(NCID,VARID(1),LON(:))
 !/SMC                  CALL CHECK_ERR(IRET)
@@ -3778,7 +3778,7 @@
               END IF
 
               ! If spherical grid
-              IF (GTYPE.EQ.CLGTYPE) THEN 
+              IF (GTYPE.EQ.CLGTYPE) THEN
                 IRET=NF90_PUT_VAR(NCID,VARID(1),LON2D(IX1:IXN,IY1:IYN))
                 CALL CHECK_ERR(IRET)
                 IRET=NF90_PUT_VAR(NCID,VARID(2),LAT2D(IX1:IXN,IY1:IYN))
@@ -3786,7 +3786,7 @@
               END IF
 
               ! If unstructured mesh
-              IF (GTYPE.EQ.UNGTYPE) THEN 
+              IF (GTYPE.EQ.UNGTYPE) THEN
                 IRET=NF90_PUT_VAR(NCID,VARID(1),LON(IX1:IXN))
                 CALL CHECK_ERR(IRET)
                 IRET=NF90_PUT_VAR(NCID,VARID(2),LAT(IX1:IXN))
@@ -3818,8 +3818,8 @@
               END IF
 
               ! Writes status map array at variable index 2+1+coordtype+idim-4
-              IF (MAPSTAOUT.EQ.1) THEN 
-                IDVAROUT=VARID(3+EXTRADIM+(COORDTYPE-1)+MAPSTAOUT) 
+              IF (MAPSTAOUT.EQ.1) THEN
+                IDVAROUT=VARID(3+EXTRADIM+(COORDTYPE-1)+MAPSTAOUT)
                 START(1)=1
                 START(2)=1
                 COUNT(1)=IXN-IX1+1
@@ -3842,7 +3842,7 @@
               DO I=1,NFIELD
                 IVAR=IVAR1+I
                 IF (COORDTYPE.EQ.1) THEN
-                  IF (NCVARTYPE.EQ.2) THEN 
+                  IF (NCVARTYPE.EQ.2) THEN
                     IF( SMCGRD ) THEN
 !/SMC                      IF( SMCTYPE .EQ. 1 ) THEN
 !/SMC                        ! SMC Flat file
@@ -3874,14 +3874,14 @@
                   DIMFIELD(1)=DIMID(2)
                   DIMFIELD(2)=DIMID(4)
                   DIMFIELD(3)=DIMID(5)
-                  IF (NCVARTYPE.EQ.2) THEN 
+                  IF (NCVARTYPE.EQ.2) THEN
                     IRET = NF90_DEF_VAR(NCID,VARNM(I), NF90_SHORT, DIMFIELD(1:2+EXTRADIM), VARID(IVAR))
 !/NC4                        IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(IVAR), 1, 1, DEFLATE)
-                  ELSE 
+                  ELSE
                     IRET = NF90_DEF_VAR(NCID,VARNM(I), NF90_FLOAT, DIMFIELD(1:2+EXTRADIM), VARID(IVAR))
 !/NC4                        IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(IVAR), 1, 1, DEFLATE)
-                  END IF  
-                  CALL CHECK_ERR(IRET)                      
+                  END IF
+                  CALL CHECK_ERR(IRET)
                 END IF
 !
                 IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'long_name',VARNL(I))
@@ -3892,19 +3892,19 @@
                 CALL CHECK_ERR(IRET)
                 IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'units',UNITVAR(I))
                 CALL CHECK_ERR(IRET)
-                IF (NCVARTYPE.EQ.2) THEN 
+                IF (NCVARTYPE.EQ.2) THEN
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'_FillValue',NF90_FILL_SHORT)
-                ELSE 
+                ELSE
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'_FillValue',NF90_FILL_FLOAT)
                   FSC=1.
                   FSC3=1.
                 END IF
                 CALL CHECK_ERR(IRET)
-                IF (I.LE.2) THEN 
+                IF (I.LE.2) THEN
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'scale_factor',FSC)
                 ELSE
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'scale_factor',FSC3)
-                ENDIF 
+                ENDIF
                 CALL CHECK_ERR(IRET)
                 IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'add_offset',0.)
                 CALL CHECK_ERR(IRET)
@@ -3967,9 +3967,9 @@
                 ELSE
                   IRET=NF90_INQ_DIMID (NCID, 'x', DIMID(2))
                   IRET=NF90_INQ_VARID (NCID, 'x', VARID(1))
-                  IRET=NF90_INQ_DIMID (NCID, 'y', DIMID(3)) 
+                  IRET=NF90_INQ_DIMID (NCID, 'y', DIMID(3))
                   IRET=NF90_INQ_VARID (NCID, 'y', VARID(1))
-                END IF 
+                END IF
                 CALL CHECK_ERR(IRET)
               END IF
               ! Get the dimension time
@@ -3992,7 +3992,7 @@
 ! 2.6.3 Defines or gets the variables identifiers
 
               ! If it is the first time step, define all the variables and attributes
-              IF (N.EQ.1) THEN 
+              IF (N.EQ.1) THEN
                 IRET = NF90_REDEF(NCID)
                 CALL CHECK_ERR(IRET)
 
@@ -4000,7 +4000,7 @@
                 DO I=1,NFIELD
                   IVAR=IVAR1+I
                   IF (COORDTYPE.EQ.1) THEN
-                    IF (NCVARTYPE.EQ.2) THEN 
+                    IF (NCVARTYPE.EQ.2) THEN
                       IF( SMCGRD ) THEN
 !/SMC                        IF( SMCTYPE .EQ. 1 ) THEN
 !/SMC                          ! SMC Flat file
@@ -4033,7 +4033,7 @@
                     DIMFIELD(1)=DIMID(2)
                     DIMFIELD(2)=DIMID(4)
                     DIMFIELD(3)=DIMID(5)
-                    IF (NCVARTYPE.EQ.2) THEN 
+                    IF (NCVARTYPE.EQ.2) THEN
                       IRET = NF90_DEF_VAR(NCID,VARNM(I), NF90_SHORT, DIMFIELD(1:2+EXTRADIM), VARID(IVAR))
 !/NC4                      IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(IVAR), 1, 1, DEFLATE)
                     ELSE
@@ -4050,20 +4050,20 @@
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'units',UNITVAR(I))
                   CALL CHECK_ERR(IRET)
 !
-                  IF (NCVARTYPE.EQ.2) THEN 
+                  IF (NCVARTYPE.EQ.2) THEN
                     IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'_FillValue',NF90_FILL_SHORT)
-                  ELSE 
+                  ELSE
                     IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'_FillValue',NF90_FILL_FLOAT)
                     FSC=1.
                     FSC3=1.
                   END IF
                   CALL CHECK_ERR(IRET)
 !
-                  IF (I.LE.2) THEN 
+                  IF (I.LE.2) THEN
                     IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'scale_factor',FSC)
                   ELSE
                     IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'scale_factor',FSC3)
-                  ENDIF 
+                  ENDIF
                   CALL CHECK_ERR(IRET)
 !
                   IRET=NF90_PUT_ATT(NCID,VARID(IVAR),'add_offset',0.)
@@ -4091,25 +4091,25 @@
                 CALL CHECK_ERR(IRET)
 
               ! If it is not the first time step, get all VARID from the netcdf file opened
-              ELSE 
+              ELSE
                 IRET=NF90_REDEF(NCID)
                 CALL CHECK_ERR(IRET)
                 DO I=1,NFIELD
                   IVAR=IVAR1+I
                   IRET=NF90_INQ_VARID (NCID, VARNM(I), VARID(IVAR))
                   CALL CHECK_ERR(IRET)
-                END DO  
+                END DO
                 IRET=NF90_ENDDEF(NCID)
-                CALL CHECK_ERR(IRET)            
+                CALL CHECK_ERR(IRET)
               END IF !   N.EQ.1
             END IF  ! IERR.EQ.0
-              
+
 ! 2.6.4 Defines the current time step and index
-     
+
             CALL T2D(TIME,CURDATE,IERR)
             OUTJULDAY=TSUB(REFDATE,CURDATE)
             WRITE(NDSO,'(3A,I6,A,I4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2,2A)')        &
-                    'Writing new record ', ENAME(2:) ,'number ',N,                  & 
+                    'Writing new record ', ENAME(2:) ,'number ',N,                  &
                     ' for ',CURDATE(1),':',CURDATE(2),':',CURDATE(3),'T',CURDATE(5),&
                     ':',CURDATE(6),':',CURDATE(7),' in file ',TRIM(FNAMENC)
 
@@ -4121,7 +4121,7 @@
             START(3)=1
             START(4)=1
 
-            ! Sets time index 
+            ! Sets time index
             START(3+1-COORDTYPE+EXTRADIM)=N
             COUNT(1)=IXN-IX1+1
             COUNT(2)=IYN-IY1+1
@@ -4143,8 +4143,8 @@
 ! 2.6.5 Puts field(s) in NetCDF file
 
 ! NFIELD=3
-            IF (NCVARTYPE.EQ.2) THEN 
-              IF ( NFIELD.EQ.3 ) THEN 
+            IF (NCVARTYPE.EQ.2) THEN
+              IF ( NFIELD.EQ.3 ) THEN
                 IF (SMCGRD) THEN
 !/SMC                  DO IX=IX1, IXN
 !/SMC                    DO IY=IY1, IYN
@@ -4207,9 +4207,9 @@
                   CALL CHECK_ERR(IRET)
                 ENDIF ! SMCGRD
 ! NFIELD=2
-              ELSE IF (NFIELD.EQ.2 ) THEN 
+              ELSE IF (NFIELD.EQ.2 ) THEN
 ! EXTRADIM=0
-                IF (EXTRADIM.EQ.0) THEN   
+                IF (EXTRADIM.EQ.0) THEN
                   IF (SMCGRD) THEN
 !/SMC                    DO IX=IX1, IXN
 !/SMC                      DO IY=IY1, IYN
@@ -4309,13 +4309,13 @@
                               MXX(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),             &
                               MYY(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                    ENDIF ! SMCGRD      
+                    ENDIF ! SMCGRD
                   END DO
                 END IF  ! EXTRADIM
 ! NFIELD=1
-              ELSE 
+              ELSE
 ! EXTRADIM=0
-                IF (EXTRADIM.EQ.0) THEN   
+                IF (EXTRADIM.EQ.0) THEN
                   IF (SMCGRD) THEN
 !/SMC                    DO IX=IX1, IXN
 !/SMC                      DO IY=IY1, IYN
@@ -4396,8 +4396,8 @@
 !
 ! Real output (NCVARTYPE.GE.3)
 !
-            ELSE 
-              IF ( NFIELD.EQ.3 ) THEN 
+            ELSE
+              IF ( NFIELD.EQ.3 ) THEN
                 IF (SMCGRD) THEN
 !/SMC                  DO IX=IX1, IXN
 !/SMC                    DO IY=IY1, IYN
@@ -4448,7 +4448,7 @@
                       END IF
                     END DO
                   END DO
-  
+
                   IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),              &
                           MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                   CALL CHECK_ERR(IRET)
@@ -4460,9 +4460,9 @@
                   CALL CHECK_ERR(IRET)
                 ENDIF ! SMCGRD
 ! NFIELD=2
-              ELSE IF (NFIELD.EQ.2 ) THEN 
+              ELSE IF (NFIELD.EQ.2 ) THEN
 ! EXTRADIM=0
-                IF (EXTRADIM.EQ.0) THEN   
+                IF (EXTRADIM.EQ.0) THEN
                   IF (SMCGRD) THEN
 !/SMC                    DO IX=IX1, IXN
 !/SMC                      DO IY=IY1, IYN
@@ -4564,9 +4564,9 @@
                   END DO
                 END IF  ! EXTRADIM
 ! NFIELD=1
-              ELSE 
+              ELSE
 ! EXTRADIM=0
-                IF (EXTRADIM.EQ.0) THEN   
+                IF (EXTRADIM.EQ.0) THEN
                   IF (SMCGRD) THEN
 !/SMC                    DO IX=IX1, IXN
 !/SMC                      DO IY=IY1, IYN
@@ -4657,14 +4657,14 @@
 560           CONTINUE
               IF (INDEXIPART.LT.NBIPART) THEN
                 INDEXIPART=INDEXIPART+1
-                IF (TABIPART(INDEXIPART).EQ.-1) GOTO 560      
-                IPART=TABIPART(INDEXIPART)   
+                IF (TABIPART(INDEXIPART).EQ.-1) GOTO 560
+                IPART=TABIPART(INDEXIPART)
                 GOTO 555
               END IF
             ELSE
               INDEXIPART=1
             END IF
-!      
+!
           END IF  ! FLG2D(IFI,IFJ)
         END DO  ! IFI=1, NOGRP
       END DO  ! IFJ=1, NGRPP
@@ -4689,7 +4689,7 @@
   999 FORMAT (/' *** WAVEWATCH III ERROR IN W3EXNC :'/                &
                '     PLEASE UPDATE FIELDS !!! '/                      &
                '     IFI = ',I2, '- IFJ = ',I2/)
-!               
+!
 !/T 9000 FORMAT (' TEST W3EXNC : FLAGS :',I3,2X,20L2)
 !/T 9001 FORMAT (' TEST W3EXNC : ITPYE :',I4/                         &
 !/T              '             IX1/N   :',2I7/                        &
@@ -4711,7 +4711,7 @@
 
 
 
-!--------------------------------------------------------------------------    
+!--------------------------------------------------------------------------
       SUBROUTINE W3CRNC (NCFILE, NCID, DIMID, DIMLN, VARID,  &
                          EXTRADIM, NCTYPE, MAPSTAOUT )
       USE W3GDATMD
@@ -4719,7 +4719,7 @@
       USE W3TIMEMD
 
       IMPLICIT NONE
-      
+
 
 
       INTEGER, INTENT(IN)               :: EXTRADIM
@@ -4741,7 +4741,7 @@
       CHARACTER                         :: ATTNAME*120,ATTVAL*120
 
 
-!      
+!
 ! Creation in netCDF3 or netCDF4
 !
       IF(NCTYPE.EQ.3)  IRET = NF90_CREATE(TRIM(NCFILE), NF90_CLOBBER, NCID)
@@ -4755,7 +4755,7 @@
 !
 ! Regular structured case
 !
-      IF (GTYPE.NE.UNGTYPE) THEN 
+      IF (GTYPE.NE.UNGTYPE) THEN
         IF (FLAGLL) THEN
           IF (SMCGRD) THEN
 !/SMC            IF(SMCTYPE .EQ. 1) THEN
@@ -4770,7 +4770,7 @@
             IRET = NF90_DEF_DIM(NCID, 'longitude', DIMLN(2), DIMID(2))
             IRET = NF90_DEF_DIM(NCID, 'latitude', DIMLN(3), DIMID(3))
           ENDIF ! SMCGRD
-        ELSE                     
+        ELSE
           IRET = NF90_DEF_DIM(NCID, 'x', DIMLN(2), DIMID(2))
           IRET = NF90_DEF_DIM(NCID, 'y', DIMLN(3), DIMID(3))
           END IF
@@ -4795,18 +4795,18 @@
       IRET = NF90_DEF_DIM(NCID, 'time',NF90_UNLIMITED, DIMID(4+EXTRADIM))
       CALL CHECK_ERR(IRET)
 
-      IF (GTYPE.EQ.UNGTYPE) THEN 
+      IF (GTYPE.EQ.UNGTYPE) THEN
         IRET = NF90_DEF_DIM(NCID, 'noel',3, DIMID(5+EXTRADIM))
         CALL CHECK_ERR(IRET)
       ENDIF
 
-      
+
 !
 !     define variables
 !
-      IF (FLAGLL) THEN 
+      IF (FLAGLL) THEN
 !longitude
-        IF (GTYPE.EQ.RLGTYPE) THEN 
+        IF (GTYPE.EQ.RLGTYPE) THEN
           IF (SMCGRD) THEN
 !/SMC            IF(SMCTYPE .EQ. 1) THEN
 !/SMC              ! Flat SMC grid - use seapoint dimension:
@@ -4873,7 +4873,7 @@
 !/RTD            IRET = NF90_DEF_VAR(NCID, 'standard_longitude', NF90_FLOAT, &
 !/RTD                    (/ DIMID(2) /), VARID(291))
 !/RTD            call CHECK_ERR(IRET)
-!/RTD 
+!/RTD
 !/RTD            IRET = NF90_DEF_VAR(NCID, 'standard_latitude', NF90_FLOAT, &
 !/RTD                    (/ DIMID(2) /), VARID(292))
 !/RTD            call CHECK_ERR(IRET)
@@ -4919,11 +4919,11 @@
 !/RTD        IRET=NF90_PUT_ATT(NCID, VARID(293), 'grid_mapping_name',              &
 !/RTD                                   'rotated_latitude_longitude')
 !
-      ELSE 
-        IF (GTYPE.EQ.RLGTYPE) THEN 
+      ELSE
+        IF (GTYPE.EQ.RLGTYPE) THEN
           IRET = NF90_DEF_VAR(NCID, 'x', NF90_FLOAT, DIMID(2), VARID(1))
           IRET = NF90_DEF_VAR(NCID, 'y', NF90_FLOAT, DIMID(3), VARID(2))
-        ELSE IF (GTYPE.EQ.CLGTYPE) THEN 
+        ELSE IF (GTYPE.EQ.CLGTYPE) THEN
           IRET = NF90_DEF_VAR(NCID, 'x', NF90_FLOAT, (/ DIMID(2), DIMID(3)/), &
                                                                             VARID(1))
           IRET = NF90_DEF_VAR(NCID, 'y', NF90_FLOAT, (/ DIMID(2), DIMID(3)/), &
@@ -4940,7 +4940,7 @@
 !
       END IF  ! FLAGLL
 !
-      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','X')    
+      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','X')
       IRET=NF90_PUT_ATT(NCID,VARID(2),'axis','Y')
 !/NC4        IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(1), 1, 1, DEFLATE)
 !/NC4        IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(2), 1, 1, DEFLATE)
@@ -4994,14 +4994,14 @@
 !
 !  Status map: useful for grid combination
 !
-      IF (MAPSTAOUT.EQ.1) THEN 
-        IF (GTYPE.EQ.UNGTYPE) THEN 
+      IF (MAPSTAOUT.EQ.1) THEN
+        IF (GTYPE.EQ.UNGTYPE) THEN
           IVAR=5+EXTRADIM
-          IRET = NF90_DEF_VAR(NCID,'MAPSTA', NF90_SHORT,(/ DIMID(2) /), VARID(IVAR)) 
-        ELSE 
+          IRET = NF90_DEF_VAR(NCID,'MAPSTA', NF90_SHORT,(/ DIMID(2) /), VARID(IVAR))
+        ELSE
           IVAR=4+EXTRADIM
           IRET = NF90_DEF_VAR(NCID,'MAPSTA', NF90_SHORT,(/ DIMID(2) , DIMID(3) /), &
-                                                                       VARID(IVAR)) 
+                                                                       VARID(IVAR))
           ENDIF
 !/NC4          IF (NCTYPE.EQ.4) IRET = NF90_DEF_VAR_DEFLATE(NCID, VARID(IVAR), 1, 1, DEFLATE)
 !
@@ -5018,7 +5018,7 @@
 !
 ! Global attributes
 !
-      IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'WAVEWATCH_III_version_number' ,TRIM(WWVER))   
+      IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'WAVEWATCH_III_version_number' ,TRIM(WWVER))
       CALL CHECK_ERR(IRET)
       IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'WAVEWATCH_III_switches',TRIM(SWITCHES))
       CALL CHECK_ERR(IRET)
@@ -5026,7 +5026,7 @@
 !/ST4    IF (AALPHA.NE.0.0095) IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'SIN4 namelist parameter ALPHA0',AALPHA)
 !/ST4    IF (BBETA.NE.1.43)    IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'SIN4 namelist parameter BETAMAX',BBETA)
 !/ST4    IF(SSDSC(7).NE.0.3)   IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'SDS4 namelist parameter WHITECAPWIDTH', SSDSC(7))
-! ... TO BE CONTINUED ... 
+! ... TO BE CONTINUED ...
 
       IF(SMCGRD) THEN
 !/SMC         IF(SMCTYPE .EQ. 1) THEN
@@ -5060,14 +5060,14 @@
         END DO
       ENDIF
       CLOSE(994)
-      IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'product_name' ,TRIM(NCFILE))   
+      IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'product_name' ,TRIM(NCFILE))
       CALL CHECK_ERR(IRET)
       IRET=NF90_PUT_ATT(NCID,NF90_GLOBAL,'area',TRIM(GNAME))
       CALL CHECK_ERR(IRET)
 
       RETURN
 
-      END SUBROUTINE W3CRNC 
+      END SUBROUTINE W3CRNC
 
 !==============================================================================
 

--- a/model/ftn/ww3_ounp.ftn
+++ b/model/ftn/ww3_ounp.ftn
@@ -55,7 +55,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -123,7 +123,7 @@
 !     TOUT is the time defined in the input file
 !     TIME is the time read from the out_pnt.ww3 file
 !     DTREQ is the stride used for the time steps
-!     at the beginning, if TOUT is after TIME, the program will read 
+!     at the beginning, if TOUT is after TIME, the program will read
 !     out_pnt.ww3 DTREQ by DTREQ until TIME is equal to TOUT
 !     /!\ if DTREQ is too big, it's possible to never have TIME=TOUT /!\
 !
@@ -133,7 +133,7 @@
 !
 !     MFL is the number of stations processed in the 'time' loop
 !     NOPTS is the total number of stations defined in out_pnt.ww3
-!     NFL is the number of bunch of MFL stations to loop on to 
+!     NFL is the number of bunch of MFL stations to loop on to
 !     process all the NOPTS stations
 !     NREQ is the number of valid stations to process, unvalid stations
 !     are duplicata or stations not specified in the input file
@@ -335,7 +335,7 @@
 !
 ! process ww3_ounp namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_ounp.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_ounp.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         ! Read namelist
         CALL W3NMLOUNP (NDSI, TRIM(FNMPRE)//'ww3_ounp.nml', NML_POINT, NML_FILE, &
@@ -369,9 +369,9 @@
           DO WHILE (LEN_TRIM(POINTLIST(IP+1)).NE.0)
             IP=IP+1
             READ(POINTLIST(IP),*) IPOINT
-            ! existing index in out_pnt.ww3   
+            ! existing index in out_pnt.ww3
             IF ((IPOINT .LE. NOPTS) .AND. (NREQ .LT. NOPTS)) THEN
-              IF ( .NOT. FLREQ(IPOINT) ) THEN 
+              IF ( .NOT. FLREQ(IPOINT) ) THEN
                 NREQ = NREQ + 1
                 INDREQTMP(NREQ)=IPOINT
               END IF
@@ -446,13 +446,13 @@
             IF (I.EQ.1) THEN
               FLREQ = .TRUE.
               NREQ = NOPTS
-              INDREQTMP=(/(J,J=1,NREQ)/) 
+              INDREQTMP=(/(J,J=1,NREQ)/)
             END IF
             EXIT
           END IF
-          ! existing index in out_pnt.ww3   
+          ! existing index in out_pnt.ww3
           IF ( (IPOINT .GT. 0) .AND. (IPOINT .LE. NOPTS) ) THEN
-            IF ( .NOT. FLREQ(IPOINT) ) THEN 
+            IF ( .NOT. FLREQ(IPOINT) ) THEN
               NREQ = NREQ + 1
               INDREQTMP(NREQ)=IPOINT
             END IF
@@ -479,7 +479,7 @@
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
         READ (NDSI,*,END=801,ERR=802) NCTYPE
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
-        READ (NDSI,*,END=801,ERR=802) TOGETHER, MFL 
+        READ (NDSI,*,END=801,ERR=802) TOGETHER, MFL
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
         READ (NDSI,*,END=801,ERR=802) ITYPE
         CALL NEXTLN ( COMSTR , NDSI , NDSE )
@@ -530,7 +530,7 @@
 
 ! 4.1.3 Loops on TIME from out_pnt file to reach the first time PASTDATE
       DTEST  = DSEC21 ( TIME , TOUT )
-      DO WHILE (DTEST.NE.0) 
+      DO WHILE (DTEST.NE.0)
         DTEST  = DSEC21 ( TIME , TOUT )
         IF ( DTEST .GT. 0. ) THEN
           CALL W3IOPO ( 'READ', NDSOP, IOTEST )
@@ -545,7 +545,7 @@
           CYCLE
         END IF
       END DO
-      WRITE(PASTDATE,'(I8.8,I6.6)') TIME(1), TIME(2) 
+      WRITE(PASTDATE,'(I8.8,I6.6)') TIME(1), TIME(2)
 
 
 ! 4.2 Output points NOPTS
@@ -560,13 +560,13 @@
       ! S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
 !
       ! Setups min and max date format
-      IF (S3.LT.4) S3=4 
-      IF (S3.GT.10) S3=10 
+      IF (S3.LT.4) S3=4
+      IF (S3.GT.10) S3=10
 !
       ! Defines the format of FILETIME as ISO8601 convention
       S5=S3-8
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHMMSSZ'
-      IF (S3.EQ.10) THEN 
+      IF (S3.EQ.10) THEN
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (FILETIME,FORMAT1) TIME(1), 'T', &
                FLOOR(REAL(TIME(2))/NINT(10.**(6-S5))), 'Z'
@@ -576,7 +576,7 @@
         WRITE (FILETIME,FORMAT1) TIME(1)
       ! if S3=>YYYYMM then filetime='YYYYMM'
       ! or S3=>YYYY then filetime='YYYY'
-      ELSE 
+      ELSE
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I',S3,'.',S3,')'
         WRITE (FILETIME,FORMAT1) FLOOR(REAL(TIME(1))/NINT(10.**(8-S3)))
       END IF
@@ -591,7 +591,7 @@
         TWO=1
       END IF
 !
-      IF ((NCTYPE.EQ.3) .AND. (.NOT.ORDER)) GOTO 803 
+      IF ((NCTYPE.EQ.3) .AND. (.NOT.ORDER)) GOTO 803
       IF ((NCTYPE.EQ.4) .AND. INDEX(NF90_INQ_LIBVERS(),'"3.').NE.0) GOTO 804
 
 
@@ -605,12 +605,12 @@
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 5.  Now creates files
-!     If too many (memory problem) then makes several reads 
+!     If too many (memory problem) then makes several reads
 !
 
 
 ! 5.1 Defines number of files/stations per file NFL
-      IF (TOGETHER) THEN 
+      IF (TOGETHER) THEN
         NFL=1
       ELSE
         NFL=1+NOPTS/MFL
@@ -632,7 +632,7 @@
         CALL EXTCDE ( 46 )
       END IF
 
-! 5.3 Redefines netCDF type 
+! 5.3 Redefines netCDF type
 !/NC4      IF((NCTYPE.EQ.4).AND.(.NOT.TOGETHER).AND.(NFL.GT.300).AND.(NREQ.GT.9000))  THEN
 !/NC4        WRITE(NDSO,'(A)') ' WARNING : Files will be generated in netCDF3 with NF90_share mode'
 !/NC4        WRITE(NDSO,'(A)') ' WARNING : this is due to NF90_sync memory problem with netCDF4 library'
@@ -663,7 +663,7 @@
               CYCLE
             END IF
           END IF  ! FLREQ(I)
-        END DO  ! I=1,NOPTS    
+        END DO  ! I=1,NOPTS
       END IF  ! .NOT.TOGETHER
 
 
@@ -677,7 +677,7 @@
 
 ! 5.6.1 Redefines the filetime when it's a new date defined by the date division S3
         ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHMMSSZ'
-        IF (S3.EQ.10) THEN 
+        IF (S3.EQ.10) THEN
           WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
           WRITE (FILETIME,FORMAT1) TIME(1), 'T', &
                  NINT(REAL(TIME(2))/NINT(10.**(6-S5))), 'Z'
@@ -687,7 +687,7 @@
           WRITE (FILETIME,FORMAT1) TIME(1)
         ! if S3=>YYYYMM then filetime='YYYYMM'
         ! or S3=>YYYY then filetime='YYYY'
-        ELSE 
+        ELSE
           WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I',S3,'.',S3,')'
           WRITE (FILETIME,FORMAT1) NINT(REAL(TIME(1))/NINT(10.**(8-S3)))
         END IF
@@ -709,7 +709,7 @@
               J = LEN_TRIM(FNMPRE)
               WRITE(NCFILE(I),'(2A)') TRIM(FNMPRE(:J)), TRIM(NCNAME)  ! filename
             END IF  ! FLREQ(I)
-          END DO  ! I=1,NOPTS    
+          END DO  ! I=1,NOPTS
         END IF  ! TOGETHER
 
 
@@ -879,7 +879,7 @@
               IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,1942) '2-D', SCALE2
             END IF
 
-! ... OTYPE = 2  
+! ... OTYPE = 2
 ! or  OTYPE = 3
           ELSE IF (( OTYPE .EQ. 2 ) .OR. ( OTYPE .EQ. 3 )) THEN
             IF ( ISCALE .LE. 2) THEN
@@ -973,7 +973,7 @@
 !
         CALL T2D(TIME,STARTDATE,IERR)
         WRITE(STRSTARTDATE,'(I4.4,A,4(I2.2,A),I2.2)') STARTDATE(1),'-',STARTDATE(2), &
-              '-',STARTDATE(3),' ',STARTDATE(5),':',STARTDATE(6),':',STARTDATE(7) 
+              '-',STARTDATE(3),' ',STARTDATE(5),':',STARTDATE(6),':',STARTDATE(7)
 
         ! loops on TIME from out_pnt.ww3 till not reach TOUT from inp file
         DO
@@ -994,7 +994,7 @@
           ! increment the time counter IOUT
           IOUT = IOUT + 1
           CALL STME21 ( TOUT , IDTIME )
-          WRITE(DATE,'(I8.8,I6.6)') TOUT(1), TOUT(2) 
+          WRITE(DATE,'(I8.8,I6.6)') TOUT(1), TOUT(2)
 
 
 ! 6.1 Creates a new file if it is a new date defined by the date division S3
@@ -1015,10 +1015,10 @@
           DO I=1+(IFL-1)*MFL,(IFL-1)*MFL+NBFILEOUT
             IF (FLREQ(I) .OR. TOGETHER) THEN
               ! together
-              IF ( TOGETHER ) THEN 
+              IF ( TOGETHER ) THEN
                 CALL W3EXNC(I,NCID(I),NREQ,INDREQ,ORDER)
               ! not together
-              ELSE 
+              ELSE
                 J=J+1
                 CALL W3EXNC(I,NCID(I),1,(/ I /),ORDER)
                 ! flush buffer (only available in netcdf3)
@@ -1029,7 +1029,7 @@
             END IF ! (FLREQ(I) .OR. TOGETHER)
           END DO ! I=1+ ...
 !
-          WRITE(PASTDATE,'(I8.8,I6.6)') TOUT(1), TOUT(2) 
+          WRITE(PASTDATE,'(I8.8,I6.6)') TOUT(1), TOUT(2)
           CALL TICK21 ( TOUT , DTREQ )
           IF ( IOUT .GE. NOUT ) GOTO 700
 !
@@ -1046,7 +1046,7 @@
 !
         CALL T2D(TIME,STOPDATE,IERR)
         WRITE(STRSTOPDATE,'(I4.4,A,4(I2.2,A),I2.2)') STOPDATE(1),'-',STOPDATE(2), &
-              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7) 
+              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7)
 
 
 ! 7.1 Writes the global attributes to netCDF file
@@ -1070,7 +1070,7 @@
               END DO
             END IF
             CLOSE(994)
-!            
+!
             WRITE(GLOBALATT,'(A)') TRIM(NCFILE(I))
             IRET=NF90_PUT_ATT(NCID(I),NF90_GLOBAL,'product_name' ,GLOBALATT(3:))
             IRET=NF90_PUT_ATT(NCID(I),NF90_GLOBAL,'area',TRIM(GNAME))
@@ -1101,7 +1101,7 @@
               IRET=NF90_PUT_ATT(NCID(I),NF90_GLOBAL,'field_type','12-hourly')
             ELSE IF (DTREQ.EQ.86400)  THEN
               IRET=NF90_PUT_ATT(NCID(I),NF90_GLOBAL,'field_type','daily')
-            ELSE  
+            ELSE
               IRET=NF90_PUT_ATT(NCID(I),NF90_GLOBAL,'field_type','n/a')
             END IF
 !
@@ -1133,7 +1133,7 @@
 
 ! 7.4 Loops on TIME till it is equal to TOUT
         DTEST  = DSEC21 ( TIME , TOUT )
-        DO WHILE (DTEST.NE.0) 
+        DO WHILE (DTEST.NE.0)
           DTEST  = DSEC21 ( TIME , TOUT )
           IF ( DTEST .GT. 0. ) THEN
             CALL W3IOPO ( 'READ', NDSOP, IOTEST )
@@ -1168,7 +1168,7 @@
       CALL EXTCDE ( 42 )
 !
   803 CONTINUE
-      WRITE (NDSE,1003) 
+      WRITE (NDSE,1003)
       CALL EXTCDE ( 43 )
 !
   804 CONTINUE
@@ -1463,7 +1463,7 @@
                                  SBT1(NK), SIS1(NK), STT1(NK),         &
                                  E1ALL(NK,6), UDIR1(NREQ), CDIR1(NREQ)
       REAL, SAVE              :: HSMIN  = 0.05
-!/IS2       REAL                     :: ICEF, ICEDMAX, DIA2(NTH,NK)                              
+!/IS2       REAL                     :: ICEF, ICEDMAX, DIA2(NTH,NK)
 !/ST1      REAL                    :: AMAX, FH1, FH2
 !/ST2      REAL                    :: AMAX, ALPHA(NK), FPI
 !/ST3      REAL                    :: AMAX, FMEANS, FMEANWS, TAUWX, TAUWY, &
@@ -1484,7 +1484,7 @@
 !
       LOGICAL                 :: LASTSTATION=.FALSE.
       LOGICAL                 :: SHORT=.TRUE.
-      LOGICAL                   :: LBREAK 
+      LOGICAL                   :: LBREAK
 !/ST3      LOGICAL                 :: LLWS(NSPEC)
 !/ST4      LOGICAL                 :: LLWS(NSPEC)
 !
@@ -1537,7 +1537,7 @@
 
 
 !
-! Selects first station index 
+! Selects first station index
 !
       IF (TOGETHER) THEN
         J=1
@@ -1548,7 +1548,7 @@
 ! Short version of the ww3_ounp code for ITYPE = 1
 !                                    and OTYPE = 3
 !
-      IF (SHORT.AND.ITYPE.EQ.1.AND.OTYPE.EQ.3) THEN 
+      IF (SHORT.AND.ITYPE.EQ.1.AND.OTYPE.EQ.3) THEN
 
           DEPTH  = MAX ( DMIN, DPO(J) )
           SQRTH  = SQRT ( DEPTH )
@@ -1570,10 +1570,10 @@
             END DO
 
 !
-! Computes 2nd order spectrum 
+! Computes 2nd order spectrum
 !
-!/IG1      IF (IGPARS(2).EQ.1) THEN 
-!/IG1        IF(IGPARS(1).EQ.1) THEN 
+!/IG1      IF (IGPARS(2).EQ.1) THEN
+!/IG1        IF(IGPARS(1).EQ.1) THEN
 !/IG1          CALL W3ADDIG(SPCO(:,J),DPO(J),WN,CG,0)
 !/IG1        ELSE
 !/IG1          CALL W3ADD2NDORDER(SPCO(:,J),DPO(J),WN,CG,0)
@@ -1589,13 +1589,13 @@
             END DO
           END DO
         END DO
- 
+
         CALL T2D(TIME,CURDATE,IERR)
         OUTJULDAY=TSUB(REFDATE,CURDATE)
         IRET=NF90_PUT_VAR(NCID,VARID(1),OUTJULDAY,(/IOUT/))
         CALL CHECK_ERR(IRET)
-! 
-        IF (IOUT.EQ.1) THEN 
+!
+        IF (IOUT.EQ.1) THEN
           DO J1=1, NREQ
             IRET=NF90_PUT_VAR(NCID,VARID(27),INDREQ(J1),(/J1/))
             CALL CHECK_ERR(IRET)
@@ -1610,19 +1610,19 @@
           IF ((FLWW3.NE.0).AND.(.NOT.ORDER)) IRET=NF90_PUT_VAR(NCID,VARID(3),FLWW3,(/IOUT,J1/))
           CALL CHECK_ERR(IRET)
         END DO
-! 
+!
         IF(ORDER) IRET=NF90_PUT_VAR(NCID,VARID(4),M2KM*PTLOC(1,INDREQ(1:NREQ)),(/1,IOUT/))
         IF(.NOT.ORDER) IRET=NF90_PUT_VAR(NCID,VARID(4),M2KM*PTLOC(1,INDREQ(1:NREQ)),(/IOUT,1/))
         CALL CHECK_ERR(IRET)
         IF(ORDER) IRET=NF90_PUT_VAR(NCID,VARID(5),M2KM*PTLOC(2,INDREQ(1:NREQ)),(/1,IOUT/))
         IF(.NOT.ORDER) IRET=NF90_PUT_VAR(NCID,VARID(5),M2KM*PTLOC(2,INDREQ(1:NREQ)),(/IOUT,1/))
         CALL CHECK_ERR(IRET)
-!             
+!
         DO J1=1,NREQ
           UDIR1(J1)  = MOD ( 270. - WDO(INDREQ(J1))*RADE , 360. )
           CDIR1(J1)   = MOD ( 270. - CDO(INDREQ(J1))*RADE , 360. )
         END DO
-! 
+!
         IF(ORDER) IRET=NF90_PUT_VAR(NCID,VARID(11),DPO(INDREQ(1:NREQ)),(/1,IOUT/))
         IF(.NOT.ORDER) IRET=NF90_PUT_VAR(NCID,VARID(11),DPO(INDREQ(1:NREQ)),(/IOUT,1/))
         CALL CHECK_ERR(IRET)
@@ -1645,11 +1645,11 @@
                            start=(/1,1,IOUT,1/),count=(/NTH,NK,1,NREQ/))
         CALL CHECK_ERR(IRET)
 !
-! End of short version 
+! End of short version
 !
-      ELSE 
+      ELSE
 !
-! And here is the full thing with all options ITYPE and OTYPE ... 
+! And here is the full thing with all options ITYPE and OTYPE ...
 !
       J1=1
       LASTSTATION=.FALSE.
@@ -1703,10 +1703,10 @@
 !
           END DO
 !
-! Computes 2nd order spectrum 
+! Computes 2nd order spectrum
 !
-!/IG1      IF (IGPARS(2).EQ.1) THEN 
-!/IG1        IF(IGPARS(1).EQ.1) THEN 
+!/IG1      IF (IGPARS(2).EQ.1) THEN
+!/IG1        IF(IGPARS(1).EQ.1) THEN
 !/IG1          CALL W3ADDIG(SPCO(:,J),DPO(J),WN,CG,0)
 !/IG1        ELSE
 !/IG1          CALL W3ADD2NDORDER(SPCO(:,J),DPO(J),WN,CG,0)
@@ -2037,8 +2037,8 @@
             IF ( FLSRCE(3) ) THEN
 !/NL1                    CALL W3SNL1 ( A, CG, WNMEAN*DEPTH,  XNL, DIA )
 !/NL2                    CALL W3SNL2 ( A, CG, DEPTH,         XNL, DIA )
-!/NL3                    CALL W3SNL3 ( A, CG, WN, DEPTH,     XNL, DIA ) 
-!/NL4                    CALL W3SNL4 ( A, CG, WN, DEPTH,     XNL, DIA ) 
+!/NL3                    CALL W3SNL3 ( A, CG, WN, DEPTH,     XNL, DIA )
+!/NL4                    CALL W3SNL4 ( A, CG, WN, DEPTH,     XNL, DIA )
 !/NLX                    CALL W3SNLX
 !
 !/TRX                    CALL W3STRX
@@ -2064,12 +2064,12 @@
 !/BT1                    CALL W3SBT1 ( A, CG, WN, DEPTH,     XBT, DIA )
 !/BT2                    SBTC2 = 2. * -0.067 / GRAV
 !/BT2                    CALL W3SBT2 ( A, CG, WN, DEPTH, XBT, DIA, SBTC2 )
-!/BT4                    IX=1    ! to be fixed later 
-!/BT4                    IY=1    ! to be fixed later 
-!/BT4                    ISEA=1  ! to be fixed later 
+!/BT4                    IX=1    ! to be fixed later
+!/BT4                    IY=1    ! to be fixed later
+!/BT4                    ISEA=1  ! to be fixed later
 !/BT4                    D50 = SED_D50(ISEA)
 !/BT4                    PSIC= SED_PSIC(ISEA)
-!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   & 
+!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   &
 !/BT4                                       BEDFORM, XBT, DIA, IX, IY )
 
 ! see remarks about BT8 and BT9 in ww3_outp.ftn
@@ -2086,7 +2086,7 @@
 !
             END IF
             IF ( FLSRCE(6) ) THEN
-              IF (IICEDISP) THEN  
+              IF (IICEDISP) THEN
                       CALL LIU_FORWARD_DISPERSION (ICETHICK,0.,DEPTH, &
                      SIG,WN_R,CG_ICE,ALPHA_LIU)
               ELSE
@@ -2095,7 +2095,7 @@
                 END IF
 !
 !/IS2              CALL W3SIS2(A, DEPTH, ICECON, ICETHICK, ICEF, ICEDMAX,  &
-!/IS2                          IX, IY, XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)          
+!/IS2                          IX, IY, XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)
             END IF
 !
 !/XXX                CALL W3SXXX
@@ -2174,11 +2174,11 @@
               OUTJULDAY=TSUB(REFDATE,CURDATE)
               IRET=NF90_PUT_VAR(NCID,VARID(1),OUTJULDAY,(/IOUT/))
               CALL CHECK_ERR(IRET)
-            END IF  
+            END IF
 
 
 !
-!  Performs subtype 1 
+!  Performs subtype 1
 !
             IF ( OTYPE .EQ. 1 ) THEN
 !
@@ -2282,7 +2282,7 @@
             IRET=NF90_PUT_VAR(NCID,VARID(1),OUTJULDAY,(/IOUT/))
 
 !
-!  Performs subtype 1 
+!  Performs subtype 1
 !
             IF ( OTYPE .EQ. 1 ) THEN
 
@@ -2411,9 +2411,9 @@
               CALL T2D(TIME,CURDATE,IERR)
               OUTJULDAY=TSUB(REFDATE,CURDATE)
               IRET=NF90_PUT_VAR(NCID,VARID(1),OUTJULDAY,(/IOUT/))
-            END IF  
+            END IF
 !
-!  Performs subtype 1 
+!  Performs subtype 1
 !
             IF ( OTYPE .EQ. 1 ) THEN
 !
@@ -2460,7 +2460,7 @@
                            'Stot(f,th)', 'm^2', PTNME(J) )
               END IF
 !
-!  Performs subtype 2 
+!  Performs subtype 2
 !
             ELSE IF ( OTYPE .EQ. 2 ) THEN
 !
@@ -2479,7 +2479,7 @@
               IRET=NF90_PUT_VAR(NCID,VARID(12),SNL1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))
               IRET=NF90_PUT_VAR(NCID,VARID(13),SDS1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))
               IRET=NF90_PUT_VAR(NCID,VARID(14),SBT1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))
-              IRET=NF90_PUT_VAR(NCID,VARID(15),SIS1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))              
+              IRET=NF90_PUT_VAR(NCID,VARID(15),SIS1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))
               IRET=NF90_PUT_VAR(NCID,VARID(16),STT1(1:NK),start=(/1,J1,IOUT /),count=(/NK,1,1/))
 
 !
@@ -2505,7 +2505,7 @@
                   IRET=NF90_PUT_VAR(NCID,VARID(12),FACT*SNL1(IK),(/ IK,J1,IOUT /))
                   IRET=NF90_PUT_VAR(NCID,VARID(13),FACT*SDS1(IK),(/ IK,J1,IOUT /))
                   IRET=NF90_PUT_VAR(NCID,VARID(14),FACT*SBT1(IK),(/ IK,J1,IOUT /))
-                  IRET=NF90_PUT_VAR(NCID,VARID(15),FACT*SIS1(IK),(/ IK,J1,IOUT /))                
+                  IRET=NF90_PUT_VAR(NCID,VARID(15),FACT*SIS1(IK),(/ IK,J1,IOUT /))
                   IRET=NF90_PUT_VAR(NCID,VARID(16),FACT*STT1(IK),(/ IK,J1,IOUT /))
                 ELSE
                   IRET=NF90_PUT_VAR(NCID,VARID(11),NF90_FILL_FLOAT,(/ IK,J1,IOUT /))
@@ -2551,13 +2551,13 @@
                  count=(/NTH,NK,1,1/)                               )
               IF ( FLSRCE(6) )  IRET=NF90_PUT_VAR(NCID,VARID(21),   &
                  TRANSPOSE(SIS(1:NK,1:NTH)), start=(/1,1,J1,IOUT/), &
-                 count=(/NTH,NK,1,1/)                               )            
+                 count=(/NTH,NK,1,1/)                               )
               IF ( FLSRCE(7) )  IRET=NF90_PUT_VAR(NCID,VARID(22),   &
                  TRANSPOSE(STT(1:NK,1:NTH)), start=(/1,1,J1,IOUT/), &
                  count=(/NTH,NK,1,1/)                               )
 !
             END IF
-!                 
+!
           END IF ! ITYPE
 
 !
@@ -2578,7 +2578,7 @@
 
       END DO ! DO WHILE (.NOT. LASTSTATION)
 
-      END IF  ! NOT SHORT ... 
+      END IF  ! NOT SHORT ...
 !
       RETURN
 !
@@ -2668,7 +2668,7 @@
       IRET=NF90_PUT_ATT(NCID,VARID(1),'calendar','standard')
       IRET=NF90_PUT_ATT(NCID,VARID(1),'units','days since 1990-01-01 00:00:00')
       IRET=NF90_PUT_ATT(NCID,VARID(1),'conventions','Relative julian days with decimal part (as parts of the day)')
-      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','T') 
+      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','T')
 
 !  station
       IRET=NF90_DEF_VAR(NCID, 'station', NF90_INT, (/DIMID(2)/), VARID(27))
@@ -2676,7 +2676,7 @@
 !/NC4      IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(27), 1, 1, DEFLATE)
       IRET=NF90_PUT_ATT(NCID,VARID(27),'long_name','station id')
       IRET=NF90_PUT_ATT(NCID,VARID(27),'_FillValue',NF90_FILL_INT)
-      IRET=NF90_PUT_ATT(NCID,VARID(27),'axis','X') 
+      IRET=NF90_PUT_ATT(NCID,VARID(27),'axis','X')
 
 !  string16
       IRET=NF90_DEF_VAR(NCID, 'string16', NF90_INT, (/DIMID(3)/), VARID(28))
@@ -2684,7 +2684,7 @@
 !/NC4      IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(28), 1, 1, DEFLATE)
       IRET=NF90_PUT_ATT(NCID,VARID(28),'long_name','station_name number of characters')
       IRET=NF90_PUT_ATT(NCID,VARID(28),'_FillValue',NF90_FILL_INT)
-      IRET=NF90_PUT_ATT(NCID,VARID(28),'axis','W') 
+      IRET=NF90_PUT_ATT(NCID,VARID(28),'axis','W')
 
 !  station_name
       IRET=NF90_DEF_VAR(NCID, 'station_name', NF90_CHAR, (/DIMID(3),DIMID(2)/), VARID(2))
@@ -2712,7 +2712,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(3),'associates','time station')
         END IF
 
-      IF (FLAGLL) THEN 
+      IF (FLAGLL) THEN
 !  longitude
         IRET=NF90_DEF_VAR(NCID, 'longitude', NF90_FLOAT, (/DIMID(TWO),DIMID(ONE)/), VARID(4))
         CALL CHECK_ERR(IRET)
@@ -2762,7 +2762,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(4),'_FillValue',NF90_FILL_FLOAT)
         IRET=NF90_PUT_ATT(NCID,VARID(4),'content','TX')
         IRET=NF90_PUT_ATT(NCID,VARID(4),'associates','time station')
-   
+
 
 !  latitude
         IRET=NF90_DEF_VAR(NCID, 'y', NF90_FLOAT, (/DIMID(TWO),DIMID(ONE)/), VARID(5))
@@ -2780,7 +2780,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(5),'content','TX')
         IRET=NF90_PUT_ATT(NCID,VARID(5),'associates','time station')
 
-      END IF 
+      END IF
 
 ! Process FREQ and DIR dimension values
       FREQ(1:NK)=SIG(1:NK)*TPIINV
@@ -2817,7 +2817,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',10.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 !d
          IRET=NF90_DEF_VAR(NCID, 'dpt', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(7))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(7), 1, 1, DEFLATE)
@@ -2959,7 +2959,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(15),'associates','time station frequency')
 
 
-        ! Add values in netCDF file      
+        ! Add values in netCDF file
         IRET=NF90_ENDDEF(NCID)
         CALL CHECK_ERR(IRET)
         IRET=NF90_PUT_VAR(NCID,VARID(6),FREQ(1:NK))
@@ -2996,7 +2996,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',10.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 
 !frequency1
         IRET=NF90_DEF_VAR(NCID, 'frequency1', NF90_FLOAT, (/DIMID(4)/), VARID(7))
@@ -3043,7 +3043,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(9),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'valid_max',360.)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(9),'axis','Z') 
+        IRET=NF90_PUT_ATT(NCID,VARID(9),'axis','Z')
 !/RTD        IF ( FLAGUNR ) THEN
 !/RTD          IRET=NF90_PUT_ATT(NCID,VARID(9),'direction_reference','True North')
 !/RTD        ELSE
@@ -3129,7 +3129,7 @@
         IRET=NF90_DEF_VAR(NCID, 'cur', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(14))
         CALL CHECK_ERR(IRET)
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(14), 1, 1, DEFLATE)
-        IRET=NF90_PUT_ATT(NCID,VARID(14),'long_name','sea water speed')        
+        IRET=NF90_PUT_ATT(NCID,VARID(14),'long_name','sea water speed')
         IRET=NF90_PUT_ATT(NCID,VARID(14),'standard_name','sea_water_speed')
         IRET=NF90_PUT_ATT(NCID,VARID(14),'globwave_name','sea_water_speed')
         IRET=NF90_PUT_ATT(NCID,VARID(14),'units','m s-1')
@@ -3163,7 +3163,7 @@
 !/RTD        END IF
 
 
-        ! Add values in netCDF file      
+        ! Add values in netCDF file
         IRET=NF90_ENDDEF(NCID)
         CALL CHECK_ERR(IRET)
         IRET=NF90_PUT_VAR(NCID,VARID(6),FREQ(1:NK))
@@ -3205,7 +3205,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',100.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_INT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 !d
          IRET=NF90_DEF_VAR(NCID, 'dpt', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(7))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(7), 1, 1, DEFLATE)
@@ -3539,11 +3539,11 @@
 
       ELSE IF (ITYPE.EQ.2 .AND. OTYPE.EQ.2) THEN
 !Hs
-         IRET=NF90_DEF_VAR(NCID, 'hs', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(6))  
+         IRET=NF90_DEF_VAR(NCID, 'hs', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(6))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(6), 1, 1, DEFLATE)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'long_name','spectral estimate of significant wave height') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'long_name','spectral estimate of significant wave height')
         IRET=NF90_PUT_ATT(NCID,VARID(6),'standard_name','sea_surface_wave_significant_height')
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'globwave_name','significant_wave_height') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'globwave_name','significant_wave_height')
         IRET=NF90_PUT_ATT(NCID,VARID(6),'units','m')
         IRET=NF90_PUT_ATT(NCID,VARID(6),'scale_factor',1.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'add_offset',0.)
@@ -3888,9 +3888,9 @@
 !Hs
          IRET=NF90_DEF_VAR(NCID, 'hs', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(8))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(8), 1, 1, DEFLATE)
-        IRET=NF90_PUT_ATT(NCID,VARID(8),'long_name','spectral estimate of significant wave height') 
-        IRET=NF90_PUT_ATT(NCID,VARID(8),'standard_name','sea_surface_wave_significant_height') 
-        IRET=NF90_PUT_ATT(NCID,VARID(8),'globwave_name','significant_wave_height') 
+        IRET=NF90_PUT_ATT(NCID,VARID(8),'long_name','spectral estimate of significant wave height')
+        IRET=NF90_PUT_ATT(NCID,VARID(8),'standard_name','sea_surface_wave_significant_height')
+        IRET=NF90_PUT_ATT(NCID,VARID(8),'globwave_name','significant_wave_height')
         IRET=NF90_PUT_ATT(NCID,VARID(8),'units','m')
         IRET=NF90_PUT_ATT(NCID,VARID(8),'scale_factor',1.)
         IRET=NF90_PUT_ATT(NCID,VARID(8),'add_offset',0.)
@@ -3903,9 +3903,9 @@
          IRET=NF90_DEF_VAR(NCID, 'hsst', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(9))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(9), 1, 1, DEFLATE)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'long_name',                    &
-                          'nondimensionalized using spectral estimate of significant wave height') 
-        IRET=NF90_PUT_ATT(NCID,VARID(9),'standard_name','sea_surface_wave_significant_height') 
-        IRET=NF90_PUT_ATT(NCID,VARID(9),'globwave_name','significant_wave_height') 
+                          'nondimensionalized using spectral estimate of significant wave height')
+        IRET=NF90_PUT_ATT(NCID,VARID(9),'standard_name','sea_surface_wave_significant_height')
+        IRET=NF90_PUT_ATT(NCID,VARID(9),'globwave_name','significant_wave_height')
         IRET=NF90_PUT_ATT(NCID,VARID(9),'units','-')
         IRET=NF90_PUT_ATT(NCID,VARID(9),'scale_factor',1.)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'add_offset',0.)
@@ -4007,7 +4007,7 @@
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(8), 1, 1, DEFLATE)
         IRET=NF90_PUT_ATT(NCID,VARID(8),'long_name','spectral estimate of significant wave height')
         IRET=NF90_PUT_ATT(NCID,VARID(8),'standard_name','sea_surface_wave_significant_height')
-        IRET=NF90_PUT_ATT(NCID,VARID(8),'globwave_name','significant_wave_height')  
+        IRET=NF90_PUT_ATT(NCID,VARID(8),'globwave_name','significant_wave_height')
         IRET=NF90_PUT_ATT(NCID,VARID(8),'units','m')
         IRET=NF90_PUT_ATT(NCID,VARID(8),'scale_factor',1.)
         IRET=NF90_PUT_ATT(NCID,VARID(8),'add_offset',0.)
@@ -4067,7 +4067,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',10.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 
 !d
         IRET=NF90_DEF_VAR(NCID, 'dpt', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(7))
@@ -4322,7 +4322,7 @@
           IRET=NF90_PUT_ATT(NCID,VARID(16),'associates','time station ffp')
         END IF
 
-!  Add values in netCDF file   
+!  Add values in netCDF file
         IRET=NF90_ENDDEF(NCID)
         CALL CHECK_ERR(IRET)
         IRET=NF90_PUT_VAR(NCID,VARID(6),FREQ(1:NK))
@@ -4361,7 +4361,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',10.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 
 !d
         IRET=NF90_DEF_VAR(NCID, 'dpt', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(7))
@@ -4616,7 +4616,7 @@
           IRET=NF90_PUT_ATT(NCID,VARID(16),'associates','time station ffp')
         END IF
 
-!  Add values in netCDF file   
+!  Add values in netCDF file
         IRET=NF90_ENDDEF(NCID)
         CALL CHECK_ERR(IRET)
         IRET=NF90_PUT_VAR(NCID,VARID(6),FREQ(1:NK))
@@ -4650,7 +4650,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',10.)
         IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y') 
+        IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Y')
 
 !frequency1
         IRET=NF90_DEF_VAR(NCID, 'frequency1', NF90_FLOAT, (/DIMID(4)/), VARID(7))
@@ -4695,7 +4695,7 @@
         IRET=NF90_PUT_ATT(NCID,VARID(9),'valid_min',0.)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'valid_max',360.)
         IRET=NF90_PUT_ATT(NCID,VARID(9),'_FillValue',NF90_FILL_FLOAT)
-        IRET=NF90_PUT_ATT(NCID,VARID(9),'axis','Z') 
+        IRET=NF90_PUT_ATT(NCID,VARID(9),'axis','Z')
 !/RTD        IF ( FLAGUNR ) THEN
 !/RTD          IRET=NF90_PUT_ATT(NCID,VARID(9),'direction_reference','True North')
 !/RTD        ELSE
@@ -4754,7 +4754,7 @@
 !Uc
         IRET=NF90_DEF_VAR(NCID, 'cur', NF90_FLOAT, (/ DIMID(TWO),DIMID(ONE) /), VARID(13))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(13), 1, 1, DEFLATE)
-        IRET=NF90_PUT_ATT(NCID,VARID(13),'long_name','sea water speed')        
+        IRET=NF90_PUT_ATT(NCID,VARID(13),'long_name','sea water speed')
         IRET=NF90_PUT_ATT(NCID,VARID(13),'standard_name','sea_water_speed')
         IRET=NF90_PUT_ATT(NCID,VARID(13),'globwave_name','sea_water_speed')
         IRET=NF90_PUT_ATT(NCID,VARID(13),'units','m s-1')
@@ -4935,7 +4935,7 @@
           ENDIF
         ENDIF
 
-!  Add values in netCDF file      
+!  Add values in netCDF file
         IRET=NF90_ENDDEF(NCID)
         CALL CHECK_ERR(IRET)
         IRET=NF90_PUT_VAR(NCID,VARID(6),FREQ(1:NK))
@@ -4951,7 +4951,7 @@
 !
       RETURN
 
-      END SUBROUTINE W3CRNC 
+      END SUBROUTINE W3CRNC
 
 !==============================================================================
 

--- a/model/ftn/ww3_outf.ftn
+++ b/model/ftn/ww3_outf.ftn
@@ -30,14 +30,14 @@
 !/    12-Dec-2012 : SMC grid sea-point text output.JG_Li( version 4.08 )
 !/    25-Dec-2012 : New structure of output fields.     ( version 4.11 )
 !/                  Minor bug fixes and clean up.
-!/    11-Nov-2013 : SMC and rotated grid incorporated in the main 
+!/    11-Nov-2013 : SMC and rotated grid incorporated in the main
 !/                  trunk                               ( version 4.13 )
 !/    27-Aug-2015 : ICEH and ICEF added as output       ( version 5.10 )
 !/    12-Sep-2018 : Added new partitioned output fields ( version 6.06 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -230,7 +230,7 @@
 !
       CALL W3READFLGRD ( NDSI, NDSO, 9, NDSE, COMSTR, FLOG,      &
                          FLREQ, 1, 1, IERR )
-      IF (IERR.NE.0) GOTO 800 
+      IF (IERR.NE.0) GOTO 800
 
 !
 ! ... Output type
@@ -615,7 +615,7 @@
 !/
 !/S      CALL STRACE (IENT, 'W3EXGO')
 !
-!/T      DO IFI=1, NOGRP 
+!/T      DO IFI=1, NOGRP
 !/T        LTEMP  = FLREQ(IFI,:)
 !/T        WRITE (NDST,9000) IFI, LTEMP
 !/T        END DO
@@ -758,8 +758,8 @@
                                                           , MAPSF, X1 )
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, CY(1:NSEA)        &
                                                           , MAPSF, X2 )
-                ENDIF 
-! 
+                ENDIF
+!
               ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 3 ) THEN
                 IF ( VECTOR ) THEN
                     FLTWO  = .TRUE.
@@ -851,7 +851,7 @@
 !/BT4                FSC    = 0.01
 !/BT4                UNITS  = 'Krumbein phi scale'
 !/BT4                ENAME  = '.d50'
-!/BT4                WHERE ( SED_D50.NE.UNDEF) SED_D50 = -LOG(SED_D50/0.001)/LOG2 
+!/BT4                WHERE ( SED_D50.NE.UNDEF) SED_D50 = -LOG(SED_D50/0.001)/LOG2
 !/BT4                IF ( ITYPE .EQ. 4 ) THEN
 !/BT4                   XS1    = SED_D50
 !/BT4                ELSE
@@ -865,7 +865,7 @@
 !/IS2               ENAME = '.ic1'
 !/IS2               IF ( ITYPE .EQ. 4) THEN
 !/IS2                  XS1    = ICEH
-!/IS2               ELSE 
+!/IS2               ELSE
 !/IS2               CALL W3S2XY (NSEA, NSEA, NX+1, NY, ICEH, MAPSF, X1 )
 !/IS2               ENDIF
 !
@@ -876,7 +876,7 @@
 !/IS2               ENAME = '.ic5'
 !/IS2               IF ( ITYPE .EQ. 4) THEN
 !/IS2                  XS1    = ICEF
-!/IS2               ELSE 
+!/IS2               ELSE
 !/IS2               CALL W3S2XY (NSEA, NSEA, NX+1, NY, ICEF, MAPSF, X1 )
 !/IS2               ENDIF
 
@@ -886,10 +886,10 @@
                 UNITS  = 'm'
                 ENAME  = '.hs'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = HS 
+                   XS1    = HS
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, HS    , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 2 ) THEN
                 FLONE  = .TRUE.
@@ -897,10 +897,10 @@
                 UNITS  = 'm'
                 ENAME  = '.lm'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = WLM 
+                   XS1    = WLM
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, WLM   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 3 ) THEN
                 FLONE  = .TRUE.
@@ -908,10 +908,10 @@
                 UNITS  = 's'
                 ENAME  = '.t02'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = T02 
+                   XS1    = T02
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, T02   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 4 ) THEN
                 FLONE  = .TRUE.
@@ -919,10 +919,10 @@
                 UNITS  = 's'
                 ENAME  = '.t0m1'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = T0M1 
+                   XS1    = T0M1
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, T0M1  , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 5 ) THEN
                 FLONE  = .TRUE.
@@ -933,7 +933,7 @@
                    XS1    = T01
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, T01   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 6 ) THEN
                 FLONE  = .TRUE.
@@ -944,7 +944,7 @@
                    XS1    = FP0
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, FP0   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 7 ) THEN
                 FLONE  = .TRUE.
@@ -961,7 +961,7 @@
                    XS1    = THM
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, THM   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 8 ) THEN
                 FLONE  = .TRUE.
@@ -972,7 +972,7 @@
                    XS1    = THS
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, THS   , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 9 ) THEN
                 FLONE  = .TRUE.
@@ -987,10 +987,10 @@
                     END IF
                   END DO
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = THP0 
+                   XS1    = THP0
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, THP0  , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 10 ) THEN
                 FLONE  = .TRUE.
@@ -1090,7 +1090,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PHS(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 2 ) THEN
                 FLONE  = .TRUE.
@@ -1102,7 +1102,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PTP(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 3 ) THEN
                 FLONE  = .TRUE.
@@ -1114,7 +1114,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PLP(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 4 ) THEN
                 FLONE  = .TRUE.
@@ -1134,7 +1134,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PDIR(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 5 ) THEN
                 FLONE  = .TRUE.
@@ -1146,7 +1146,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PSI(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 6 ) THEN
                 FLONE  = .TRUE.
@@ -1158,7 +1158,7 @@
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PWS(:,IPART)      &
                                                       , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 7 ) THEN
                 FLONE  = .TRUE.
@@ -1274,10 +1274,10 @@
                 UNITS  = '1'
                 ENAME  = '.tws'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = PWST(:) 
+                   XS1    = PWST(:)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PWST(:), MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 4 .AND. IFJ .EQ. 17 ) THEN
                 FLONE  = .TRUE.
@@ -1285,10 +1285,10 @@
                 UNITS  = '1'
                 ENAME  = '.pnr'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = PNR(:) 
+                   XS1    = PNR(:)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PNR(:), MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 5 .AND. IFJ .EQ. 1 ) THEN
                 IF ( VECTOR ) THEN
@@ -1521,9 +1521,9 @@
 !/RTD                ! Radition stress components are always left on rotated pole
 !/RTD                ! at present - need to confirm how to de-rotate (A. Saulter)
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = SXX(1:NSEA) 
-                   XS2    = SYY(1:NSEA) 
-                   XS3    = SXY(1:NSEA) 
+                   XS1    = SXX(1:NSEA)
+                   XS2    = SYY(1:NSEA)
+                   XS3    = SXY(1:NSEA)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, SXX(1:NSEA)       &
                                                           , MAPSF, X1 )
@@ -1545,8 +1545,8 @@
 !/RTD                ! Rotate x,y vector back to standard pole
 !/RTD                IF ( FLAGUNR ) CALL W3XYRTN(NSEA, TAUOX, TAUOY, AnglD)
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = TAUOX(1:NSEA) 
-                   XS2    = TAUOY(1:NSEA) 
+                   XS1    = TAUOX(1:NSEA)
+                   XS2    = TAUOY(1:NSEA)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, TAUOX(1:NSEA)     &
                                                           , MAPSF, XX )
@@ -1567,8 +1567,8 @@
                   TAUOX(ISEA) = UABS
                   END DO
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS3    = TAUOX(1:NSEA) 
-                   XS4    = TAUOY(1:NSEA) 
+                   XS3    = TAUOX(1:NSEA)
+                   XS4    = TAUOY(1:NSEA)
                 ELSE
                 CALL W3S2XY (NSEA,NSEA,NX+1,NY, TAUOX(1:NSEA)         &
                                                       , MAPSF, X1 )
@@ -1582,11 +1582,11 @@
                 UNITS  = 'N m-1'
                 ENAME  = '.bhd'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = BHD(1:NSEA) 
+                   XS1    = BHD(1:NSEA)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, BHD(1:NSEA)    &
                                                           , MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 4 ) THEN
                 FLONE  = .TRUE.
@@ -1597,7 +1597,7 @@
                    PHIOC(ISEA)=MIN(99.98,PHIOC(ISEA))
                    END DO
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = PHIOC(1:NSEA) 
+                   XS1    = PHIOC(1:NSEA)
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, PHIOC(1:NSEA)    &
                                                           , MAPSF, X1 )
@@ -1846,8 +1846,8 @@
                   ELSE
                     FLDIR  = .TRUE.
                   END IF
-                FSC    = 1.E-6     
-                ENAME  = '.mss' 
+                FSC    = 1.E-6
+                ENAME  = '.mss'
                 FORMF  = '(1X,20I6)'
                 UNITS  = '1'
 !/RTD                ! Rotate x,y vector back to standard pole
@@ -1974,7 +1974,7 @@
                 UNITS  = 's-1'
                 ENAME  = '.fc'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = FCUT 
+                   XS1    = FCUT
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, FCUT  , MAPSF, X1 )
                 ENDIF
@@ -1983,7 +1983,7 @@
                 FLONE  = .TRUE.
                 FSC    = 0.001
                 FSC    = 1.
-                UNITS  = '1' 
+                UNITS  = '1'
                 ENAME  = '.cfx'
                 IF ( ITYPE .EQ. 4 ) THEN
                    XS1    = CFLXYMAX
@@ -1997,10 +1997,10 @@
                 UNITS  = '1'
                 ENAME  = '.cfd'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = CFLTHMAX 
+                   XS1    = CFLTHMAX
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, CFLTHMAX, MAPSF, X1 )
-                ENDIF 
+                ENDIF
 !
               ELSE IF ( IFI .EQ. 9 .AND. IFJ .EQ. 5 ) THEN
                 FLONE  = .TRUE.
@@ -2008,7 +2008,7 @@
                 UNITS  = '1'
                 ENAME  = '.cfk'
                 IF ( ITYPE .EQ. 4 ) THEN
-                   XS1    = CFLKMAX 
+                   XS1    = CFLKMAX
                 ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, CFLKMAX, MAPSF, X1 )
                 ENDIF
@@ -2071,7 +2071,7 @@
                   IXA    = IXB + IXS
                   IXB    = IXA + (NXMAX-1)*IXS
                   IXB    = MIN ( IXB , IXN )
-                  IF ( FLTRI ) THEN 
+                  IF ( FLTRI ) THEN
                       CALL PRTBLK (NDSO, NX, NY, NX+1, X1, MAP, 0,    &
                                    FSC, IXA, IXB, IXS, IY1, IYN, IYS, &
                                    IDOUT(IFI,IFJ), UNITS)
@@ -2157,13 +2157,13 @@
                        MINVAL(YGRD(IY1:IYN,IX1:IXN)),                 &
                        MAXVAL(YGRD(IY1:IYN,IX1:IXN)), IYN-IY1+1,      &
                        ENAME, FSC, UNITS, IDLA, IDFM, FORMF, MFILL
-                  ELSE 
+                  ELSE
                     OPEN (NDSDAT,FILE=FNAME,             &
                     FORM='UNFORMATTED',ERR=800,IOSTAT=IERR)
                     WRITE (NDSDAT) FILEID, TIME,                      &
                          X0,MAXX,NX, &
                          Y0,MAXY,NY, &
-                         ENAME, FSC, UNITS, IDLA, IDFM, FORMF, MFILL  
+                         ENAME, FSC, UNITS, IDLA, IDFM, FORMF, MFILL
                   ENDIF
                 ELSE
                    IF(GTYPE .NE. UNGTYPE) THEN
@@ -2196,7 +2196,7 @@
                       WRITE (NDSDAT, 949) FILEID, TIME,              &
                          X0,MAXX,NX, &
                          Y0,MAXY,NY, &
-                         ENAME, FSC, UNITS, IDLA, IDFM, FORMF, MFILL  
+                         ENAME, FSC, UNITS, IDLA, IDFM, FORMF, MFILL
                      ENDIF
                 END IF
 !
@@ -2239,7 +2239,7 @@
                             END DO
                           END DO
                       END IF
-                ELSE 
+                ELSE
                   IF ( FLTWO .OR. FLDIR ) THEN
                     DO IX=IX1, IXN
                      DO IY=IY1, IYN
@@ -2339,7 +2339,7 @@
                 IF ( FLTWO .OR. FLDIR ) THEN
                   WRITE (NDSDAT,980)  FILEID, TIME, NSEA, 2,       &
                                  FSC, ENAME, UNITS, GNAME
-                  WRITE(NDSDAT, 113)  XS1 
+                  WRITE(NDSDAT, 113)  XS1
                   WRITE(NDSDAT, 113)  XS2
                 ENDIF
                 IF ( FLONE ) THEN
@@ -2349,7 +2349,7 @@
                 ENDIF
 !
                 CLOSE (NDSDAT)
-! 
+!
               END IF
 !
 ! ... End of fields loop

--- a/model/ftn/ww3_outp.ftn
+++ b/model/ftn/ww3_outp.ftn
@@ -62,7 +62,7 @@
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -345,9 +345,9 @@
           END IF
           EXIT
         END IF
-        ! existing index in out_pnt.ww3   
+        ! existing index in out_pnt.ww3
         IF ( (IPOINT .GT. 0) .AND. (IPOINT .LE. NOPTS) ) THEN
-          IF ( .NOT. FLREQ(IPOINT) ) THEN 
+          IF ( .NOT. FLREQ(IPOINT) ) THEN
             NREQ = NREQ + 1
           END IF
           FLREQ(IPOINT) = .TRUE.
@@ -440,8 +440,8 @@
                                   NK, NTH, NREQ, GNAME
                   WRITE (NDSTAB) (SIG(IK)*TPIINV,IK=1,NK)
 !
-! conversion of directions from trignonmetric to nautical (still uses directions TO ) 
-! 
+! conversion of directions from trignonmetric to nautical (still uses directions TO )
+!
                  WRITE (NDSTAB) (MOD(2.5*PI-TH(ITH),TPI),ITH=1,NTH)
 
                 ELSE
@@ -612,7 +612,7 @@
                   WRITE (NDSE,1012) OTYPE
                   CALL EXTCDE ( 45 )
                 ENDIF
-                IF (FLREQ(IJ)) THEN 
+                IF (FLREQ(IJ)) THEN
                   NDSBUL = NDSTAB + (IJ - 1)
                   OPEN(NDSBUL,FILE=TRIM(PTNME(IJ))//'.bull',ERR=803,IOSTAT=IERR)
                   WRITE (NDSO,1947) TRIM(PTNME(IJ))//'.bull'
@@ -628,7 +628,7 @@
               DO IJ = 1,NOPTS
                 IF (FLREQ(IJ)) THEN
                   ICSV = 0
-                  IF ( NDSBUL .GT. 0 ) ICSV = NDSBUL 
+                  IF ( NDSBUL .GT. 0 ) ICSV = NDSBUL
 !/NCO                   IF ( NDSCBUL .GT. 0 ) ICSV = NDSCBUL
                   NDSCSV = NDSTAB + (IJ - 1) + ICSV
                   OPEN(NDSCSV,FILE=TRIM(PTNME(IJ))//'.csv',ERR=803,IOSTAT=IERR)
@@ -711,8 +711,8 @@
         DO IJ = 1,NOPTS
           IF (FLREQ(IJ)) THEN
             NDSBUL = NDSTAB + (IJ - 1)
-            WRITE(NDSBUL,971) 
-            WRITE(NDSBUL,974) BHSDROP, BHSMIN 
+            WRITE(NDSBUL,971)
+            WRITE(NDSBUL,974) BHSDROP, BHSMIN
 !/NCO             NDSCBUL = NDSTAB + (IJ - 1) + NOPTS
 !/NCO             WRITE(NDSCBUL,961)
 !/NCO             WRITE(NDSCBUL,962)
@@ -809,7 +809,7 @@
        75X,'Tp  : Peak period of separate wave field.'/               &
        75X,'dir : Mean direction of separate wave field.'/            &
        75X,'*   : Wave generation due to local wind probable.')
- 
+
  1940 FORMAT ( '      ',A,' print plots not requested.')
  1941 FORMAT ( '      ',A,' print plots normalized.')
  1942 FORMAT ( '      Scale factor ',A,' spectrum : ',E10.3)
@@ -980,10 +980,10 @@
 !     - Note that arrays CX and CY of the main program now contain
 !       the absolute current speed and direction respectively.
 !
-!     - BT8&9 issues : 
+!     - BT8&9 issues :
 !
 !       Q: What is the problem?
-!       A: Point output of Sbot with BT8 or BT9 is not presently 
+!       A: Point output of Sbot with BT8 or BT9 is not presently
 !          supported.
 !
 !       Q: What can a user do now?
@@ -996,20 +996,20 @@
 !        $               | | | ^ Dissipation
 !        $               | | ^ Nonlinear interactions
 !        $               | ^ Wind-wave interactions
-!        $               ^ Spectrum 
+!        $               ^ Spectrum
 !          If the user really need this source function, he/she
-!          needs to add test output to the mud subroutine 
+!          needs to add test output to the mud subroutine
 !          directly
 !
 !       Q: Why doesn't this functionality exist?
-!       A: The Sbot source function in ww3_outp was originally written 
-!          with the case of BT1 in mind. BT1 uses a uniform friction 
-!          factor, so it does not need any special variable for the 
-!          local friction factor. BT8 and BT9 allow non-uniform mud 
-!          variables (thickness, density, viscosity) and the mud 
-!          subroutines are written with ww3_shel in mind, where the 
-!          source function is calculated on the computational grid 
-!          point IX IY. 
+!       A: The Sbot source function in ww3_outp was originally written
+!          with the case of BT1 in mind. BT1 uses a uniform friction
+!          factor, so it does not need any special variable for the
+!          local friction factor. BT8 and BT9 allow non-uniform mud
+!          variables (thickness, density, viscosity) and the mud
+!          subroutines are written with ww3_shel in mind, where the
+!          source function is calculated on the computational grid
+!          point IX IY.
 
 !       Q: How can we add this functionality?
 !       A: To fix it, we would need to :
@@ -1310,10 +1310,10 @@
               END DO
 
 !
-! Computes 2nd order spectrum 
+! Computes 2nd order spectrum
 !
-!/IG1      IF (IGPARS(2).EQ.1) THEN 
-!/IG1        IF(IGPARS(1).EQ.1) THEN 
+!/IG1      IF (IGPARS(2).EQ.1) THEN
+!/IG1        IF(IGPARS(1).EQ.1) THEN
 !/IG1          CALL W3ADDIG(SPCO(:,J),DPO(J),WN,CG,0)
 !/IG1        ELSE
 !/IG1          CALL W3ADD2NDORDER(SPCO(:,J),DPO(J),WN,CG,0)
@@ -1661,13 +1661,13 @@
 !/BT1                    CALL W3SBT1 ( A, CG, WN, DEPTH,     XBT, DIA )
 !/BT2                    SBTC2 = 2. * -0.067 / GRAV
 !/BT2                    CALL W3SBT2 ( A, CG, WN, DEPTH, XBT, DIA, SBTC2 )
-!/BT4                    IX=1    ! to be fixed later 
-!/BT4                    IY=1    ! to be fixed later 
-!/BT4                    ISEA=1  ! to be fixed later 
+!/BT4                    IX=1    ! to be fixed later
+!/BT4                    IY=1    ! to be fixed later
+!/BT4                    ISEA=1  ! to be fixed later
 !/BT4                    D50 = SED_D50(ISEA)
 !/BT4                    PSIC= SED_PSIC(ISEA)
 
-!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   & 
+!/BT4                    CALL W3SBT4 ( A, CG, WN, DEPTH, D50, PSIC, TAUBBL,   &
 !/BT4                                       BEDFORM, XBT, DIA, IX, IY )
 
                  BT8MSG='ww3_outp: ITYPE=3 with BT8 or BT9: Sbot out'//&
@@ -1701,7 +1701,7 @@
 !/IS2                     END IF
 !
 !/IS2                  CALL W3SIS2(A, DEPTH, ICECON, ICETHICK, ICEF, ICEDMAX, &
-!/IS2                              IX, IY, XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)    
+!/IS2                              IX, IY, XIS, DIA, DIA2, WN, CG, WN_R, CG_ICE, R)
                   END IF
 !
 !/XXX                CALL W3SXXX
@@ -2022,7 +2022,7 @@
                       WRITE (NDSTAB,2930) FACF*SIG(IK), E1(IK),       &
                         SIN1(IK), SNL1(IK), SDS1(IK), SBT1(IK),       &
                         SIS1(IK), STT1(IK)
-                     
+
                       END DO
                     WRITE (NDSTAB,2940)
 !
@@ -2103,7 +2103,7 @@
                         IF ( FLSRCE(5) ) WRITE (NDSTAB,902)           &
                               ((SBT(IK,ITH),IK=1,NK),ITH=1,NTH)
                         IF ( FLSRCE(6) ) WRITE (NDSTAB,902)           &
-                              ((SIS(IK,ITH),IK=1,NK),ITH=1, NTH) 
+                              ((SIS(IK,ITH),IK=1,NK),ITH=1, NTH)
                         IF ( FLSRCE(7) ) WRITE (NDSTAB,902)           &
                               ((STT(IK,ITH),IK=1,NK),ITH=1,NTH)
                       END IF
@@ -2164,11 +2164,11 @@
 !/NCO                         NDSCBUL=NDSTAB + (J - 1) + NOPTS
                         IF (IOUT .EQ. 1) THEN
                           WRITE(HSTR,'(I2,1X,A)') TIMEV(2)/10000,   &
-                                   HTYPE 
+                                   HTYPE
                           WRITE (NDSBUL,970) PTNME(J), Y, IDLAT, X, &
                                            IDLON, GNAME, TIMEV(1),  &
                                            HSTR
-                          WRITE (NDSBUL,971) 
+                          WRITE (NDSBUL,971)
                           WRITE (NDSBUL,972)
                           WRITE (NDSBUL,971)
 !/NCO                           WRITE (NDSCBUL,960) PTNME(J), Y, IDLAT,   &
@@ -2180,7 +2180,7 @@
 !/NCO                         WRITE (NDSCBUL,963) CASCBLINE
                      ENDIF
                       IF ( OTYPE .EQ. 3 .OR. OTYPE .EQ. 4 ) THEN
-                        ICSV = 0 
+                        ICSV = 0
                         IF ( NDSBUL .GT. 0 ) ICSV = NDSBUL
 !/NCO                         IF ( NDSCBUL .GT. 0 ) ICSV = NDSCBUL
                         NDSCSV = NDSTAB + (J - 1) + ICSV
@@ -2242,7 +2242,7 @@
   941 FORMAT ('        hs     tp     lp       theta     sp      wf')
   942 FORMAT (I3,3F8.2,2F9.2,10F7.2)
 !
-! 
+!
 !/NCO  960 FORMAT ( 'Location : ',A,' (',F5.2,A,1X,F6.2,A,')'/              &
 !/NCO                'Model    : ',A/                                       &
 !/NCO                'Cycle    : ',I8,1X,A//                                &

--- a/model/ftn/ww3_prep.ftn
+++ b/model/ftn/ww3_prep.ftn
@@ -26,9 +26,9 @@
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
-!/    15-May-2010 : Add ISI (icebergs and sea ice).     ( version 3.14.4 )   
+!/    15-May-2010 : Add ISI (icebergs and sea ice).     ( version 3.14.4 )
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    06-Dec-2010 : Change from GLOBAL (logical) to ICLOSE (integer) to
 !/                  specify index closure for a grid.   ( version 3.14 )
 !/                  (T. J. Campbell, NRL)
@@ -42,7 +42,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -128,14 +128,14 @@
 !  7. Remarks :
 !
 !     - Input fields need to be continuous in longitude and latitude.
-!     - Longitude - latitude grid (Section 4.a) : program attempts to 
-!       detect closure type (ICLO) using longitudes of the grid. Thus, 
+!     - Longitude - latitude grid (Section 4.a) : program attempts to
+!       detect closure type (ICLO) using longitudes of the grid. Thus,
 !       it does not allow the user to specify the closure type, and so
 !       tripole closure is not supported.
 !     - Grid(s) from file (Section 4.a) : program reads logical variable
-!       CLO(J) from .inp file. Thus, it does not allow the user to 
+!       CLO(J) from .inp file. Thus, it does not allow the user to
 !       specify more than two closure type (SMPL or NONE), and so
-!       tripole closure is not supported. 
+!       tripole closure is not supported.
 
 !  8. Structure :
 !
@@ -259,7 +259,7 @@
 !/
 !/ ------------------------------------------------------------------- /
 !/
-! notes: Is it possible to combine ice parameters into one group, 
+! notes: Is it possible to combine ice parameters into one group,
 !        similar to the way 1D spectra are in one group?
       DATA IDSTR1 / 'ice param. 1' , 'ice param. 2' ,                 &
                     'ice param. 3' , 'ice param. 4' ,                 &
@@ -562,8 +562,8 @@
 
                      WRITE(NDSO,1042) IX, IY, XGRD(IY,IX), YGRD(IY,IX)
 
-! Notes: We need to set these variables, even if we never intend to use them. 
-!...........Especially in the case of IX?? IY??, we cannot leave them unset, 
+! Notes: We need to set these variables, even if we never intend to use them.
+!...........Especially in the case of IX?? IY??, we cannot leave them unset,
 !...........since they will be used as array indices later.
 
                      IX21(IX,IY) = 1
@@ -591,22 +591,22 @@
 !/T1                    RD11(IX,IY),RD12(IX,IY),RD21(IX,IY),RD22(IX,IY)
                   END DO
                 END DO
-            ELSE 
+            ELSE
               DO IX=1, NX
                 X = XYB(IX,1)
                 Y = XYB(IX,2)
- 
+
                 IX21(IX,1) =   1 + INT(MOD(360.+(X-X0I),360.)/SXI)
 !
 ! Manages the simple closure of the grid
 !
-                IF (ICLO.EQ.ICLOSE_NONE) THEN 
+                IF (ICLO.EQ.ICLOSE_NONE) THEN
                   IX21(IX,1) =   MAX ( 1 , MIN(IX21(IX,1),NXI-1) )
                   IX22(IX,1) =   IX21(IX,1) + 1
                 ELSE
                   IX21(IX,1) =   MAX ( 1 , MIN(IX21(IX,1),NXI) )
                   IX22(IX,1) =   MOD(IX21(IX,1),NXI)+1
-                  END IF 
+                  END IF
                 IY21(IX,1) =   1 + INT((Y-Y0I)/SYI)
                 IY21(IX,1) =   MAX ( 1 , MIN(IY21(IX,1),NYI-1) )
                 IY22(IX,1) =   IY21(IX,1) + 1
@@ -635,13 +635,13 @@
                 EFAC       = SQRT ( MAX(0.,ABS(RW(1)-0.5)-0.5)**2 +  &
                                     MAX(0.,ABS(RW(2)-0.5)-0.5)**2 )
                 EFAC        = 1. / ( 1. + 0.25*EFAC**2 )
-                
+
 
                 RD11(IX,1) = EFAC * (1.-RW(1)) * (1.-RW(2))
                 RD21(IX,1) = EFAC *    RW(1)   * (1.-RW(2))
                 RD12(IX,1) = EFAC * (1.-RW(1)) *    RW(2)
                 RD22(IX,1) = EFAC *    RW(1)   *    RW(2)
-                END DO 
+                END DO
               END IF ! GTYPE .NE. UNGTYPE
 !
               CALL W3GSUD( GSI )
@@ -904,10 +904,10 @@
                           .OR. NYT .NE. NYI ) THEN
                           WRITE (NDSE,1052) TSFLD, NXT, NYT, IDFLD,   &
                                  NXI, NYI
-                          CALL EXTCDE ( 21 ) 
+                          CALL EXTCDE ( 21 )
                       END IF
                   ELSE
-                      REWIND(NDSF(J)) 
+                      REWIND(NDSF(J))
                   END IF
               END IF
           ELSE

--- a/model/ftn/ww3_prnc.ftn
+++ b/model/ftn/ww3_prnc.ftn
@@ -10,12 +10,12 @@
 !/                  | Last update :         04-Jan-2018 |
 !/                  +-----------------------------------+
 !/
-!/    01-Jan-2011 : Creation                            ( version 4.01 )   
+!/    01-Jan-2011 : Creation                            ( version 4.01 )
 !/    17-Nov-2011 : Fix bug on latitudes                ( version 4.04 )
 !/    30-Sep-2012 : Implement tidal analysis            ( version 4.08 )
 !/    29-Oct-2012 : Parallelization of tidal analysis   ( version 4.08 )
-!/     4-Mar-2012 : allows any NetCDF dimensions names  ( version 4.09 ) 
-!/    13-Mar-2012 : Makes compatible with NC3           ( version 4.10 ) 
+!/     4-Mar-2012 : allows any NetCDF dimensions names  ( version 4.09 )
+!/    13-Mar-2012 : Makes compatible with NC3           ( version 4.10 )
 !/    18-Oct-2013 : Debug compile issue with TIDE switch( version 4.12 )
 !/    18-Oct-2013 : Initialize interpolation weights    ( version 4.12 )
 !/    20-Dec-2013 : Allow scale factor and offset in    ( version 4.16 )
@@ -27,13 +27,13 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
 !     Pre-processing of the input water level, current, wind and ice
-!     fields as well as assimilation data ... from NetCDF input       
+!     fields as well as assimilation data ... from NetCDF input
 !
 !  2. Method :
 !
@@ -116,7 +116,7 @@
 !
 !     - Input fields need to be continuous in longitude and latitude.
 !     - Program attempts to detect closure type using longitudes of the
-!       grid. Thus, it does not allow the user to specify the closure 
+!       grid. Thus, it does not allow the user to specify the closure
 !       type, and so tripole closure is not supported.
 !
 !  8. Structure :
@@ -311,7 +311,7 @@
       CHARACTER*100           :: LIST(70)
 !/TIDET      CHARACTER*21            :: FNAMETXT
 !
-      LOGICAL                 :: TIDESWITCH, DISTSWITCH 
+      LOGICAL                 :: TIDESWITCH, DISTSWITCH
 !
       EQUIVALENCE              ( NXI , NXJ(1) ) , ( NYI , NYJ(1) )
 !/
@@ -388,7 +388,7 @@
 !
       IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,900)
 !
- 
+
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 2.  Read model definition file.
@@ -412,7 +412,7 @@
 !
 ! process ww3_prnc namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_prnc.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_prnc.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
          ! Read namelist
          CALL W3NMLPRNC (NDSI, TRIM(FNMPRE)//'ww3_prnc.nml', NML_FORCING, NML_FILE, IERR)
@@ -531,7 +531,7 @@
         FLTIME = .TRUE.
         READ(NML_FILE%TIMESHIFT,*) TIMESHIFT
         IF(TIMESHIFT(1).NE.0 .OR. TIMESHIFT(2).NE.0) FLTIME = .FALSE.
-        
+
       END IF ! FLGNML
 
 !
@@ -700,7 +700,7 @@
       IF ( IRET/=NF90_NOERR ) IRET=NF90_INQ_VARID(NCID,"MT",VARIDTMP)
       CALL CHECK_ERR(IRET)
       IRET=NF90_GET_ATT(NCID,VARIDTMP,"calendar",CALENDAR)
-      IF ( IRET/=NF90_NOERR ) THEN 
+      IF ( IRET/=NF90_NOERR ) THEN
         WRITE(NDSE,1028)
       ELSE IF ((INDEX(CALENDAR, "standard").EQ.0) .AND. &
                (INDEX(CALENDAR, "gregorian").EQ.0)) THEN
@@ -723,7 +723,7 @@
           CALL CHECK_ERR(IRET)
         END DO
         IRET=NF90_GET_ATT(NCID,VARIDF(I),"_FillValue", FILLVALUE)
-        IF ( IRET/=NF90_NOERR ) THEN 
+        IF ( IRET/=NF90_NOERR ) THEN
           WRITE(NDSE,1027) TRIM(FIELDSNAME(I))
           CALL EXTCDE ( 27 )
         END IF
@@ -731,7 +731,7 @@
 
       ! instanciates generic variables dimensions
       NXI=0
-      NYI=0 
+      NYI=0
       NDIMSGRID=2
       DO i=1,NDIMSVAR
         IF (DIMNAME(i) .EQ. "time".OR.DIMNAME(i) .EQ."MT") NTI = DIMLN(i)
@@ -740,7 +740,7 @@
           NDIMSGRID=1
           NYI = 1
         END IF
-        IF (NIDIMS.GE.2) THEN 
+        IF (NIDIMS.GE.2) THEN
           IF (DIMNAME(i) .EQ. DIMSNAME(2)) NYI = DIMLN(i)
         END IF
       END DO
@@ -775,7 +775,7 @@
           DO i=1,NYI
             ALO(:,i)=ALO(:,1)
           END DO
-        ELSE 
+        ELSE
           IRET=NF90_GET_VAR(NCID,VARIDTMP,X0I,start=(/1,1/))
           call CHECK_ERR(IRET)
           IRET=NF90_GET_VAR(NCID,VARIDTMP,XNI,start=(/NXI,1/))
@@ -800,7 +800,7 @@
           DO i=1,NXI
             ALA(i,:)=ALA(1,:)
           END DO
-        ELSE 
+        ELSE
           IRET=NF90_GET_VAR(NCID,VARIDTMP,ALA(:,:))
           CALL CHECK_ERR(IRET)
           YNI=ALA(1,NYI)
@@ -955,14 +955,14 @@
 !
 ! Manages the simple closure of the grid
 !
-              IF (ICLO.EQ.ICLOSE_NONE) THEN 
-                IF (IX21(IX,1).LT.1.OR.IX21(IX,1).GT.NXI-1) WRITE(NDSO,1042) IX, IY, X, Y 
+              IF (ICLO.EQ.ICLOSE_NONE) THEN
+                IF (IX21(IX,1).LT.1.OR.IX21(IX,1).GT.NXI-1) WRITE(NDSO,1042) IX, IY, X, Y
                 IX21(IX,1) =   MAX ( 1 , MIN(IX21(IX,1),NXI-1) )
                 IX22(IX,1) =   IX21(IX,1) + 1
               ELSE
                 IX21(IX,1) =   MAX ( 1 , MIN(IX21(IX,1),NXI) )
                 IX22(IX,1) =   MOD(IX21(IX,1),NXI)+1
-                END IF 
+                END IF
               IY21(IX,1) =   1 + INT((Y-Y0I)/SYI)
               IF (IY21(IX,1).LT.1.OR.IY21(IX,1).GT.NYI-1) WRITE(NDSO,1042) IX, IY, X, Y
               IY21(IX,1) =   MAX ( 1 , MIN(IY21(IX,1),NYI-1) )
@@ -970,7 +970,7 @@
 !
               RW(1) =  MOD(360.+(X-X0I),360.)/SXI - REAL(IX21(IX,1)-1)
               RW(2) =  (Y-Y0I)/SYI - REAL(IY21(IX,1)-1)
-!       
+!
               IF (IX21(IX,1).LE.1 .AND. RW(1).LT.ACC) THEN
                 IF (RW(1).LT.0.) THEN
                   RW(1) = 0.
@@ -1002,11 +1002,11 @@
 !/T                       FLMOD  = .TRUE.
                 END IF
               END IF
-!       
+!
               EFAC = SQRT ( MAX(0.,ABS(RW(1)-0.5)-0.5)**2 +  &
                             MAX(0.,ABS(RW(2)-0.5)-0.5)**2 )
               EFAC        = 1. / ( 1. + 0.25*EFAC**2 )
-                
+
               RD11(IX,1) = EFAC * (1.-RW(1)) * (1.-RW(2))
               RD21(IX,1) = EFAC *    RW(1)   * (1.-RW(2))
               RD12(IX,1) = EFAC * (1.-RW(1)) *    RW(2)
@@ -1187,7 +1187,7 @@
                 NXJ(J), NYJ(J), NXJ(J), NYJ(J), CLO(J), ALA, ALO, &
                 MASK, XD11, XD21, XD12, XD22, JX21, JX22, JY21,   &
                 JY22 )
-            END IF ! J .EQ. 1 
+            END IF ! J .EQ. 1
 !
           END DO ! J=1, NFCOMP
 !
@@ -1248,7 +1248,7 @@
       IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,971)
       J      = LEN_TRIM(FNMPRE)
       IF ( ITYPE .LE. 4 .OR. ITYPE.EQ.6 ) THEN
-!/TIDE          IF (ITYPE.EQ.6) THEN 
+!/TIDE          IF (ITYPE.EQ.6) THEN
 !/TIDE            CALL VUF_SET_PARAMETERS
 !/TIDE            TIDE_NDEF = NFIELDS
 !/TIDE            CALL TIDE_FIND_INDICES_ANALYSIS(LIST)
@@ -1262,7 +1262,7 @@
           CALL W3FLDO ( 'WRITE', IDFLD, NDSDAT, NDST, NDSE,           &
                RECLDT, 0, GTYPEDUM, IERR, FPRE=FNMPRE(:J) )
         END IF
-!/TIDET   IF (TIDEFLAG.GT.0) THEN  
+!/TIDET   IF (TIDEFLAG.GT.0) THEN
 !/TIDET   LRECL  = TIDE_MF*LRB*NFIELDS*2
 !/TIDET   NREC = LRECL / LRB
 !/TIDET   ALLOCATE(NULLBUFF(NREC))
@@ -1273,7 +1273,7 @@
 !/TIDET   FNAMETXT  = 'tidanaNNN.txt'
 !/TIDET          WRITE (FNAMETXT(7:9),'(I3.3)') IAPROC
 !/TIDET   OPEN (989,FILE=FNAMETXT,status='unknown')
-!/TIDET   ENDIF 
+!/TIDET   ENDIF
 !
 ! 7.c Initialize fields
 !
@@ -1283,7 +1283,7 @@
           FA = 0.
           MXM = MAX ( NXJ(1), NXJ(2) )
           MYM = MAX ( NYJ(1), NYJ(2) )
-          IF (ITYPE.EQ.1.AND.GTYPE.EQ.UNGTYPE) THEN 
+          IF (ITYPE.EQ.1.AND.GTYPE.EQ.UNGTYPE) THEN
             ALLOCATE ( XC(MXM,1), YC(MXM,1), AC(MXM,1) )
           ELSE
             ALLOCATE ( XC(MXM,MYM), YC(MXM,MYM), AC(MXM,MYM) )
@@ -1293,23 +1293,23 @@
           AC = 0.
         END IF
 !
-! For ITYPE.LE.5 time steps are read one by one. 
+! For ITYPE.LE.5 time steps are read one by one.
 ! Otherwise points are read one by one for tidal analysis
 !
       TIDESWITCH=.FALSE.
 !/TIDE      TIDESWITCH=.TRUE.
       IF (ITYPE.GE.6.AND.TIDESWITCH) THEN
-! 
+!
 ! Reads in the full time vector
 !
-        IF (NX*NY.GT.4000) THEN 
-!/MPI     IF ((NX*NY)/NAPROC.LT.4000) THEN 
+        IF (NX*NY.GT.4000) THEN
+!/MPI     IF ((NX*NY)/NAPROC.LT.4000) THEN
 !/MPI        IF (IAPROC.EQ.NAPOUT) WRITE(NDSE,*) 'Starting tidal analysis ... '
 !/MPI     ELSE
 !/MPI       IF (IAPROC.EQ.NAPOUT) WRITE(NDSE,*) 'Starting tidal analysis for ',NX*NY,     &
 !/MPI                         ' points. This can take hours ...'
-!/MPI     ENDIF 
-!/MPI     IF (NX*NY.LT.4000) THEN 
+!/MPI     ENDIF
+!/MPI     IF (NX*NY.LT.4000) THEN
           WRITE(NDSE,*) 'Starting tidal analysis for ',NX*NY, ' points.'
           IF (NAPROC.EQ.1) WRITE(NDSE,*) 'This can take hours ...Consider running this with MPI '
           END IF
@@ -1325,17 +1325,17 @@
         IF (INDEX(TIMEUNITS, "hours").NE.0)   ALLTIMES=ALLTIMES/24.
         ALLTIMES=REFJULDAY+ALLTIMES
 
-! 
+!
 ! Performs tidal analysis
 !
-!/TIDE        TIDE_NTI = NTI 
+!/TIDE        TIDE_NTI = NTI
 !/TIDE        TIDE_NDEF = NFIELDS
 !/TIDE        ALLOCATE(SDEV0(TIDE_NDEF),SDEV(TIDE_NDEF), RMSR(TIDE_NDEF), &
 !/TIDE                   RES(TIDE_NDEF), SSQ(TIDE_NDEF),RMSR0(TIDE_NDEF), &
 !/TIDE                 RMSRP(TIDE_NDEF), IMAX(TIDE_NDEF), RESMAX(TIDE_NDEF))
 
-!/TIDE        ALLOCATE( TIDE_DATA(TIDE_NTI,TIDE_NDEF) )  
-!/TIDE        ALLOCATE( TIDE_DAYS(TIDE_NTI), TIDE_SECS(TIDE_NTI), TIDE_HOURS(TIDE_NTI) )  
+!/TIDE        ALLOCATE( TIDE_DATA(TIDE_NTI,TIDE_NDEF) )
+!/TIDE        ALLOCATE( TIDE_DAYS(TIDE_NTI), TIDE_SECS(TIDE_NTI), TIDE_HOURS(TIDE_NTI) )
 !/TIDE        ALLOCATE(V_ARG(170,TIDE_NTI),F_ARG(170,TIDE_NTI),U_ARG(170,TIDE_NTI))
 !/TIDE        TIDE_NX=NX
 !/TIDE        TIDE_NY=NY
@@ -1384,7 +1384,7 @@
         WRITE(NDSE,*) "Number of points for this processor :", IAPROC,NXL(IAPROC)
               DISTSWITCH = .FALSE.
 !/DIST        DISTSWITCH = .TRUE.
-!/TIDE        IF (DISTSWITCH) THEN 
+!/TIDE        IF (DISTSWITCH) THEN
 !/TIDE          TIDESIZ = MAXVAL(NXL) * TIDE_MF * NFIELDS * 2
 !/MPI!/TIDE         CALL MPI_TYPE_VECTOR ( TIDESIZ, 1, 1, MPI_REAL, TIDALSTUFF, IERR_MPI )
 !/MPI!/TIDE         CALL MPI_TYPE_COMMIT ( TIDALSTUFF, IERR_MPI )
@@ -1397,8 +1397,8 @@
         DO IY=1,NY
           IND=0
 !
-! big data read split in small data read ... 
-          IF (NDIMSGRID.EQ.1) THEN 
+! big data read split in small data read ...
+          IF (NDIMSGRID.EQ.1) THEN
             DO I=1,NFIELDS
                 IRET=NF90_GET_VAR(NCID,VARIDF(I),TIDE_DATA_ALL(:,:,I), &
                                 start=(/1+(IAPROC-1)*NXLM,1/),count=(/NXL(IAPROC),NTI/))
@@ -1406,7 +1406,7 @@
            if (i.eq.1) TIDE_DATA_ALL(:,:,I)=TIDE_DATA_ALL(:,:,I)*XCFAC+XCOFF
            if (i.eq.2) TIDE_DATA_ALL(:,:,I)=TIDE_DATA_ALL(:,:,I)*YCFAC+YCOFF
               END DO
-          ELSE 
+          ELSE
             DO I=1,NFIELDS
               IRET=NF90_GET_VAR(NCID,VARIDF(I),TIDE_DATA_ALL(:,:,I), &
                                 start=(/1+(IAPROC-1)*NXLM,IY,1/),count=(/NXL(IAPROC),1,NTI/))
@@ -1416,7 +1416,7 @@
               END DO
           END IF
 !
-          DO JX=1,NXL(IAPROC)  ! This loop is parallelized with MPI 
+          DO JX=1,NXL(IAPROC)  ! This loop is parallelized with MPI
 !/DIST      IX = JX + (IAPROC-1)*NXLM ! IAPROC + (JX-1)*NAPROC
 !/SHRD      IX = JX
 !
@@ -1424,13 +1424,13 @@
 !/TIDE            DO I=1,NTI
 !
 ! Defines usable timesteps ... criteria could be improved
-! remove the times when the point IX,IY is dry ... 
+! remove the times when the point IX,IY is dry ...
 ! and redefine TIDE_NTI based on wet times only
 !
 !/TIDE              IF (TIDE_DATA_ALL(JX,I,1).NE.FILLVALUE     &
 !/TIDE                  .AND.TIDE_DATA_ALL(JX,I,NFIELDS).NE.FILLVALUE                   &
-!/TIDE                  .AND.TIDE_DATA_ALL(JX,I,1).NE.0.0) THEN 
-!/TIDE                TIDE_NTI=TIDE_NTI+1            
+!/TIDE                  .AND.TIDE_DATA_ALL(JX,I,1).NE.0.0) THEN
+!/TIDE                TIDE_NTI=TIDE_NTI+1
 !/TIDE                TIDE_DATA(TIDE_NTI,:)=TIDE_DATA_ALL(JX,I,:)
 !/TIDE                TIDE_DAYS(TIDE_NTI)=INT(ALLTIMES(I))
 !/TIDE                TIDE_SECS(TIDE_NTI)=(ALLTIMES(I)-TIDE_DAYS(TIDE_NTI))*86400
@@ -1440,7 +1440,7 @@
 !/TIDE            TIDE_HOURS(1:TIDE_NTI)=24.d0*dfloat(TIDE_DAYS(1:TIDE_NTI)) &
 !/TIDE                                   +dfloat(TIDE_SECS(1:TIDE_NTI))/3600.d0
 !
-!/TIDE            IF (TIDE_NTI.GT.(TIDE_MF*3)) THEN 
+!/TIDE            IF (TIDE_NTI.GT.(TIDE_MF*3)) THEN
 !/TIDE              TIDE_LAT= YGRD(IY,IX)
 !/TIDE              IF (ABS(TIDE_LAT).LT.5.) TIDE_LAT=SIGN(5.,TIDE_LAT)
 !/TIDE                DO I=1,TIDE_NTI
@@ -1449,7 +1449,7 @@
 !/TIDE                CALL flex_tidana_webpage(IX,IY,XGRD(IY,IX),TIDE_LAT,TIDE_DAYS(1),TIDE_DAYS(TIDE_NTI), &
 !/TIDE                                         TIDE_NDEF, TIDE_ITREND, RES, SSQ, RMSR0,          &
 !/TIDE                                         SDEV0, RMSR, RESMAX, IMAX, 0)
-                
+
 !/TIDE                TIDAL_CONST(IX,IY,1:TIDE_MF,1:NFIELDS,1)=TIDE_AMPC(1:TIDE_MF,1:NFIELDS)
 !/TIDE                TIDAL_CONST(IX,IY,1:TIDE_MF,1:NFIELDS,2)=TIDE_PHG(1:TIDE_MF,1:NFIELDS)
 !/TIDET    WRITE (989,'(2I10,X,176F10.3)'),IX,TIDE_NTI,TIDE_AMPC(1:TIDE_MF,1:NFIELDS) !,TIDE_PHG(1:TIDE_MF,1:NFIELDS)
@@ -1457,13 +1457,13 @@
 !/TIDET    RPOS = 1_8 + LRECL*(IX-1_8)
 !/TIDET    WRITE (990,POS=RPOS),NULLBUFF(1:NREC)
 !/TIDET    WRITE (990,POS=RPOS),TIDE_AMPC(1:TIDE_MF,1:NFIELDS),TIDE_PHG(1:TIDE_MF,1:NFIELDS)
-!              
+!
 ! Only keeps constituents with high enough SNR ? (T-TEST > 2 : not a very good test ...)
 !
 !              DO J=1,TIDE_MF
 !                DO I=1,NFIELDS
 !                  WRITE(990+IAPROC,*) IX,IY,J,I,TIDE_TTEST(J,I),TIDE_AMPC(J,I),TIDE_PHG(J,I)
-!                  IF (TIDE_TTEST(J,I).GT.1.) THEN 
+!                  IF (TIDE_TTEST(J,I).GT.1.) THEN
 !                    TIDAL_CONST(IX,IY,J,I,1)=TIDE_AMPC(J,I)
 !                    TIDAL_CONST(IX,IY,J,I,2)=TIDE_PHG(J,I)
 !                  END IF
@@ -1471,7 +1471,7 @@
 !              END DO
 
 ! Fills 1-D array for MPI communication
-            IF (DISTSWITCH) THEN 
+            IF (DISTSWITCH) THEN
 !/TIDE         DO J=1,TIDE_MF
 !/TIDE           DO K=1,NFIELDS
 !/TIDE             DO L=1,2
@@ -1483,8 +1483,8 @@
 !/TIDE         IF (IAPROC.EQ.NAPOUT) WRITE(6,'(A,I6,A,I6,A,I6)') 'IY, JX = ', &
 !/TIDE           IY,',',JX, ' out of  ', NXL(IAPROC)
               END IF
-!/TIDE            ELSE 
-!/TIDE              WRITE(NDSE,*) 'WARNING NOT ENOUGH DATA AT POINT:',IX,IY, & 
+!/TIDE            ELSE
+!/TIDE              WRITE(NDSE,*) 'WARNING NOT ENOUGH DATA AT POINT:',IX,IY, &
 !/TIDE                                                            NTI, TIDE_NTI
 !/TIDE              TIDAL_CONST(IX,IY,1:TIDE_MF,1:NFIELDS,1)=0.
 !/TIDE              TIDAL_CONST(IX,IY,1:TIDE_MF,1:NFIELDS,2)=0.
@@ -1504,7 +1504,7 @@
 !
 ! We need to send and receive the bits of TIDAL_CONST(:,IY,:,:,:)
 !
-!/TIDE     IF (DISTSWITCH) THEN 
+!/TIDE     IF (DISTSWITCH) THEN
 !/TIDE     IF (IAPROC.NE.NAPOUT)  THEN
 !/DIST!/TIDE       CALL MPI_SEND ( TIDALSTUFFA, 1, TIDALSTUFF, NAPOUT-1, 0,  &
 !/DIST!/TIDE                       MPI_COMM_WORLD, IERR_MPI )
@@ -1520,7 +1520,7 @@
 !/TIDET             END DO
 !/TIDET           END DO       ! JX=1,NXL
 !/TIDE       DO JPC=1,NAPROC
-!/TIDE         IF (JPC .NE. NAPOUT )  THEN 
+!/TIDE         IF (JPC .NE. NAPOUT )  THEN
 !/DIST!/TIDE           CALL MPI_RECV ( TIDALSTUFFA, 1, TIDALSTUFF, JPC-1, MPI_ANY_TAG,  &
 !/DIST!/TIDE                             MPI_COMM_WORLD, STAT_MPI, IERR_MPI )
 !/TIDE           ! Now unpacks the 1-D array
@@ -1542,25 +1542,25 @@
 !/TIDET       WRITE(NDSE,*) "IY = ", IY, "on ", NY
 !/TIDE     END IF
 !/TIDE     END IF
-          
+
         END DO ! IY=1,NY
 !/TIDET    CLOSE (990)
 !/TIDET    CLOSE (989)
-!/TIDET  IF (IDFLD.EQ.'CUR') WRITE(986,'(F10.3,/)') TIDAL_CONST(:,1,15,1,1) 
+!/TIDET  IF (IDFLD.EQ.'CUR') WRITE(986,'(F10.3,/)') TIDAL_CONST(:,1,15,1,1)
 !/TIDET  IF (IDFLD.EQ.'CUR') WRITE(986,'(F10.3,/)') TIDAL_CONST(:,1,15,1,1)
 
-!/TIDE   IF (DISTSWITCH) THEN 
+!/TIDE   IF (DISTSWITCH) THEN
 !/DIST!/TIDE     CALL MPI_TYPE_FREE(TIDALSTUFF, IERR_MPI)
 !/TIDE     DEALLOCATE(TIDALSTUFFA)
 !/TIDE   END IF
 
-!/MPI   IF (IAPROC .EQ. NAPOUT )  THEN 
+!/MPI   IF (IAPROC .EQ. NAPOUT )  THEN
 !/MPI     WRITE(NDSE,*) "parallelization done"
 !/MPI   ELSE
 !/MPI     GOTO 888
 !/MPI   END IF
 !/TIDE!
-!/TIDE! After loop on points, write tidal constituents to file. 
+!/TIDE! After loop on points, write tidal constituents to file.
 !/TIDE!
 !/TIDE   IF ( IAPROC .EQ. NAPOUT.AND.TIDEFLAG.GE.1)  &
 !/TIDE     CALL W3FLDTIDE1 ( 'WRITE',  NDSDAT, NDST, NDSE, NX, NY, IDFLD, IERR )
@@ -1617,7 +1617,7 @@
           call CHECK_ERR(IRET)
           IF (INDEX(TIMEUNITS, "seconds").NE.0)   CURJULDAY=CURJULDAY/86400.
           IF (INDEX(TIMEUNITS, "minutes").NE.0)   CURJULDAY=CURJULDAY/1440.
-          IF (INDEX(TIMEUNITS, "hours").NE.0)     CURJULDAY=CURJULDAY/24. 
+          IF (INDEX(TIMEUNITS, "hours").NE.0)     CURJULDAY=CURJULDAY/24.
           CURJULDAY=REFJULDAY+CURJULDAY
 
           ! cycle until reaching the start time
@@ -1631,7 +1631,7 @@
           CALL D2T(CURDATE,TIME,IERR)
           CALL STME21 (TIME,IDTIME)
 
-          ! define time delay 
+          ! define time delay
           IF (.NOT.FLTIME.AND.TIMEDELAY.EQ.0) THEN
             TIMEDELAY = DSEC21 (TIME,TIMESHIFT)
           END IF
@@ -1650,17 +1650,17 @@
 ! ... Input
 !
           IF ( ITYPE .LE. 4 .OR. ITYPE.EQ.6) THEN
-            IF (NDIMSGRID.EQ.1) THEN 
+            IF (NDIMSGRID.EQ.1) THEN
               IRET=NF90_GET_VAR(NCID,VARIDF(1),XC(:,1),start=(/1,ITIME/),count=(/MXM,1/))
             ELSE
-              IF (NDIMSVAR.EQ.3) THEN 
+              IF (NDIMSVAR.EQ.3) THEN
                 IRET=NF90_GET_VAR(NCID,VARIDF(1),XC,start=(/1,1,ITIME/),count=(/MXM,MYM,1/))
-              ELSE 
+              ELSE
                 IRET=NF90_GET_VAR(NCID,VARIDF(1),XC,start=(/1,1,1,ITIME/),count=(/MXM,MYM,1,1/))
               END IF
             END IF
             ! forces to 0 values that are undefined
-            WHERE(XC.NE.XC) XC = 0. 
+            WHERE(XC.NE.XC) XC = 0.
             WHERE(XC.EQ.FILLVALUE) XC = 0.
             CALL CHECK_ERR(IRET)
             XC  = XC * XCFAC + XCOFF
@@ -1682,7 +1682,7 @@
             IF (NFCOMP.EQ.2 .OR. IFLD.GE.3 .OR. FLBERG) THEN
 
 ! This is a quick fix that works if the lon,lat,level,time dimensions are in that order
-! otherwise, one should check the length of each dimension ... 
+! otherwise, one should check the length of each dimension ...
                     IF (NDIMSGRID.EQ.1) THEN
                       IRET=NF90_GET_VAR(NCID,VARIDF(2),YC(:,1),start=(/1,ITIME/),count=(/MXM,1/))
                     ELSE
@@ -1714,10 +1714,10 @@
 !
                 IF (FLSTAB) THEN
 ! This is a quick fix that works if the lon,lat,level,time dimensions are in that order
-! otherwise, one should check the length of each dimension ... 
-                    IF (NDIMSGRID.EQ.1) THEN 
+! otherwise, one should check the length of each dimension ...
+                    IF (NDIMSGRID.EQ.1) THEN
                       IRET=NF90_GET_VAR(NCID,VARIDF(3),AC(:,1),start=(/1,ITIME/),count=(/MXM,1/))
-                    ELSE 
+                    ELSE
                       IF (NDIMSVAR.EQ.3) THEN
                         IRET=NF90_GET_VAR(NCID,VARIDF(3),AC,start=(/1,1,ITIME/),count=(/MXM,MYM,1/))
                       ELSE
@@ -1990,7 +1990,7 @@
 !
       END DO
 !
-      DEALLOCATE(XC,YC,AC)  
+      DEALLOCATE(XC,YC,AC)
       IF (ASSOCIATED(ALA)) DEALLOCATE(ALA,ALO)
 !
 !     End loop over input fields

--- a/model/ftn/ww3_prtide.ftn
+++ b/model/ftn/ww3_prtide.ftn
@@ -9,20 +9,20 @@
 !/                  | Last update :         06-Jun-2018 |
 !/                  +-----------------------------------+
 !/
-!/    29-Mar-2013 : Creation                            ( version 4.11 )   
+!/    29-Mar-2013 : Creation                            ( version 4.11 )
 !/    17-Oct-2013 : Manages missing data for UNST grids ( version 4.12 )
-!/    06-Jun-2018 : COMPUTE VNEIGH: calculate the number of connected 
-!/                  triangles for a given point         ( version 6.04 )   
+!/    06-Jun-2018 : COMPUTE VNEIGH: calculate the number of connected
+!/                  triangles for a given point         ( version 6.04 )
 !/
 !/    Copyright 2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Predicts tides (current or water level) to be used during 
-!     run by ww3_shel or ww3_multi  (this takes much less memory). 
+!     Predicts tides (current or water level) to be used during
+!     run by ww3_shel or ww3_multi  (this takes much less memory).
 !
 !  2. Method :
 !
@@ -90,7 +90,7 @@
 !  8. Structure :
 !
 !     ----------------------------------------------------
-!        To be updated ... 
+!        To be updated ...
 !     ----------------------------------------------------
 !
 !  9. Switches :
@@ -110,7 +110,7 @@
       USE W3ODATMD, ONLY: W3NOUT, W3SETO
       USE W3SERVMD, ONLY : ITRACE, NEXTLN, EXTCDE, STRSPLIT
 !/S      USE W3SERVMD, ONLY : STRACE
-      USE W3TIMEMD 
+      USE W3TIMEMD
       USE W3ARRYMD, ONLY : INA2R, INA2I
       USE W3IOGRMD, ONLY: W3IOGR
       USE W3FLDSMD, ONLY: W3FLDO, W3FLDG, W3FLDD, W3FLDTIDE1, W3FLDTIDE2
@@ -138,11 +138,11 @@
       CHARACTER(LEN=100)      :: TIDECON_PRNAMES(70), TIDECON_MAXNAMES(70), &
                                  TIDECON_MAXVALS(70)
       INTEGER                 :: PR_INDS(70), K, IND, IX2, SUMOK, NBAD, ITER
-      CHARACTER*23            :: IDTIME 
+      CHARACTER*23            :: IDTIME
       CHARACTER               :: COMSTR*1, IDFLD*3
       REAL, ALLOCATABLE       :: FX(:,:), FY(:,:), FA(:,:)
       INTEGER, ALLOCATABLE    :: BADPOINTS(:,:)
-      REAL                    :: MAXVALCON(70) 
+      REAL                    :: MAXVALCON(70)
       REAL             :: WCURTIDEX, WCURTIDEY, TIDE_ARGX, TIDE_ARGY
       INTEGER(KIND=4)  :: TIDE_KD0, INT24, INTDYS       ! "Gregorian day constant"
       REAL             :: WLEVTIDE, TIDE_ARG, WLEVTIDE2(1)
@@ -254,18 +254,18 @@
                                   NDSE, NX, NY, GTYPE,               &
                                   IERR, FILENAMEXT, '', TIDEFLAGIN=FLAGTIDE )
 !
-      IF (FLAGTIDE.NE.1) GOTO 803 
+      IF (FLAGTIDE.NE.1) GOTO 803
 !
       CALL VUF_SET_PARAMETERS
       ALLOCATE(V_ARG(170,1),F_ARG(170,1),U_ARG(170,1))  ! to be removed later ...
-! 
-! Reads tidal amplitudes and phases        
+!
+! Reads tidal amplitudes and phases
 !
 !
       CALL W3FLDTIDE1 ( 'READ',  NDSF, NDST, NDSE, NX, NY, IDFLD, IERR )
       CALL W3FLDTIDE2 ( 'READ',  NDSF, NDST, NDSE, NX, NY, IDFLD, 0, IERR )
       CLOSE(NDSF)
-      
+
 !
       COUNTRI = MAXVAL(CCON)
       ALLOCATE(VNEIGH(NX,2*COUNTRI))
@@ -320,7 +320,7 @@
         END DO ! CCON
 ! CONN is a counter on connected points. In comparison with the number of connected triangle
 ! CCON, it will enable to spot whether a point belong to the contour
-!         
+!
         CONN(IP)=IFOUND
         do I=2,IFOUND
            do JJ=1,i-1
@@ -331,7 +331,7 @@
               END IF
            enddo
         enddo
-      END DO !NX   
+      END DO !NX
 
 !
 ! Counts the number of tidal constituents
@@ -342,7 +342,7 @@
       DO WHILE (len_trim(TIDECON_MAXNAMES(TIDE_MAXI+1)).NE.0)
         TIDE_MAXI=TIDE_MAXI+1
         DO J=1,TIDE_MF
-          IF (TRIM(TIDECON_NAME(J)).EQ.TRIM(TIDECON_MAXNAMES(TIDE_MAXI))) THEN 
+          IF (TRIM(TIDECON_NAME(J)).EQ.TRIM(TIDECON_MAXNAMES(TIDE_MAXI))) THEN
             TIDE_MAX=TIDE_MAX+1
             INDMAX(TIDE_MAX)=J
             READ(TIDECON_MAXVALS(TIDE_MAXI),*) MAXVALCON(TIDE_MAX)
@@ -351,7 +351,7 @@
           END DO
         END DO
 !
-! Now writes new file 
+! Now writes new file
 !
       FLAGTIDE = 0
       CALL W3FLDO ('WRITE', IDFLD, NDSDAT, NDST,     &
@@ -361,13 +361,13 @@
 ! Loop on time steps
 !
       DTTST  = DSEC21 ( TIDE_START , TIDE_END )
-      IF ( DTTST .LE. 0. .OR. PRTIDE_DT .LT. 1 ) GOTO 888 
+      IF ( DTTST .LE. 0. .OR. PRTIDE_DT .LT. 1 ) GOTO 888
       TIME = TIDE_START
       TIDE_KD0= 2415020
 !
       TINDEX = 1
 !
-      DO    
+      DO
         DTTST  = DSEC21 ( TIME, TIDE_END )
         IF ( DTTST .LT. 0. ) GOTO 888
 !
@@ -376,7 +376,7 @@
 
         TIDE_HOUR = TIME2HOURS(TIME)
 !
-!*  THE ASTRONOMICAL ARGUMENTS ARE CALCULATED 
+!*  THE ASTRONOMICAL ARGUMENTS ARE CALCULATED
 !
         d1=TIDE_HOUR/24.d0
         d1=d1-dfloat(TIDE_kd0)-0.5d0
@@ -392,17 +392,17 @@
         BADPOINTS(:,:)=0
         NBAD =0
         DO IY = 1, NY
-          DO IX = 1, NX 
+          DO IX = 1, NX
             CALL SETVUF_FAST(h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau,YGRD(IY,IX),TIDE_FX,UX,VX)
-            IF (TINDEX.EQ.1) THEN 
+            IF (TINDEX.EQ.1) THEN
               TIDEOK=1
               DO I=1,TIDE_MAX
                 IF (ABS(TIDAL_CONST(IX,IY,INDMAX(I),1,1)) .GT.MAXVALCON(I) &
-                  .OR.ABS(TIDAL_CONST(IX,IY,INDMAX(I),2,1)) .GT.MAXVALCON(I)) & 
+                  .OR.ABS(TIDAL_CONST(IX,IY,INDMAX(I),2,1)) .GT.MAXVALCON(I)) &
                   TIDEOK = 0
                   BADPOINTS(IX,IY) = BADPOINTS(IX,IY) + (1-TIDEOK)
                 END DO
-                IF (BADPOINTS(IX,IY).GT.0) THEN 
+                IF (BADPOINTS(IX,IY).GT.0) THEN
                   NBAD = NBAD +1
                   WRITE(NDSE,*) 'BAD POINT:',IX,IY,NBAD, &
                      TIDAL_CONST(IX,IY,:,1,1),'##',TIDAL_CONST(IX,IY,:,2,1)
@@ -410,46 +410,46 @@
               END IF
             END DO
           END DO
-!   
+!
         DO ITER=1,2
         DO IY = 1, NY
-          DO IX = 1, NX 
-            IF (TINDEX.EQ.1) THEN 
-              IF (BADPOINTS(IX,IY).GT.0) THEN 
+          DO IX = 1, NX
+            IF (TINDEX.EQ.1) THEN
+              IF (BADPOINTS(IX,IY).GT.0) THEN
                 TIDAL_CONST(IX,IY,:,1,1)=0
                 TIDAL_CONST(IX,IY,:,2,1)=0
-                IF (TIDEFILL.AND.(GTYPE.EQ.UNGTYPE)) THEN 
+                IF (TIDEFILL.AND.(GTYPE.EQ.UNGTYPE)) THEN
 !
 ! Performs a vector sum of tidal constituents over neighbor nodes
-!  
-                   DO J=1, TIDE_MF 
+!
+                   DO J=1, TIDE_MF
                      DO K=1, 2
                       AMPCOS = 0
                       AMPSIN = 0
                       SUMOK = 0
-                      DO IND=1,COUNTCON(IX) 
+                      DO IND=1,COUNTCON(IX)
                         IX2=VNEIGH(IX,IND)
-                        IF (BADPOINTS(IX2,IY).EQ.0) THEN 
+                        IF (BADPOINTS(IX2,IY).EQ.0) THEN
                           SUMOK = SUMOK + 1
                           AMPCOS = AMPCOS+TIDAL_CONST(IX2,IY,J,K,1)*COS(TIDAL_CONST(IX2,IY,J,K,2)*DERA)
                           AMPSIN = AMPSIN+TIDAL_CONST(IX2,IY,J,K,1)*SIN(TIDAL_CONST(IX2,IY,J,K,2)*DERA)
                           END IF
                         END DO
-                      IF (SUMOK.GT.1) THEN 
+                      IF (SUMOK.GT.1) THEN
 !
-! Finalizes the amplitude and phase calculation from COS and SIN. Special case for mean value Z0. 
+! Finalizes the amplitude and phase calculation from COS and SIN. Special case for mean value Z0.
 !
-                        IF (TIDECON_NAME(J).NE.'Z0   ') THEN 
+                        IF (TIDECON_NAME(J).NE.'Z0   ') THEN
                           TIDAL_CONST(IX,IY,J,K,1) = SQRT(AMPCOS**2+AMPSIN**2)/SUMOK
                           TIDAL_CONST(IX,IY,J,K,2) = ATAN2(AMPSIN,AMPCOS)/DERA
                         ELSE
                           TIDAL_CONST(IX,IY,J,K,1) = AMPCOS/SUMOK
                           TIDAL_CONST(IX,IY,J,K,2) = 0.
                           END IF
-                        IF(K.EQ.2.AND.J.EQ.TIDE_MF) THEN 
+                        IF(K.EQ.2.AND.J.EQ.TIDE_MF) THEN
                           NBAD=NBAD-1
                           BADPOINTS(IX,IY) = 0
-                          END IF 
+                          END IF
 
                          ENDIF
                        END DO
@@ -466,22 +466,22 @@
 !
 ! For currents: 2 components
 !
-        IF (IFLD.EQ.4) THEN 
+        IF (IFLD.EQ.4) THEN
         DO IY = 1, NY
-          DO IX = 1, NX 
+          DO IX = 1, NX
             WCURTIDEX = 0.
             WCURTIDEY = 0.
             DO I=1,TIDE_PRMF
               J=PR_INDS(I)
-              IF (TRIM(TIDECON_NAME(J)).EQ.'Z0') THEN 
+              IF (TRIM(TIDECON_NAME(J)).EQ.'Z0') THEN
                  WCURTIDEX = WCURTIDEX+TIDAL_CONST(IX,IY,J,1,1)
                  WCURTIDEY = WCURTIDEY+TIDAL_CONST(IX,IY,J,2,1)
-              ELSE 
+              ELSE
                 TIDE_ARGX=(VX(J)+UX(J))*twpi-TIDAL_CONST(IX,IY,J,1,2)*DERA
                 TIDE_ARGY=(VX(J)+UX(J))*twpi-TIDAL_CONST(IX,IY,J,2,2)*DERA
                 WCURTIDEX = WCURTIDEX+TIDE_FX(J)*TIDAL_CONST(IX,IY,J,1,1)*COS(TIDE_ARGX)
-                WCURTIDEY = WCURTIDEY+TIDE_FX(J)*TIDAL_CONST(IX,IY,J,2,1)*COS(TIDE_ARGY)    
-                END IF         
+                WCURTIDEY = WCURTIDEY+TIDE_FX(J)*TIDAL_CONST(IX,IY,J,2,1)*COS(TIDE_ARGY)
+                END IF
               END DO
             IF (ABS(WCURTIDEX).GT.10..OR.ABS(WCURTIDEY).GT.10.)  &
             WRITE(NDSE,*) &
@@ -496,39 +496,39 @@
 !
 ! For water levels: only 1 component
 !
-        IF (IFLD.EQ.2) THEN 
+        IF (IFLD.EQ.2) THEN
         DO IY = 1, NY
-          DO IX = 1, NX 
+          DO IX = 1, NX
 
             CALL SETVUF_FAST(h,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau,YGRD(IY,IX),TIDE_FX,UX,VX)
 !
-! Removes unlikely values ... 
+! Removes unlikely values ...
 !
-            IF (TINDEX.EQ.1) THEN 
+            IF (TINDEX.EQ.1) THEN
               TIDEOK=1
               DO I=1,TIDE_MAX
-                IF (ABS(TIDAL_CONST(IX,IY,INDMAX(I),1,1)) .GT.MAXVALCON(I)) & 
+                IF (ABS(TIDAL_CONST(IX,IY,INDMAX(I),1,1)) .GT.MAXVALCON(I)) &
                   TIDEOK = 0
                 END DO
-              IF (TIDEOK.EQ.0) THEN   
+              IF (TIDEOK.EQ.0) THEN
                 WRITE(NDSE,*) 'BAD POINT:',IX,IY, &
                      TIDAL_CONST(IX,IY,:,1,1)
                 TIDAL_CONST(IX,IY,:,1,1)=0
                 END IF
-              END IF   
+              END IF
 
             WCURTIDEX = 0.
             DO I=1,TIDE_PRMF
               J=PR_INDS(I)
-              IF (TRIM(TIDECON_NAME(J)).EQ.'Z0') THEN 
+              IF (TRIM(TIDECON_NAME(J)).EQ.'Z0') THEN
                  WCURTIDEX = WCURTIDEX+TIDAL_CONST(IX,IY,J,1,1)
-              ELSE 
+              ELSE
                 TIDE_ARGX=(VX(J)+UX(J))*twpi-TIDAL_CONST(IX,IY,J,1,2)*DERA
                 WCURTIDEX = WCURTIDEX+TIDE_FX(J)*TIDAL_CONST(IX,IY,J,1,1)*COS(TIDE_ARGX)
-                END IF         
+                END IF
               END DO
 
-            FX(IX,IY) = 0.       
+            FX(IX,IY) = 0.
             FY(IX,IY) = 0.
             FA(IX,IY) = WCURTIDEX
             END DO
@@ -548,7 +548,7 @@
 ! Increments the clock
 !
         CALL TICK21 ( TIME, FLOAT(PRTIDE_DT) )
-        TINDEX = TINDEX +1 
+        TINDEX = TINDEX +1
         END DO
 !
       GOTO 888

--- a/model/ftn/ww3_sbs1.ftn
+++ b/model/ftn/ww3_sbs1.ftn
@@ -11,25 +11,25 @@
 !/                  +-----------------------------------+
 !/
 !/    04-May-2005 : Origination.                        ( version 3.07 )
-!/    11-Aug-2010 : Upgrade for operations and inclusion in svn.        
+!/    11-Aug-2010 : Upgrade for operations and inclusion in svn.
 !/                                                    ( version 3.14.4 )
 !/    05-Dec-2012 : Making sleep a system call.       ( version 4.11   )
 !/
 !/    Copyright 2010 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
 !
-!     Program shell or driver to run the multi-grid wave model in 
+!     Program shell or driver to run the multi-grid wave model in
 !     'half-coupled' mode, that is running side-by-side with a weather
 !     model while waiting for wind field to become available.
 !
 !     This version is set up for running at NCEP with a single input
-!     wind file, and requires an additional input file. 
+!     wind file, and requires an additional input file.
 !       times.inp  Input file with time stamps. Add to this input file
-!                  a time stamp after the field has been properly 
+!                  a time stamp after the field has been properly
 !                  added to the wind.ww3 or equavalent file.
 !     This file should have the time stamps of fields available in
 !     the first auxiliary wind input file (grid).
@@ -43,17 +43,17 @@
 !
 !  2. Method :
 !
-!     Calling WMWAVE in a loop as wind data become available, with 
+!     Calling WMWAVE in a loop as wind data become available, with
 !     test on wind file.
 !
 !     In order for this to work properly, the user needs to increment
 !     then main wind input file (wind.XXXX) as data become avalable
-!     while this program is running. After a new field is added to 
-!     wind file, the corresponding time stamp in YYYYMMDD YYMMSS 
+!     while this program is running. After a new field is added to
+!     wind file, the corresponding time stamp in YYYYMMDD YYMMSS
 !     format is concatenated to the times.inp file. As the code
 !     reads the new time stamp (1X,I8,1Z,I6 format), a test read of
 !     the wind file is performed until the file is readable, after
-!     which the wave model is run until the new time stamp and the 
+!     which the wave model is run until the new time stamp and the
 !     process is repeated. The test reading of the wind file proved
 !     essential on the NCEP IBM systems to deal with file system
 !     latencies and buffer flushing.
@@ -304,11 +304,11 @@
 !
       GO TO 888
 !
-  820 CONTINUE 
+  820 CONTINUE
       WRITE (MDSS,1020) IERR
       CALL EXTCDE ( 20 )
 !
-  825 CONTINUE 
+  825 CONTINUE
       WRITE (MDSS,1025) NDST2
       CALL EXTCDE ( 25 )
 !
@@ -330,7 +330,7 @@
 !
  1020 FORMAT (/' *** WAVEWATCH-III ERROR IN W3SBS1 : '/               &
                '     ERROR IN OPENING TIMES FILE'/                    &
-               '     IOSTAT =',I5/) 
+               '     IOSTAT =',I5/)
 !
  1025 FORMAT (/' *** WAVEWATCH-III ERROR IN W3SBS1 : '/               &
                '     WIND FILE NOT FOUND, NDST2 =  ',I8/)
@@ -357,7 +357,7 @@
 !/
 !  1. Purpose :
 !
-!     Internal subroutine to get next time in time file, including 
+!     Internal subroutine to get next time in time file, including
 !     waiting until the file is there.
 !
 !  3. Parameters :
@@ -545,7 +545,7 @@
 !
 ! Escape locations read errors --------------------------------------- *
 !
-  800 CONTINUE 
+  800 CONTINUE
       WRITE (MDSS,1010)
       CALL EXTCDE ( 10 )
 !

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -35,13 +35,13 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    29-Oct-2010 : Implement unstructured grids        ( version 3.14.4 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    23-Nov-2011 : Comments clean up                   ( version 4.04 )
 !/    06-Mar-2012 : Repairing test output.              ( version 4.07 )
 !/    03-Sep-2012 : Output initialization time.         ( version 4.10 )
 !/    27-Sep-2012 : Implement use of tidal constituents ( version 4.08 )
 !/    04-Feb-2014 : Switched clock to DATE_AND_TIME     ( version 4.18 )
-!/                  (A. Chawla and Mark Szyszka)      
+!/                  (A. Chawla and Mark Szyszka)
 !/    23-Apr-2015 : Adding NCEP Coupler                 ( version 5.06 )
 !/                  (A. Chawla and Dmitry Sheinin)
 !/    24-Apr-2015 : Adding OASIS coupling calls         ( version 5.07 )
@@ -54,7 +54,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -130,7 +130,7 @@
 !      W3FLDH    Subr.   Id.    Udates homogeneous fields.
 !
 !      W3INIT    Subr. W3INITMD Wave model initialization.
-!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags. 
+!      W3READFLGRD Subr. W3IOGOMD Reading output fields flags.
 !      W3WAVE    Subr. W3WAVEMD Wave model.
 !      W3WDAS    Subr. W3WDASMD Data assimilation interface.
 !
@@ -158,9 +158,9 @@
 !       (in case of homogeneous input field),  grabs field value at next
 !       input time, which may in fact be far in the future from current
 !       compute time. Example: user says
-!       field=1   on 19680101 000000 and 
-!       field=100 on 20160101 000000 
-!       then on if 7.a.2 is reached on 19680101 010000, WW3 will set 
+!       field=1   on 19680101 000000 and
+!       field=100 on 20160101 000000
+!       then on if 7.a.2 is reached on 19680101 010000, WW3 will set
 !       field to 100.
 !
 !  8. Structure :
@@ -296,7 +296,7 @@
                              STARTDATE(8), STOPDATE(8), IHH(-7:8)
 !/OASIS      INTEGER             :: OASISED
 !/COU      INTEGER             :: OFL
-!/F90      INTEGER             :: CLKDT1(8), CLKDT2(8), CLKDT3(8) 
+!/F90      INTEGER             :: CLKDT1(8), CLKDT2(8), CLKDT3(8)
 !/MPI      INTEGER             :: IERR_MPI
 !
       REAL                :: FACTOR, DTTST, XX, YY,                    &
@@ -330,8 +330,8 @@
                              FLAGSTIDE(4), FLH(-7:8), FLGDAS(3),       &
                              FLLST_ALL(-7:8)
       LOGICAL             :: DEBUG_NCC = .FALSE.
-!/NCC      LOGICAL             :: CFLAG(10) 
-!/OASIS      LOGICAL             :: L_MASTER    
+!/NCC      LOGICAL             :: CFLAG(10)
+!/OASIS      LOGICAL             :: L_MASTER
 !
 !/
 !/ ------------------------------------------------------------------- /
@@ -356,12 +356,12 @@
                     'MVS', 'LEV', 'CUR', 'WND', 'ICE', 'DT0', 'DT1',  &
                     'DT2', 'MOV' /
 !
-      FLGR2 = .FALSE.  
+      FLGR2 = .FALSE.
       FLAGSTIDE(:) = .FALSE.
       FLH(:)       = .FALSE.
 !
 !/T      PRTFRM = .TRUE.
-!/T      DEBUG_NCC = .TRUE. 
+!/T      DEBUG_NCC = .TRUE.
 !
 !/F90      CALL DATE_AND_TIME ( VALUES=CLKDT1 )
 !
@@ -370,7 +370,7 @@
 !
 !/OASIS     OASISED=1
 !/PDLIB     LPDLIB = .TRUE.
-!  
+!
       CALL W3NMOD ( 1, 6, 6 )
       CALL W3NDAT (    6, 6 )
       CALL W3NAUX (    6, 6 )
@@ -527,7 +527,7 @@
 !
 ! 1.c Local parameters
 !
-! inferred from context: these flags (FL) are to indicate that the last (LST) 
+! inferred from context: these flags (FL) are to indicate that the last (LST)
 !   field has been read from a file.
       FLLSTL = .FALSE. ! This is associated with J.EQ.1 (wlev)
       FLLSTI = .FALSE. ! This is associated with J.EQ.4 (ice)
@@ -563,7 +563,7 @@
 !
 ! process ww3_prnc namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_shel.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_shel.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         ! Read namelist
         CALL W3NMLSHEL (MPI_COMM, NDSI, TRIM(FNMPRE)//'ww3_shel.nml',  &
@@ -642,30 +642,30 @@
         IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,920)
         DO J=JFIRST, 7
           IF ( J .LE. 4 ) THEN
-            IF (FLAGTFC(J).EQ.'T') THEN 
+            IF (FLAGTFC(J).EQ.'T') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'F') THEN 
+            IF (FLAGTFC(J).EQ.'F') THEN
               INFLAGS1(J)=.FALSE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'C') THEN 
+            IF (FLAGTFC(J).EQ.'C') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.TRUE.
             END IF
             FLH(J) = FLH(J) .AND. INFLAGS1(J)
           ELSE
             FLH(J) = .FALSE.
-            IF (FLAGTFC(J).EQ.'T') THEN 
+            IF (FLAGTFC(J).EQ.'T') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'F') THEN 
+            IF (FLAGTFC(J).EQ.'F') THEN
               INFLAGS1(J)=.FALSE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'C') THEN 
+            IF (FLAGTFC(J).EQ.'C') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.TRUE.
             END IF
@@ -824,7 +824,7 @@
                   IF ( ILOOP .EQ. 2 ) THEN
                     X(IPTS)      = XX
                     Y(IPTS)      = YY
-                    PNAMES(IPTS) = PN 
+                    PNAMES(IPTS) = PN
                     IF ( IAPROC .EQ. NAPOUT ) THEN
                       IF ( FLAGLL ) THEN
                         IF ( IPTS .EQ. 1 ) THEN
@@ -845,7 +845,7 @@
                       END IF
                     END IF
                   END IF ! ILOOP.EQ.2
-                END DO ! end of file                      
+                END DO ! end of file
               END DO ! ILOOP
               CLOSE(NDSL)
 
@@ -1048,30 +1048,30 @@
         IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,920)
         DO J=JFIRST, 7
           IF ( J .LT. 4 ) THEN
-            IF (FLAGTFC(J).EQ.'T') THEN 
+            IF (FLAGTFC(J).EQ.'T') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'F') THEN 
+            IF (FLAGTFC(J).EQ.'F') THEN
               INFLAGS1(J)=.FALSE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'C') THEN 
+            IF (FLAGTFC(J).EQ.'C') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.TRUE.
             END IF
             FLH(J) = FLH(J) .AND. INFLAGS1(J)
           ELSE
             FLH(J) = .FALSE.
-            IF (FLAGTFC(J).EQ.'T') THEN 
+            IF (FLAGTFC(J).EQ.'T') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'F') THEN 
+            IF (FLAGTFC(J).EQ.'F') THEN
               INFLAGS1(J)=.FALSE.
               FLAGSC(J)=.FALSE.
             END IF
-            IF (FLAGTFC(J).EQ.'C') THEN 
+            IF (FLAGTFC(J).EQ.'C') THEN
               INFLAGS1(J)=.TRUE.
               FLAGSC(J)=.TRUE.
             END IF
@@ -1218,7 +1218,7 @@
                       ALLOCATE ( X(NPTS), Y(NPTS), PNAMES(NPTS) )
                     ELSE
                       ALLOCATE ( X(1), Y(1), PNAMES(1) )
-                      GOTO 2054 
+                      GOTO 2054
                     END IF
                   END IF
                 END IF
@@ -1460,7 +1460,7 @@
 !
 
         DO J=JFIRST, 4
-!/DEBUGINIT     write(740+IAPROC,*), 'J=',J,'INFLAGS1(J)=',INFLAGS1(J), 'FLAGSC(J)=', FLAGSC(J) 
+!/DEBUGINIT     write(740+IAPROC,*), 'J=',J,'INFLAGS1(J)=',INFLAGS1(J), 'FLAGSC(J)=', FLAGSC(J)
           IF ( INFLAGS1(J) .AND. .NOT. FLAGSC(J)) THEN
             IF ( FLH(J) ) THEN
               IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,954) IDFLDS(J)
@@ -1615,12 +1615,12 @@
 
       IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,951) 'Wave model ...'
 !
-!/TIDE      IF (FLAGSTIDE(1).OR.FLAGSTIDE(2)) THEN 
+!/TIDE      IF (FLAGSTIDE(1).OR.FLAGSTIDE(2)) THEN
 !/TIDE        CALL VUF_SET_PARAMETERS
 !/TIDE        IF (FLAGSTIDE(1)) CALL W3FLDTIDE1 ( 'READ',  NDSF(1), NDST, NDSEN, NX, NY, IDSTR(1), IERR )
 !/TIDE        IF (FLAGSTIDE(2)) CALL W3FLDTIDE1 ( 'READ',  NDSF(2), NDST, NDSEN, NX, NY, IDSTR(2), IERR )
 !/TIDE      END IF
-! 
+!
      CALL W3INIT ( 1, .FALSE., 'ww3', NDS, NTRACE, ODAT, FLGRD, FLGR2, FLGD,    &
                    FLG2, NPTS, X, Y, PNAMES, IPRT, PRTFRM, MPI_COMM,   &
                    FLAGSTIDEIN=FLAGSTIDE )
@@ -1661,7 +1661,7 @@
 !/OASIS        L_MASTER = .TRUE.
 !/OASIS      ELSE
 !/OASIS        L_MASTER = .FALSE.
-!/OASIS      ENDIF 
+!/OASIS      ENDIF
 !/OASIS ! Estimate the weights for the spatial interpolation
 !/OASIS      IF (DTOUT(7).NE.0) THEN
 !/OASIS        CALL CPL_OASIS_GRID(L_MASTER,MPI_COMM)
@@ -1702,7 +1702,7 @@
 !
       IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,970)
 !
-!/NCC      CFLAG = .FALSE. 
+!/NCC      CFLAG = .FALSE.
 !/NCC      CALL WW_INIT(1,GRIDS(1)%NX,GRIDS(1)%NY,            &
 !/NCC      GRIDS(1)%X0,GRIDS(1)%Y0,GRIDS(1)%SX,GRIDS(1)%SY)
 !/NCC      CALL WW_RECVDTC
@@ -1767,7 +1767,7 @@
 !
 ! 7.a.2 Check if update is needed
 !
-          IF (.NOT.FLAGSC(J)) THEN 
+          IF (.NOT.FLAGSC(J)) THEN
             TTT(1) = TFN(1,J)
             TTT(2) = TFN(2,J)
             IF ( TTT(1) .EQ. -1 ) THEN
@@ -1775,7 +1775,7 @@
             ELSE
               DTTST  = DSEC21 ( TIME0 , TTT )
             END IF
-!/OASIS          ELSE 
+!/OASIS          ELSE
 !/OASIS            ID_OASIS_TIME = DSEC21 ( TIME00 , TIME )
 !/OASIS            IF ( (DTOUT(7).NE.0) .AND.                               &
 !/OASIS                 (MOD(ID_OASIS_TIME/DTOUT(7),1.0) .LT. 1.E-7 ) .AND. &
@@ -1788,7 +1788,7 @@
 !
           IF ( DTTST .LE. 0. ) THEN
 
-!/TIDE            IF ((FLLEVTIDE .AND.(J.EQ.1)).OR.(FLCURTIDE.AND.(J.EQ.2))) THEN 
+!/TIDE            IF ((FLLEVTIDE .AND.(J.EQ.1)).OR.(FLCURTIDE.AND.(J.EQ.2))) THEN
 !/TIDE              IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,974) IDFLDS(J)
 !/TIDE            ELSE
             IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,972) IDFLDS(J)
@@ -1923,11 +1923,11 @@
                              TIME0, TIMEN, NH(J), NHMAX, THO, HA, HD, HS,&
                              TTT, XXX, XXX, XXX, TLN, XXX, XXX, WLEV, IERR)
               ELSE
-!/TIDE                IF ( FLLEVTIDE ) THEN 
+!/TIDE                IF ( FLLEVTIDE ) THEN
 !/TIDE                  IERR=0
-!/TIDE                  IF ( TLN(1) .EQ. -1 ) THEN 
-!/TIDE                    TLN = TIME 
-!/TIDE                  ELSE 
+!/TIDE                  IF ( TLN(1) .EQ. -1 ) THEN
+!/TIDE                    TLN = TIME
+!/TIDE                  ELSE
 !/TIDE                    CALL TICK21 ( TLN, TIDE_DT )
 !/TIDE                  END IF
 !/TIDE                ELSE
@@ -1951,20 +1951,20 @@
                              TIME0, TIMEN, NH(J), NHMAX, THO, HA, HD, HS,&
                              TC0, CX0, CY0, XXX, TCN, CXN, CYN, XXX, IERR)
 !
-!/SMC !!Li  Reshape the CX0/N CY0/N space for sea-point only current. 
-!/SMC !!Li              JGLi26Jun2018. 
+!/SMC !!Li  Reshape the CX0/N CY0/N space for sea-point only current.
+!/SMC !!Li              JGLi26Jun2018.
 !/SMC              ELSE IF( FSWND ) THEN
 !/SMC                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J), NDST,    &
 !/SMC                      NDSEN, NSEA, 1, NSEA, 1, TIME0, TIMEN, TC0, &
-!/SMC                      CX0, CY0, XXX, TCN, CXN, CYN, XXX, IERR) 
-!/SMC !!Li  
+!/SMC                      CX0, CY0, XXX, TCN, CXN, CYN, XXX, IERR)
+!/SMC !!Li
               ELSE
-!/TIDE                IF ( FLCURTIDE ) THEN 
+!/TIDE                IF ( FLCURTIDE ) THEN
 !/TIDE                  IERR=0
-!/TIDE                  IF ( TCN(1) .EQ. -1 ) THEN 
-!/TIDE                    TCN = TIME 
+!/TIDE                  IF ( TCN(1) .EQ. -1 ) THEN
+!/TIDE                    TCN = TIME
 !/TIDE                  END IF
-!/TIDE                  TC0(:) = TCN(:)               
+!/TIDE                  TC0(:) = TCN(:)
 !/TIDE                  CALL TICK21 ( TCN, TIDE_DT )
 !/TIDE                ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
@@ -1985,13 +1985,13 @@
                              TIME0, TIMEN, NH(J), NHMAX, THO, HA, HD, HS,&
                              TW0, WX0, WY0, DT0, TWN, WXN, WYN, DTN, IERR)
 !
-!/SMC !!Li  Reshape the WX0/N WY0/N space for sea-point only wind. 
-!/SMC !!Li              JGLi26Jun2018. 
+!/SMC !!Li  Reshape the WX0/N WY0/N space for sea-point only wind.
+!/SMC !!Li              JGLi26Jun2018.
 !/SMC              ELSE IF( FSWND ) THEN
 !/SMC                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J), NDST,    &
 !/SMC                      NDSEN, NSEA, 1, NSEA, 1, TIME0, TIMEN, TW0, &
-!/SMC                      WX0, WY0, DT0, TWN, WXN, WYN, DTN, IERR)  
-!/SMC !!Li  
+!/SMC                      WX0, WY0, DT0, TWN, WXN, WYN, DTN, IERR)
+!/SMC !!Li
               ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASACM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
@@ -2099,7 +2099,7 @@
 !
             IF ( IERR.GT.0 ) GOTO 2222
             IF ( IERR.LT.0 .AND. IAPROC.EQ.NAPOUT ) WRITE (NDSO,973) IDFLDS(J)
-                           
+
 
           END IF ! DTTST .LE. 0.
 !
@@ -2120,8 +2120,8 @@
                      (FLLST_ALL(J) .AND. J.EQ.0 ) .OR.            &
                      (FLLSTI .AND. J.EQ.4) ) ) THEN
               TTIME  = TTT
-! notes: if model has run out beyond field input, then this line should not 
-!    be reached. 
+! notes: if model has run out beyond field input, then this line should not
+!    be reached.
             END IF
           END IF
 !
@@ -2178,10 +2178,10 @@
 !/MEMCHECK      call getMallocInfo(mallinfos)
 !/MEMCHECK      call printMallInfo(IAPROC,mallInfos)
 !
-      ! The following lines prevents us from trying to read past the end 
+      ! The following lines prevents us from trying to read past the end
       ! of the files. This feature existed in v3.14.
       ! "1" is for water levels
-      ! "4" is for ice concentration: 
+      ! "4" is for ice concentration:
       IF ( FLLSTL ) INFLAGS1(1) = .FALSE.
       IF ( FLLSTI ) INFLAGS1(4) = .FALSE.
 
@@ -2212,7 +2212,7 @@
 
         IF ( DTTST .EQ. 0. ) THEN
           IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,*) ' '
-          CALL W3WAVE ( 1, TIME0                                       & 
+          CALL W3WAVE ( 1, TIME0                                       &
 !/OASIS                       , .TRUE., .FALSE., MPI_COMM              &
                       )
         END IF

--- a/model/ftn/ww3_strt.ftn
+++ b/model/ftn/ww3_strt.ftn
@@ -24,7 +24,7 @@
 !/    30-Oct-2009 : Implement curvilinear grid type.    ( version 3.14 )
 !/                  (W. E. Rogers & T. J. Campbell, NRL)
 !/    31-Oct-2010 : Implement unstructured grid         ( version 3.14 )
-!/                  (A. Roland and F. Ardhuin) 
+!/                  (A. Roland and F. Ardhuin)
 !/    05-Jul-2011 : Revert to X-Y gaussian shape        ( version 4.01 )
 !/    06-Mar-2012 : Hardening output.                   ( version 4.07 )
 !/    06-Jun-2018 : Add DEBUGINIT/EXPORTWWM             ( version 6.04 )
@@ -32,7 +32,7 @@
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -118,16 +118,16 @@
 !     - While reading the restart file W3IORS will recognize the
 !       need for checking the time, as the restart file contains
 !       information on the origine of the file ("cold" or "hot").
-!     - User input for x-wise gaussian spread control, SIX, is 
-!       now available again (option for SIX.NE.SIY available.) 
-!       If user desires a distribution that is circular in real 
+!     - User input for x-wise gaussian spread control, SIX, is
+!       now available again (option for SIX.NE.SIY available.)
+!       If user desires a distribution that is circular in real
 !       distances, user should input a negative number for SIX.
 !
 !  8. Structure :
 !
 !     ----------------------------------------------------
 !        1.a  Set up data structures.
-!                            ( W3NMOD , W3NDAT , W3NOUT 
+!                            ( W3NMOD , W3NDAT , W3NOUT
 !                              W3SETG , W3SETW , W3SETO )
 !          b  I-O setup.
 !          b  Print heading(s).
@@ -458,7 +458,7 @@
 !
 !/DIST            ISEA   = IAPROC + (JSEA-1)*NAPROC
 !/SHRD            ISEA   = JSEA
-            IF (GTYPE .EQ. UNGTYPE) THEN 
+            IF (GTYPE .EQ. UNGTYPE) THEN
                IX     = MAPSF(ISEA,1)
                X      = XYB(IX,1)
                Y      = XYB(IX,2)
@@ -625,7 +625,7 @@
 !
 !/DIST            ISEA   = IAPROC + (JSEA-1)*NAPROC
 !/SHRD            ISEA   = JSEA
-            IF (GTYPE .EQ. UNGTYPE) THEN 
+            IF (GTYPE .EQ. UNGTYPE) THEN
                IX     = MAPSF(ISEA,1)
                X      = XYB(IX,1)
                Y      = XYB(IX,2)
@@ -810,7 +810,7 @@
   901 FORMAT ( '  Comment character is ''',A,''''/)
   902 FORMAT ( '  Grid name : ',A/)
   903 FORMAT ( '  Negative SIX was provided by user.         '/       &
-               '  WW3 will create a gaussian distribution    '/       &         
+               '  WW3 will create a gaussian distribution    '/       &
                '  that is circular in real space. ')
 !
   930 FORMAT (/'  Initial field ITYPE =',I2/                          &

--- a/model/ftn/ww3_systrk.ftn
+++ b/model/ftn/ww3_systrk.ftn
@@ -26,7 +26,7 @@
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
       USE W3STRKMD
@@ -37,14 +37,14 @@
 !
 !  1. Purpose :
 !
-!     Perform spatial and temporal tracking of wave systems, based 
+!     Perform spatial and temporal tracking of wave systems, based
 !     on spectral partition (bulletin) output.
 !
 !  2. Method :
 !
-!     This is a controller program. It reads the input parameter file 
-!     ww3_systrk.inp and calls subroutine waveTracking_NWS_V2 to 
-!     perform the actual tracking procedure. Write output (fields and 
+!     This is a controller program. It reads the input parameter file
+!     ww3_systrk.inp and calls subroutine waveTracking_NWS_V2 to
+!     perform the actual tracking procedure. Write output (fields and
 !     point output).
 !
 !  3. Parameters :
@@ -103,7 +103,7 @@
               BL_latprt,BR_latprt,TR_latprt,TL_latprt
       REAL :: t, u, BL_W, BR_W, TR_W, TL_W
       REAL      :: PI
-      PARAMETER  (PI = 3.1416) 
+      PARAMETER  (PI = 3.1416)
 !
 !  4. Subroutines used :
 !
@@ -133,7 +133,7 @@
 !
 !/MPI/!     Start of parallel region
 !/MPI      CALL MPI_INIT(ierr)
-!/MPI    
+!/MPI
 !/MPI      CALL MPI_COMM_RANK(MPI_COMM_WORLD, rank, ierr)
 !/MPI      CALL MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierr)
 !/MPI
@@ -200,7 +200,7 @@
 !/TRKNC     outputCheck1 = .FALSE.
          IF(outputCheck1)  THEN
             WRITE(6,993)
-            STOP 
+            STOP
          END IF
       ELSEIF (outputType.EQ.4) THEN
          !NetCDF 4 - requrires !/TRKNC and !/NC4 switch
@@ -237,7 +237,7 @@
          READ(10,'(A72)') inpstr
       END DO
       BACKSPACE(10)
-      READ(10,*) dirKnob, perKnob, hsKnob, wetPts, & 
+      READ(10,*) dirKnob, perKnob, hsKnob, wetPts, &
                 dirTimeKnob, tpTimeKnob
 
       READ(10,'(A72)') inpstr
@@ -260,7 +260,7 @@
          IF ((lonout(noutp).EQ.0.).AND.(latout(noutp).EQ.0.)) EXIT
          noutp = noutp + 1
       END DO
-      noutp = noutp - 1 
+      noutp = noutp - 1
 
       CLOSE(10)
 
@@ -271,9 +271,9 @@
       WRITE(20,'(A,2F7.2)') 'Domain limits: Longitude =',minlon, maxlon
       WRITE(20,'(A,2F7.2)') '               Latitude  =',minlat, maxlat
       WRITE(20,*) 'No. increments: Long, Lat  =',mxcwt, mycwt
-      WRITE(20,*) 'dirKnob, perKnob, hsKnob, wetPts, & 
+      WRITE(20,*) 'dirKnob, perKnob, hsKnob, wetPts, &
                 dirTimeKnob, tpTimeKnob, seedLat, seedLon ='
-      WRITE(20,'(8F6.2)') dirKnob, perKnob, hsKnob, wetPts, & 
+      WRITE(20,'(8F6.2)') dirKnob, perKnob, hsKnob, wetPts, &
                 dirTimeKnob, tpTimeKnob, seedLat, seedLon
       WRITE(20,*) 'No. output points =',noutp
       DO i = 1,noutp
@@ -292,7 +292,7 @@
 
 !/MPI      END IF
 
-!/MPI/!     MPI communication block 
+!/MPI/!     MPI communication block
 !/MPI      CALL MPI_BCAST(filename,80,MPI_CHARACTER,0,MPI_COMM_WORLD,IERR)
 !/MPI      CALL MPI_BCAST(tstart,1,MPI_DOUBLE_PRECISION,0, &
 !/MPI                     MPI_COMM_WORLD,IERR)
@@ -324,7 +324,7 @@
                                 tcur       ,filename   , &
                                 tstart     ,tend       , &
                                 dt         ,ntint      , &
-                                minlon     ,maxlon     , & 
+                                minlon     ,maxlon     , &
                                 minlat     ,maxlat     , &
                                 mxcwt      ,mycwt      , &
                                 dirKnob    ,             &
@@ -396,12 +396,12 @@
 !/TRKNC      ENDIF
 
       DO it = 1,SIZE(sysA)
-!        Loop through identified groups, limiting the output in file to ulimGroup    
+!        Loop through identified groups, limiting the output in file to ulimGroup
          IF(outputType == 1) THEN
             WRITE(22,'(F15.6,60x,A)') wsdat(it)%date,'Time'
             WRITE(22,'(I6,69x,A)') MIN(ulimGroup,maxGroup), &
                'Tot number of systems'
-         ENDIF 
+         ENDIF
          DO igrp = 1,MIN(ulimGroup,maxGroup)
             dum(1:maxI,1:maxJ) = 9999.00
 !           Find system with this group tag
@@ -421,9 +421,9 @@
             ELSE
                leng = 0
             END IF
-            
+
       IF(outputType == 1) THEN
-            WRITE(22,'(I6,69x,A)') igrp,'System number'  
+            WRITE(22,'(I6,69x,A)') igrp,'System number'
             WRITE(22,'(I6,69x,A)') leng,'Number of points in system'
 
             DO J = maxJ,1,-1
@@ -442,7 +442,7 @@
 
          END DO
       END DO
-        
+
 !/TRKNC      IF(outputType == 3 .OR. outputType == 4 ) THEN
 !/TRKNC      call t2netcdf(longitude_nc,latitude_nc,dum2nc,maxI,maxJ,&
 !/TRKNC         maxGroup,date1,date2,dt,NTIME_NC,1,outputType)
@@ -464,7 +464,7 @@
             WRITE(23,'(F15.6,60x,A)') wsdat(it)%date,'Time'
             WRITE(23,'(I6,69X,A)') MIN(ulimGroup,maxGroup), &
                'Tot number of systems'
-         ENDIF 
+         ENDIF
          DO igrp = 1,MIN(ulimGroup,maxGroup)
             dum(1:maxI,1:maxJ) = 9999.00
 !           Find system with this group tag
@@ -484,9 +484,9 @@
             ELSE
                leng = 0
             END IF
-            
+
       IF(outputType == 1) THEN
-            WRITE(23,'(I6,69X,A)') igrp,'System number'  
+            WRITE(23,'(I6,69X,A)') igrp,'System number'
             WRITE(23,'(I6,69X,A)') leng,'Number of points in system'
             DO J = maxJ,1,-1
                DO i = 1,maxI
@@ -528,7 +528,7 @@
              WRITE(24,'(F15.6,60x,A)') wsdat(it)%date,'Time'
              WRITE(24,'(I6,69X,A)') MIN(ulimGroup,maxGroup), &
                'Tot number of systems'
-         ENDIF 
+         ENDIF
          DO igrp = 1,MIN(ulimGroup,maxGroup)
             dum(1:maxI,1:maxJ) = 9999.00
 !           Find system with this group tag
@@ -542,15 +542,15 @@
                leng = sysA(it)%sys(sysmatch)%nPoints
                DO ind = 1, leng
                   dum(sysA(it)%sys(sysmatch)%i(ind), &
-                      sysA(it)%sys(sysmatch)%j(ind)) = & 
+                      sysA(it)%sys(sysmatch)%j(ind)) = &
                       sysA(it)%sys(sysmatch)%dir(ind)
                END DO
             ELSE
                leng = 0
             END IF
-            
+
       IF(outputType == 1) THEN
-            WRITE(24,'(I6,69X,A)') igrp,'System number'  
+            WRITE(24,'(I6,69X,A)') igrp,'System number'
             WRITE(24,'(I6,69X,A)') leng,'Number of points in system'
             DO J = maxJ,1,-1
                DO i = 1,maxI
@@ -603,15 +603,15 @@
                leng = sysA(it)%sys(sysmatch)%nPoints
                DO ind = 1, leng
                   dum(sysA(it)%sys(sysmatch)%i(ind), &
-                      sysA(it)%sys(sysmatch)%j(ind)) = & 
+                      sysA(it)%sys(sysmatch)%j(ind)) = &
                       sysA(it)%sys(sysmatch)%dspr(ind)
                END DO
             ELSE
                leng = 0
             END IF
-            
+
       IF(outputType == 1) THEN
-            WRITE(25,'(I6,69X,A)') igrp,'System number'  
+            WRITE(25,'(I6,69X,A)') igrp,'System number'
             WRITE(25,'(I6,69X,A)') leng,'Number of points in system'
             DO J = maxJ,1,-1
                DO i = 1,maxI
@@ -663,7 +663,7 @@
            'TpSY09        TpSY10        ', &
            'DrSY01        DrSY02        DrSY03        DrSY04        ', &
            'DrSY05        DrSY06        DrSY07        DrSY08        ', &
-           'DrSY09        DrSY10'   
+           'DrSY09        DrSY10'
       WRITE(26,'(10A)') '%       [degr]        [degr]        ', &
            '[m]           [m]           [m]           [m]           ', &
            '[m]           [m]           [m]           [m]           ', &
@@ -833,11 +833,11 @@
                       tpprt(igrp) = 999.9999
                       dirprt(igrp) = 999.9999
                    END IF
-               END IF  
+               END IF
             END DO
       IF(outputType == 1) THEN
             WRITE(26,'(32F14.4)') lonprt,latprt, &
-                       hsprt(1:10),tpprt(1:10),dirprt(1:10)  
+                       hsprt(1:10),tpprt(1:10),dirprt(1:10)
         ENDIF
 !/TRKNC      IF(outputType.EQ.3.OR.outputType.EQ.4) THEN
 !/TRKNC        lonprt_nc(ip)=lonprt
@@ -874,7 +874,7 @@
            'TpSY09        TpSY10        ', &
            'DrSY01        DrSY02        DrSY03        DrSY04        ', &
            'DrSY05        DrSY06        DrSY07        DrSY08        ', &
-           'DrSY09        DrSY10'   
+           'DrSY09        DrSY10'
       WRITE(28,'(10A)') '%       [degr]        [degr]        ', &
            '[m]           [m]           [m]           [m]           ', &
            '[m]           [m]           [m]           [m]           ', &
@@ -941,10 +941,10 @@
                          dirprt(igrp) = sysA(it)%sys(sysmatch)%dir(ind)
                    END IF
                  END DO
-               END IF  
+               END IF
             END DO
             WRITE(28,'(32F14.4)') lonprt,latprt, &
-                       hsprt(1:10),tpprt(1:10),dirprt(1:10)  
+                       hsprt(1:10),tpprt(1:10),dirprt(1:10)
          END DO
       END DO
 
@@ -1063,7 +1063,7 @@
 !/TRKNC      Jday0=julday(1,1,1990)
 !/TRKNC      timenc=timenc-Jday0
 !/TRKNC      do rec=1,ntime
-!/TRKNC       times(rec)=timenc+DBLE( (rec-1)*dt)/3600.0D0/24.0D0 
+!/TRKNC       times(rec)=timenc+DBLE( (rec-1)*dt)/3600.0D0/24.0D0
 !/TRKNC      enddo
 !/TRKNC      if( ivar == 1) then
 !/TRKNC       file_name = "sys_hs.ww3.nc"
@@ -1075,7 +1075,7 @@
 !/TRKNC      file_name = "sys_dspr.ww3.nc"
 !/TRKNC      endif
 !
-!/TRKNC! create the netcdf file. 
+!/TRKNC! create the netcdf file.
 !/TRKNC      if (outputType.EQ.3) then
 !/TRKNC      call check( nf90_create(file_name, NF90_CLOBBER, ncid) )
 !/TRKNC      endif
@@ -1100,7 +1100,7 @@
 !/TRKNC      call check( nf90_put_att(ncid, lon_varid, 'long_name', 'longitude') )
 !/TRKNC      call check( nf90_put_att(ncid, lon_varid, 'standard_name', 'longitude') )
 !/TRKNC      call check( nf90_put_att(ncid, lon_varid, 'axis','X'))
-!/TRKNC      call check(nf90_put_att(ncid,rec_varid,units,& 
+!/TRKNC      call check(nf90_put_att(ncid,rec_varid,units,&
 !/TRKNC                  'days since 1990-01-01 00:00:00'))
 !/TRKNC      call check(nf90_put_att(ncid,rec_varid,'long_name','julian day (UT)'))
 !/TRKNC      call check( nf90_put_att(ncid, rec_varid,'standard_name', 'time') )
@@ -1135,11 +1135,11 @@
 !/TRKNC      call check( nf90_put_att(ncid, var4_varid,'missing_value','9999.00') )
 !/TRKNC      endif
 !/TRKNC      call check( nf90_enddef(ncid) )
-!  
+!
 !/TRKNC      call check( nf90_put_var(ncid, lat_varid, lats) )
 !/TRKNC      call check( nf90_put_var(ncid, lon_varid, lons) )
 !/TRKNC      call check( nf90_put_var(ncid, rec_varid, times) )
-!  
+!
 !/TRKNC      count = (/ nlons, nlats, nsys, ntime /)
 !/TRKNC      start = (/ 1, 1, 1, 1 /)
 !/TRKNC      if( ivar == 1) then
@@ -1161,14 +1161,14 @@
 !/TRKNC      subroutine check(status)
 !/TRKNC      use netcdf
 !/TRKNC      integer, intent ( in) :: status
-!/TRKNC      if(status /= nf90_noerr) then 
+!/TRKNC      if(status /= nf90_noerr) then
 !/TRKNC        write(6,996)
 !/TRKNC          996 FORMAT (/' *** WAVEWATCH III ERROR IN WW3_SYSTRK:'/           &
 !/TRKNC                       'netCDF error:')
 !/TRKNC        print *, trim(nf90_strerror(status))
 !/TRKNC        stop "Stopped in netcdf output part"
 !/TRKNC      endif
-!/TRKNC      end subroutine check  
+!/TRKNC      end subroutine check
 !
 !/TRKNC      subroutine pt2netcdf(longitude,latitude,hs,tp,&
 !/TRKNC       dir,npoints,date1,date2,dt,ntime,outputType)
@@ -1222,7 +1222,7 @@
 !/TRKNC      Jday0=julday(1,1,1990)
 !/TRKNC      timenc=timenc-Jday0
 !/TRKNC      do rec=1,ntime
-!/TRKNC       times(rec)=timenc+DBLE( (rec-1)*dt)/3600.0D0/24.0D0 
+!/TRKNC       times(rec)=timenc+DBLE( (rec-1)*dt)/3600.0D0/24.0D0
 !/TRKNC      enddo
 !
 !/TRKNC      if(outputType.EQ.3) then
@@ -1230,7 +1230,7 @@
 !/TRKNC      endif
 !/TRKNC      if (outputType.EQ.4) iret = nf90_create('sys_pnt.ww3.nc',NF90_NETCDF4, ncid)
 !/TRKNC      call check(iret)
-!/TRKNC      iret = nf90_set_fill(ncid,nf90_nofill,oldMode) 
+!/TRKNC      iret = nf90_set_fill(ncid,nf90_nofill,oldMode)
 !/TRKNC      call check(iret)
 !/TRKNC! define dimensions
 !/TRKNC      iret = nf90_def_dim(ncid, 'system_index', nsys, system_index_dim)
@@ -1269,7 +1269,7 @@
 !/TRKNC      dir_dims(3) = rec_dim
 !/TRKNC      dir_dims(2) = point_dim
 !/TRKNC      dir_dims(1) = system_index_dim
-!/TRKNC      iret = nf90_def_var(ncid, 'dir', NF90_REAL, & 
+!/TRKNC      iret = nf90_def_var(ncid, 'dir', NF90_REAL, &
 !/TRKNC        dir_dims, dir_id)
 !/TRKNC      call check(iret)
 !/NC4        call check( nf90_def_var_deflate(ncid,dir_id,1,1,deflate))
@@ -1306,7 +1306,7 @@
 !/TRKNC      call check(iret)
 !/TRKNC      iret = nf90_put_att(ncid, hs_id,'long_name','significant_wave_height')
 !/TRKNC      call check(iret)
-!/TRKNC      iret = nf90_put_att(ncid, hs_id, 'missing_value', & 
+!/TRKNC      iret = nf90_put_att(ncid, hs_id, 'missing_value', &
 !/TRKNC        '999.9999')
 !/TRKNC      call check(iret)
 !/TRKNC      iret = nf90_put_att(ncid, tp_id, 'units', 's')
@@ -1320,7 +1320,7 @@
 !/TRKNC      call check(iret)
 !/TRKNC      iret = nf90_put_att(ncid, dir_id,'long_name','peak_direction')
 !/TRKNC      call check(iret)
-!/TRKNC      iret = nf90_put_att(ncid, dir_id, 'missing_value',& 
+!/TRKNC      iret = nf90_put_att(ncid, dir_id, 'missing_value',&
 !/TRKNC         '999.9999')
 !/TRKNC      call check(iret)
 !/TRKNC! leave define mode
@@ -1331,10 +1331,10 @@
 !
 !/TRKNC      iret = nf90_put_var(ncid, longitude_id, longitude)
 !/TRKNC      call check(iret)
-! 
+!
 !/TRKNC      iret = nf90_put_var(ncid, time_id, times)
 !/TRKNC      call check(iret)
-! 
+!
 !/TRKNC      start = (/ 1, 1, 1 /)
 !/TRKNC      count = (/ nsys,npoints,ntime /)
 !

--- a/model/ftn/ww3_trck.ftn
+++ b/model/ftn/ww3_trck.ftn
@@ -21,7 +21,7 @@
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :

--- a/model/ftn/ww3_trnc.ftn
+++ b/model/ftn/ww3_trnc.ftn
@@ -15,7 +15,7 @@
 !/
 !/    Copyright 2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
-!/       reserved.  WAVEWATCH III is a trademark of the NWS. 
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
 !/       No unauthorized use without permission.
 !/
 !  1. Purpose :
@@ -139,7 +139,7 @@
 !
 ! process ww3_trnc namelist
 !
-      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_trnc.nml", EXIST=FLGNML) 
+      INQUIRE(FILE=TRIM(FNMPRE)//"ww3_trnc.nml", EXIST=FLGNML)
       IF (FLGNML) THEN
         ! Read namelist
         CALL W3NMLTRNC (NDSI, TRIM(FNMPRE)//'ww3_trnc.nml', NML_TRACK, NML_FILE, IERR)
@@ -311,7 +311,7 @@
 ! 4.1.3 Defines the stop date
         CALL T2D(TOUT,STOPDATE,IERR)
         WRITE(STRSTOPDATE,'(I4.4,A,4(I2.2,A),I2.2)') STOPDATE(1),'-',STOPDATE(2), &
-              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7) 
+              '-',STOPDATE(3),' ',STOPDATE(5),':',STOPDATE(6),':',STOPDATE(7)
 
         IF ( IOUT .GE. NOUT ) EXIT
       END DO
@@ -512,15 +512,15 @@
       ! S3 defines the number of characters in the date for the filename
       ! S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
       ! Setups min and max date format
-      IF (S3.LT.4) S3=4 
-      IF (S3.GT.10) S3=10 
+      IF (S3.LT.4) S3=4
+      IF (S3.GT.10) S3=10
 !
       ! Defines the format of FILETIME
       S5=S3-8
       S4=S3
       OLDTIMEID=TIMEID
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHMMSSZ'
-      IF (S3.EQ.10) THEN 
+      IF (S3.EQ.10) THEN
         S4=S4+2 ! add chars for ISO8601 : day T hours Z
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (TIMEID,FORMAT1) TIME(1), 'T', &
@@ -531,10 +531,10 @@
         WRITE (TIMEID,FORMAT1) TIME(1)
       ! if S3=>YYYYMM then filetime='YYYYMM'
       ! or S3=>YYYY then filetime='YYYY'
-      ELSE 
+      ELSE
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I',S3,'.',S3,')'
         WRITE (TIMEID,FORMAT1) FLOOR(REAL(TIME(1))/NINT(10.**(8-S3)))
-      END IF       
+      END IF
       ! redefines filename with updated date format
       S1=LEN_TRIM(FILEPREFIX)
       FNAMENC=''
@@ -583,17 +583,17 @@
         NCID=NCID
       END IF
 
-                        
+
 ! 1.4 Creates the netcdf file
 
-      IF (NCID.EQ.0) THEN 
+      IF (NCID.EQ.0) THEN
 
         ! Initializes the time iteration counter n
         IT      = 0
         ILOC    = 0
         ISPEC   = 0
 
-! 1.4.1 Creates the NetCDF file 
+! 1.4.1 Creates the NetCDF file
 
         CALL W3CRNC(NCTYPE,FNAMENC,NCID,DIMID,DIMLN,VARID)
 
@@ -646,11 +646,11 @@
 
 
 ! 1.5 Defines the current time step and index
-     
+
       CALL T2D(TIME,CURDATE,IERR)
       OUTJULDAY=TSUB(REFDATE,CURDATE)
       WRITE(NDSO,'(3A,I6,A,I4,A,I2.2,A,I2.2,A,I2.2,A,I2.2,A,I2.2,2A)')       &
-            'Writing new record ', ENAME(2:) ,'number ',IT,                  & 
+            'Writing new record ', ENAME(2:) ,'number ',IT,                  &
             ' for ',CURDATE(1),':',CURDATE(2),':',CURDATE(3),'T',CURDATE(5), &
             ':',CURDATE(6),':',CURDATE(7),' in file ',TRIM(FNAMENC)
 
@@ -677,7 +677,7 @@
       ELSE
         CDO = 0.
       END IF
-              
+
 !
 ! 1.7.1 Puts dimensions variables in NetCDF file
 !
@@ -712,7 +712,7 @@
       CALL CHECK_ERR(IRET)
       ! Write CAO (current - x direction)
       IRET=NF90_PUT_VAR(NCID, VARID(11),CAO ,start=(/IT/))
-      CALL CHECK_ERR(IRET)   
+      CALL CHECK_ERR(IRET)
       ! Write CDO (current - y direction)
       IRET=NF90_PUT_VAR(NCID,VARID(12),CDO ,start=(/IT/))
       CALL CHECK_ERR(IRET)
@@ -797,7 +797,7 @@
       IRET=NF90_PUT_ATT(NCID,VARID(1),'units','days since 1990-01-01 00:00:00')
       IRET=NF90_PUT_ATT(NCID,VARID(1),'conventions',                   &
          'Relative julian days with decimal part (as parts of the day)')
-      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','T') 
+      IRET=NF90_PUT_ATT(NCID,VARID(1),'axis','T')
 
 ! frequency
       IRET=NF90_DEF_VAR(NCID, 'frequency', NF90_FLOAT, (/DIMID(2)/),VARID(2))
@@ -810,7 +810,7 @@
       IRET=NF90_PUT_ATT(NCID,VARID(2),'valid_min',0.)
       IRET=NF90_PUT_ATT(NCID,VARID(2),'valid_max',10.)
       IRET=NF90_PUT_ATT(NCID,VARID(2),'_FillValue',NF90_FILL_FLOAT)
-      IRET=NF90_PUT_ATT(NCID,VARID(2),'axis','Y') 
+      IRET=NF90_PUT_ATT(NCID,VARID(2),'axis','Y')
 
 !frequency1
       IRET=NF90_DEF_VAR(NCID, 'frequency1', NF90_FLOAT, (/DIMID(2)/), VARID(3))
@@ -869,9 +869,9 @@
       IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_min',0.)
       IRET=NF90_PUT_ATT(NCID,VARID(6),'valid_max',360.)
       IRET=NF90_PUT_ATT(NCID,VARID(6),'_FillValue',NF90_FILL_FLOAT)
-      IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Z') 
+      IRET=NF90_PUT_ATT(NCID,VARID(6),'axis','Z')
 
-      IF (FLAGLL) THEN 
+      IF (FLAGLL) THEN
 !  longitude
         IRET=NF90_DEF_VAR(NCID, 'longitude', NF90_FLOAT, (/DIMID(1)/),VARID(7))
 !/NC4        IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(7), 1, 1, DEFLATE)
@@ -1035,7 +1035,7 @@
 !/NC4      IF (NCTYPE.EQ.4) IRET=NF90_DEF_VAR_DEFLATE(NCID, VARID(17), 1, 1, DEFLATE)
       IRET=NF90_PUT_ATT(NCID,VARID(17),'long_name','track_name number of characters')
       IRET=NF90_PUT_ATT(NCID,VARID(17),'_FillValue',NF90_FILL_INT)
-      IRET=NF90_PUT_ATT(NCID,VARID(17),'axis','W') 
+      IRET=NF90_PUT_ATT(NCID,VARID(17),'axis','W')
 
 !  track_name
       IRET=NF90_DEF_VAR(NCID, 'track_name', NF90_CHAR, (/DIMID(4),DIMID(1)/), VARID(18))
@@ -1047,7 +1047,7 @@
 
       RETURN
 
-      END SUBROUTINE W3CRNC 
+      END SUBROUTINE W3CRNC
 
 !==============================================================================
 

--- a/model/ftn/ww3_uprstr.ftn
+++ b/model/ftn/ww3_uprstr.ftn
@@ -18,8 +18,8 @@
 !/    01-Oct-2018 :  Fixes to preserve spectral energy correctly
 !/                   (Andy Saulter)                      ( version 6.06 )
 !/    17-Oct-2018 :  Version 0.95                        ( version 6.06 )
-!/                   Simplified the code, remove some user unfriendly 
-!/                   options, add reg test ta1, add logical checks, 
+!/                   Simplified the code, remove some user unfriendly
+!/                   options, add reg test ta1, add logical checks,
 !/                   unified the operator, add/update the documentation.
 !/
 !/    Copyright 2010 National Weather Service (NWS),
@@ -29,17 +29,17 @@
 !/
 !  1. Purpose :
 !
-!     Update the WAVEWATCH III restart files based on the significant 
+!     Update the WAVEWATCH III restart files based on the significant
 !     wave height analysis from any data assimilation system.
-!     
+!
 !  2. Method :
-!     
+!
 !  2.1. General:
 !     The W3UPRSTR is the intermediator between the background WW3
-!     and the analysis of the wave field, it modifies the original restart 
+!     and the analysis of the wave field, it modifies the original restart
 !     file according to the analysis.
-!     For the wave modeling and DA, the ww3_uprstr program applies the 
-!     operator from the diagnostic to the prognostic variable. 
+!     For the wave modeling and DA, the ww3_uprstr program applies the
+!     operator from the diagnostic to the prognostic variable.
 !
 !     See the chart below:
 !
@@ -47,39 +47,39 @@
 !                       | WW3 Background Run|
 !                       +-------------------+
 !    +--------------+              |                   +-----+
-!    | Restart File | <------------|-----------------> |  Hs |   
+!    | Restart File | <------------|-----------------> |  Hs |
 !    +--------------+                                  +-----+
 !            |                                            |
 !            |                                            |
-!            |               +---------------+         +-----+   
+!            |               +---------------+         +-----+
 !            |               |Hs Observations|-------> | D.A.|
 !            |               +---------------+         +-----+
 !            |                                            |
 !            |                  +----------+              |
-!            +----------------> | W3UPRSTR |<-/Analysis/--+  
-!                               +----------+  
+!            +----------------> | W3UPRSTR |<-/Analysis/--+
+!                               +----------+
 !                                     |
 !                          +----------------------+
 !                          | Updated Restart File |
 !                          +----------------------+
 !
-!     A. The WW3 Background Run has to provide two files: 
-!         i. The field of Hs (for NCEP at grib2 format) and 
+!     A. The WW3 Background Run has to provide two files:
+!         i. The field of Hs (for NCEP at grib2 format) and
 !        ii. the restart.ww3, at the WW3 format for restart files.
 !     Both of them, at the moment of the assimilation (Nevertheless, the WW3
 !     restart reader will fail when the timestamps are not identical).
 !
-!     B. The DA module produces the analysis and/or the difference (%) of 
-!     the analysis from the first guess of Hs in the space of model and 
-!     exports the results. 
+!     B. The DA module produces the analysis and/or the difference (%) of
+!     the analysis from the first guess of Hs in the space of model and
+!     exports the results.
 !
 !     C. The algorithm
 !     The Hs correction is redistributed to each frequency and direction.
 !
-!     1. The W3UPRSTR imports: i. the restart.ww3, 
+!     1. The W3UPRSTR imports: i. the restart.ww3,
 !                             ii. the analysis file and
 !                            iii. the input file: ww3_uprstr.inp, details at 2.2.2.i.
-!     
+!
 !     2. The W3UPRSTR updates the restart file according to the option at
 !     ww3_uprstr UPD[N]
 !     Note: With the version 6.06 some options have been removed, but the naming
@@ -89,24 +89,24 @@
 !     restart.ww3. The name of the output file is: restart001.ww3 and it has to
 !     be renamed "restart.ww3" for the initialization of the next prediction
 !     cycle.
-!     
+!
 !     E. The user runs WW3 with the analysis restart file.
 !
 !     2.2. How to use ww3_uprstr
 !     The ww3_uperstr is one of the WW3 auxilary programs, therefore it works in
 !     a very similar way as the other auxilary programs.
-!     
+!
 !     A. To compile:
-!     
+!
 !     ww3_uprstr is included in the make_makefile.sh, to compile:
-!     $ ./w3_make ww3_uprstr 
+!     $ ./w3_make ww3_uprstr
 !     or
 !     $ ./w3_make
-!     
+!
 !     And the executable "ww3_uprstr" will appear at [...]/model/exe/
 !
 !     B. To run:
-!     At the computational path: 
+!     At the computational path:
 !        > ${EXE}/ww3_uprstr
 !     And it should run if the input files are at ./
 !
@@ -125,7 +125,7 @@
 ! This is the assimilation starting time and has to be the same with
 ! the time at the restart.ww3.
 !
-!   19680607 120000 
+!   19680607 120000
 !
 ! Choose algorithm to update restart file
 !  UPDN for the Nth approach
@@ -145,7 +145,7 @@
 !   UPD4 :: [NOT INCLUDED in this Version, Just keeping the spot]
 !           Option 4  The generalization of the UPD3. The update factor
 !           is the sum of surfaces which are applied on the background
-!           spectrum. 
+!           spectrum.
 !           The algorithm requires the mapping of each partition on the
 !           individual spectra; the map is used to determine the weighting
 !           surfaces.
@@ -158,7 +158,7 @@
 !
 !   0.475
 !
-! PRCNTG_CAP is global input for option UPD2 and UPD3 and it is a cap on the 
+! PRCNTG_CAP is global input for option UPD2 and UPD3 and it is a cap on the
 ! maximun correction applied to all the gridpoints (e.g. 0.5)
 !
 !  0.6
@@ -173,33 +173,33 @@
 ! -------------------------------------------------------------------- $
 !
 !   ii. Data files anl.XXX
-! 
+!
 ! USE THE grbtxt FORMAT, See Format E.
 !
-! Format E. 
-!        Text file created by wgrib2. This format is tested more extensively 
+! Format E.
+!        Text file created by wgrib2. This format is tested more extensively
 !        and currently the only format supported for anl.grbtxt.
-!     
+!
 !        NX NY
 !        VAL0001
 !        VAL0002
 !        ...
 !        VALNX*NY
 !
-! IMPORTANT : All the tests are with the format E. strongly recommended. 
-! The order of the values in .grbtxt, it is the same by 
+! IMPORTANT : All the tests are with the format E. strongly recommended.
+! The order of the values in .grbtxt, it is the same by
 ! defaults with the order in the restart file.
 !
-! NOTE About Format: if you prefer a different format; there are several 
-! I/O subroutines ready, not included in the current version of the code, 
-! contact the prgmr to get access to the source code. 
-! 
+! NOTE About Format: if you prefer a different format; there are several
+! I/O subroutines ready, not included in the current version of the code,
+! contact the prgmr to get access to the source code.
+!
 !        iii. restart.ww3
-! The restart file as came out of the background run, the name has to be 
+! The restart file as came out of the background run, the name has to be
 ! restart.ww3, but the name of the output depends on the mod_def.ww3, the
 ! ww3_uprstr follows its content (be careful with ovewriting).
 !
-!  3. Example 
+!  3. Example
 !     Use the regression tests ww3_ta1
 !
 !  4. Parameters :
@@ -223,7 +223,7 @@
 !      NEXTLN    Subr.   Id.    Get next line from input file.
 !      EXTCDE    Subr.   Id.    Abort program as graceful as possible.
 !      W3IOGR    Subr. W3IOGRMD Reading/writing model definition file.
-!      WAVNU1    Subr. W3DISPMD 
+!      WAVNU1    Subr. W3DISPMD
 
 !     ----------------------------------------------------------------
 !  Internal Subroutines:
@@ -267,7 +267,7 @@
 ! 11. Known Bugs
 !
 !     1. Fix the format for the output (NSDO) of non strings, e.g. for
-!     TIME. 
+!     TIME.
 !
 ! 12. Source code :
 !
@@ -286,7 +286,7 @@
       USE W3WDATMD, ONLY: VA, TIME
       USE W3ADATMD, ONLY: NSEALM
       USE W3ODATMD, ONLY: IAPROC, NAPERR, NAPLOG, NDS, NAPOUT
-      USE W3ODATMD, ONLY: NDSE, NDSO, NDST, IDOUT, FNMPRE  
+      USE W3ODATMD, ONLY: NDSE, NDSO, NDST, IDOUT, FNMPRE
 !/
       IMPLICIT NONE
 !/
@@ -294,7 +294,7 @@
 !/ Local variables
 !/
       INTEGER                 :: NDSI, NDSM, NDSTRC, NTRACE, IERR, I, J
-      CHARACTER               :: COMSTR*1 
+      CHARACTER               :: COMSTR*1
 !/
 !      REAL, ALLOCATABLE       :: BETAW(:)
 !      LOGICAL, ALLOCATABLE    :: MASK(:)
@@ -399,7 +399,7 @@
       END IF
 !
 !/T      WRITE (NDST,*), MYNAME,' : Exporting VA as imported to VA01.txt'
-!/T      CALL writeMatrix('VA01.txt', REAL(VA))      
+!/T      CALL writeMatrix('VA01.txt', REAL(VA))
 !/
 !/ ------------------------------------------------------------------- /
 ! 5. Update restart spectra array according to the selected option
@@ -430,12 +430,12 @@
 !
 !/T      CALL writeMatrix('SWHBCKG_UPD0F.txt', REAL(SWHBCKG))
 !/T      CALL writeMatrix('SWHANL_UPD0F.txt' , REAL(SWHANL ))
-!/T      CALL writeMatrix('SWHRSTR_UPD0F.txt', REAL(SWHANL )) 
+!/T      CALL writeMatrix('SWHRSTR_UPD0F.txt', REAL(SWHANL ))
 !/T      DEALLOCATE ( VATMP, SWHBCKG, SWHANL )
 !
-!/ ------------------------------------------------------------------- /     
+!/ ------------------------------------------------------------------- /
       case ('UPD2')
-         write (NDSO,902) 'UPD2' 
+         write (NDSO,902) 'UPD2'
 !        Additional Input: Analysis Field
          INQUIRE(FILE=FLNMANL, EXIST=anl_exists)
          IF (anl_exists) then
@@ -467,8 +467,8 @@
 !/T             WRITE (NDSO,*) 'ISEA = ', ISEA,' IX = ',IX,' IY = ', IY,         &
 !/T                            ' PRCNTG = ',PRCNTG,' SWHBCKG = ',SWHBCKG(IY,IX), &
 !/T                            ' SWHANL = ', SWHANL(IY,IX)
-            
-               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP) 
+
+               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP)
                CALL UPDATE_VA(PRCNTG, VA(:,ISEA))
                CALL SWH_RSRT_1p (VA(:,ISEA), ISEA, SWHUPRSTR(IY,IX))
 
@@ -491,9 +491,9 @@
 !/T
          DEALLOCATE( SWHANL,VATMP,SWHBCKG,SWHUPRSTR )
 !
-!/ ------------------------------------------------------------------- /     
-! UPD3 
-! As per UPD2, but the update factor is a surface with the shape of the 
+!/ ------------------------------------------------------------------- /
+! UPD3
+! As per UPD2, but the update factor is a surface with the shape of the
 ! background spectrum
       case ('UPD3')
          WRITE (NDSO,902) 'UPD3'
@@ -519,14 +519,14 @@
          DO ISEA=1, NSEA, 1
             IX = MAPSF(ISEA,1)
             IY = MAPSF(ISEA,2)
-!/            
+!/
             VATMP = VA(:,ISEA)
 !/
             CALL SWH_RSRT_1p (VATMP, ISEA, SWHBCKG_1)
             SWHBCKG(IY,IX)=SWHBCKG_1
 !/
             IF ( SWHBCKG(IY,IX) > 0.01 .AND. SWHANL(IY,IX) > 0.01 ) THEN
-            !Step 1. 
+            !Step 1.
                PRCNTG=(SWHANL(IY,IX)/SWHBCKG_1)
 
 !/T            WRITE (NDSO,*) ' =========== Step 1. ==========='
@@ -534,7 +534,7 @@
 !/T                           ' PRCNTG = ',PRCNTG,' SWHBCKG = ',SWHBCKG(IY,IX), &
 !/T                           ' SWHANL = ', SWHANL(IY,IX)
 
-               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP) 
+               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP)
                VATMP_NORM=VATMP/SUM(VATMP)
 
 !/T            WRITE (NDSO,*)' ISEA =', ISEA,' IX = ',IX,' IY = ', IY, &
@@ -558,7 +558,7 @@
 !/T                           ' SWHANL= ', SWHANL(IY,IX),                  &
 !/T                           ' SWHUPRSTR(IY,IX) = ', SWHUPRSTR(IY,IX)
 !/
-               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP) 
+               CALL CHECK_PRCNTG (PRCNTG,PRCNTG_CAP)
                CALL UPDATE_VA(PRCNTG, VATMP)
 
                VA(:,ISEA)=VATMP
@@ -577,20 +577,20 @@
 !/T      CALL writeMatrix('SWHANL_UPD3.txt' , REAL(SWHANL ))
 !/T      CALL writeMatrix('SWHRSTR_UPD3.txt', REAL(SWHUPRSTR))
 !/T
-         DEALLOCATE( SWHANL,VATMP,SWHBCKG,SWHUPRSTR,VATMP_NORM,A ) 
+         DEALLOCATE( SWHANL,VATMP,SWHBCKG,SWHUPRSTR,VATMP_NORM,A )
       end select
 !
 !/ ------------------------------------------------------------------- /
 ! 6. Write updated restart file
       WRITE (NDSO,903)
       INTYPE = 3
-      CALL W3IORS ( 'HOT', NDS(6), SIG(NK), INTYPE, 1 )   
+      CALL W3IORS ( 'HOT', NDS(6), SIG(NK), INTYPE, 1 )
 !
 !/ ------------------------------------------------------------------- /
 !/T   WRITE (NDST,*), MYNAME,' : Exporting VA at the end of the re-analysis'
 !/T   CALL writeMatrix('VA02.txt', REAL(VA))
-      
-!/ 
+
+!/
 ! Escape locations read errors 08k:
 !
       GOTO 888
@@ -606,7 +606,7 @@
       802 CONTINUE
       WRITE (NDSE,1002) IERR
       CALL EXTCDE ( 12 )
-! 
+!
       888 CONTINUE
       WRITE (NDSO,999)
 !
@@ -658,7 +658,7 @@
                '     IOSTAT =',I5/)
 1004 FORMAT (/' '/,A/)
 1005 FORMAT (/' '/,A, I5, I5/)
-!     
+!
 !/
    CONTAINS
 !/
@@ -681,7 +681,7 @@
 !/
 !  1. Purpose :
 !     Apply correction to the spectrum
-!     
+!
 !  2. Method :
 !     The factor is (swh_anal/swh_bkg)**2 as applying to wave energy
 !  3. Parameters :
@@ -733,7 +733,7 @@
 !/    No unauthorized use without permission.
 !/
 !  1. Purpose :
-!     Last sanity check before the update of the spectrum 
+!     Last sanity check before the update of the spectrum
 !  2. Method :
 !     The percentage of change is compared against a user defined cap.
 !  3. Parameters :
@@ -760,14 +760,14 @@
 !
 ! 10. Source code :
 
-   SUBROUTINE CHECK_PRCNTG (PRCNTG,PRCNTG_CAP) 
+   SUBROUTINE CHECK_PRCNTG (PRCNTG,PRCNTG_CAP)
 !
       REAL, INTENT(INOUT)  ::    PRCNTG
       REAL, INTENT(IN   )  ::    PRCNTG_CAP
 ! local
       CHARACTER(12), PARAMETER :: MYNAME='CHECK_PRCNTG'
 !/T
-!/T      WRITE (NDSO,*) trim(MYNAME)," The original correction is ",PRCNTG 
+!/T      WRITE (NDSO,*) trim(MYNAME)," The original correction is ",PRCNTG
 !/T      WRITE (NDSO,*) trim(MYNAME)," The cap is ",PRCNTG_CAP
       IF ( PRCNTG > 1. ) THEN
 !/T      WRITE (NDSO,*) trim(MYNAME)," PRCNTG > 1."
@@ -775,9 +775,9 @@
       ELSE IF ( PRCNTG < 1. ) THEN
 !/T      WRITE (NDSO,*) trim(MYNAME)," PRCNTG < 1."
          PRCNTG = MAX(PRCNTG, 1. / PRCNTG_CAP)
-!/T  
+!/T
       END IF
-!/T      WRITE (NDSO,*) trim(MYNAME)," The updated correction is ",PRCNTG 
+!/T      WRITE (NDSO,*) trim(MYNAME)," The updated correction is ",PRCNTG
 !/
    END SUBROUTINE CHECK_PRCNTG
 !/
@@ -803,7 +803,7 @@
 !  1. Purpose :
 !     Read gribtxt files
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !
 !     Local parameters.
@@ -827,17 +827,17 @@
 !     !/T
 !
 ! 10. Source code :
-         
+
          REAL, DIMENSION(:,:), INTENT(OUT) :: UPDPRCNT
          CHARACTER(*), INTENT(IN) :: FLNMCOR
 ! Local Variables
          INTEGER            :: I, J, IERR
-         INTEGER            :: K, L, M, N 
+         INTEGER            :: K, L, M, N
          REAL :: A
          INTEGER, PARAMETER :: IP_FID = 123
          CHARACTER(25), PARAMETER::myname='read_grbtxt'
 !/
-!/T         WRITE (NDSO,*) trim(myname), ' starts'         
+!/T         WRITE (NDSO,*) trim(myname), ' starts'
 !/
          J     = LEN_TRIM(FNMPRE)
          OPEN (IP_FID,FILE=FNMPRE(:J)//TRIM(FLNMCOR),STATUS='OLD' &
@@ -855,21 +855,21 @@
          DO L=1,N
             DO K=1,M
                A=0.
-               READ(IP_FID,*)A 
+               READ(IP_FID,*)A
                UPDPRCNT(N+1-L,K)=A
             END DO
          END DO
 
          CLOSE(IP_FID)
-!/T         WRITE (NDSO,*) trim(myname), ' ends'         
+!/T         WRITE (NDSO,*) trim(myname), ' ends'
 
 110 format (2(I4) )
-         
+
       END SUBROUTINE READ_GRBTXT
 !/
 !/
 !/ ------------------------------------------------------------------- /
-!/ 
+!/
 !/                  +-----------------------------------+
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |         Stelios Flampouris        |
@@ -885,9 +885,9 @@
 !/    No unauthorized use without permission.
 !/
 !  1. Purpose :
-!     Calculate the significant wave height from the restart file for 1 point 
+!     Calculate the significant wave height from the restart file for 1 point
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !
 !     Local parameters.
@@ -913,15 +913,15 @@
 ! 10. Source code :
 !
 !/
-      SUBROUTINE SWH_RSRT_1p (VA1p, ISEA1p, HSIG1p )  
-         
+      SUBROUTINE SWH_RSRT_1p (VA1p, ISEA1p, HSIG1p )
+
          REAL, INTENT(OUT) :: HSIG1p
          INTEGER, INTENT(IN) :: ISEA1p
          REAL, DIMENSION(:), INTENT(IN)  :: VA1p
          CHARACTER(25),PARAMETER :: myname='SWH_RSRT_1p'
 !/
 !/FT         WRITE (NDSO,*)' '
-!/FT         WRITE (NDSO,*) trim(myname), ' starts'         
+!/FT         WRITE (NDSO,*) trim(myname), ' starts'
          HSIG1p = 0.
          DEPTH  = MAX ( DMIN , -ZB(ISEA1p) )
          ETOT   = 0.
@@ -962,7 +962,7 @@
 !  1. Purpose :
 !     Writes a 2D array to text file, column by column
 !  2. Method :
-!     
+!
 !  3. Parameters :
 !     fileName path to the output file
 !     rda_A 2D array to write
@@ -976,7 +976,7 @@
 !  Internal Subroutines:
 !
 !  5. Called by :
-!  Any routine that has to write 2d arrays !?!  
+!  Any routine that has to write 2d arrays !?!
 !
 !  6. Error messages :
 !
@@ -995,7 +995,7 @@
          CHARACTER(*)         , INTENT(IN) :: FILENAME
          INTEGER IB_I, IB_J, IL_IOS
          INTEGER, PARAMETER :: IP_FID = 123
-!            
+!
          OPEN( UNIT = IP_FID, FILE = FILENAME, STATUS = 'REPLACE', &
                FORM = 'FORMATTED', IOSTAT = IL_IOS)
          IF (IL_IOS /= 0) PRINT*,'In writeMatrix : Error creating file'//FILENAME


### PR DESCRIPTION
WW3 source code has **7,344** cases of lines ending with whitespace.  Generally this is not problematic, but it is probably worth purging for best practice (and cleaner git diff's if your editor automatically purges whitespace).  For the future, I think it is straightforward to automate testing for white-space during a P/R to eliminate these creeping back into the code.

This P/R just removes trailing whitespace from all files (.ftn, .f, .mk, .f90), so I have not done any testing.  But please let me know if you think I am being too brave...