### PR TITLE
develop: Updated version number to 7.12

### DIFF
--- a/guide/guide.tex
+++ b/guide/guide.tex
@@ -17,7 +17,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % proper link to most recent manual %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-\newcommand{\manver}{6.07}
+\newcommand{\manver}{7.12}
 \newcommand{\manref}{ww3man2019}
 \newcommand{\manregtestsec}{5.6}
 

--- a/manual/defs.tex
+++ b/manual/defs.tex
@@ -1,4 +1,4 @@
-\newcommand{\WWver}{7.00}
+\newcommand{\WWver}{7.12}
 \newcommand{\guidever}{1.2}
 \newcommand{\guideref}{tol:MMABguide}
 \newcommand{\genever}{1.5}

--- a/model/ftn/w3fldsmd.ftn
+++ b/model/ftn/w3fldsmd.ftn
@@ -929,7 +929,7 @@
 !/    26-Dec-2012 : Modified obsolete declarations.     ( version 4.11 )
 !/    24-Apr-2015 : Adding OASIS coupling calls         ( version 5.07 )
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
-!/    25-Sep-2020 : Receive coupled fields at T+0       ( version 7.xx )
+!/    25-Sep-2020 : Receive coupled fields at T+0       ( version 7.10 )
 !/
 !  1. Purpose :
 !

--- a/model/ftn/w3initmd.ftn
+++ b/model/ftn/w3initmd.ftn
@@ -57,7 +57,7 @@
 !/    05-Jun-2018 : Adds PDLIB/MEMCHECK/DEBUG           ( version 6.04 )
 !/    21-Aug-2018 : Add WBT parameter                   ( version 6.06 )
 !/    26-Aug-2018 : UOST (Mentaschi et al. 2015, 2018)  ( version 6.06 )
-!/    25-Sep-2020 : Extra fields for coupling restart   ( version 7.xx )
+!/    25-Sep-2020 : Extra fields for coupling restart   ( version 7.10 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -110,7 +110,7 @@
       PUBLIC
 !/
       REAL, PARAMETER                :: CRITOS = 15.
-      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.00  '
+      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.12  '
       CHARACTER(LEN=512), PARAMETER  :: SWITCHES  = &
                     'PUT_SW1' // &
                     'PUT_SW2' // &

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -55,7 +55,7 @@
 !/                  calculations. (J Dykes, NRL)
 !/    04-Oct-2019 : Optional one file per output stride ( version 7.00 )
 !/                  (Roberto Padilla-Hernandez & J.H. Alves)
-!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.XX )
+!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.12 )
 !/                  seperate subroutine. (C. Bunney)
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
@@ -292,8 +292,8 @@
 !/    15-Apr-2013 : Origination.                        ( version 4.10 )
 !/    31-Jan-2014 : Bug fix warning output (Tolman).    ( version 4.18 )
 !/    30-Apr-2014 : Add th2m and sth2m calculation      ( version 5.01 )
-!/    25-Sep-2020 : Calculate FLG1D for any processor   ( version 7.xx )
-!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.XX )
+!/    25-Sep-2020 : Calculate FLG1D for any processor   ( version 7.10 )
+!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.12 )
 !/                  seperate subroutine (C. Bunney)
 !/
 !  1. Purpose :
@@ -522,8 +522,8 @@
 !/    31-Jan-2014 : Bug fix warning output (Tolman).    ( version 4.18 )
 !/    30-Apr-2014 : Add th2m and sth2m calculation      ( version 5.01 )
 !/    17-Feb-2016 : New version for namelist use        ( version 5.11 )
-!/    25-Sep-2020 : Calculate FLG1D for any processor   ( version 7.xx )
-!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.XX )
+!/    25-Sep-2020 : Calculate FLG1D for any processor   ( version 7.10 )
+!/    03-Nov-2020 : Factored out NAME matching into     ( version 7.12 )
 !/                  seperate subroutine (C. Bunney)
 !/
 !  1. Purpose :
@@ -675,7 +675,7 @@
 !/                  | Last update :         03-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    03-Nov-2020 : Origination.                        ( version 7.XX )
+!/    03-Nov-2020 : Origination.                        ( version 7.12 )
 !
 !  1. Purpose :
 !

--- a/model/ftn/w3iorsmd.ftn
+++ b/model/ftn/w3iorsmd.ftn
@@ -103,7 +103,7 @@
 !/    19-Dec-2019 : Optional second stream of           ( version 7.00 )
 !/                  restart files 
 !/                  (Roberto Padilla-Hernandez & J.H. Alves)
-!/    25-Sep-2020 : Extra fields for coupled restart    ( version 7.xx )
+!/    25-Sep-2020 : Extra fields for coupled restart    ( version 7.10 )
 
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),

--- a/model/ftn/w3nmlmultimd.ftn
+++ b/model/ftn/w3nmlmultimd.ftn
@@ -917,7 +917,7 @@
 !/
 !/    09-Aug-2016 : Adding comments                     ( version 5.12 )
 !/    15-May-2018 : Update namelist                     ( version 6.05 )
-!/    25-Sep-2020 : Update namelist                     ( version 7.xx )
+!/    25-Sep-2020 : Update namelist                     ( version 7.10 )
 !/
 !  1. Purpose :
 !
@@ -1716,7 +1716,7 @@
 !/
 !/    09-Aug-2016 : Adding comments                     ( version 5.12 )
 !/    15-May-2018 : Update namelist                     ( version 6.05 )
-!/    25-Sep-2020 : Update namelist                     ( version 7.xx )
+!/    25-Sep-2020 : Update namelist                     ( version 7.10 )
 !/
 !  1. Purpose :
 !

--- a/model/ftn/w3oacpmd.ftn
+++ b/model/ftn/w3oacpmd.ftn
@@ -12,7 +12,7 @@
 !/      July-2013 : Origination.                         ( version 4.18 )
 !/                    For upgrades see subroutines.
 !/     April-2016 : Add comments (J. Pianezze)           ( version 5.07 )
-!/    25-Sep-2020 : Coupling at T+0 support              ( version 7.xx )
+!/    25-Sep-2020 : Coupling at T+0 support              ( version 7.10 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/ftn/w3odatmd.ftn
+++ b/model/ftn/w3odatmd.ftn
@@ -43,7 +43,7 @@
 !/    27-Jul-2018 : Added PTMETH and PTFCUT variables   ( version 6.05 )
 !/                  for alternative partition methods.
 !/                  (C. Bunney, UKMO)
-!/    25-Sep-2020 : Flags for coupling restart          ( version 7.xx )
+!/    25-Sep-2020 : Flags for coupling restart          ( version 7.10 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -1399,7 +1399,7 @@
 !/    27-Jul-2010 : Add NKI, NTHI, XFRI, FR1I, TH1I.    ( version 3.14.3 )
 !/    19-Dec-2012 : Move NOSWLL to data structure.      ( version 4.11 )
 !/    12-Dec-2014 : Modify instanciation of NRQTR       ( version 5.04 )
-!/    25-Sep-2020 : Flags for coupling restart          ( version 7.xx )
+!/    25-Sep-2020 : Flags for coupling restart          ( version 7.10 )
 !/
 !  1. Purpose :
 !

--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -9,7 +9,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    02-Nov-2020 : Creation                            ( version 7.XX )
+!/    02-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !  1. Purpose :
 !
@@ -180,7 +180,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -259,7 +259,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -297,7 +297,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -400,7 +400,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    02-Nov-2020 : Creation                            ( version 7.XX )
+!/    02-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -449,7 +449,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -597,7 +597,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -703,7 +703,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -886,7 +886,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -985,7 +985,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1088,7 +1088,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1173,7 +1173,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1227,7 +1227,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1273,7 +1273,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1405,7 +1405,7 @@
 !/                  | Last update :         09-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1478,7 +1478,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    09-Nov-2020 : Creation                            ( version 7.XX )
+!/    09-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :
@@ -1521,7 +1521,7 @@
 !/                  | Last update :         02-Nov-2020 |
 !/                  +-----------------------------------+
 !/
-!/    02-Nov-2020 : Creation                            ( version 7.XX )
+!/    02-Nov-2020 : Creation                            ( version 7.12 )
 !/
 !
 !  1. Purpose :

--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -250,7 +250,7 @@
 !/                  OASIS/DEBUGINIT/DEBUGSRC/DEBUGRUN/DEBUGCOH
 !/                  DEBUGIOBP/DEBUGIOBC                 ( version 6.04 )
 !/    14-Sep-2018 : Remove PALM implementation          ( version 6.06 )
-!/    25-Sep-2020 : Oasis coupling at T+0               ( version 7.xx )
+!/    25-Sep-2020 : Oasis coupling at T+0               ( version 7.10 )
 !/
 !  1. Purpose :
 !

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -36,7 +36,7 @@
 !/    18-Jun-2020 : Support for 360-day calendar.       ( version 7.08 )
 !/    07-Oct-2019 : RTD option with standard lat-lon
 !/                  grid when nesting to rotated grid   ( version 7.11 )
-!/    03-Nov-2020 : Moved NetCDF metadata to separate   ( version 7.XX )
+!/    03-Nov-2020 : Moved NetCDF metadata to separate   ( version 7.12 )
 !/                  module.
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
@@ -697,7 +697,7 @@
 !/    30-Apr-2014 : Correct group3 freq dim.            ( version 5.00 )
 !/    23-May-2014 : Adding ice fluxes to W3SRCE         ( version 5.01 )
 !/    14-Oct-2014 : Keep the output files opened        ( version 5.01 )
-!/    03-Nov-2020 : NetCDF metadata moved to separate   ( version 7.XX )
+!/    03-Nov-2020 : NetCDF metadata moved to separate   ( version 7.12 )
 !/                  module.
 !/
 !  1. Purpose :

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -54,7 +54,7 @@
 !/    04-Oct-2019 : Inline Output implementation        ( version 6.07 )
 !/                  (Roberto Padilla-Hernandez)
 !/    16-Jul-2020 : Variable coupling time step         ( version 7.08 )
-!/    25-Sep-2020 : Oasis coupling at T+0               ( version 7.xx )
+!/    25-Sep-2020 : Oasis coupling at T+0               ( version 7.10 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights


### PR DESCRIPTION
I  have also retrospectively updated the version number for Juan's OASIS coupling changes (milestone 7.10) which were still set to `7.xx`.

A grep of "7.xx" in the model/ftn/ directory shows that there are still some version numbers that have not been updated.