### PR TITLE
Fb port2hera

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -64,7 +64,7 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || \
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then optc="$optc -openmp"; optl="$optl -openmp"; fi
+  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -openmp"; optl="$optl -openmp"; fi
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then
@@ -126,7 +126,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || \
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then 
+  if [ "$omp_mod" == 'yes' ] ; then 
     if [ "$cmplr" == "hera" ] ; then
       optc="$optc -qopenmp"
       optl="$optl -qopenmp"
@@ -192,7 +192,7 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || \
   optl='-o $prog -p -g'
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then optc="$optc -fopenmp"; optl="$optl -fopenmp"; fi
+  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -fopenmp"; optl="$optl -fopenmp"; fi
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then
@@ -250,7 +250,7 @@ if [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ] || \
   if [ "$list" == 'yes' ] ; then optc="$optc -Mlist"; fi
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then optc="$optc -mp"; optl="$optl -mp";  fi
+  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -mp"; optl="$optl -mp";  fi
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -94,13 +94,14 @@ fi
 # INTEL                       #
 ###############################
 
-if [ "$cmplr" == "intel" ] || [ "$cmplr" == "intel_debug" ] || \
-   [ "$cmplr" == "so_intel" ] || [ "$cmplr" == "so_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_phase2_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_cray_intel_debug" ] || \
-   [ "$cmplr" == "wcoss_dell_p3" ] || [ "$cmplr" == "wcoss_dell_p3_intel_debug" ] || \
-   [ "$cmplr" == "theia" ] || [ "$cmplr" == "theia_intel_debug" ] || \
+if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || \
+   [ "$cmplr" == "so_intel" ]       || [ "$cmplr" == "so_intel_debug" ] || \
+   [ "$cmplr" == "wcoss_phase2" ]   || [ "$cmplr" == "wcoss_phase2_intel_debug" ]  || \
+   [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_cray_intel_debug" ]    || \
+   [ "$cmplr" == "wcoss_dell_p3" ]  || [ "$cmplr" == "wcoss_dell_p3_intel_debug" ] || \
+   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "hera" ] || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] ; then
+
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -126,7 +126,15 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || \
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then optc="$optc -openmp"; optl="$optl -openmp"; fi
+  if [ "$omp_mod" = 'yes' ] ; then 
+    if [ "$cmplr" == "hera" ] ; then
+      optc="$optc -qopenmp"
+      optl="$optl -qopenmp"
+    else
+      optc="$optc -openmp" 
+      optl="$optl -openmp" 
+    fi
+  fi
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -415,6 +415,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
+       [ "$cmplr" == "hera" ]                                                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
@@ -438,6 +439,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
+       [ "$cmplr" == "hera" ]                                                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -34,7 +34,7 @@ ifeq ($(WW3_COMP),Portland)
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","pgi" "datarmor_pgi" "datarmor_pgi_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -byteswapio
 # intel
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel" "hera"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_phase2" "wcoss_cray" "wcoss_dell_p3"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian

--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -159,7 +159,7 @@
               binaryfiles=`grep . -r * | grep 'Binary file' | sed -e "s/^Binary file //" -e "s/ matches$//"`
 
               #Generate list of files to skip
-              skipfiles="ww3_shel.out ww3_multi.out prf.*.mww3 finished ww3_systrk.out"
+              skipfiles="ww3_shel.out ww3_multi.out prf.*.mww3 finished ww3_systrk.out gmon.out time_count.txt"
 
               nf_1=`echo $files_1 | wc -w | awk '{print $1}'`
               echo "  found $nf_1 files in base directory" >> $home_dir/fulldiff.tmp

--- a/regtests/bin/matrix_ncep
+++ b/regtests/bin/matrix_ncep
@@ -32,11 +32,15 @@
   echo "Save listings     : $list"
 
 # Set batchq queue to define headers etc (default to original version if empty)
-HOSTCHAR=`hostname | cut -c 1`
-if [ "$HOSTCHAR" = "h" ]
+ishera=`hostname | grep hfe`
+if [ $ishera ]
 then
 # If no other h, assuming Hera 
   batchq="slurm"
+  modcomp='intel/18.0.5.274'
+  modmpi='impi/2018.0.4'
+  modnetcdf='netcdf/4.6.1'
+  metispath='/scratch2/COASTAL/coastal/save/Ali.Abdolali/parmetis-4.0.3'
 else
   batchq=
 fi
@@ -69,18 +73,10 @@ fi
 
 # Netcdf and Parmetis modules & variables
 
-istheia=`hostname | grep tfe`
-if [ $istheia ]
-then
-  modcomp='intel/14.0.2'
-  modmpi='impi/5.1.2.150'
-  modnetcdf='netcdf/4.3.0'
-fi
-
   echo "  module load $modcomp $modmpi $modnetcdf"                   >> matrix.head
   echo "  export WWATCH3_NETCDF=NC4"                        >> matrix.head
   echo "  export NETCDF_CONFIG=`which nc-config`"           >> matrix.head
-  echo "  export METIS_PATH=/scratch3/NCEPDEV/stmp2/Jessica.Meixner/parmetis-4.0.3"   >> matrix.head
+  echo "  export METIS_PATH=${metispath}"   >> matrix.head
   echo "  export WW3_PARCOMPN=4"                            >> matrix.head
   echo ' ' 
 
@@ -92,7 +88,7 @@ fi
 
   if [ "$batchq" = 'slurm' ]
   then
-    export  mpi='srun'
+    export  mpi='mpirun'
   else
     export  mpi='mpirun'
   fi

--- a/regtests/bin/matrix_ncep
+++ b/regtests/bin/matrix_ncep
@@ -32,7 +32,14 @@
   echo "Save listings     : $list"
 
 # Set batchq queue to define headers etc (default to original version if empty)
-batchq="slurm"
+HOSTCHAR=`hostname | cut -c 1`
+if [ "$HOSTCHAR" = "h" ]
+then
+# If no other h, assuming Hera 
+  batchq="slurm"
+else
+  batchq=
+fi
 
 # 1. Set up
 # 1.a Computer/ user dependent set up

--- a/regtests/bin/matrix_ncep
+++ b/regtests/bin/matrix_ncep
@@ -31,11 +31,19 @@
   echo "Save source codes : $source"
   echo "Save listings     : $list"
 
-# Set batchq queue to define headers etc (default to original version if empty)
+# Compiler option. Choose appropriate compiler and set cmplOption to
+# y if using for the first time or using a different compiler
+
+  cmplr=intel
+  export cmplOption='y'
+
+# Set batchq queue, choose modules and other custom variables to fit system and 
+# to define headers etc (default to original version if empty)
 ishera=`hostname | grep hfe`
 if [ $ishera ]
 then
 # If no other h, assuming Hera 
+  cmplr=hera
   batchq="slurm"
   modcomp='intel/18.0.5.274'
   modmpi='impi/2018.0.4'
@@ -79,12 +87,6 @@ fi
   echo "  export METIS_PATH=${metispath}"   >> matrix.head
   echo "  export WW3_PARCOMPN=4"                            >> matrix.head
   echo ' ' 
-
-# Compiler option. Choose appropriate compiler and set cmplOption to
-# y if using for the first time or using a different compiler
-
-  cmplr=Intel
-  export cmplOption='y'
 
   if [ "$batchq" = 'slurm' ]
   then

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -1436,7 +1436,7 @@ then
     then
       if [ $nproc ]
       then
-        if [ $batchq = "slurm" ]
+        if [ -z $batchq ] && [ $batchq = "slurm" ]
         then 
           runcmd="$runcmd -n $nproc"
         


### PR DESCRIPTION
Branch FB_port2hera provides changes to make WW3 package run on Hera, the NCEP/NOAA R&D machine (replacing Theia). 

Includes 
* Several Hera updates for running WW3 under NEMS
* Adding hera port to w3_setup 
* Changes for porting regtest matrix to Hera in scripts matrix_ncep,  matrix.comp, run_test.
