### PR TITLE
Corrected th2m and sth2m calculations.  2nd attempt.

### DIFF
--- a/model/aux/bash/ww3_ounf_inp2nml.sh
+++ b/model/aux/bash/ww3_ounf_inp2nml.sh
@@ -182,7 +182,7 @@ cat >> $nmlfile << EOF
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/model/bin/make_makefile.sh
+++ b/model/bin/make_makefile.sh
@@ -97,7 +97,7 @@
               shared mpp mpiexp thread GSE prop \
               stress s_ln source stab s_nl snls s_bot s_db miche s_tr s_bs \
               dstress s_ice s_is reflection s_xx \
-              wind windx rwind curr currx mgwind mgprop mggse \
+              wind windx wcor rwind curr currx mgwind mgprop mggse \
               subsec tdyn dss0 pdif tide refrx ig rotag arctic nnt mprf \
               cou oasis agcm ogcm igcm trknc setup pdlib memck uost
   do
@@ -247,6 +247,11 @@
       windx  ) TY='one'
                ID='wind interpolation in space'
                OK='WNX0 WNX1 WNX2' ;;
+#sort:wcor:
+      wcor   ) TY='upto1'
+               ID='wind speed correction'
+               TS='WCOR'
+               OK='WCOR' ;;
 #sort:rwind:
       rwind  ) TY='upto1'
                ID='wind vs. current definition'

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -1145,6 +1145,8 @@
 !/    01-Mar-2018 : Removed RTD code (now used in post  ( version 6.02 )
 !/                  processing code)
 !/    22-Aug-2018 : Add WBT parameter                   ( version 6.06 )
+!/    25-Sep-2019 : Corrected th2m and sth2m            ( version 6.07 )
+!/                  calculations. (J Dykes, NRL)
 !/
 !  1. Purpose :
 !
@@ -1433,8 +1435,9 @@
             AB (JSEA)  = AB (JSEA) + A(ITH,IK,JSEA)
             ABX(JSEA)  = ABX(JSEA) + A(ITH,IK,JSEA)*ECOS(ITH)
             ABY(JSEA)  = ABY(JSEA) + A(ITH,IK,JSEA)*ESIN(ITH)
-            ABX2(JSEA) = ABX2(JSEA) + A(ITH,IK,JSEA)*EC2(ITH)
-            ABY2(JSEA) = ABY2(JSEA) + A(ITH,IK,JSEA)*ES2(ITH)
+! Using trig identities to represent cos2theta and sin2theta.
+            ABX2(JSEA) = ABX2(JSEA) + A(ITH,IK,JSEA)*(2*EC2(ITH) - 1)
+            ABY2(JSEA) = ABY2(JSEA) + A(ITH,IK,JSEA)*(2*ESC(ITH))
             ABYX(JSEA) = ABYX(JSEA) + A(ITH,IK,JSEA)*ESC(ITH)
             IF (ITH.LE.NTH/2) THEN
               ABST(JSEA) = ABST(JSEA) +                               &

--- a/model/ftn/w3triamd.ftn
+++ b/model/ftn/w3triamd.ftn
@@ -666,7 +666,10 @@ CONTAINS
         DO IBC = 1, N_OUTSIDE_BOUNDARY
            IX = OUTSIDE_BOUNDARY(IBC)
            !write(*,*) 'TEST1', IX, TMPSTA(1,IX), CCON(IX), COUNTCON(IX), ZBIN(1,IX), ZLIM
-           IF (IX.NE.0) THEN  ! There was a bug in the mesh conversion, OUTSIDE_BOUNDARY(IBC) should not be zero 
+
+           ! OUTSIDE_BOUNDARY(IBC) is defined over the full nodes NODES indexes
+           ! whereas TMPSTA and ZBIN are defined over the clean up list of nodes NX
+           IF ((IX.NE.0).AND.(IX.LE.NX)) THEN
              IF ((TMPSTA(1,IX).EQ.1).AND.(STATUS(IX).EQ.0)  &
                .AND.(ZBIN(1,IX).LT.ZLIM))  TMPSTA(1,IX)=2  
             END IF       

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -157,10 +157,9 @@
                                  IOUT, S3, IRET, HASNC4,               &
                                  NBIPART, CNTIPART, NCVARTYPE, IPART,  &
                                  RTDNX, RTDNY
-      INTEGER                 :: TOUT(2), TDUM(2),                     &
-                                 NCIDS(NOGRP,NGRPP,6), STOPDATE(8)
+      INTEGER                 :: TOUT(2), TDUM(2), STOPDATE(8)
 !
-      INTEGER, ALLOCATABLE    :: TABIPART(:)
+      INTEGER, ALLOCATABLE    :: TABIPART(:), NCIDS(:,:,:)
 !
 !/S      INTEGER, SAVE           :: IENT = 0
 !
@@ -383,6 +382,7 @@
       ! Alternative processing of TABIPART to capture requests 
       ! greater than NOSWLL (C.Bunney):
       ALLOCATE(TABIPART(NOSWLL + 1))
+      ALLOCATE(NCIDS(NOGRP,NGRPP,NOSWLL + 1))
       NBIPART=0
       DO I=1,30
         IF(STRINGIPART(I:I) .EQ. ' ') CYCLE
@@ -874,17 +874,21 @@
 
 ! 1.2 Sets the date as ISO8601 convention 
       ! S3 defines the number of characters in the date for the filename
-      ! S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
+      ! S3=0 -> field, S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
       ! Setups min and max date format
-      IF (S3.LT.4) S3=4 
+      IF (S3.GT.0 .AND. S3.LT.4) S3=4 
       IF (S3.GT.10) S3=10 
 !
       ! Defines the format of FILETIME
       S5=S3-8
       S4=S3
       OLDTIMEID=TIMEID
+      ! if S3=>nodate then filetime='field'
+      IF (S3.EQ.0) THEN
+        S4=5
+        TIMEID="field"
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHZ'
-      IF (S3.EQ.10) THEN 
+      ELSE IF (S3.EQ.10) THEN 
         S4=S4+2 ! add chars for ISO8601 : day T hours Z
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (TIMEID,FORMAT1) TIME(1), 'T', &
@@ -3397,9 +3401,6 @@
             ! Defines the netcdf extension
             FNAMENC(S1+S2+1:S1+S2+3) = '.nc'
             FNAMENC(S1+S2+4:S1+S2+6) = '   '
-
-!/NCO ! For NCEP application, requires fixed netcdf file name
-!/NCO            FNAMENC='ww3.gridded.nc'
 
             ! If the flag frequency is .TRUE., defines the fourth dimension
             IF (FLFRQ) THEN 

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1297,7 +1297,6 @@
             ELSE IF ( J .EQ. 6 ) THEN
 !             IPRT: IX0, IXN, IXS, IY0, IYN, IYS
               CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-              READ (NDSI,*,END=2001,ERR=2002) IPRT, PRTFRM
 !/DEBUGINIT              write(740+IAPROC,*), 'Before reading IPRT'
 !/DEBUGINIT              write(740+IAPROC,*), 'Before read 2002, case 10'
               READ (NDSI,*) IPRT, PRTFRM

--- a/model/inp/ww3_ounf.inp
+++ b/model/inp/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/model/nml/ww3_ounf.nml
+++ b/model/nml/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTART            = '19000101 000000'  ! Stop date for the output field
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file

--- a/regtests/bin/matrix.base
+++ b/regtests/bin/matrix.base
@@ -1965,9 +1965,9 @@
    echo ' ' >> matrix.body
    if [ "$dist" = 'y' ]
    then 
-     echo "$rtst -s MPI -w work_rg_shel_MPI -i input_rg_shel $ww3 ww3_ts4" >> matrix.body
-     echo "$rtst -s MPI -w work_rg_multi_MPI -i input_rg_multi -m grdset $ww3 ww3_ts4" >> matrix.body
-     echo "$rtst -s MPI -w work_ug_MPI -i input_ug $ww3 ww3_ts4" >> matrix.body
+     echo "$rtst -s MPI -w work_rg_shel_MPI -i input_rg_shel -f -p $mpi -n $np $ww3 ww3_ts4" >> matrix.body
+     echo "$rtst -s MPI -w work_rg_multi_MPI -i input_rg_multi -m grdset -f -p $mpi -n $np $ww3 ww3_ts4" >> matrix.body
+     echo "$rtst -s MPI -w work_ug_MPI -i input_ug -f -p $mpi -n $np $ww3 ww3_ts4" >> matrix.body
    else 
      echo "$rtst -w work_rg_shel -i input_rg_shel $ww3 ww3_ts4" >> matrix.body
      echo "$rtst -w work_rg_multi -i input_rg_multi -m grdset $ww3 ww3_ts4" >> matrix.body

--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -19,9 +19,21 @@
 # 1. Set up
 # 1.a Computer/ user dependent set up
 
+  if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
+  then     
+    printf "\n ERROR ABORTING \n"
+    printf "\n matrix.comp requires 3 arguments: "
+    printf "   1: test type (eg, all or test-name), 2: base directory and 3: reference directory. \n"
+    printf "\n Usage:"
+    printf "    ./bin/matrix.comp all basedir compdir \n\n"
+    exit
+  fi
+
+  ctest=$1
+  base_dir=$2
+  comp_dir=$3
   home_dir=`pwd`
-  base_dir='.'
-  comp_dir='../../EMC_ww3_master/regtests'
+
   rm -rf $home_dir/output
   rm -f $home_dir/matrixDiff.out
 
@@ -58,18 +70,12 @@
   echo '**********************************************************************' >> $home_dir/fulldiff.tmp
 
 
-  if [ "$#" != '1' ] ; then
-    echo "usage: matrix.comp test"
-    echo "       test can be 'all'" ; exit 1 ; fi
-
-  test=$1
-
-  if [ "$test" = 'all' ] ; then
-    test=`ls -d ww3_tp1.? ww3_tp2.? ww3_ts? ww3_tbt1.? ww3_tbt2.? ww3_tic1.? ww3_tic2.? ww3_tig1.? ww3_tp2.1? mww3_test_0?` ; fi
+  if [ "$ctest" = 'all' ] ; then
+    ctest=`ls -d ww3_tp1.? ww3_tp2.? ww3_ts? ww3_tbt1.? ww3_tbt2.? ww3_tic1.? ww3_tic2.? ww3_tig1.? ww3_tp2.1? mww3_test_0?` ; fi
   echo "base directory : $base_dir" >> $home_dir/header.tmp
   echo "comp directory : $comp_dir" >> $home_dir/header.tmp
   echo "test(s)        : "          >> $home_dir/header.tmp
-  echo $test                        >> $home_dir/header.tmp
+  echo $ctest                        >> $home_dir/header.tmp
   echo " "                          >> $home_dir/header.tmp
 
   cat $home_dir/header.tmp
@@ -84,7 +90,7 @@
 # 2.  Looping over tests                                                      #
 # --------------------------------------------------------------------------- #
 
-  for tst in $test
+  for tst in $ctest
   do
     cd $home_dir ; cd $base_dir
     if [ ! -d $tst ]

--- a/regtests/bin/matrix_ncep
+++ b/regtests/bin/matrix_ncep
@@ -1,0 +1,157 @@
+#!/bin/bash
+# --------------------------------------------------------------------------- #
+# matrix.go: Run matrix of regression tests on target machine.                #
+#                                                                             #
+# Remarks:                                                                    #
+# - This version is set up for automatic w3_setenv script and for the         #
+#   NOAA RDHPC 'zeus' system. When using this for your own setup and          #
+#   computer, please copy rather than modify.                                 #
+#                                                                             #
+#                                                      Hendrik L. Tolman      #
+#                                                      August 2013            #
+#                                                      December 2013          #
+#                                                      April 2018             #
+#                                                                             #
+#    Copyright 2013 National Weather Service (NWS),                           #
+#       National Oceanic and Atmospheric Administration.  All rights          #
+#       reserved.  WAVEWATCH III is a trademark of the NWS.                   #
+#       No unauthorized use without permission.                               #
+#                                                                             #
+# --------------------------------------------------------------------------- #
+# 0. Environment file
+
+  source $(dirname $0)/../../model/bin/w3_setenv
+  main_dir=$WWATCH3_DIR
+  temp_dir=$WWATCH3_TMP
+  source=$WWATCH3_SOURCE
+  list=$WWATCH3_LIST
+
+  echo "Main directory    : $main_dir"
+  echo "Scratch directory : $temp_dir"
+  echo "Save source codes : $source"
+  echo "Save listings     : $list"
+
+# Set batchq queue to define headers etc (default to original version if empty)
+batchq="slurm"
+
+# 1. Set up
+# 1.a Computer/ user dependent set up
+
+  echo '#!/bin/sh --login'                                   > matrix.head
+  echo ' '                                                  >> matrix.head
+if [ $batchq = "slurm" ]
+then
+  echo '#SBATCH -n 24'                                      >> matrix.head
+  echo '#SBATCH -q batch'                                   >> matrix.head
+  echo '#SBATCH -t 08:00:00'                                >> matrix.head
+  echo '#SBATCH -A marine-cpu'                              >> matrix.head
+  echo '#SBATCH -J ww3_regtest'                             >> matrix.head
+  echo '#SBATCH -o matrix.out'                              >> matrix.head
+else
+  echo '#PBS -l procs=24'                                   >> matrix.head
+  echo '#PBS -q batch'                                      >> matrix.head
+  echo '#PBS -l walltime=08:00:00'                          >> matrix.head
+  echo '#PBS -A marine-cpu'                                 >> matrix.head
+  echo '#PBS -N ww3_regtest'                                >> matrix.head
+  echo '#PBS -j oe'                                         >> matrix.head
+  echo '#PBS -o matrix.out'                                 >> matrix.head
+  echo ' '                                                  >> matrix.head
+fi
+  echo "  cd $(dirname $main_dir)/regtests"                 >> matrix.head
+  echo ' '                                                  >> matrix.head
+
+# Netcdf and Parmetis modules & variables
+
+istheia=`hostname | grep tfe`
+if [ $istheia ]
+then
+  modcomp='intel/14.0.2'
+  modmpi='impi/5.1.2.150'
+  modnetcdf='netcdf/4.3.0'
+fi
+
+  echo "  module load $modcomp $modmpi $modnetcdf"                   >> matrix.head
+  echo "  export WWATCH3_NETCDF=NC4"                        >> matrix.head
+  echo "  export NETCDF_CONFIG=`which nc-config`"           >> matrix.head
+  echo "  export METIS_PATH=/scratch3/NCEPDEV/stmp2/Jessica.Meixner/parmetis-4.0.3"   >> matrix.head
+  echo "  export WW3_PARCOMPN=4"                            >> matrix.head
+  echo ' ' 
+
+# Compiler option. Choose appropriate compiler and set cmplOption to
+# y if using for the first time or using a different compiler
+
+  cmplr=Intel
+  export cmplOption='y'
+
+  if [ "$batchq" = 'slurm' ]
+  then
+    export  mpi='srun'
+  else
+    export  mpi='mpirun'
+  fi
+    export   np='24'
+    export   nr='4'
+    export  nth='6'
+# Compile option
+  if [ "$cmplOption" = 'y' ]
+  then
+     opt="-c $cmplr -S -T"
+  else
+     opt="-S"
+  fi
+# Batch queue option
+  if [ "$batchq" = 'slurm' ]
+  then
+     opt="-b $batchq $opt"
+  fi
+
+# Base run_test command line
+  export rtst="./bin/run_test $opt"
+
+  export  ww3='../model'
+
+# 1.b Flags to do course selection - - - - - - - - - - - - - - - - - - - - - -
+#     Addition selection by commenting out lines as below
+
+  export     shrd='y' # Do shared architecture tests
+  export     dist='y' # Do distributed architecture (MPI) tests
+  export      omp='y' # Threaded (OpenMP) tests
+  export     hybd='n' # Hybrid options
+
+  export   prop1D='y' # 1-D propagation tests (ww3_tp1.X)
+  export   prop2D='y' # 2-D propagation tests (ww3_tp2.X)
+  export     time='y' # time linmited growth
+  export    fetch='y' # fetch linmited growth
+  export   hur1mg='y' # Hurricane with one moving grid
+  export    shwtr='y' # shallow water tests
+  export    unstr='y' # unstructured grid tests
+  export    pdlib='y' # unstr with pdlib for domain decomposition and implicit solver
+  export    smcgr='y' # SMC/Rotated grid test
+  export   mudice='y' # Mud/Ice and wave interaction tests 
+  export   infgrv='y' # Second harmonic generation tests
+  export     uost='y' # ww3_ts4 Unresolved Obstacles Source Term (UOST)
+  export    assim='y' # Restart spectra update
+
+  export  multi01='y' # mww3_test_01 (wetting and drying)
+  export  multi02='y' # mww3_test_02 (basic two-way nesting test))
+  export  multi03='y' # mww3_test_03 (three high and three low res grids).
+  export  multi04='y' # mww3_test_04 (swell on sea mount and/or current)
+  export  multi05='y' # mww3_test_05 (three-grid moving hurricane)
+  export  multi06='y' # mww3_test_06 (curvilinear grid tests)
+  export  multi07='y' # mww3_test_07 (unstructured grid tests)
+  export  multi08='y' # mww3_test_08 (wind and ice tests)
+
+# export   filter='PR3 ST2 UQ'
+                      # The filter does a set of consecutinve greps on the 
+                      # command lines generated by filter.base with the above
+                      # selected options.
+
+# --------------------------------------------------------------------------- #
+# 2.  Execute matrix.base ...                                                 #
+# --------------------------------------------------------------------------- #
+             
+  $main_dir/../regtests/bin/matrix.base
+
+# --------------------------------------------------------------------------- #
+# End to the matrix                                                           #
+# --------------------------------------------------------------------------- #

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -40,7 +40,7 @@ errmsg ()
 
 # 1.b Usage function
 myname="`basename $0`"  #name of script
-optstr="a:c:C:defg:Ghi:m:n:No:Op:q:r:s:t:Sw:"  #option string for getopt function
+optstr="a:b:c:C:defg:Ghi:m:n:No:Op:q:r:s:t:STw:"  #option string for getopt function
 usage ()
 {
 
@@ -54,6 +54,7 @@ Options:
   -a ww3_env       : use WW3 environment setup file <ww3_env>
                    :   *default is <source_dir>/bin/wwatch3.env
                    :   *file will be created if it does not already exist
+  -b batchq        : optional setting to determine batch queue type (for slurm now)
   -c cmplr         : setup comp & link files for specified cmplr
   -C coupl         : invoke test using <coupl> coupled application
                    :   OASIS : OASIS3-mct ww3_shel coupled application
@@ -97,6 +98,7 @@ Options:
                      tests not executed if file is found.
   -t nthrd         : Threading option. (this is system dependant and can be used
                    : only for the hybrid option)
+  -T               : Run w3_make under time command to create compile-time metric
   -w work_dir      : run test case in test_name/work_dir (default test_name/work)
 
 EOF
@@ -107,6 +109,10 @@ EOF
 # 2. Preparations                                                             #
 # --------------------------------------------------------------------------- #
 
+echo ' '
+echo " Running now options: run_test $*"
+echo ' '
+
 # 2.a Setup array of command-line arguments
 args=`getopt $optstr $*`
 if [ $? != 0 ]
@@ -115,6 +121,8 @@ then
   exit 1
 fi
 set -- $args
+
+ARGS=$args
 
 # 2.b Process command-line options
 exit_p=none
@@ -129,6 +137,7 @@ while :
 do
   case "$1" in
   -a) shift; ww3_env="$1" ;;
+  -b) shift; batchq="$1" ;;
   -c) shift; cmplr="$1" ;;
   -C) shift; coupl="$1" ;;
   -d) use_gdb=1 ;;
@@ -155,6 +164,7 @@ do
   -s) shift; swtstr="$1" ;;
   -S) stub=1 ;;
   -t) shift; nthrd="$1" ;;
+  -T) time_count=1 ;;
   -w) shift; wrkdir="$1" ;;
   --) break ;;
   esac
@@ -276,6 +286,7 @@ then
 else
   file_c="$path_i/switch"
 fi
+
 if [ ! -f $file_c ]
 then
   errmsg "switch file $file_c not found"
@@ -387,6 +398,12 @@ fi
 #  $path_b/w3_setup $path_s -s $file_c -q
 #fi
 
+# 2.m Initialize time counter if time_count option
+if [ $time_count ]
+then # Add time counter if -T
+  cumult_comp=0
+  cumult_run=0
+fi
 
 # --------------------------------------------------------------------------- #
 # 3. Execute Test                                                             #
@@ -403,6 +420,11 @@ then
     \rm -f *.inp *.out *.txt $ncfiles finished
     \ls *.ww3  2>/dev/null | grep -v 'restart.ww3' | grep -v 'nest.ww3' | grep -v 'wind.ww3' | grep -v 'ice.ww3' | grep -v 'ice1.ww3' | xargs \rm 2>/dev/null
   fi
+fi
+
+if [ $time_count ]
+then # Add time counter if -T
+  echo " REGTESTS Time counter: run_test $ARGS" >> time_count.txt
 fi
 
 if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
@@ -464,11 +486,25 @@ then
     cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
     rm $path_b/switch_noST
   fi
+
+  if [ $time_count ]
+  then # Add time counter if -T
+    Tstart=`date +"%s.%2N"`
+  fi
+
   if $path_b/w3_make $prog
   then :
   else
     errmsg "Error occured during WW3 $prog build"
     exit 1
+  fi
+
+  if [ $time_count ]
+  then # Add time counter if -T
+    Tend=`date +"%s.%2N"`
+    Maketime=`echo "$Tend - $Tstart" | bc`
+    cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
   fi
 
   for g in $all_grids
@@ -521,6 +557,11 @@ then
     echo "   Processing $ifile"
     echo "   Screen output routed to $ofile"
 
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+
     if $path_e/$prog > $ofile
     then
       \rm -f $prog.inp
@@ -536,6 +577,14 @@ then
     else
       errmsg "Error occured during $path_e/$prog execution"
       exit 1
+    fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      cumult_run=`echo "$Maketime + $cumult_run" | bc`
+      printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
     fi
 
   done
@@ -554,100 +603,128 @@ if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/$prog.inp 2>/dev/null`"
-fi
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
+  then
+    ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/$prog.inp 2>/dev/null`"
+  fi
 
-if [ $? = 0 ]
-then
+  if [ $? = 0 ]
+  then
 
-  echo ' '
-  echo '+--------------------+'
-  echo '| Initial conditions |'
-  echo '+--------------------+'
-  echo ' '
+    echo ' '
+    echo '+--------------------+'
+    echo '| Initial conditions |'
+    echo '+--------------------+'
+    echo ' '
 
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'| \
                   sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
 
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
-  then
-    errmsg "$path_e/$prog not found"
-    exit 1
-  fi
-
-  for g in $model_grids
-  do
-
-    if [ $multi -eq 2 ]
-    then
-      gu="_$g"
-    fi
-
-    # link conf file
-    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-    then
-      \rm -f $prog.nml
-      \ln -s $ifile $prog.nml
-      ofile="$path_w/`basename $ifile .nml`${gu}.out"
     else
-      \rm -f $prog.inp
-      \ln -s $ifile $prog.inp
-      ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      \cp -f $file_c $path_b/switch
+    fi
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
     fi
 
-    echo "   Processing $ifile"
-    echo "   Screen output routed to $ofile"
-
-    if [ $multi -eq 2 ]
-    then
-      \rm -f mod_def.ww3
-      \ln -s mod_def.$g mod_def.ww3
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
     fi
-    if $path_e/$prog > $ofile
-    then
-      \rm -f $prog.inp
-      \rm -f $prog.nml
-      if [ $multi -eq 2 ]
-      then
-        mv restart.ww3 restart.$g
-        \rm -f mod_def.ww3
-        if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-        then
-          mv $prog.nml.log ${prog}_$g.nml.log
-        fi
-      fi
+
+    if $path_b/w3_make $prog
+    then :
     else
-      errmsg "Error occured during $path_e/$prog execution"
+      errmsg "Error occured during WW3 $prog build"
       exit 1
     fi
 
-  done
-
-fi
-
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+  
+    if [ ! -f $path_e/$prog ]
+    then
+      errmsg "$path_e/$prog not found"
+      exit 1
+    fi
+  
+    for g in $model_grids
+    do
+  
+      if [ $multi -eq 2 ]
+      then
+        gu="_$g"
+      fi
+  
+      # link conf file
+      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+      then
+        \rm -f $prog.nml
+        \ln -s $ifile $prog.nml
+        ofile="$path_w/`basename $ifile .nml`${gu}.out"
+      else
+        \rm -f $prog.inp
+        \ln -s $ifile $prog.inp
+        ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      fi
+  
+      echo "   Processing $ifile"
+      echo "   Screen output routed to $ofile"
+  
+      if [ $multi -eq 2 ]
+      then
+        \rm -f mod_def.ww3
+        \ln -s mod_def.$g mod_def.ww3
+      fi
+  
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
+      fi
+  
+      if $path_e/$prog > $ofile
+      then
+        \rm -f $prog.inp
+        \rm -f $prog.nml
+        if [ $multi -eq 2 ]
+        then
+          mv restart.ww3 restart.$g
+          \rm -f mod_def.ww3
+          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+          then
+            mv $prog.nml.log ${prog}_$g.nml.log
+          fi
+        fi
+      else
+        errmsg "Error occured during $path_e/$prog execution"
+        exit 1
+      fi
+  
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        cumult_run=`echo "$Maketime + $cumult_run" | bc`
+        printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+      fi
+  
+    done
+  
+  fi
+  
 fi
 
 if [ $exit_p = $prog ]
@@ -655,104 +732,132 @@ then
   exit
 fi
 
-# 3.d boundary conditions -------------------------------------------------- #
+# 3.d.1 boundary conditions -------------------------------------------------- #
 
 prog=ww3_bound
 if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/$prog.inp 2>/dev/null`"
-fi
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
+  then
+    ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/$prog.inp 2>/dev/null`"
+  fi
 
-if [ $? = 0 ]
-then
+  if [ $? = 0 ]
+  then
+  
+    echo ' '
+    echo '+---------------------+'
+    echo '| Boundary conditions |'
+    echo '+---------------------+'
+    echo ' '
 
-  echo ' '
-  echo '+---------------------+'
-  echo '| Boundary conditions |'
-  echo '+---------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'| \
                   sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
-  then
-    errmsg "$path_e/$prog not found"
-    exit 1
-  fi
-
-  for g in $model_grids
-  do
-    if [ $multi -eq 2 ]
-    then
-      gu="_$g"
-    fi
-
-    # link conf file
-    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-    then
-      \rm -f $prog.nml
-      \ln -s $ifile $prog.nml
-      ofile="$path_w/`basename $ifile .nml`${gu}.out"
     else
-      \rm -f $prog.inp
-      \ln -s $ifile $prog.inp
-      ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      \cp -f $file_c $path_b/switch
     fi
-
-    echo "   Processing $ifile"
-    echo "   Screen output routed to $ofile"
-
-    if [ $multi -eq 2 ]
-    then
-      \rm -f mod_def.ww3
-      \ln -s mod_def.$g mod_def.ww3
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
     fi
-    if $path_e/$prog > $ofile
-    then
-      \rm -f $prog.inp
-      \rm -f $prog.nml
-      if [ $multi -eq 2 ]
-      then
-        mv nest.ww3 nest.$g
-        \rm -f mod_def.ww3
-        if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-        then
-          mv $prog.nml.log ${prog}_$g.nml.log
-        fi
-      fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+  
+    if $path_b/w3_make $prog
+    then :
     else
-      errmsg "Error occured during $path_e/$prog execution"
+      errmsg "Error occured during WW3 $prog build"
       exit 1
     fi
-
-  done
-
-fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+  
+    if [ ! -f $path_e/$prog ]
+    then
+      errmsg "$path_e/$prog not found"
+      exit 1
+    fi
+  
+    for g in $model_grids
+    do
+      if [ $multi -eq 2 ]
+      then
+        gu="_$g"
+      fi
+  
+      # link conf file
+      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+      then
+        \rm -f $prog.nml
+        \ln -s $ifile $prog.nml
+        ofile="$path_w/`basename $ifile .nml`${gu}.out"
+      else
+        \rm -f $prog.inp
+        \ln -s $ifile $prog.inp
+        ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      fi
+  
+      echo "   Processing $ifile"
+      echo "   Screen output routed to $ofile"
+  
+      if [ $multi -eq 2 ]
+      then
+        \rm -f mod_def.ww3
+        \ln -s mod_def.$g mod_def.ww3
+      fi
+      
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
+      fi
+  
+      if $path_e/$prog > $ofile
+      then
+        \rm -f $prog.inp
+        \rm -f $prog.nml
+        if [ $multi -eq 2 ]
+        then
+          mv nest.ww3 nest.$g
+          \rm -f mod_def.ww3
+          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+          then
+            mv $prog.nml.log ${prog}_$g.nml.log
+          fi
+        fi
+      else
+        errmsg "Error occured during $path_e/$prog execution"
+        exit 1
+      fi
+  
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        cumult_run=`echo "$Maketime + $cumult_run" | bc`
+        printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+      fi
+  
+    done
+  
+  fi
 
 fi
 
@@ -761,104 +866,132 @@ then
   exit
 fi
 
-# 3.d boundary conditions -------------------------------------------------- #
+# 3.d.2 boundary conditions -------------------------------------------------- #
 
 prog=ww3_bounc
 if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/$prog.inp 2>/dev/null`"
-fi
-
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+---------------------+'
-  echo '| Boundary conditions |'
-  echo '+---------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
   then
-    errmsg "$path_e/$prog not found"
-    exit 1
+    ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/$prog.inp 2>/dev/null`"
   fi
-
-  for g in $model_grids
-  do
-    if [ $multi -eq 2 ]
-    then
-      gu="_$g"
-    fi
-
-    # link conf file
-    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-    then
-      \rm -f $prog.nml
-      \ln -s $ifile $prog.nml
-      ofile="$path_w/`basename $ifile .nml`${gu}.out"
+  
+  if [ $? = 0 ]
+  then
+  
+    echo ' '
+    echo '+---------------------+'
+    echo '| Boundary conditions |'
+    echo '+---------------------+'
+    echo ' '
+  
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                    sed 's/OMPG //'    | sed 's/OMPX //'| \
+                    sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
     else
-      \rm -f $prog.inp
-      \ln -s $ifile $prog.inp
-      ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      \cp -f $file_c $path_b/switch
+    fi
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
+    fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
     fi
 
-    echo "   Processing $ifile"
-    echo "   Screen output routed to $ofile"
-
-    if [ $multi -eq 2 ]
-    then
-      \rm -f mod_def.ww3
-      \ln -s mod_def.$g mod_def.ww3
-    fi
-    if $path_e/$prog > $ofile
-    then
-      \rm -f $prog.inp
-      \rm -f $prog.nml
-      if [ $multi -eq 2 ]
-      then
-        mv nest.ww3 nest.$g
-        \rm -f mod_def.ww3
-        if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-        then
-          mv $prog.nml.log ${prog}_$g.nml.log
-        fi
-      fi
+    if $path_b/w3_make $prog
+    then :
     else
-      errmsg "Error occured during $path_e/$prog execution"
+      errmsg "Error occured during WW3 $prog build"
       exit 1
     fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
 
-  done
+    if [ ! -f $path_e/$prog ]
+    then
+      errmsg "$path_e/$prog not found"
+      exit 1
+    fi
+  
+    for g in $model_grids
+    do
+      if [ $multi -eq 2 ]
+      then
+        gu="_$g"
+      fi
+  
+      # link conf file
+      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+      then
+        \rm -f $prog.nml
+        \ln -s $ifile $prog.nml
+        ofile="$path_w/`basename $ifile .nml`${gu}.out"
+      else
+        \rm -f $prog.inp
+        \ln -s $ifile $prog.inp
+        ofile="$path_w/`basename $ifile .inp`${gu}.out"
+      fi
+  
+      echo "   Processing $ifile"
+      echo "   Screen output routed to $ofile"
+  
+      if [ $multi -eq 2 ]
+      then
+        \rm -f mod_def.ww3
+        \ln -s mod_def.$g mod_def.ww3
+      fi
+  
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
+      fi
 
-fi
+      if $path_e/$prog > $ofile
+      then
+        \rm -f $prog.inp
+        \rm -f $prog.nml
+        if [ $multi -eq 2 ]
+        then
+          mv nest.ww3 nest.$g
+          \rm -f mod_def.ww3
+          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+          then
+            mv $prog.nml.log ${prog}_$g.nml.log
+          fi
+        fi
+      else
+        errmsg "Error occured during $path_e/$prog execution"
+        exit 1
+      fi
+  
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        cumult_run=`echo "$Maketime + $cumult_run" | bc`
+        printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+      fi
+  
+    done
+  
+  fi
 
 fi
 
@@ -867,111 +1000,139 @@ then
   exit
 fi
 
-# 3.e Prep forcing fields --------------------------------------------------- #
+# 3.e.1 Prep forcing fields --------------------------------------------------- #
 
 prog=ww3_prep
 if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
-then
-  inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
-else
-  inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
-fi
-
-if [ $? = 0 ]
-then
-  echo ' '
-  echo '+---------------------+'
-  echo '| Prep forcing fields |'
-  echo '+---------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
   then
-    errmsg "$path_e/$prog not found"
-    exit 1
+    inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
+  else
+    inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
   fi
 
-  for g in $input_grids
-  do
+  if [ $? = 0 ]
+  then
+    echo ' '
+    echo '+---------------------+'
+    echo '| Prep forcing fields |'
+    echo '+---------------------+'
+    echo ' '
 
-    if [ $multi -eq 2 ]
-    then
-      gu="_$g"
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                    sed 's/OMPG //'    | sed 's/OMPX //'| \
+                    sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
+    else
+      \cp -f $file_c $path_b/switch
+    fi
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
     fi
 
-    for ifile in $inputs
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+
+    if $path_b/w3_make $prog
+    then :
+    else
+      errmsg "Error occured during WW3 $prog build"
+      exit 1
+    fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+
+    if [ ! -f $path_e/$prog ]
+    then
+      errmsg "$path_e/$prog not found"
+      exit 1
+    fi
+
+    for g in $input_grids
     do
-
-      # link conf file
-      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-      then
-        \rm -f $prog.nml
-        \ln -s $ifile $prog.nml
-        otype="`basename $ifile .nml | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .nml`.out"
-      else
-        \rm -f $prog.inp
-        \ln -s $ifile $prog.inp
-        otype="`basename $ifile .inp | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .inp`.out"
-      fi
-
-      echo "   Processing $ifile for $otype"
-      echo "   Screen output routed to $ofile"
-
+  
       if [ $multi -eq 2 ]
       then
-        \rm -f mod_def.ww3
-        \ln -s mod_def.$g mod_def.ww3
+        gu="_$g"
       fi
-      if $path_e/$prog > $ofile
-      then
-        \rm -f $prog.inp
-        \rm -f $prog.nml
+  
+      for ifile in $inputs
+      do
+
+# link conf file
+        if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+        then
+          \rm -f $prog.nml
+          \ln -s $ifile $prog.nml
+          otype="`basename $ifile .nml | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .nml`.out"
+        else
+          \rm -f $prog.inp
+          \ln -s $ifile $prog.inp
+          otype="`basename $ifile .inp | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .inp`.out"
+        fi
+
+        echo "   Processing $ifile for $otype"
+        echo "   Screen output routed to $ofile"
+
         if [ $multi -eq 2 ]
         then
           \rm -f mod_def.ww3
-          mv $otype.ww3 $otype.$g
-          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-          then
-            mv $prog.nml.log ${prog}_$g.nml.log
-          fi
+          \ln -s mod_def.$g mod_def.ww3
         fi
-      else
-        errmsg "Error occured during $path_e/$prog execution"
-        exit 1
-      fi
+
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tstart=`date +"%s.%2N"`
+        fi
+
+        if $path_e/$prog > $ofile
+        then
+          \rm -f $prog.inp
+          \rm -f $prog.nml
+          if [ $multi -eq 2 ]
+          then
+            \rm -f mod_def.ww3
+            mv $otype.ww3 $otype.$g
+            if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+            then
+              mv $prog.nml.log ${prog}_$g.nml.log
+            fi
+          fi
+        else
+          errmsg "Error occured during $path_e/$prog execution"
+          exit 1
+        fi
+  
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tend=`date +"%s.%2N"`
+          Maketime=`echo "$Tend - $Tstart" | bc`
+          cumult_run=`echo "$Maketime + $cumult_run" | bc`
+          printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+        fi
+
+      done
 
     done
 
-  done
-
-fi
+  fi
 
 fi
 
@@ -980,111 +1141,139 @@ then
   exit
 fi
 
-# 3.e Prep forcing fields --------------------------------------------------- #
+# 3.e.2 Prep forcing fields --------------------------------------------------- #
 
 prog=ww3_prnc
 if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
-then
-  inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
-else
-  inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
-fi
-
-if [ $? = 0 ]
-then
-  echo ' '
-  echo '+-------------------------------+'
-  echo '| Prep of NetCDF forcing fields |'
-  echo '+-------------------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
   then
-    errmsg "$path_e/$prog not found"
-    exit 1
+    inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
+  else
+    inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
   fi
 
-  for g in $input_grids
-  do
+  if [ $? = 0 ]
+  then
+    echo ' '
+    echo '+-------------------------------+'
+    echo '| Prep of NetCDF forcing fields |'
+    echo '+-------------------------------+'
+    echo ' '
 
-    if [ $multi -eq 2 ]
-    then
-      gu="_$g"
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                    sed 's/OMPG //'    | sed 's/OMPX //'| \
+                    sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
+    else
+      \cp -f $file_c $path_b/switch
+    fi
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
+    fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
     fi
 
-    for ifile in $inputs
+    if $path_b/w3_make $prog
+    then :
+    else
+      errmsg "Error occured during WW3 $prog build"
+      exit 1
+    fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+  
+    if [ ! -f $path_e/$prog ]
+    then
+      errmsg "$path_e/$prog not found"
+      exit 1
+    fi
+
+    for g in $input_grids
     do
-
-      # link conf file
-      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-      then
-        \rm -f $prog.nml
-        \ln -s $ifile $prog.nml
-        otype="`basename $ifile .nml | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .nml`.out"
-      else
-        \rm -f $prog.inp
-        \ln -s $ifile $prog.inp
-        otype="`basename $ifile .inp | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .inp`.out"
-      fi
-
-      echo "   Processing $ifile"
-      echo "   Screen output routed to $ofile"
 
       if [ $multi -eq 2 ]
       then
-        \rm -f mod_def.ww3
-        \ln -s mod_def.$g mod_def.ww3
+        gu="_$g"
       fi
-      if $path_e/$prog > $ofile
-      then
-        \rm -f $prog.inp
-        \rm -f $prog.nml
+
+      for ifile in $inputs
+      do
+
+# link conf file
+        if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+        then
+          \rm -f $prog.nml
+          \ln -s $ifile $prog.nml
+          otype="`basename $ifile .nml | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .nml`.out"
+        else
+          \rm -f $prog.inp
+          \ln -s $ifile $prog.inp
+          otype="`basename $ifile .inp | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .inp`.out"
+        fi
+  
+        echo "   Processing $ifile"
+        echo "   Screen output routed to $ofile"
+  
         if [ $multi -eq 2 ]
         then
           \rm -f mod_def.ww3
-          mv $otype.ww3 $otype.$g
-          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-          then
-            mv $prog.nml.log ${prog}_$g.nml.log
-          fi
+          \ln -s mod_def.$g mod_def.ww3
         fi
-      else
-        errmsg "Error occured during $path_e/$prog execution"
-        exit 1
-      fi
+  
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tstart=`date +"%s.%2N"`
+        fi
+
+        if $path_e/$prog > $ofile
+        then
+          \rm -f $prog.inp
+          \rm -f $prog.nml
+          if [ $multi -eq 2 ]
+          then
+            \rm -f mod_def.ww3
+            mv $otype.ww3 $otype.$g
+            if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+            then
+              mv $prog.nml.log ${prog}_$g.nml.log
+            fi
+          fi
+        else
+          errmsg "Error occured during $path_e/$prog execution"
+          exit 1
+        fi
+
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tend=`date +"%s.%2N"`
+          Maketime=`echo "$Tend - $Tstart" | bc`
+          cumult_run=`echo "$Maketime + $cumult_run" | bc`
+          printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+        fi
+
+      done
 
     done
 
-  done
-
-fi
+  fi
 
 fi
 
@@ -1113,171 +1302,204 @@ else
   prog=ww3_shel
   prgb=ww3_shel
 fi
+
 if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # track file - multigrid option (ge 1)
-if [ $multi -ge 1 ]
-then
-  for g in $all_grids
-  do
-    ifile="`ls $path_i/track_i.$g 2>/dev/null`"
+  if [ $multi -ge 1 ]
+  then
+    for g in $all_grids
+    do
+      ifile="`ls $path_i/track_i.$g 2>/dev/null`"
+      if [ $? = 0 ]
+      then
+        \rm -f track_i.$g
+        \ln -s $ifile
+      fi
+    done
+  else
+    ifile="`ls $path_i/track_i.ww3 2>/dev/null`"
     if [ $? = 0 ]
     then
-      \rm -f track_i.$g
+      \rm -f track_i.ww3
       \ln -s $ifile
     fi
-  done
-else
-  ifile="`ls $path_i/track_i.ww3 2>/dev/null`"
+  fi
+  
+# config filename - gridset option (eq 2)
+  if [ $multi -eq 2 ]
+  then
+    fileconf="${prog}_${grdset}"
+  else
+    fileconf="${prog}"
+  fi
+  
+# select inp/nml files
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
+  then
+    ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
+  fi
+  
+  
   if [ $? = 0 ]
   then
-    \rm -f track_i.ww3
-    \ln -s $ifile
-  fi
-fi
-
-# config filename - gridset option (eq 2)
-if [ $multi -eq 2 ]
-then
-  fileconf="${prog}_${grdset}"
-else
-  fileconf="${prog}"
-fi
-
-# select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
-fi
-
-
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+--------------------+'
-  echo '|    Main program    |'
-  echo '+--------------------+'
-  echo ' '
-
-  \cp -f $file_c $path_b/switch
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prgb
-  then :
-  else
-    errmsg "Error occured during WW3 $prgb build"
-    exit 1
-  fi
-  if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
-  then
-    if [ $cmplr ]
-    then
-      export WW3_COMP=$cmplr
+  
+    echo ' '
+    echo '+--------------------+'
+    echo '|    Main program    |'
+    echo '+--------------------+'
+    echo ' '
+  
+    \cp -f $file_c $path_b/switch
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
     fi
-    if make -C $path_s/esmf $prgb
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+  
+    if $path_b/w3_make $prgb
     then :
     else
-      errmsg "Error occured during WW3 ESMF build"
+      errmsg "Error occured during WW3 $prgb build"
       exit 1
     fi
-  fi
-
-  if [ ! -f $path_e/$prgb ]
-  then
-    errmsg "$path_e/$prgb not found"
-    exit 1
-  fi
-
-  ofile="$path_w/$prog.out"
-
-  # link conf file
-  if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-  then
-    \rm -f $prog.nml
-    \ln -s $ifile $prog.nml
-  else
-    \rm -f $prog.inp
-    \ln -s $ifile $prog.inp
-  fi
-
-  if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
-  then
-    \rm -f PET*.ESMF_LogFile
-    \rm -f ww3_esmf.rc
-    \cp -f ${path_i}/ww3_esmf.rc ww3_esmf.rc
-    if [ ! -z "`echo ${ifile} | grep -o nml`" ]
-    then
-      echo "WAV_input_file_name: $prog.nml" >> ww3_esmf.rc
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
     fi
-    if [ $nproc ]
+  
+    if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
     then
-      echo "pet_count: $nproc" >> ww3_esmf.rc
-    else
-      echo "pet_count: 1" >> ww3_esmf.rc
-    fi
-  fi
-
-  echo "   Processing $ifile"
-  echo "   Screen output copied to $ofile"
-  if [ $pmpi ]
-  then
-    if [ $nproc ]
-    then
-      runcmd="$runcmd -np $nproc"
-    fi
-    if [ $nthrd ]
-    then
-      if ( which omplace ) ; then
-        runcmd="$runcmd omplace -nt $nthrd"
+      if [ $cmplr ]
+      then
+        export WW3_COMP=$cmplr
+      fi
+      if make -C $path_s/esmf $prgb
+      then :
       else
-        runcmd="$runcmd /usr/bin/env OMP_NUM_THREADS=$nthrd"
+        errmsg "Error occured during WW3 ESMF build"
+        exit 1
       fi
     fi
-  fi
-  if [ $pomp ]
-  then
-    if [ $nproc ]
+  
+    if [ ! -f $path_e/$prgb ]
     then
-      export OMP_NUM_THREADS=$nproc
-    fi
-  fi
-
-  if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
-  then
-    halfnproc=$(($nproc / 2))
-    if $runcmd1 -np $halfnproc $path_e/$prgb : -np $halfnproc $path_w/toy_model | tee $ofile
-    then
-      \rm -f track_i.ww3
-      \rm -f $prog.inp
-    else
-      errmsg "Error occured during $path_e/$prog execution"
+      errmsg "$path_e/$prgb not found"
       exit 1
     fi
-  else
-    if $runcmd $path_e/$prgb | tee $ofile
+  
+    ofile="$path_w/$prog.out"
+  
+# link conf file
+    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
     then
-      \rm -f track_i.ww3
-      \rm -f $prog.inp
       \rm -f $prog.nml
-      for file_p in ${files_p}
-      do
-        \rm -f ${file_p}
-      done
+      \ln -s $ifile $prog.nml
     else
-      errmsg "Error occured during $path_e/$prog execution"
-      exit 1
+      \rm -f $prog.inp
+      \ln -s $ifile $prog.inp
+    fi
+  
+    if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
+    then
+      \rm -f PET*.ESMF_LogFile
+      \rm -f ww3_esmf.rc
+      \cp -f ${path_i}/ww3_esmf.rc ww3_esmf.rc
+      if [ ! -z "`echo ${ifile} | grep -o nml`" ]
+      then
+        echo "WAV_input_file_name: $prog.nml" >> ww3_esmf.rc
+      fi
+      if [ $nproc ]
+      then
+        echo "pet_count: $nproc" >> ww3_esmf.rc
+      else
+        echo "pet_count: 1" >> ww3_esmf.rc
+      fi
+    fi
+  
+    echo "   Processing $ifile"
+    echo "   Screen output copied to $ofile"
+    if [ $pmpi ]
+    then
+      if [ $nproc ]
+      then
+        if [ $batchq = "slurm" ]
+        then 
+          runcmd="$runcmd -n $nproc"
+        
+        else
+          runcmd="$runcmd -np $nproc"
+        fi
+      fi
+      if [ $nthrd ]
+      then
+        if ( which omplace ) ; then
+          runcmd="$runcmd omplace -nt $nthrd"
+        else
+          runcmd="$runcmd /usr/bin/env OMP_NUM_THREADS=$nthrd"
+        fi
+      fi
+    fi
+    if [ $pomp ]
+    then
+      if [ $nproc ]
+      then
+        export OMP_NUM_THREADS=$nproc
+      fi
+    fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+  
+    if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
+    then
+      halfnproc=$(($nproc / 2))
+      if $runcmd1 -np $halfnproc $path_e/$prgb : -np $halfnproc $path_w/toy_model | tee $ofile
+      then
+        \rm -f track_i.ww3
+        \rm -f $prog.inp
+      else
+        errmsg "Error occured during $path_e/$prog execution"
+        exit 1
+      fi
+    else
+      if $runcmd $path_e/$prgb | tee $ofile
+      then
+        \rm -f track_i.ww3
+        \rm -f $prog.inp
+        \rm -f $prog.nml
+        for file_p in ${files_p}
+        do
+          \rm -f ${file_p}
+        done
+      else
+        errmsg "Error occured during $path_e/$prog execution"
+        exit 1
+      fi
+    fi
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      cumult_run=`echo "$Maketime + $cumult_run" | bc`
+      printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
     fi
   fi
-fi
-
 fi
 
 if [ $exit_p = $prog ]
@@ -1292,85 +1514,111 @@ if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # config filename - gridset option (eq 2)
-if [ $multi -eq 2 ]
-then
-  fileconf="${prog}_${grdset}"
-else
-  fileconf="${prog}"
-fi
+  if [ $multi -eq 2 ]
+  then
+    fileconf="${prog}_${grdset}"
+  else
+    fileconf="${prog}"
+  fi
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
-fi
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
+  then
+    ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
+  fi
 
 
-if [ $? = 0 ]
-then
+  if [ $? = 0 ]
+  then
 
-  echo ' '
-  echo '+-------------------------+'
-  echo '|    Integrated output    |'
-  echo '+-------------------------+'
-  echo ' '
+    echo ' '
+    echo '+-------------------------+'
+    echo '|    Integrated output    |'
+    echo '+-------------------------+'
+    echo ' '
 
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+    if [ $force_shrd ]
+    then # build pre- & post-processing programs with SHRD only
+      cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'| \
                   sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
+    else
+      \cp -f $file_c $path_b/switch
+    fi
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
+    fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
 
+    if $path_b/w3_make $prog
+    then :
+    else
+      errmsg "Error occured during WW3 $prog build"
+      exit 1
+    fi
 
-  # link conf file
-  if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-  then
-    \rm -f $prog.nml
-    \ln -s $ifile $prog.nml
-    ofile="$path_w/`basename $ifile .nml`.out"
-  else
-    \rm -f $prog.inp
-    \ln -s $ifile $prog.inp
-    ofile="$path_w/`basename $ifile .inp`.out"
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+
+# link conf file
+    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+    then
+      \rm -f $prog.nml
+      \ln -s $ifile $prog.nml
+      ofile="$path_w/`basename $ifile .nml`.out"
+    else
+      \rm -f $prog.inp
+      \ln -s $ifile $prog.inp
+      ofile="$path_w/`basename $ifile .inp`.out"
+    fi
+
+    echo "   Processing $ifile"
+    echo "   Screen output copied to $ofile"
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+
+    if $path_e/$prog > $ofile
+    then
+      \rm -f $prog.inp
+      \rm -f $prog.nml
+      for g in $intgl_grids
+      do
+        if [ -f "out_grd.$g" ]
+        then
+          model_grids="$model_grids $g"
+        fi
+      done
+    else
+      errmsg "Error occured during $path_e/$prog execution"
+      exit 1
+    fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      cumult_run=`echo "$Maketime + $cumult_run" | bc`
+      printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+    fi
+
   fi
-
-  echo "   Processing $ifile"
-  echo "   Screen output copied to $ofile"
-
-  if $path_e/$prog > $ofile
-  then
-    \rm -f $prog.inp
-    \rm -f $prog.nml
-    for g in $intgl_grids
-    do
-      if [ -f "out_grd.$g" ]
-      then
-        model_grids="$model_grids $g"
-      fi
-    done
-  else
-    errmsg "Error occured during $path_e/$prog execution"
-    exit 1
-  fi
-
-fi
 
 fi
 
@@ -1402,169 +1650,197 @@ fi
 for prog in $out_progs
 do
 
-rline='|   Gridded output   |'
-if [ $prog = ww3_ounf ]
-then
-  rline='| NC Gridded output  |'
-fi
-if [ $prog = gx_outf ]
-then
-  rline='|GrADS Gridded output|'
-fi
+  rline='|   Gridded output   |'
+  if [ $prog = ww3_ounf ]
+  then
+    rline='| NC Gridded output  |'
+  fi
+  if [ $prog = gx_outf ]
+  then
+    rline='|GrADS Gridded output|'
+  fi
 
-if [ $exec_p = $prog -o $exec_p = "none" ]
-then
+  if [ $exec_p = $prog -o $exec_p = "none" ]
+  then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
-then
-  inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
-else
-  inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
-fi
-
-
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+--------------------+'
-  echo "$rline"
-  echo '+--------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
-  then
-    errmsg "$path_e/$prog not found"
-    exit 1
-  fi
-
-  for g in $model_grids
-  do
-
-    if [ $multi -eq 2 ]
+    if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
     then
-      if [ ! -e out_grd.$g ]
-      then
-        continue
-      fi
-      gu="_$g"
+      inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
+    else
+      inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
     fi
 
-    for ifile in $inputs
-    do
 
-      # link conf file
-      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-      then
-        \rm -f $prog.nml
-        \ln -s $ifile $prog.nml
-        otype="`basename $ifile .nml | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .nml`${gu}.out"
+    if [ $? = 0 ]
+    then
+
+      echo ' '
+      echo '+--------------------+'
+      echo "$rline"
+      echo '+--------------------+'
+      echo ' '
+    
+      if [ $force_shrd ]
+      then # build pre- & post-processing programs with SHRD only
+        cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                      sed 's/OMPG //'    | sed 's/OMPX //'| \
+                      sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
       else
-        \rm -f $prog.inp
-        \ln -s $ifile $prog.inp
-        otype="`basename $ifile .inp | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .inp`${gu}.out"
+        \cp -f $file_c $path_b/switch
+      fi
+      if [ $testST ]
+      then #add S T switches 
+        \cp -f $path_b/switch $path_b/switch_noST
+        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+        rm $path_b/switch_noST
+      fi
+    
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
       fi
 
-      echo "   Processing $ifile"
-      echo "   Screen output routed to $ofile"
-
-      if [ $multi -eq 2 ]
-      then
-        \rm -f mod_def.ww3
-        \rm -f out_grd.ww3
-        \ln -s mod_def.$g mod_def.ww3
-        \ln -s out_grd.$g out_grd.ww3
-        \rm -f ww3.????????.*
-        \rm -fr ${otype}_$g
-      fi
-      if $path_e/$prog > $ofile
-      then
-        \rm -f $prog.inp
-        \rm -f $prog.nml
-        if [ $multi -eq 2 ]
-        then
-          \rm -f mod_def.ww3
-          \rm -f out_grd.ww3
-          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-          then
-            mv $prog.nml.log ${prog}_$g.nml.log
-          fi
-          ofiles="`ls ww3.????????.* 2>/dev/null`"
-          if [ $? = 0 ]
-          then
-            mkdir ${otype}_$g
-            mv -f $ofiles ${otype}_$g/.
-            echo "   ASCII output files moved to ${otype}_$g"
-          fi
-          ofiles="`ls ww3.????*.nc 2>/dev/null`"
-          if [ $? = 0 ]
-          then
-            mkdir ${otype}_$g
-            mv -f $ofiles ${otype}_$g/.
-            echo "   NetCDF output files moved to ${otype}_$g"
-          fi
-#
-          if [ "$prog" = 'gx_outf' ]
-          then
-            case $g in
-              'grd2' )  sed -e "s/ww3\.grads/ww3\.$g/g" \
-                            -e "s/37\.5/3\.75/g" \
-                            -e "s/1\.50/0\.15/g" \
-                                                  ww3.ctl > $g.ctl ;;
-              'grd3' )  sed -e "s/ww3\.grads/ww3\.$g/g" \
-                            -e "s/12\.5/1\.25/g" \
-                            -e "s/0\.50/0\.05/g" \
-                                                  ww3.ctl > $g.ctl ;;
-                *    )  sed -e "s/ww3\.grads/ww3\.$g/g" \
-                            -e "s/0\.25/2\.50/g" ww3.ctl > $g.ctl ;;
-            esac
-            rm -f ww3.ctl
-            echo "   ww3.ctl moved to $g.ctl"
-            mv ww3.grads ww3.$g
-            echo "   ww3.grads moved to ww3.$g"
-          fi
-        fi
+      if $path_b/w3_make $prog
+      then :
       else
-        errmsg "Error occured during $path_e/$prog execution"
+        errmsg "Error occured during WW3 $prog build"
+        exit 1
+      fi
+    
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+        cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+      fi
+
+      if [ ! -f $path_e/$prog ]
+      then
+        errmsg "$path_e/$prog not found"
         exit 1
       fi
 
-    done
+      for g in $model_grids
+      do
 
-  done
+        if [ $multi -eq 2 ]
+        then
+          if [ ! -e out_grd.$g ]
+          then
+            continue
+          fi
+          gu="_$g"
+        fi
 
-fi
+        for ifile in $inputs
+        do
 
-fi
+# link conf file
+          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+          then
+            \rm -f $prog.nml
+            \ln -s $ifile $prog.nml
+            otype="`basename $ifile .nml | sed s/^${prog}_//`"
+            ofile="$path_w/`basename $ifile .nml`${gu}.out"
+          else
+            \rm -f $prog.inp
+            \ln -s $ifile $prog.inp
+            otype="`basename $ifile .inp | sed s/^${prog}_//`"
+            ofile="$path_w/`basename $ifile .inp`${gu}.out"
+          fi
 
-if [ $exit_p = $prog ]
-then
-  exit
-fi
+          echo "   Processing $ifile"
+          echo "   Screen output routed to $ofile"
+    
+          if [ $multi -eq 2 ]
+          then
+            \rm -f mod_def.ww3
+            \rm -f out_grd.ww3
+            \ln -s mod_def.$g mod_def.ww3
+            \ln -s out_grd.$g out_grd.ww3
+            \rm -f ww3.????????.*
+            \rm -fr ${otype}_$g
+          fi
+
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tstart=`date +"%s.%2N"`
+        fi
+    
+        if $path_e/$prog > $ofile
+          then
+            \rm -f $prog.inp
+            \rm -f $prog.nml
+            if [ $multi -eq 2 ]
+            then
+              \rm -f mod_def.ww3
+              \rm -f out_grd.ww3
+              if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+              then
+                mv $prog.nml.log ${prog}_$g.nml.log
+              fi
+              ofiles="`ls ww3.????????.* 2>/dev/null`"
+              if [ $? = 0 ]
+              then
+                mkdir ${otype}_$g
+                mv -f $ofiles ${otype}_$g/.
+                echo "   ASCII output files moved to ${otype}_$g"
+              fi
+              ofiles="`ls ww3.????*.nc 2>/dev/null`"
+              if [ $? = 0 ]
+              then
+                mkdir ${otype}_$g
+                mv -f $ofiles ${otype}_$g/.
+                echo "   NetCDF output files moved to ${otype}_$g"
+              fi
+#
+              if [ "$prog" = 'gx_outf' ]
+              then
+                case $g in
+                  'grd2' )  sed -e "s/ww3\.grads/ww3\.$g/g" \
+                                -e "s/37\.5/3\.75/g" \
+                                -e "s/1\.50/0\.15/g" \
+                                                      ww3.ctl > $g.ctl ;;
+                  'grd3' )  sed -e "s/ww3\.grads/ww3\.$g/g" \
+                                -e "s/12\.5/1\.25/g" \
+                                -e "s/0\.50/0\.05/g" \
+                                                      ww3.ctl > $g.ctl ;;
+                    *    )  sed -e "s/ww3\.grads/ww3\.$g/g" \
+                                -e "s/0\.25/2\.50/g" ww3.ctl > $g.ctl ;;
+                esac
+                rm -f ww3.ctl
+                echo "   ww3.ctl moved to $g.ctl"
+                mv ww3.grads ww3.$g
+                echo "   ww3.grads moved to ww3.$g"
+              fi
+            fi
+          else
+            errmsg "Error occured during $path_e/$prog execution"
+            exit 1
+          fi
+
+          if [ $time_count ]
+          then # Add time counter if -T
+            Tend=`date +"%s.%2N"`
+            Maketime=`echo "$Tend - $Tstart" | bc`
+            cumult_run=`echo "$Maketime + $cumult_run" | bc`
+            printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+          fi
+
+        done
+
+      done
+
+    fi
+
+  fi
+
+  if [ $exit_p = $prog ]
+  then
+    exit
+  fi
 
 done # end of loop on progs
 
@@ -1593,129 +1869,156 @@ fi
 for prog in $out_progs
 do
 
-rline='|    Point output    |'
-if [ $prog = ww3_ounp ]
-then
-  rline='| NC Point output    |'
-fi
+  rline='|    Point output    |'
+  if [ $prog = ww3_ounp ]
+  then
+    rline='| NC Point output    |'
+  fi
 
-if [ $exec_p = $prog -o $exec_p = "none" ]
-then
+  if [ $exec_p = $prog -o $exec_p = "none" ]
+  then
 
 # select inp/nml format for input file to program $prog
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
-then
-  inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
-else
-  inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
-fi
-
-
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+--------------------+'
-  echo "$rline"
-  echo '+--------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
-  then
-    errmsg "$path_e/$prog not found"
-    exit 1
-  fi
-
-  for g in $point_grids
-  do
-
-    if [ $multi -eq 2 ]
+    if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
     then
-      if [ ! -e out_pnt.$g ]
-      then
-        continue
-      fi
-      gu="_$g"
+      inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
+    else
+      inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
     fi
 
-    for ifile in $inputs
-    do
+    if [ $? = 0 ]
+    then
 
-      # link conf file
-      if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-      then
-        \rm -f $prog.nml
-        \ln -s $ifile $prog.nml
-        otype="`basename $ifile .nml | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .nml`${gu}.out"
+      echo ' '
+      echo '+--------------------+'
+      echo "$rline"
+      echo '+--------------------+'
+      echo ' '
+
+      if [ $force_shrd ]
+      then # build pre- & post-processing programs with SHRD only
+        cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                      sed 's/OMPG //'    | sed 's/OMPX //'| \
+                      sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
       else
-        \rm -f $prog.inp
-        \ln -s $ifile $prog.inp
-        otype="`basename $ifile .inp | sed s/^${prog}_//`"
-        ofile="$path_w/`basename $ifile .inp`${gu}.out"
+        \cp -f $file_c $path_b/switch
+      fi
+      if [ $testST ]
+      then #add S T switches 
+        \cp -f $path_b/switch $path_b/switch_noST
+        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+        rm $path_b/switch_noST
       fi
 
-      echo "   Processing $ifile"
-      echo "   Screen output routed to $ofile"
-
-      if [ $multi -eq 2 ]
-      then
-        \rm -f mod_def.ww3
-        \rm -f out_pnt.ww3
-        \ln -s mod_def.$g mod_def.ww3
-        \ln -s out_pnt.$g out_pnt.ww3
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
       fi
-      if $path_e/$prog > $ofile
-      then
-        \rm -f $prog.inp
-        \rm -f $prog.nml
-        if [ $multi -eq 2 ]
-        then
-          \rm -f mod_def.ww3
-          \rm -f out_pnt.ww3
-          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-          then
-            mv $prog.nml.log ${prog}_$g.nml.log
-          fi
-        fi
+
+      if $path_b/w3_make $prog
+      then :
       else
-        errmsg "Error occured during $path_e/$prog execution"
+        errmsg "Error occured during WW3 $prog build"
         exit 1
       fi
 
-    done
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+        cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+      fi
+    
+      if [ ! -f $path_e/$prog ]
+      then
+        errmsg "$path_e/$prog not found"
+        exit 1
+      fi
 
-  done
+      for g in $point_grids
+      do
 
-fi
+        if [ $multi -eq 2 ]
+        then
+          if [ ! -e out_pnt.$g ]
+          then
+            continue
+          fi
+          gu="_$g"
+        fi
 
-fi
+        for ifile in $inputs
+        do
+    
+          # link conf file
+          if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+          then
+            \rm -f $prog.nml
+            \ln -s $ifile $prog.nml
+            otype="`basename $ifile .nml | sed s/^${prog}_//`"
+            ofile="$path_w/`basename $ifile .nml`${gu}.out"
+          else
+            \rm -f $prog.inp
+            \ln -s $ifile $prog.inp
+            otype="`basename $ifile .inp | sed s/^${prog}_//`"
+            ofile="$path_w/`basename $ifile .inp`${gu}.out"
+          fi
 
-if [ $exit_p = $prog ]
-then
-  exit
-fi
+          echo "   Processing $ifile"
+          echo "   Screen output routed to $ofile"
+    
+          if [ $multi -eq 2 ]
+          then
+            \rm -f mod_def.ww3
+            \rm -f out_pnt.ww3
+            \ln -s mod_def.$g mod_def.ww3
+            \ln -s out_pnt.$g out_pnt.ww3
+          fi
+
+          if [ $time_count ]
+          then # Add time counter if -T
+            Tstart=`date +"%s.%2N"`
+          fi
+
+          if $path_e/$prog > $ofile
+          then
+            \rm -f $prog.inp
+            \rm -f $prog.nml
+            if [ $multi -eq 2 ]
+            then
+              \rm -f mod_def.ww3
+              \rm -f out_pnt.ww3
+              if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+              then
+                mv $prog.nml.log ${prog}_$g.nml.log
+              fi
+            fi
+          else
+            errmsg "Error occured during $path_e/$prog execution"
+            exit 1
+          fi
+
+          if [ $time_count ]
+          then # Add time counter if -T
+            Tend=`date +"%s.%2N"`
+            Maketime=`echo "$Tend - $Tstart" | bc`
+            cumult_run=`echo "$Maketime + $cumult_run" | bc`
+            printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+          fi
+
+        done
+
+      done
+
+    fi
+
+  fi
+
+  if [ $exit_p = $prog ]
+  then
+    exit
+  fi
 
 done # end of loop on progs
 
@@ -1731,138 +2034,166 @@ esac
 for prog in $out_progs
 do
 
-if [ $exec_p = $prog -o $exec_p = "none" ]
-then
+  if [ $exec_p = $prog -o $exec_p = "none" ]
+  then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
-then
-  inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
-else
-  inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
-fi
-
-
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+--------------------+'
-  echo '|    Track output    |'
-  echo '+--------------------+'
-  echo ' '
-
-  if [ $force_shrd ]
-  then # build pre- & post-processing programs with SHRD only
-    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
-                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
-  else
-    \cp -f $file_c $path_b/switch
-  fi
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  if [ ! -f $path_e/$prog ]
-  then
-    errmsg "$path_e/$prog not found"
-    exit 1
-  fi
-
-  for g in $point_grids
-  do
-
-    if [ $multi -eq 2 ]
+    if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
     then
-      if [ ! -e track_o.$g ]
-      then
-        continue
+      inputs="`ls ${path_i}/${prog}*.nml 2>/dev/null`"
+    else
+      inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
+    fi
+
+
+    if [ $? = 0 ]
+    then
+
+      echo ' '
+      echo '+--------------------+'
+      echo '|    Track output    |'
+      echo '+--------------------+'
+      echo ' '
+
+      if [ $force_shrd ]
+      then # build pre- & post-processing programs with SHRD only
+        cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
+                    sed 's/OMPG //'    | sed 's/OMPX //'| \
+                    sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switch
+      else
+        \cp -f $file_c $path_b/switch
       fi
-      gu="_$g"
-      fileconf="$prog${gu}"
-    else
-      fileconf="$prog"
-    fi
+      if [ $testST ]
+      then #add S T switches 
+        \cp -f $path_b/switch $path_b/switch_noST
+        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+        rm $path_b/switch_noST
+      fi
 
-    # select inp/nml files
-    if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
-    then
-      ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
-    else
-      ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
-    fi
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tstart=`date +"%s.%2N"`
+      fi
 
-    if [ ! -f $ifile ]
-    then
-      errmsg "$ifile not found"
-      exit 1
-    fi
+      if $path_b/w3_make $prog
+      then :
+      else
+        errmsg "Error occured during WW3 $prog build"
+        exit 1
+      fi
 
-    # link conf file
-    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-    then
-      \rm -f $prog.nml
-      \ln -s $ifile $prog.nml
-      otype="`basename $ifile .nml | sed s/^${prog}_//`"
-      ofile="$path_w/`basename $ifile .nml`.out"
-    else
-      \rm -f $prog.inp
-      \ln -s $ifile $prog.inp
-      otype="`basename $ifile .inp | sed s/^${prog}_//`"
-      ofile="$path_w/`basename $ifile .inp`.out"
-    fi
+      if [ $time_count ]
+      then # Add time counter if -T
+        Tend=`date +"%s.%2N"`
+        Maketime=`echo "$Tend - $Tstart" | bc`
+        printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+        cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+      fi
 
-    echo "   Processing $ifile"
-    echo "   Screen output routed to $ofile"
-
-    if [ $multi -eq 2 ]
-    then
-      \rm -f track_o.ww3
-      \ln -s track_o.$g track_o.ww3
-    fi
-    if $path_e/$prog > $ofile
-    then
-      \rm -f $prog.inp
-      \rm -f $prog.nml
-      if [ $multi -eq 2 ]
+      if [ ! -f $path_e/$prog ]
       then
-        \rm -f track_o.ww3
+        errmsg "$path_e/$prog not found"
+        exit 1
+      fi
+    
+      for g in $point_grids
+      do
+    
+        if [ $multi -eq 2 ]
+        then
+          if [ ! -e track_o.$g ]
+          then
+            continue
+          fi
+          gu="_$g"
+          fileconf="$prog${gu}"
+        else
+          fileconf="$prog"
+        fi
+  
+# select inp/nml files
+        if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
+        then
+          ifile="`ls ${path_i}/${fileconf}.nml 2>/dev/null`"
+        else
+          ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
+        fi
+
+        if [ ! -f $ifile ]
+        then
+          errmsg "$ifile not found"
+          exit 1
+        fi
+
+# link conf file
         if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
         then
-          mv $prog.nml.log ${prog}_$g.nml.log
+          \rm -f $prog.nml
+          \ln -s $ifile $prog.nml
+          otype="`basename $ifile .nml | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .nml`.out"
+        else
+          \rm -f $prog.inp
+          \ln -s $ifile $prog.inp
+          otype="`basename $ifile .inp | sed s/^${prog}_//`"
+          ofile="$path_w/`basename $ifile .inp`.out"
         fi
-        if [ -e track.ww3 ]
+    
+        echo "   Processing $ifile"
+        echo "   Screen output routed to $ofile"
+
+        if [ $multi -eq 2 ]
         then
-          mv track.ww3 track.$g
-        elif [ -e track.nc ]
+          \rm -f track_o.ww3
+          \ln -s track_o.$g track_o.ww3
+        fi
+
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tstart=`date +"%s.%2N"`
+        fi
+
+        if $path_e/$prog > $ofile
         then
-          mv track.nc track_$g.nc
-        fi        
-      fi
-    else
-      errmsg "Error occured during $path_e/$prog execution"
-      exit 1
+          \rm -f $prog.inp
+          \rm -f $prog.nml
+          if [ $multi -eq 2 ]
+          then
+            \rm -f track_o.ww3
+            if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+            then
+              mv $prog.nml.log ${prog}_$g.nml.log
+            fi
+            if [ -e track.ww3 ]
+            then
+              mv track.ww3 track.$g
+            elif [ -e track.nc ]
+            then
+              mv track.nc track_$g.nc
+            fi        
+          fi
+        else
+          errmsg "Error occured during $path_e/$prog execution"
+          exit 1
+        fi
+
+        if [ $time_count ]
+        then # Add time counter if -T
+          Tend=`date +"%s.%2N"`
+          Maketime=`echo "$Tend - $Tstart" | bc`
+          cumult_run=`echo "$Maketime + $cumult_run" | bc`
+          printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+        fi
+      done
+
     fi
-  done
 
-fi
+  fi
 
-fi
-
-if [ $exit_p = $prog ]
-then
-  exit
-fi
+  if [ $exit_p = $prog ]
+  then
+    exit
+  fi
 
 done # end of loop on progs
 
@@ -1873,24 +2204,24 @@ if [ $exec_p = $prog -o $exec_p = "none" ]
 then
 
 # select inp/nml files
-if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
-then
-  ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
-else
-  ifile="`ls $path_i/$prog.inp 2>/dev/null`"
-fi
+  if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}.nml 2>/dev/null`" ]
+  then
+    ifile="`ls ${path_i}/${prog}.nml 2>/dev/null`"
+  else
+    ifile="`ls $path_i/$prog.inp 2>/dev/null`"
+  fi
 
 
-if [ $? = 0 ]
-then
+  if [ $? = 0 ]
+  then
 
-  echo ' '
-  echo '+-------------------------+'
-  echo '|  Wave system tracking   |'
-  echo '+-------------------------+'
-  echo ' '
+    echo ' '
+    echo '+-------------------------+'
+    echo '|  Wave system tracking   |'
+    echo '+-------------------------+'
+    echo ' '
 
-    \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_b/switch
 #  if [ $force_shrd ]
 #  then # build pre- & post-processing programs with SHRD only
 #    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
@@ -1899,50 +2230,86 @@ then
 #  else
 #    \cp -f $file_c $path_b/switch
 #  fi  
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch 
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-
-  # link conf file
-  if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
-  then
-    \rm -f $prog.nml
-    \ln -s $ifile $prog.nml
-    ofile="$path_w/`basename $ifile .nml`.out"
-  else
-    \rm -f $prog.inp
-    \ln -s $ifile $prog.inp
-    ofile="$path_w/`basename $ifile .inp`.out"
-  fi
-
-  echo "   Processing $ifile"
-  echo "   Screen output copied to $ofile"
-
-  if [ $pmpi ]
-  then
-    if [ $nproc ]
-    then
-      runcmd="$runcmd -np $nproc"
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch 
+      rm $path_b/switch_noST
     fi
-  fi
-  if $runcmd $path_e/$prog | tee $ofile
-  then
-    \rm -f $prog.inp
-    \rm -f $prog.nml
-  else
-    errmsg "Error occured during $path_e/$prog execution"
-    exit 1
-  fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+
+    if $path_b/w3_make $prog
+    then :
+    else
+      errmsg "Error occured during WW3 $prog build"
+      exit 1
+    fi
+
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+
+
+# link conf file
+    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+    then
+      \rm -f $prog.nml
+      \ln -s $ifile $prog.nml
+      ofile="$path_w/`basename $ifile .nml`.out"
+    else
+      \rm -f $prog.inp
+      \ln -s $ifile $prog.inp
+      ofile="$path_w/`basename $ifile .inp`.out"
+    fi
+
+    echo "   Processing $ifile"
+    echo "   Screen output copied to $ofile"
+
+    if [ $pmpi ]
+    then
+      if [ $nproc ]
+      then
+        if [ $batchq = "slurm" ]
+        then
+          runcmd="$runcmd -n $nproc"
+  
+        else
+          runcmd="$runcmd -np $nproc"
+        fi
+      fi
+    fi
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+    if $runcmd $path_e/$prog | tee $ofile
+    then
+      \rm -f $prog.inp
+      \rm -f $prog.nml
+    else
+      errmsg "Error occured during $path_e/$prog execution"
+      exit 1
+    fi
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      cumult_run=`echo "$Maketime + $cumult_run" | bc`
+      printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+    fi
+#  if [ $time_count ]
+#  then # Add time counter if -T
+#    Tstart=`date +"%s.%2N"`
+#  fi
+#
 #  if $path_e/$prog > $ofile
 #  then
 #    \rm -f $prog.inp
@@ -1957,8 +2324,16 @@ then
 #    errmsg "Error occured during $path_e/$prog execution"
 #    exit 1
 #  fi
+#
+#   if [ $time_count ]
+#   then # Add time counter if -T
+#     Tend=`date +"%s.%2N"`
+#     Maketime=`echo "$Tend - $Tstart" | bc`
+#     cumult_run=`echo "$Maketime + $cumult_run" | bc`
+#     printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+#   fi
 
-fi
+  fi
 
 fi
 
@@ -1983,68 +2358,99 @@ then
   ifile="`ls $path_i/$prog.inp 2>/dev/null`"
 #fi
 
-if [ $? = 0 ]
-then
-
-  echo ' '
-  echo '+-------------------------+'
-  echo '|   Update Restart File   |'
-  echo '+-------------------------+'
-  echo ' '
-
-  \cp -f $file_c $path_b/switch
-  if [ $testST ]
-  then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
-  fi
-  if $path_b/w3_make $prog
-  then :
-  else
-    errmsg "Error occured during WW3 $prog build"
-    exit 1
-  fi
-
-  # link conf file
-  if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+  if [ $? = 0 ]
   then
-    \rm -f $prog.nml
-    \ln -s $ifile $prog.nml
-    ofile="$path_w/`basename $ifile .nml`.out"
-  else
-    \rm -f $prog.inp
-    \ln -s $ifile $prog.inp
-    ofile="$path_w/`basename $ifile .inp`.out"
-  fi
 
-  echo "   Processing $ifile"
-  echo "   Screen output copied to $ofile"
+    echo ' '
+    echo '+-------------------------+'
+    echo '|   Update Restart File   |'
+    echo '+-------------------------+'
+    echo ' '
   
-# Additional Files
-   \rm -f anl.grbtxt
-   \ln -s "$path_i/anl.grbtxt" anl.grbtxt
-   
-  mv -f restart001.ww3 restart.ww3
-  
-  if [ $pmpi ]
-  then
-    if [ $nproc ]
-    then
-      runcmd="$runcmd -np $nproc"
+    \cp -f $file_c $path_b/switch
+    if [ $testST ]
+    then #add S T switches 
+      \cp -f $path_b/switch $path_b/switch_noST
+      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
+      rm $path_b/switch_noST
     fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tstart=`date +"%s.%2N"`
+    fi
+  
+    if $path_b/w3_make $prog
+    then :
+    else
+      errmsg "Error occured during WW3 $prog build"
+      exit 1
+    fi
+  
+    if [ $time_count ]
+    then # Add time counter if -T
+      Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      printf "\n $prog \n %8.2f sec compile time" $Maketime  >> time_count.txt
+      cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
+    fi
+  
+# link conf file
+    if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
+    then
+      \rm -f $prog.nml
+      \ln -s $ifile $prog.nml
+      ofile="$path_w/`basename $ifile .nml`.out"
+    else
+      \rm -f $prog.inp
+      \ln -s $ifile $prog.inp
+      ofile="$path_w/`basename $ifile .inp`.out"
+    fi
+  
+    echo "   Processing $ifile"
+    echo "   Screen output copied to $ofile"
+    
+# Additional Files
+     \rm -f anl.grbtxt
+     \ln -s "$path_i/anl.grbtxt" anl.grbtxt
+     
+     mv -f restart001.ww3 restart.ww3
+    
+     if [ $pmpi ]
+     then
+       if [ $nproc ]
+       then
+         if [ $batchq = "slurm" ]
+         then
+           runcmd="$runcmd -n $nproc"
+         else
+           runcmd="$runcmd -np $nproc"
+         fi
+       fi
+     fi
+     if [ $time_count ]
+     then # Add time counter if -T
+       Tstart=`date +"%s.%2N"`
+     fi
+  
+     if $runcmd $path_e/$prog | tee $ofile
+     then
+       \rm -f $prog.inp
+       \rm -f $prog.nml
+     else
+       errmsg "Error occured during $path_e/$prog execution"
+       exit 1
+     fi
+     if [ $time_count ]
+     then # Add time counter if -T
+       Tend=`date +"%s.%2N"`
+      Maketime=`echo "$Tend - $Tstart" | bc`
+      cumult_run=`echo "$Maketime + $cumult_run" | bc`
+      printf "\n %8.2f sec run time \n" $Maketime >> time_count.txt
+    fi
+  
   fi
-  if $runcmd $path_e/$prog | tee $ofile
-  then
-    \rm -f $prog.inp
-    \rm -f $prog.nml
-  else
-    errmsg "Error occured during $path_e/$prog execution"
-    exit 1
-  fi
-
-fi
-
+  
 fi
 
 if [ $exit_p = $prog ]
@@ -2052,13 +2458,18 @@ then
   exit
 fi
 
-
-
 # 3.k End ------------------------------------------------------------------- #
 
 if [ "$stub" ]
 then
   date > finished
+fi
+
+if [ $time_count ]
+then # Export cumultive time if time_count  
+  printf "\n\n Total compile time: %8.2f sec" $cumult_comp >> time_count.txt
+  printf "\n Total run time    : %8.2f sec" $cumult_run >> time_count.txt
+  printf "\n" >> time_count.txt
 fi
 
 echo ' ' ; echo ' ' ; echo "Files in `pwd` :" ; echo ' '

--- a/regtests/mww3_test_01/input/ww3_ounf.nml
+++ b/regtests/mww3_test_01/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_02/input/ww3_ounf.nml
+++ b/regtests/mww3_test_02/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_03/input/ww3_ounf.nml
+++ b/regtests/mww3_test_03/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_04/input/ww3_ounf.inp
+++ b/regtests/mww3_test_04/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_04/input/ww3_ounf.nml
+++ b/regtests/mww3_test_04/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_05/input/ww3_ounf.inp
+++ b/regtests/mww3_test_05/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_05/input/ww3_ounf.nml
+++ b/regtests/mww3_test_05/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_06/input/ww3_ounf.inp
+++ b/regtests/mww3_test_06/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_06/input/ww3_ounf.nml
+++ b/regtests/mww3_test_06/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf_rect1.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf_rect1.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_07/input/ww3_ounf_zcmpl.nml
+++ b/regtests/mww3_test_07/input/ww3_ounf_zcmpl.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_multi/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_multi/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_multi/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_shel/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_shel/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_shel/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_highres_shel_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.inp
+++ b/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.nml
+++ b/regtests/mww3_test_08/i_lowres_shel_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/mww3_test_08/input/ww3_ounf.inp
+++ b/regtests/mww3_test_08/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/mww3_test_08/input/ww3_ounf.nml
+++ b/regtests/mww3_test_08/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD0F_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD0F_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD0F_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD0F_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD2_U_cap/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD2_U_cap/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_O/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_O/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_U/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_U/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ta1/input_UPD3_U_cap/ww3_ounf.nml
+++ b/regtests/ww3_ta1/input_UPD3_U_cap/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tbt1.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tbt1.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tbt1.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tbt1.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tbt2.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tbt2.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tbt2.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tbt2.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC1/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC1/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC1_156x3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_ifr/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_nondisp/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC2_nrl/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC3/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC3/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC3_nondisp/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M1/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M2/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M3/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M3/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M4/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M4/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M5/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M5/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M6/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M6/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC4_M7/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC4_M7/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IC5/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IC5/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IC5/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IC5/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.1/input_IS2/ww3_ounf.inp
+++ b/regtests/ww3_tic1.1/input_IS2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.1/input_IS2/ww3_ounf.nml
+++ b/regtests/ww3_tic1.1/input_IS2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A1.0k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_A2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B1.0k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_B2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_CHENG/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_V1_G/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.inp
+++ b/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.nml
+++ b/regtests/ww3_tic1.2/input_IC3_V1_h/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_0.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_2.5k/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_CHENG/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_V1_G/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.inp
+++ b/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.nml
+++ b/regtests/ww3_tic1.3/input_IC3_V1_h/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic1.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tic1.4/input/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic1.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tic1.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.1/input_IC1/ww3_ounf.inp
+++ b/regtests/ww3_tic2.1/input_IC1/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.1/input_IC1/ww3_ounf.nml
+++ b/regtests/ww3_tic2.1/input_IC1/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.inp
+++ b/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.nml
+++ b/regtests/ww3_tic2.1/input_IC2IS2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tic2.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tic2.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.2/input_IC2/ww3_ounf.inp
+++ b/regtests/ww3_tic2.2/input_IC2/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.2/input_IC2/ww3_ounf.nml
+++ b/regtests/ww3_tic2.2/input_IC2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tic2.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tic2.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tic2.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tic2.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.1/input2/ww3_ounf.nml
+++ b/regtests/ww3_tp1.1/input2/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.10/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.10/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.10/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.10/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]
@@ -33,6 +33,7 @@
   FIELD%TIMESTART        =  '19680606 000000'
   FIELD%TIMESTRIDE       =  '3600.'
   FIELD%TIMECOUNT        =  '1000'
+  FIELD%TIMESPLIT        =  6
   FIELD%LIST             =  'DPT HS FC CFX'
   FIELD%PARTITION        =  '0 1 2'
   FIELD%TYPE             =  4

--- a/regtests/ww3_tp1.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.4/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.5/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.5/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.5/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.5/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.6/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.6/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.6/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.6/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.7/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.7/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.7/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.7/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.7/input_OBST/ww3_ounf.nml
+++ b/regtests/ww3_tp1.7/input_OBST/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.8/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.8/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.8/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.8/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.8/input_BJ/ww3_ounf.nml
+++ b/regtests/ww3_tp1.8/input_BJ/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp1.9/input/ww3_ounf.inp
+++ b/regtests/ww3_tp1.9/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp1.9/input/ww3_ounf.nml
+++ b/regtests/ww3_tp1.9/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.1/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.1/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.1/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.inp
+++ b/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.nml
+++ b/regtests/ww3_tp2.1/input/ww3_ounf_flds_hrly.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.10/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.10/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.11/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.11/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.13/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.13/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.14/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.14/input/ww3_ounf.inp
@@ -25,7 +25,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY DX DY, unstructured:IP NP DP DP]
 $
 ww3.

--- a/regtests/ww3_tp2.14/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.14/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.15/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.15/input/ww3_ounf.inp
@@ -12,7 +12,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.15/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.15/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.16/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.16/input/ww3_ounf.inp
@@ -33,7 +33,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.16/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.16/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.17/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.17/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.2/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.2/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.2/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.2/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.3/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.3/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.4/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.4/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.4/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.4/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.5/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.5/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_tp2.5/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.5/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.5/input_REF/ww3_ounf.nml
+++ b/regtests/ww3_tp2.5/input_REF/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.6/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.6/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.7/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.7/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.7/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.7/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.8/input/ww3_ounf.inp
+++ b/regtests/ww3_tp2.8/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.

--- a/regtests/ww3_tp2.8/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.8/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.9/input/ww3_ounf.nml
+++ b/regtests/ww3_tp2.9/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_tp2.9/input/ww3_ounf_flds_hrly.nml
+++ b/regtests/ww3_tp2.9/input/ww3_ounf_flds_hrly.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts1/input/ww3_ounf.nml
+++ b/regtests/ww3_ts1/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts1/input_fld/ww3_ounf.nml
+++ b/regtests/ww3_ts1/input_fld/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts3/input/ww3_ounf.inp
+++ b/regtests/ww3_ts3/input/ww3_ounf.inp
@@ -27,7 +27,7 @@ $
 $
 $ -------------------------------------------------------------------- $
 $ File prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ IX and IY ranges [regular:IX NX IY NY, unstructured:IP NP 1 1]
 $
  ww3.         

--- a/regtests/ww3_ts3/input/ww3_ounf.nml
+++ b/regtests/ww3_ts3/input/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_rg_multi/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_rg_multi/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_rg_shel/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_rg_shel/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]

--- a/regtests/ww3_ts4/input_ug/ww3_ounf.nml
+++ b/regtests/ww3_ts4/input_ug/ww3_ounf.nml
@@ -23,7 +23,7 @@
 !     FIELD%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     FIELD%TIMESTOP             = '29001231 000000'  ! Stop date for the output field
 !     FIELD%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     FIELD%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     FIELD%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     FIELD%LIST                 = 'unset'            ! List of output fields
 !     FIELD%PARTITION            = '0 1 2 3'          ! List of wave partitions ['0 1 2 3 4 5']
 !     FIELD%SAMEFILE             = T                  ! All the variables in the same file [T|F]


### PR DESCRIPTION

On lines 1439 and 1440, the calculations for ABX2 and ABY2 were like that of ABX and ABY.  This may have been an oversight when inserted.  Page 112 of the manual lays out the formulas for mean direction and spreading from a2 and b2 coefficients.  To represent cos2Theta and sin2Theta, trigonometric identities were used to exploit the previous calculated values in EC2 and ES2.  The first five moments of spectra and the wave frequency spectrum are useful in representing the energy spectra for every grid point in a model domain reducing space requirements by O(10).  Having these spectra handy allows for access to on-the-fly boundary conditions from reconstructed spectra with minimal loss of accuracy (soon to be shown in a later presentation).