### PR TITLE
bf_ww3ounf_init: Initialize NSEALM, so ww3_ounf doesn't fail.

### DIFF
--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -111,6 +111,7 @@
       USE W3IOGOMD, ONLY: W3IOGO, W3READFLGRD, W3FLGRDFLAG
       USE W3INITMD, ONLY: WWVER, SWITCHES
       USE W3ODATMD, ONLY: NAPROC, NOSWLL, PTMETH, PTFCUT
+      USE W3PARALL, ONLY: SET_UP_NSEAL_NSEALM
 !/DEBUG      USE W3ODATMD, only : IAPROC
 !/
       USE W3GDATMD
@@ -131,7 +132,7 @@
                           CFLTHMAX, CFLXYMAX, CFLKMAX, TAUICE, PHICE,  &
                           STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD, HCMAXD,&
                           P2SMS, EF, US3D, TH1M, STH1M, TH2M, STH2M,   &
-                          WN, USSP, WBT
+                          WN, USSP, WBT, NSEALM
       USE W3ODATMD, ONLY: NDSO, NDSE, SCREEN, NOGRP, NGRPP, IDOUT,     &
                           UNDEF, FLOGRD, FNMPRE, NOSWLL, NOGE
 !
@@ -207,6 +208,10 @@
 !
       CALL W3IOGR ( 'READ', NDSM )
       WRITE (NDSO,920) GNAME
+!
+!--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!     Also, set NSEAL and NSEALM
+      CALL SET_UP_NSEAL_NSEALM(NSEAL, NSEALM)
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3.  Read general data and first fields from file


### PR DESCRIPTION
This pull request fixes a failed allocation causing ww3_ounf to exit, by initializing the "NSEALM" variable.

The "NSEALM" is an integer variable with the pointer attribute, and is defined on line 619 of the W3ADATMD module, see [this link](https://github.com/NOAA-EMC/WW3/blob/92cb41f70e91da97be9e5cd8bfee1de0a569f676/model/ftn/w3adatmd.ftn#L619).

The allocation causing ww3_ounf to exit occurs in the W3DIMA subroutine, on lines 934-946 of the same module, see [this link](https://github.com/NOAA-EMC/WW3/blob/92cb41f70e91da97be9e5cd8bfee1de0a569f676/model/ftn/w3adatmd.ftn#L931).

As far as I can tell, in the ww3_ounf program, NSEALM was not initialized prior to be used in the W3DIMA subroutine.  If I understand Fortran pointers correctly, if it is uninitialized then its value will be some random number out of memory.  In my case, the number was ~1.4 billion, so the attempt to allocate approximately 112 gigabytes (1.4billion x 20 x 4bytes) was the reason for the failed allocation.