### PR TITLE
Initializing empty array WORDS where an optional parameter, for output fields and points, is stored.

### DIFF
--- a/model/ftn/wminitmd.ftn
+++ b/model/ftn/wminitmd.ftn
@@ -1121,6 +1121,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
 !
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
           READ (MDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
 !        
@@ -1146,6 +1147,7 @@
           END IF
 ! CHECKPOINT
         ELSE IF(J .EQ. 4) THEN
+            WORDS(1:6)=''
             READ (MDSI,'(A)') LINEIN
             READ(LINEIN,*,iostat=ierr) WORDS
 !

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1201,6 +1201,7 @@
 !
 ! CHECKPOINT
         IF(J .EQ. 4) THEN
+          WORDS(1:6)=''
           ODAT(38)=0 
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
@@ -1219,6 +1220,7 @@
 !          READ (NDSI,*) (ODAT(I),I=5*(J-1)+1,5*J)
 !          READ (NDSI,*,IOSTAT=IERR) (ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
 !          READ (NDSI,*,END=2001,ERR=2002)(ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS


### PR DESCRIPTION
In this bug fix branch a solution was provided for an array (WORDS) that must start as an empty array. That is used to store dates (init date - output time step - end date) for field and point output, it is also used to store an optional user choice to have the output (fields and/or points)  in a separate files, producing one file per output  per-time step or to have all fields (and/or points) in one big file having all fields (and or points) for all output times. That array (WORDS) is used for fields and points output, the array is not initialized as an empty array when is going to read the times and output time step for points, and if it happens that the user provide the optional parameter to have fields output separated but no adding any value for the optional parameter for points, the value provided for fields will be valid for the points output which it will produce separated files for points when it was not the case.