### PR TITLE
Corrected th2m and sth2m calculations.

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1145,6 +1145,8 @@
 !/    01-Mar-2018 : Removed RTD code (now used in post  ( version 6.02 )
 !/                  processing code)
 !/    22-Aug-2018 : Add WBT parameter                   ( version 6.06 )
+!/    25-Sep-2019 : Corrected th2m and sth2m            ( version 6.07 )
+!/                  calculations. (J Dykes, NRL)
 !/
 !  1. Purpose :
 !
@@ -1433,8 +1435,9 @@
             AB (JSEA)  = AB (JSEA) + A(ITH,IK,JSEA)
             ABX(JSEA)  = ABX(JSEA) + A(ITH,IK,JSEA)*ECOS(ITH)
             ABY(JSEA)  = ABY(JSEA) + A(ITH,IK,JSEA)*ESIN(ITH)
-            ABX2(JSEA) = ABX2(JSEA) + A(ITH,IK,JSEA)*EC2(ITH)
-            ABY2(JSEA) = ABY2(JSEA) + A(ITH,IK,JSEA)*ES2(ITH)
+! Using trig identities to represent cos2theta and sin2theta.
+            ABX2(JSEA) = ABX2(JSEA) + A(ITH,IK,JSEA)*(2*EC2(ITH) - 1)
+            ABY2(JSEA) = ABY2(JSEA) + A(ITH,IK,JSEA)*(2*ESC(ITH))
             ABYX(JSEA) = ABYX(JSEA) + A(ITH,IK,JSEA)*ESC(ITH)
             IF (ITH.LE.NTH/2) THEN
               ABST(JSEA) = ABST(JSEA) +                               &


### PR DESCRIPTION
On lines 1439 and 1440, the calculations for ABX2 and ABY2 were like that of ABX and ABY.  This may have been an oversight when inserted.  Page 112 of the manual lays out the formulas for mean direction and spreading from a2 and b2 coefficients.  To represent cos2Theta and sin2Theta, trigonometric identities were used to exploit the previous calculated values in EC2 and ES2.  The first five moments of spectra and the wave frequency spectrum are useful in representing the energy spectra for every grid point in a model domain reducing space requirements by O(10).  Having these spectra handy allows for access to on-the-fly boundary conditions from reconstructed spectra with minimal loss of accuracy (soon to be shown in a later presentation).