### PR TITLE
Declaring WORDS as empty array and adding call nextline when 2nd line…

### DIFF
--- a/model/ftn/wminitmd.ftn
+++ b/model/ftn/wminitmd.ftn
@@ -1121,6 +1121,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
 !
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
           READ (MDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
 !        
@@ -1146,6 +1147,7 @@
           END IF
 ! CHECKPOINT
         ELSE IF(J .EQ. 4) THEN
+            WORDS(1:6)=''
             READ (MDSI,'(A)') LINEIN
             READ(LINEIN,*,iostat=ierr) WORDS
 !
@@ -1155,6 +1157,7 @@
             READ(WORDS( 4 ), * ) ODAT(19,1)
             READ(WORDS( 5 ), * ) ODAT(20,1)
             IF (WORDS(6) .EQ. 'T') THEN
+              CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
               READ (MDSI,*,END=2001,ERR=2002)(ODAT(I,1),I=5*(8-1)+1,5*8)
               END IF
         ELSE
@@ -1450,7 +1453,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
         IF(J .LE. 2) THEN
           OUTFF(J,I)=0
-          WORDS(6) =''
+          WORDS(1:6) =''
           READ (MDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
           IF(J .EQ. 1) THEN

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1202,6 +1202,7 @@
 ! CHECKPOINT
         IF(J .EQ. 4) THEN
           ODAT(38)=0 
+          WORDS(1:6)=''
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
           READ(WORDS( 1 ), * ) ODAT(16)
@@ -1210,6 +1211,7 @@
           READ(WORDS( 4 ), * ) ODAT(19)
           READ(WORDS( 5 ), * ) ODAT(20)
           IF (WORDS(6) .EQ. 'T') THEN
+          CALL NEXTLN ( COMSTR , NDSI , NDSEN )
             READ (NDSI,*,END=2001,ERR=2002)(ODAT(I),I=5*(8-1)+1,5*8)
             WRITE(*,*)(ODAT(I),I=5*(8-1)+1,5*8)
           END IF
@@ -1219,12 +1221,10 @@
 !          READ (NDSI,*) (ODAT(I),I=5*(J-1)+1,5*J)
 !          READ (NDSI,*,IOSTAT=IERR) (ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
 !          READ (NDSI,*,END=2001,ERR=2002)(ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
-          DO I=1,6
-!            WRITE(*,*) I, WORDS(I)
-          END DO
 !
           IF(J .EQ. 1) THEN
             READ(WORDS( 1 ), * ) ODAT(1)


### PR DESCRIPTION
In this bug fix branch a solution was provided when the user choose the option to have  a second stream of restart files and adding comments before the second restart line, and also initialize an  array (WORDS) as an empty array. 
A "CALL NEXTLINE()" was added when reading the optional second line for restart file to allow comment lines before reading the second line for restart .
That  WORDS array, this is used to store dates (init date - output time step - end date) for field and point output, it is also used to store an optional user choice to have the output (fields and/or points) in a separate files, producing one file per output per-time step or to have all fields (and/or points) in one big file having all fields (and or points) for all output times. That array (WORDS) is used for fields and points output, the array was not initialized as an empty array when the times and output time step for points are read, and if it happens that the user provide the optional parameter to have fields output separated but no adding any value for the optional parameter for points, the value provided for fields will be valid for the points output which it will produce separated files for points when it was not the case. 