### PR TITLE
Bug fixes for z0 over ice for ESMF cap 

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -109,7 +109,7 @@ fi
 if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$cmplr" == "intel_prof" ]    || \
    [ "$cmplr" == "so_intel" ]       || [ "$cmplr" == "so_intel_debug" ] || [ "$cmplr" == "so_intel_prof" ] || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] || [ "$cmplr" == "datarmor_intel_prof" ] || \
-   [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_dell_p3" ]  || \
+   [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_dell_p3" ]  || [ "$cmplr" == "cheyenne" ]      || \
    [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] ; then
 
 
@@ -123,6 +123,11 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   if [ ! -z "$(echo $cmplr | grep wcoss_cray)" ] ; then
     comp_seq='ftn'
     comp_mpi='ftn'
+  fi
+
+  if [ ! -z "$(echo $cmplr | grep cheyenne)" ] ; then
+    comp_seq='ifort'
+    comp_mpi='mpif90'
   fi
 
 
@@ -151,7 +156,8 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ ! -z "$(echo $cmplr | grep datarmor)" ] || [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] || [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]; then
+  if [ ! -z "$(echo $cmplr | grep datarmor)" ] || [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] || \
+     [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ] || [ "$cmplr" == "cheyenne" ]; then
      optomp="-qopenmp"
   else
      optomp="-openmp"

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -415,6 +415,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ]                            || \
+       [ "$cmplr" == "cheyenne" ]                                                   || \
        [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]              || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
@@ -440,6 +441,7 @@ then
        [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ]   || \
        [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ]                         || \
        [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ]                            || \
+       [ "$cmplr" == "cheyenne" ]                                                   || \
        [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]              || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -35,7 +35,7 @@ ifeq ($(WW3_COMP),Portland)
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","pgi" "datarmor_pgi" "datarmor_pgi_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -byteswapio
 # intel
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","Intel" "hera" "orion"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","Intel" "hera" "orion" "cheyenne"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_cray" "wcoss_dell_p3"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian

--- a/model/ftn/wmesmfmd.ftn
+++ b/model/ftn/wmesmfmd.ftn
@@ -5621,9 +5621,6 @@
 !/ST4                           dlwmean )
             endif !firstCall
             wrln(jsea) = charn(jsea)*ust(isea)**2/grav
-          else  
-            !ice value 
-            wrln(jsea) = 0.00001d0
           endif 
         enddo jsea_loop
 

--- a/model/ftn/wmesmfmd.ftn
+++ b/model/ftn/wmesmfmd.ftn
@@ -2302,7 +2302,7 @@
 !/WRST            wy0 = WYNwrst  
 !/WRST            if (ESMF_LogFoundError(rc, PASSTHRU)) return
 !/WRST          enddo
-!/WRST        endif
+        endif
     
 !/WRST       if ( ((twn(1)-tw0(1))*1000000+((twn(2)-tw0(2)))) .le. 0  ) then 
 !/WRST        !If the time of the field is still initial time, replace


### PR DESCRIPTION
A value of z0 was put over ice, however this was not correct and was done in attempt to fix other issues.  However, this caused it's own issues and is now being removed. 

This also addressed: 
* Bug reported in Issue #247 
* Porting to cheyenne for UFS applications 