### PR TITLE
Merging GFS.v16 production branch changes to develop

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -151,7 +151,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$cmplr" == "hera" ] || [ "$cmplr" == "wcoss_dell_p3" ]; then
+  if [ "$cmplr" == "hera" ] || [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]; then
      optomp="-qopenmp"
   else
      optomp="-openmp"

--- a/model/ftn/wmesmfmd.ftn
+++ b/model/ftn/wmesmfmd.ftn
@@ -4730,9 +4730,9 @@
 !/
       character(ESMF_MAXSTR) :: cname
       character(500) :: msg
-      integer :: k, ir, ip, count
+      integer :: i, j, k, ir, ip, count
       real(ESMF_KIND_RX) :: floc(n1,n2)
-      real(ESMF_KIND_RX) :: floc1d(n1)
+      real(ESMF_KIND_RX) :: floc1d(n1), floc1dary(n1*n2)
 !/PDLIB      real(ESMF_KIND_R8), pointer :: fldptr(:)
 !
 ! -------------------------------------------------------------------- /
@@ -4742,16 +4742,30 @@
 
 !      call ESMF_FieldWrite(field,fileName="ww3_import_dump.nc",overwrite=.true.,rc=rc)
       if ( (GTYPE.eq.RLGTYPE).or.(GTYPE.eq.CLGTYPE) ) then
-        do k = 0,npet-1
-          call ESMF_FieldGather( field,  floc, rootPet=k, vm=vm, rc=rc )
-          if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        count = n1 * n2
+        floc = 0.
+        floc1dary = 0.
+        call ESMF_FieldGather( field,  floc, rootPet=0, vm=vm, rc=rc )
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        do j=1,n2
+          do i=1,n1
+            floc1dary(i+(j-1)*n1) = floc(i,j)
+          enddo
         enddo
-        fout(1:n1,1:n2) = floc(1:n1,1:n2)
+        call ESMF_VMbroadcast( vm, bcstData=floc1dary, count=count, rootPet=0, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        do j=1,n2
+          do i=1,n1
+            fout(i,j) = floc1dary(i+(j-1)*n1)
+          enddo
+        enddo
       elseif (GTYPE.eq.UNGTYPE) then
-        do k = 0,npet-1
-          call ESMF_FieldGather( field,  floc1d, rootPet=k, vm=vm, rc=rc )
-          if (ESMF_LogFoundError(rc, PASSTHRU)) return
-        enddo
+        count = n1
+        floc1d = 0.
+        call ESMF_FieldGather( field,  floc1d, rootPet=0, vm=vm, rc=rc )
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        call ESMF_VMbroadcast( vm, bcstData=floc1d, count=count, rootPet=0, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
 !/PDLIB      if ( LPDLIB == .FALSE. ) then
         do k = 1, n1
           fout(k,1) = floc1d(k)

--- a/model/ftn/wmgridmd.ftn
+++ b/model/ftn/wmgridmd.ftn
@@ -1489,6 +1489,7 @@
                   DO JBND=1,NY
                      IF ( ABS(MAPSTA(JBND,IBND)) .EQ. 2 ) THEN
                         ! (boundary point)
+!/OMPH/!$OMP PARALLEL DO PRIVATE(IDST,JDST,DD),SCHEDULE(DYNAMIC)
                         DO IDST=NX_BEG(IMPROC), NX_END(IMPROC)
                            DO JDST=1, NY
                               IF (ABS(MAPSTA(JDST,IDST)) .EQ. 1) THEN
@@ -1508,6 +1509,7 @@
                               ENDIF
                            END DO ! DO JDST
                         END DO ! DO IDST
+!/OMPH/!$OMP END PARALLEL DO
                      ENDIF ! (if BND point)
 
                   END DO ! DO JBND

--- a/model/ftn/wminitmd.ftn
+++ b/model/ftn/wminitmd.ftn
@@ -1121,6 +1121,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
 !
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
           READ (MDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
 !        
@@ -1146,6 +1147,7 @@
           END IF
 ! CHECKPOINT
         ELSE IF(J .EQ. 4) THEN
+            WORDS(1:6)=''
             READ (MDSI,'(A)') LINEIN
             READ(LINEIN,*,iostat=ierr) WORDS
 !
@@ -1155,6 +1157,7 @@
             READ(WORDS( 4 ), * ) ODAT(19,1)
             READ(WORDS( 5 ), * ) ODAT(20,1)
             IF (WORDS(6) .EQ. 'T') THEN
+              CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
               READ (MDSI,*,END=2001,ERR=2002)(ODAT(I,1),I=5*(8-1)+1,5*8)
               END IF
         ELSE
@@ -1450,7 +1453,7 @@
         CALL NEXTLN ( COMSTR , MDSI , MDSE2 )
         IF(J .LE. 2) THEN
           OUTFF(J,I)=0
-          WORDS(6) =''
+          WORDS(1:6) =''
           READ (MDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
           IF(J .EQ. 1) THEN

--- a/model/ftn/wmupdtmd.ftn
+++ b/model/ftn/wmupdtmd.ftn
@@ -1177,7 +1177,7 @@
                                  YGRDC(:,:), HPFACI(:,:), HQFACI(:,:) !RP
 
       INTEGER, POINTER        :: ICLOSE
-      real,allocatable :: XGRTMP(:),YGRTMP(:)
+      REAL, ALLOCATABLE       :: XGRTMP(:),YGRTMP(:)
 !/T1      CHARACTER(LEN=17)       :: FORMAT1
 !/
 !/ ------------------------------------------------------------------- /

--- a/model/ftn/wmupdtmd.ftn
+++ b/model/ftn/wmupdtmd.ftn
@@ -1177,6 +1177,7 @@
                                  YGRDC(:,:), HPFACI(:,:), HQFACI(:,:) !RP
 
       INTEGER, POINTER        :: ICLOSE
+      real,allocatable :: XGRTMP(:),YGRTMP(:)
 !/T1      CHARACTER(LEN=17)       :: FORMAT1
 !/
 !/ ------------------------------------------------------------------- /
@@ -1185,7 +1186,6 @@
 !
 !/S      CALL STRACE (IENT, 'WMUPDV')
 !
-
       IF ( GRIDS(IMOD)%GTYPE .EQ. UNGTYPE .OR. &
                 GRIDS(JMOD)%GTYPE .EQ. UNGTYPE ) THEN
           WRITE (MDSE,'(/2A)') ' *** ERROR WMUPDV: ', &
@@ -1313,40 +1313,24 @@
 !IS THE TOLERANCE USED TO DETERMINE IF TWO VALUES ARE EQUAL IN LOCATION
         DTOLER = 1E-5 
 ! 2.a.1  running over the curvilinear grid
+        ALLOCATE (XGRTMP(NXI),YGRTMP(NYI))
+        XGRTMP=XGRDI(1,:)
+        YGRTMP=YGRDI(:,1)
+!/OMPH!$OMP PARALLEL DO PRIVATE(J,I,LONC,LATC,VALUEX,VALUEY)
         DO J=1,NY
           DO I=1,NX
             LONC=XGRDC(J,I)   !LON FOR EVERY CURVL GRID POINT
             LATC=YGRDC(J,I)   !LAT FOR EVERY CURVL GRID POINT
 
-            !SXC  =HPFAC(J,I)  !DELTA IN LON FOR CURVI GRID
-            !SYC  =HQFAC(J,I)  !DELTA IN LAT FOR CURVI GRID
-            !CHOOSING THE LARGEST DELTA
-            !!SXYC=MAX(SXC,SYC)
-            !!XDI=SXYC/SXI
-            !!IF(XDI .LT. 2.00) THEN
-            !!  MXA=2
-            !!ELSE
-            !!  MXA=2+INT(XDI)
-            !!ENDIF
-
-            !IF (MXA .EQ. 2) THEN
-            CALL INTERPOLATE2D(NXI,XGRDI(1,:),NYI,YGRDI(:,1), &
+            CALL INTERPOLATE2D(NXI,XGRTMP,NYI,YGRTMP, &
                        VXI,VYI,LONC,LATC,DTOLER,VALUEX,VALUEY)
-            !ELSE
-            ! COMPUTING THE NUMBER OF POINTS IN THE REGULAR GRID THAT
-            ! SURROUND THE POINT IN THE CURVILINEAR GRID, COULD BE 
-            ! DIFFERENT FOR LAT AND LONG, IN THE AVERAGING PROCESS.
-            !NPOIX=INT(SXC/SXI)
-            !NPOIY=INT(SYC/SYI)
-            !!VALUEX=AVERAGING(NXI,XGRDI(1,:),NYI,YGRDI(:,1),  &
-            !!           VARIN,LONC,LATC,NPOIX,NPOIY)
-            !ENDIF
-
             VX(I,J)=VALUEX
             VY(I,J)=VALUEY
 
           END DO  !END I
         END DO  !END J
+!/OMPH/!$OMP END PARALLEL DO
+        DEALLOCATE (XGRTMP, YGRTMP)
 
       ELSE
 !

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1202,6 +1202,7 @@
 ! CHECKPOINT
         IF(J .EQ. 4) THEN
           ODAT(38)=0 
+          WORDS(1:6)=''
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
           READ(WORDS( 1 ), * ) ODAT(16)
@@ -1210,6 +1211,7 @@
           READ(WORDS( 4 ), * ) ODAT(19)
           READ(WORDS( 5 ), * ) ODAT(20)
           IF (WORDS(6) .EQ. 'T') THEN
+          CALL NEXTLN ( COMSTR , NDSI , NDSEN )
             READ (NDSI,*,END=2001,ERR=2002)(ODAT(I),I=5*(8-1)+1,5*8)
             WRITE(*,*)(ODAT(I),I=5*(8-1)+1,5*8)
           END IF
@@ -1219,12 +1221,10 @@
 !          READ (NDSI,*) (ODAT(I),I=5*(J-1)+1,5*J)
 !          READ (NDSI,*,IOSTAT=IERR) (ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
         IF(J .LE. 2) THEN
+          WORDS(1:6)=''
 !          READ (NDSI,*,END=2001,ERR=2002)(ODAT(I),I=5*(J-1)+1,5*J),OFILES(J)
           READ (NDSI,'(A)') LINEIN
           READ(LINEIN,*,iostat=ierr) WORDS
-          DO I=1,6
-!            WRITE(*,*) I, WORDS(I)
-          END DO
 !
           IF(J .EQ. 1) THEN
             READ(WORDS( 1 ), * ) ODAT(1)


### PR DESCRIPTION
* Adding OMP loop in wmgridmd for optimizing initialization time, speeds up by up to OMP_NUM_THREADS init time, 
* Removes the excessive esmf field gather in wmesmfmd.ftn, speeds up exchange of ATM->WAV data,
* Added OMP loop and allocatable variables to WMUPDV in call to interpolation subroutine: speeds up more expensive interpolation loop for curvilinear grids,
* Bug fix for WORD array within the context of defining second restart file stream.