### PR TITLE
Port 2 hera

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -99,9 +99,9 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || \
    [ "$cmplr" == "wcoss_phase2" ]   || [ "$cmplr" == "wcoss_phase2_intel_debug" ]  || \
    [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_cray_intel_debug" ]    || \
    [ "$cmplr" == "wcoss_dell_p3" ]  || [ "$cmplr" == "wcoss_dell_p3_intel_debug" ] || \
-   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "theia_intel_debug" ] || \
-   [ "$cmplr" == "hera" ]           || [ "$cmplr" == "hera.intel" ]        || \
+   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "hera" ] || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] ; then
+
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -94,12 +94,13 @@ fi
 # INTEL                       #
 ###############################
 
-if [ "$cmplr" == "intel" ] || [ "$cmplr" == "intel_debug" ] || \
-   [ "$cmplr" == "so_intel" ] || [ "$cmplr" == "so_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_phase2_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_cray_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_dell_p3" ] || [ "$cmplr" == "wcoss_dell_p3_intel_debug" ] || \
-   [ "$cmplr" == "theia" ] || [ "$cmplr" == "theia_intel_debug" ] || \
+if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || \
+   [ "$cmplr" == "so_intel" ]       || [ "$cmplr" == "so_intel_debug" ] || \
+   [ "$cmplr" == "wcoss_phase2" ]   || [ "$cmplr" == "wcoss_phase2_intel_debug" ]  || \
+   [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_cray_intel_debug" ]    || \
+   [ "$cmplr" == "wcoss_dell_p3" ]  || [ "$cmplr" == "wcoss_dell_p3_intel_debug" ] || \
+   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "theia_intel_debug" ] || \
+   [ "$cmplr" == "hera" ]           || [ "$cmplr" == "hera.intel" ]        || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] ; then
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -415,6 +415,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
+       [ "$cmplr" == "hera" ]                                                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
@@ -438,6 +439,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
+       [ "$cmplr" == "hera" ]                                                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -34,7 +34,7 @@ ifeq ($(WW3_COMP),Portland)
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","pgi" "datarmor_pgi" "datarmor_pgi_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -byteswapio
 # intel
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel" "hera"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_phase2" "wcoss_cray" "wcoss_dell_p3"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian

--- a/regtests/bin/matrix_ncep
+++ b/regtests/bin/matrix_ncep
@@ -32,7 +32,14 @@
   echo "Save listings     : $list"
 
 # Set batchq queue to define headers etc (default to original version if empty)
-batchq="slurm"
+HOSTCHAR=`hostname | cut -c 1`
+if [ "$HOSTCHAR" = "h" ]
+then
+# If no other h, assuming Hera 
+  batchq="slurm"
+else
+  batchq=
+fi
 
 # 1. Set up
 # 1.a Computer/ user dependent set up

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -1436,7 +1436,7 @@ then
     then
       if [ $nproc ]
       then
-        if [ $batchq = "slurm" ]
+        if [ -z $batchq ] && [ $batchq = "slurm" ]
         then 
           runcmd="$runcmd -n $nproc"
         


### PR DESCRIPTION
Includes NCEP development machine Hera to cmplr.env if blocks allowing compilation of WW3 executables under NEMS. A correction to run_test is made to allow empty values of the batchq parameter. 