### PR TITLE
Bugfix in wmesmf flipping nx/ny in exports

### DIFF
--- a/model/ftn/wmesmfmd.ftn
+++ b/model/ftn/wmesmfmd.ftn
@@ -3175,7 +3175,7 @@
 ! -------------------------------------------------------------------- /
 ! 4.  Create ESMF grid with arbitrary domain decomposition to match
 !     the native domain decomposition of the non-excluded points
-!     Note that the native grid layout is dim1=Y, dim2=X
+!     Note that the native grid layout is dim1=X, dim2=Y
 !     Note that coordinates and mask are not needed since this
 !     grid is only used to define fields for a redist operation
 !
@@ -3200,9 +3200,9 @@
             if (ipass.eq.2) then
               ix = mapsf(isea,1)
               iy = mapsf(isea,2)
-              ! native grid layout: dim1=Y, dim2=X
-              arbIndexList(arbIndexCount,1) = iy
-              arbIndexList(arbIndexCount,2) = ix
+              ! native grid layout: dim1=X, dim2=Y
+              arbIndexList(arbIndexCount,1) = ix
+              arbIndexList(arbIndexCount,2) = iy
             endif
           enddo
         endif
@@ -3213,9 +3213,9 @@
               if ( mapsta(iy,ix).ne.0 ) cycle ! skip non-excluded point
               arbIndexCount = arbIndexCount+1
               if (ipass.eq.2) then
-                ! native grid layout: dim1=Y, dim2=X
-                arbIndexList(arbIndexCount,1) = iy
-                arbIndexList(arbIndexCount,2) = ix
+                ! native grid layout: dim1=X, dim2=Y
+                arbIndexList(arbIndexCount,1) = ix
+                arbIndexList(arbIndexCount,2) = iy
               endif
             enddo
           enddo
@@ -3228,7 +3228,7 @@
         case (iclose_none)
           natGrid = ESMF_GridCreateNoPeriDim( &
             minIndex=(/ 1, 1/), &
-            maxIndex=(/ny,nx/), &
+            maxIndex=(/nx,ny/), &
             coordDep1=(/ESMF_DIM_ARB,ESMF_DIM_ARB/), &
             coordDep2=(/ESMF_DIM_ARB,ESMF_DIM_ARB/), &
             arbIndexCount=arbIndexCount, &
@@ -3239,11 +3239,11 @@
           if (ESMF_LogFoundError(rc, PASSTHRU)) return
         case (iclose_smpl)
           natGrid = ESMF_GridCreate1PeriDim( &
-            periodicDim=2, &
-            poleDim=1, &
+            periodicDim=1, &
+            poleDim=2, &
             poleKindFlag=(/ESMF_POLEKIND_NONE,ESMF_POLEKIND_NONE/), &
             minIndex=(/ 1, 1/), &
-            maxIndex=(/ny,nx/), &
+            maxIndex=(/nx,ny/), &
             coordDep1=(/ESMF_DIM_ARB,ESMF_DIM_ARB/), &
             coordDep2=(/ESMF_DIM_ARB,ESMF_DIM_ARB/), &
             arbIndexCount=arbIndexCount, &


### PR DESCRIPTION
The nx/ny for exporting from wmesmf got flipped again.  

The ww3 regtests were not run because they do not test wmesmf.  This was tested in the ufs-weather app and we can now again correctly export z0 from WW3. 