### PR TITLE
w3adc multi-switch updates

### DIFF
--- a/manual/sys/w3adc.tex
+++ b/manual/sys/w3adc.tex
@@ -6,7 +6,7 @@ The \ws\ source code files are not ready to use {\fortran} files; mandatory
 and optional program options still have to be selected, and test output may be
 activated\footnote{~Exceptions are some modules that are not originally part
   of \ws, like the exact interaction modules. Such modules with the extension
-  {\file .f} of {\file .f90} bypass the preprocessor and get copied to the
+  {\file .f} or {\file .f90} bypass the preprocessor and get copied to the
   work directory with the {\file .f} extension.}. Compile level options are
 activated using `switches'. The arbitrary switch '{\F swt}' is included in the
 \ws\ files as comment of the form {\F !/swt}, where the switch name {\F swt}
@@ -15,9 +15,29 @@ preprocessor removes the comment characters, thus activating the corresponding
 source code line. If '{\F/}' follows the switch, it is also removed, thus
 allowing the selective inclusion of hardware-dependent compiler directives
 etc. The switches are case sensitive, and available switches are presented in
-\para\ref{sec:switches}. Files which contain the switch {\F c/swt} can be
+\para\ref{sec:switches}.
+
+Files which contain the switch {\F c/swt} can be
 found by typing \command{find\_switch '!/SWT'} A list of all switches included
 in the \ws\ files can be obtained by typing \command{all\_switches}
+
+\pb
+\noindent
+Traditionally, only one switch can be used per line of source code. However,
+as of {\ww} version 7.00, multiple switches (up to 4) can be set on a single
+line. For the line to be included in the compilation step all switches must
+be activated. Multiple switches must be chained together at the beginning of
+the line, with no spaces in between. Each switch must start with '{\F !/}' and
+may optionally be terminated with '{\F /}'. This allows for the handling of
+circumstances where a source code line needs to be included only if a
+particular combination of switches is set. For example, to enable a line only
+if the '{\F /OMPH}' and '{\F /T1}' switches are set:
+
+\begin{footnotesize}
+\begin{verbatim}
+!/OMPH!/!T1     ! Line included only if OMPH and T1 activated
+\end{verbatim}
+\end{footnotesize}
 
 \pb
 %\vspace{\baselineskip}

--- a/model/aux/w3adc.f
+++ b/model/aux/w3adc.f
@@ -6,6 +6,7 @@ C/                  |                        FORTRAN 77 |
 C/                  | Last update :         03-Feb-2020 |
 C/                  +-----------------------------------+
 C/
+C/    05-Jan-2001 : Origination
 C/    03-Feb-2020 : Added ability to process multiple   ( version 7.00 )
 C/                  switches on a single line. Chris Bunney, UKMO
 C/

--- a/model/aux/w3adc.f
+++ b/model/aux/w3adc.f
@@ -14,8 +14,8 @@ C/    Version to preprocess FORTRAN 90 free format code.
 C/
 C  1. Purpose :
 C
-C     Pre-processing of FORTRAN files by switching on and of of
-C     selected lines and by including COMMON's.
+C     Pre-processing of FORTRAN files by switching on and off of
+C     selected lines and by including COMMONs.
 C
 C                                  - Based on ADCOM by N. Booij,
 C                                    Delft University of Technology.
@@ -49,6 +49,7 @@ C     Data in PARAMETER statements :
 C     ----------------------------------------------------------------
 C       MMLOUT  Int.  Line length of output.
 C       MMSWTC  Int.  Maximum number of switches.
+C       MMSWLN  Int.  Maximum number of switches on a single line.
 C       MMFILE  Int.  Maximum number of include files.
 C       MMLINE  Int.  Maximum length of include files.
 C     ----------------------------------------------------------------
@@ -132,9 +133,10 @@ C
       PARAMETER ( MMLOUT = 132 )
       PARAMETER ( MMFILE =  30 )
       PARAMETER ( MMSWTC =  52 )
+      PARAMETER ( MMSWLN =   4 )
       PARAMETER ( MMLINE = 200 )
 *
-      INTEGER       NSWTCH, IDLEN(MMFILE), NLINES(MMFILE), LL,
+      INTEGER       NSWTCH, IDLEN(MMFILE), NLINES(MMFILE), LL, NSWLN,
      &              LENGTH(MMFILE,MMLINE), NINCF(MMFILE), LS(MMSWTC)
       LOGICAL       FLOLD, FLKEEP, FLINCL, FLSWTC, LSTEXC, NOWEXC,
      &              QUOTES
@@ -254,6 +256,7 @@ C
       LSTEXC = .FALSE.
   130 CONTINUE
       READ (NDSINC,'(A)',END=190,ERR=190) NEWLNE
+      OLDLNE = NEWLNE
       ILINE1 = ILINE1 + 1
 *
 * switches
@@ -263,7 +266,12 @@ C
 *
       ! Rewrite for multiple switches on single line
       ! Chris Bunney, Feb 2020.
+      NSWLN = 0
       DO 140
+        IF(NSWLN .GT. MMSWLN) THEN
+          WRITE(*,9950) ILINE1, TRIM(FNAMER), TRIM(OLDLNE)
+          STOP
+        ENDIF
         IF(NEWLNE(1:2) .EQ. '!/') THEN
           ! Potential switch
           FLSWTC = .FALSE.
@@ -285,12 +293,14 @@ C
      &             NEWLNE(3+J:3+J) .EQ. '!') THEN
                 NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
                 FLSWTC = .TRUE.
+                NSWLN = NSWLN + 1
                 GOTO 140
               ENDIF
 *
               IF(NEWLNE(3+J:3+J) .EQ. '/' ) THEN
                 NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
                 FLSWTC = .TRUE.
+                NSWLN = NSWLN + 1
                 GOTO 140
               ENDIF
 *
@@ -400,7 +410,12 @@ C
 *
       ! Rewrite for multiple switches on single line
       ! Chris Bunney, Feb 2020.
+      NSWLN = 0
       DO 310
+        IF(NSWLN .GT. MMSWLN) THEN
+          WRITE(*,9950) ILINE1, TRIM(FNAMEI), TRIM(OLDLNE)
+          STOP
+        ENDIF
         IF(NEWLNE(1:2) .EQ. '!/') THEN
           ! Potential switch
           FLSWTC = .FALSE.
@@ -422,12 +437,14 @@ C
      &             NEWLNE(3+J:3+J) .EQ. '!') THEN
                 NEWLNE(1:MMLOUT) = NEWLNE(3+J:MMLOUT+3+J-1)
                 FLSWTC = .TRUE.
+                NSWLN = NSWLN + 1
                 GOTO 310
               ENDIF
 *
               IF(NEWLNE(3+J:3+J) .EQ. '/' ) THEN
                 NEWLNE(1:MMLOUT) = NEWLNE(4+J:MMLOUT+4+J-1)
                 FLSWTC = .TRUE.
+                NSWLN = NSWLN + 1
                 GOTO 310
               ENDIF
 *
@@ -594,6 +611,13 @@ C
  9941 FORMAT ( '   |',A33,'|    |',A33,'|')
  9942 FORMAT ( '   +---------------------------------+  ',
      &         '  +---------------------------------+')
+*
+ 9950 FORMAT (/'*** ERROR: MAXIMUM NUMBER OF SWITCHES ON',
+     &         ' INPUT LINE EXCEEDED                  ',/
+     &         '       LINE NUMBER: ', I5, /
+     &         '       FILENAME: ', A, /
+     &         '       LINE: ', A//)
+*
  9999 FORMAT ( ' TEST W3ADC/2 : PROGRAM ENDED DUE TO VALUE OF ITEST'/)
 *
 * End of W3ADC  --------------------------------------------------------

--- a/model/bin/all_switches
+++ b/model/bin/all_switches
@@ -41,6 +41,7 @@
   cd $main_dir/ftn
 
   all=`sed -n '/^!\/[[:alpha:]]/'p *.ftn | awk '{print $1}' | \
+       awk -F'!/' 'BEGIN{OFS="\n"}{$1=$1; print $0}' | \
        sed 's/^!\///' | sed 's/[\/!].*$//' | sort -u`
 
   set $all


### PR DESCRIPTION
PR #160 included an update to `w3adc.f` to handle multiple switches on a single source code line.
This PR continues that work with the following enhancements:
- Limit on the maximum number of switches on a line (currently 4)
- Increase the maximum input line length to 172 characters.
- Update to `all_switches` script to capture multiple switches.
- Update to the System/Preprocessor section of the manual.