### PR TITLE
BF w3setup

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -57,7 +57,7 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || [ "$cmplr" == "mpt_pr
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias'
+  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-falias'
   optl='-o $prog -g'
 
   # list options
@@ -123,7 +123,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-fnalias -sox'
+  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias -sox'
   optl='-o $prog -g'
 
   if [ ! -z "$(echo $cmplr | grep datarmor)" ] ; then

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -57,7 +57,7 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || [ "$cmplr" == "mpt_pr
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias'
+  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias'
   optl='-o $prog -g'
 
   # list options
@@ -73,7 +73,7 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || [ "$cmplr" == "mpt_pr
   fi
 
   # profiling option
-  if [ -z "$(echo $cmplr | grep prof)" ] ; then
+  if [ ! -z "$(echo $cmplr | grep prof)" ] ; then
     optc="$optc -p"
     optl="$optl -p"
   fi
@@ -123,7 +123,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias -sox'
+  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-fnalias -sox'
   optl='-o $prog -g'
 
   if [ ! -z "$(echo $cmplr | grep datarmor)" ] ; then
@@ -162,7 +162,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   fi
 
   # profiling option
-  if [ -z "$(echo $cmplr | grep prof)" ] ; then
+  if [ ! -z "$(echo $cmplr | grep prof)" ] ; then
     optc="$optc -p"
     optl="$optl -p"
   fi
@@ -173,15 +173,6 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
     optl="$optl -O0 -traceback"
   fi
 
-  # system-dependant options
-  if [ ! -z "$(echo $cmplr | grep datarmor)" ] ; then
-    optc="$optc -xcore-avx2"
-    optl="$optl -xcore-avx2"
-  else
-    optc="$optc -xhost"
-    optl="$optl -xhost"
-  fi
-  
   if [ ! -z "$(echo $cmplr | grep so)" ] ; then
     optc="$optc -fPIC"
     optl='-o $prog -g'
@@ -228,7 +219,7 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || [ "$cmplr" == "gnu_pr
   fi
 
   # profiling option
-  if [ -z "$(echo $cmplr | grep prof)" ] ; then
+  if [ ! -z "$(echo $cmplr | grep prof)" ] ; then
     optc="$optc -p"
     optl="$optl -p"
   fi
@@ -295,7 +286,7 @@ if [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ] || [ "$cmplr" == "pgi_pr
   fi
 
   # profiling option
-  if [ -z "$(echo $cmplr | grep prof)" ] ; then
+  if [ ! -z "$(echo $cmplr | grep prof)" ] ; then
     optc="$optc -p"
     optl="$optl -p"
   fi

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -104,7 +104,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
    [ "$cmplr" == "so_intel" ]       || [ "$cmplr" == "so_intel_debug" ] || [ "$cmplr" == "so_intel_prof" ] || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] || [ "$cmplr" == "datarmor_intel_prof" ] || \
    [ "$cmplr" == "wcoss_phase2" ]   || [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_dell_p3" ]  || \
-   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "hera" ] ; then
+   [ "$cmplr" == "hera" ] ; then
 
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -133,7 +133,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
     optc="$optc -xCORE-AVX2"
     optl="$optl -xCORE-AVX2"
   elif [ ! -z "$(echo $cmplr | grep wcoss_dell_p3)" ] ; then
-    optc="$opt -xHOST"
+    optc="$optc -xHOST"
     optl="$optl -xHOST"
   else
     optc="$optc -xhost"

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -398,9 +398,56 @@ else
 fi
 echo ' '
 
-# 3.c Setup comp & link files
+# 3.c Setup switch file
+if [ $swtch ]
+then
+  echo ' '
+  echo '   Setup switch file'
+  if [ -f $path_b/switch_$swtch ]
+  then
+    rm -f $path_b/switch
+    cp -f $path_b/switch_$swtch $path_b/switch
+    echo "      $path_b/switch_$swtch => $path_b/switch"
+  else
+    errmsg "$path_b/switch_$swtch not found"
+    exit 1
+  fi
+fi
+
+# 3.d Edit switch file
+if [ $edit ]
+  then
+  echo "      Edit $path_b/switch"
+  if [ ! -f $path_b/switch ]
+  then
+    errmsg "$path_b/switch not found"
+    exit 1
+  fi
+  if [ $EDITOR ]
+  then
+    if $EDITOR $path_b/switch
+    then :
+    else
+      errmsg "Error occured during edit of $path_b/switch"
+      exit 1
+    fi
+  else
+    errmsg "the EDITOR environment variable must be set"
+    exit 1
+  fi
+fi
+
+# 3.e Setup comp & link files
 if [ $cmplr ]
 then
+# Check for omp_mod
+  omp_mod=no
+  if [ -n "`grep OMP $path_b/switch`" ]
+  then
+    omp_mod=yes
+  fi
+  export omp_mod
+
   echo ' '
   echo '   Setup comp & link files'
   if [ -f $path_b/comp.$cmplr ]
@@ -414,8 +461,7 @@ then
        [ "$cmplr" == "so_intel" ] || [ "$cmplr" == "so_intel_debug" ]               || \
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
-       [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
-       [ "$cmplr" == "hera" ]                                                       || \
+       [ "$cmplr" == "hera" ] || [ "$cmplr" == "wcoss_cray" ]                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
@@ -440,8 +486,7 @@ then
        [ "$cmplr" == "so_intel" ] || [ "$cmplr" == "so_intel_debug" ]               || \
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
-       [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
-       [ "$cmplr" == "hera" ]                                                       || \
+       [ "$cmplr" == "hera" ] || [ "$cmplr" == "wcoss_cray" ]                       || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
@@ -456,44 +501,6 @@ then
     exit 1
   fi
   chmod 775 $path_b/comp $path_b/link
-fi
-# 3.d Setup switch file
-if [ $swtch ]
-then
-  echo ' '
-  echo '   Setup switch file'
-  if [ -f $path_b/switch_$swtch ]
-  then
-    rm -f $path_b/switch
-    cp -f $path_b/switch_$swtch $path_b/switch
-    echo "      $path_b/switch_$swtch => $path_b/switch"
-  else
-    errmsg "$path_b/switch_$swtch not found"
-    exit 1
-  fi
-fi
-
-# 3.e Edit switch file
-if [ $edit ] 
-  then
-  echo "      Edit $path_b/switch"
-  if [ ! -f $path_b/switch ]
-  then
-    errmsg "$path_b/switch not found"
-    exit 1
-  fi
-  if [ $EDITOR ]
-  then
-    if $EDITOR $path_b/switch
-    then :
-    else
-      errmsg "Error occured during edit of $path_b/switch"
-      exit 1
-    fi
-  else
-    errmsg "the EDITOR environment variable must be set"
-    exit 1
-  fi
 fi
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Adjusts w3_setup to activate omp_mod option including the appropriate compiler flag for omp or mpi/omp hybrid builds, reflected in cmplr.env and comp/link.tmpl. Also cleanup removing reference to NCEP R&D machine theia, repeated flags and proper activation of profiling flag -p in cmplr.env.