### PR TITLE
Emergency fix in ESMF Makefile

### DIFF
--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -3,6 +3,7 @@
 ################################################################################
 
 WW3_DIR  := $(shell cd .. 1>/dev/null 2>&1 && pwd)
+WW3_BASEDIR  := $(shell cd ../.. 1>/dev/null 2>&1 && pwd)
 WW3_BINDIR := $(WW3_DIR)/bin
 WW3_TMPDIR := $(WW3_DIR)/tmp
 WW3_EXEDIR := $(WW3_DIR)/exe
@@ -88,6 +89,7 @@ default: env setup gout switch
 ww3_nems: env setup gout switch
 	$(WW3_BINDIR)/w3_make ww3_multi_esmf
 	$(WW3_BINDIR)/w3_make ww3_multi
+	\cp -f $(WW3_EXEDIR)/ww3_multi $(WW3_BASEDIR)/exec
 
 ww3_nemslibonly: env setup switch
 	$(WW3_BINDIR)/w3_make ww3_multi_esmf
@@ -186,5 +188,8 @@ gout:
                   $(WW3_BINDIR)/tempswitch > $(WW3_BINDIR)/switch
 	\rm -f $(WW3_BINDIR)/tempswitch
 	$(WW3_BINDIR)/w3_make ww3_grib
+	\rm -rf $(WW3_BASEDIR)/exec
+	\mkdir -p $(WW3_BASEDIR)/exec
+	\cp -f $(WW3_EXEDIR)/ww3_* $(WW3_BASEDIR)/exec
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Creates a temporary WW3/exec directory to retain ww3_ codes used in NEMS application. Emergency fix for immediate application at NCEP. Does not affect other parts of the WW3 package.