### PR TITLE
Add WNDDIR, CURDIR and TP outputs

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -57,6 +57,9 @@
 !/                  (Roberto Padilla-Hernandez & J.H. Alves)
 !/    03-Nov-2020 : Factored out NAME matching into     ( version 7.12 )
 !/                  seperate subroutine. (C. Bunney)
+!/    15-Jan-2020 : Added TP, WNDDIR and CURDIR outputs ( version 7.12 )
+!/                  based on existing internal fields.
+!/                  (C. Bunney)
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -732,15 +735,21 @@
       CASE('IBG')
         I = 1
         J = 7
+      CASE('CURDIR') ! Uses CX/CY internally, as per CUR
+        I = 1
+        J = 8
+      CASE('WNDDIR') ! Uses UA/UD internally, as per WND
+        I = 1
+        J = 9
 !/BT4           CASE('D50')
 !/BT4             I = 1
-!/BT4             J = 8
+!/BT4             J = 10
 !/IS2           CASE('IC1')
 !/IS2             I = 1
-!/IS2             J = 9
+!/IS2             J = 11
 !/IS2           CASE('IC5')
 !/IS2             I = 1
-!/IS2             J = 10
+!/IS2             J = 12
 ! Group 2
 !
 !/OASACM         CASE('AHS')
@@ -800,6 +809,9 @@
       CASE('WBT')
         I = 2
         J = 17
+      CASE('TP') ! Uses FP0 internally, as per FP
+        I = 2
+        J = 18
 !
 ! Group 3
 !
@@ -2653,7 +2665,8 @@
                 IF ( FLOGRD( 2, 3) ) T02   (ISEA) = UNDEF
                 IF ( FLOGRD( 2, 4) ) T0M1  (ISEA) = UNDEF
                 IF ( FLOGRD( 2, 5) ) T01   (ISEA) = UNDEF
-                IF ( FLOGRD( 2, 6) ) FP0   (ISEA) = UNDEF
+                IF ( FLOGRD( 2, 6) .OR. FLOGRD( 2,18) )                 &
+                                     FP0   (ISEA) = UNDEF  ! FP or TP
                 IF ( FLOGRD( 2, 7) ) THM   (ISEA) = UNDEF
                 IF ( FLOGRD( 2, 8) ) THS   (ISEA) = UNDEF
                 IF ( FLOGRD( 2, 9) ) THP0  (ISEA) = UNDEF
@@ -2818,10 +2831,14 @@
 !
                 IF ( IFI .EQ. 1 .AND. IFJ .EQ. 1 ) THEN
                     WRITE ( NDSOG ) DW(1:NSEA)
-                  ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 2 ) THEN
+                  ELSE IF ( (IFI .EQ. 1 .AND. IFJ .EQ. 2) .OR.          &
+                            (IFI .EQ. 1 .AND. IFJ .EQ. 8) ) THEN
+                    ! CUR or CURDIR
                     WRITE ( NDSOG ) CX(1:NSEA)
                     WRITE ( NDSOG ) CY(1:NSEA)
-                  ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 3 ) THEN
+                  ELSE IF ( (IFI .EQ. 1 .AND. IFJ .EQ. 3) .OR.          &
+                            (IFI .EQ. 1 .AND. IFJ .EQ. 9) ) THEN
+                    ! WND or WNDDIR
                     DO ISEA=1, NSEA
 !/ARC  !!Li  Rotate map-east wind in Arctic part back to local east.  JGLi02Feb2016
 !/ARC                      IF(ISEA .GT. NGLO) THEN
@@ -2868,7 +2885,9 @@
                     WRITE ( NDSOG ) T0M1(1:NSEA)
                   ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 5 ) THEN
                     WRITE ( NDSOG ) T01(1:NSEA)
-                  ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 6 ) THEN
+                  ELSE IF ( (IFI .EQ. 2 .AND. IFJ .EQ. 6) .OR.         &
+                            (IFI .EQ. 2 .AND. IFJ .EQ. 18) ) THEN
+                    ! TP output is derived from FP field.
                     WRITE ( NDSOG ) FP0(1:NSEA)
                   ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 7 ) THEN
                     WRITE ( NDSOG ) THM(1:NSEA)
@@ -3105,10 +3124,14 @@
 !
                 IF ( IFI .EQ. 1 .AND. IFJ .EQ. 1 ) THEN
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) DW(1:NSEA)
-                  ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 2 ) THEN
+                  ELSE IF ( (IFI .EQ. 1 .AND. IFJ .EQ. 2) .OR.         &
+                            (IFI .EQ. 1 .AND. IFJ .EQ. 8) ) THEN
+                    ! CUR or CURDIR
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) CX(1:NSEA)
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) CY(1:NSEA)
-                  ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 3 ) THEN
+                  ELSE IF ( (IFI .EQ. 1 .AND. IFJ .EQ. 3) .OR.         &
+                            (IFI .EQ. 1 .AND. IFJ .EQ. 9) ) THEN
+                    ! WND or WNDDIR
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) UA(1:NSEA)
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) UD(1:NSEA)
                   ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 4 ) THEN
@@ -3140,7 +3163,9 @@
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) T0M1(1:NSEA)
                   ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 5 ) THEN
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) T01(1:NSEA)
-                  ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 6 ) THEN
+                  ELSE IF ( (IFI .EQ. 2 .AND. IFJ .EQ. 6) .OR.       &
+                            (IFI .EQ. 2 .AND. IFJ .EQ. 18) ) THEN
+                    ! TP output is derived from FP field.
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) FP0(1:NSEA)
                   ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 7 ) THEN
                     READ (NDSOG,END=801,ERR=802,IOSTAT=IERR) THM(1:NSEA)

--- a/model/ftn/w3odatmd.ftn
+++ b/model/ftn/w3odatmd.ftn
@@ -44,6 +44,9 @@
 !/                  for alternative partition methods.
 !/                  (C. Bunney, UKMO)
 !/    25-Sep-2020 : Flags for coupling restart          ( version 7.10 )
+!/    15-Jan-2020 : Added TP, WNDDIR and CURDIR outputs ( version 7.12 )
+!/                  based on existing internal fields.
+!/                  (C. Bunney, UKMO)
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -669,26 +672,28 @@
 !
 ! 1) Forcing fields
 !
-      NOGE(1) = 7
-!/BT4      NOGE(1) = 8
-!/IS2      NOGE(1) = 10    ! CB
-!/SETUP    NOGE(1) = 11    ! CB
+      NOGE(1) = 9
+!/BT4      NOGE(1) = 10
+!/IS2      NOGE(1) = 12
+!/SETUP    NOGE(1) = 13
 !
       IDOUT( 1, 1)  = 'Water depth         '
-      IDOUT( 1, 2)  = 'Current vel.        '
-      IDOUT( 1, 3)  = 'Wind speed          '
+      IDOUT( 1, 2)  = 'Current vel. (U/V)  '
+      IDOUT( 1, 3)  = 'Wind speed (U/V)    '
       IDOUT( 1, 4)  = 'Air-sea temp. dif.  '
       IDOUT( 1, 5)  = 'Water level         '
       IDOUT( 1, 6)  = 'Ice concentration   '
       IDOUT( 1, 7)  = 'Iceberg damp coeffic'
-!/BT4      IDOUT( 1, 8)  = 'Sediment diam D50   '
-!/IS2      IDOUT( 1, 9)  = 'ice thickness   '
-!/IS2      IDOUT( 1, 10) = 'Avg. ice floe diam. '
-!/SETUP    IDOUT( 1, 11)  = 'wave induced setup'
+      IDOUT( 1, 8)  = 'Current dir/spd     '
+      IDOUT( 1, 9)  = 'Wind dir/spd        '
+!/BT4      IDOUT( 1, 10)  = 'Sediment diam D50   '
+!/IS2      IDOUT( 1, 11)  = 'ice thickness   '
+!/IS2      IDOUT( 1, 12) = 'Avg. ice floe diam. '
+!/SETUP    IDOUT( 1, 13)  = 'wave induced setup'
 !
 ! 2) Standard mean wave parameters
 !
-      NOGE(2) = 17
+      NOGE(2) = 18
 !
       IDOUT( 2, 1)  = 'Wave height         '
       IDOUT( 2, 2)  = 'Mean wave length    '
@@ -707,6 +712,7 @@
       IDOUT( 2, 15)  = 'STD Space-Time Hmax'
       IDOUT( 2, 16)  = 'STD ST Hmax^crest  '
       IDOUT( 2, 17)  = 'Dominant wave bT   '
+      IDOUT( 2, 18)  = 'Peak period        '
 !      IDOUT( 2,10)  = 'Mean wave dir. a2b2'
 !      IDOUT( 2,11)  = 'Mean dir. spr. a2b2'
 !      IDOUT( 2,12)  = 'Windsea height(Sin)'

--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -10,6 +10,7 @@
 !/                  +-----------------------------------+
 !/
 !/    02-Nov-2020 : Creation                            ( version 7.12 )
+!/    15-Jan-2021 : Added TP, WNDDIR and CURDIR outputs ( version 7.12 )
 !/
 !  1. Purpose :
 !
@@ -1643,8 +1644,52 @@
       META(1)%VARNG='icebergs_damping'
       META(1)%VMIN = 0
       META(1)%VMAX = 3.2
-! IFI=1, IFJ=8
-!/BT4      META => GROUP(1)%FIELD(8)%META
+! IFI=, IFJ=8, CURDIR
+      META => GROUP(1)%FIELD(8)%META
+      META(1)%FSC    = 0.01
+      META(1)%ENAME  = '.curdir'
+      META(1)%UNITS  = 'm s-1'
+      META(1)%VMIN = 0
+      META(1)%VMAX = 10.0
+      META(1)%VARNM='cspd'
+      META(1)%VARNL='current speed'
+      META(1)%VARNS='sea_water_speed'
+      META(1)%VARNG='sea_water_speed'
+
+      ! Second component
+      META(2) = META(1)
+      META(2)%FSC = 0.1
+      META(2)%VARNM='cdir'
+      META(2)%UNITS= 'degrees'
+      META(2)%VARNL='current direction (toward)'
+      META(2)%VARNS='direction_of_sea_water_velocity'
+      META(2)%VARNG='direction_of_sea_water_velocity'
+      META(2)%VMIN = 0
+      META(2)%VMAX = 360.0
+! IFI=, IFJ=9, WNDDIR
+      META => GROUP(1)%FIELD(9)%META
+      META(1)%FSC = 0.01
+      META(1)%ENAME  = '.wnddir'
+      META(1)%UNITS= 'm s-1'
+      META(1)%VARNM='wspd'
+      META(1)%VARNL='wind speed'
+      META(1)%VARNS='wind_speed'
+      META(1)%VARNG='wind_speed'
+      META(1)%VMIN = 0.0
+      META(1)%VMAX = 100.0
+
+      ! Second component
+      META(2) = META(1)
+      META(2)%FSC = 0.1
+      META(2)%VARNM='wdir'
+      META(2)%UNITS='degrees'
+      META(2)%VARNL='wind direction (from)'
+      META(2)%VARNS='wind_from_direction'
+      META(2)%VARNG='wind_from_direction'
+      META(2)%VMIN = 0.0
+      META(2)%VMAX = 360.0
+! IFI=1, IFJ=10
+!/BT4      META => GROUP(1)%FIELD(10)%META
 !/BT4      META(1)%FSC    = 0.001
 !/BT4      META(1)%UNITS  = 'Krumbein phi scale'
 !/BT4      META(1)%ENAME  = '.d50'
@@ -1654,8 +1699,8 @@
 !/BT4      META(1)%VARNG='sediment_grain_size'
 !/BT4      META(1)%VMIN = -10.0
 !/BT4      META(1)%VMAX = 32.0
-! IFI=1, IFJ=9
-!/IS2      META => GROUP(1)%FIELD(9)%META
+! IFI=1, IFJ=11
+!/IS2      META => GROUP(1)%FIELD(11)%META
 !/IS2      META(1)%FSC = 0.001
 !/IS2      META(1)%UNITS = 'm'
 !/IS2      META(1)%ENAME = '.ic1'
@@ -1665,8 +1710,8 @@
 !/IS2      META(1)%VARNG='ice_thickness'
 !/IS2      META(1)%VMIN = 0
 !/IS2      META(1)%VMAX = 30
-! IFI=1, IFJ=10
-!/IS2      META => GROUP(1)%FIELD(10)%META
+! IFI=1, IFJ=12
+!/IS2      META => GROUP(1)%FIELD(12)%META
 !/IS2      META(1)%FSC = 0.05
 !/IS2      META(1)%UNITS = 'm'
 !/IS2      META(1)%ENAME = '.ic5'
@@ -1871,6 +1916,17 @@
       META(1)%VARNG='dominant_wave_breaking_probability'
       META(1)%VMIN = 0
       META(1)%VMAX = 1
+! IFI=2, IFJ=18, TP
+      META => GROUP(2)%FIELD(18)%META
+      META(1)%FSC    = 0.01
+      META(1)%UNITS  = 's'
+      META(1)%ENAME  = '.tp'
+      META(1)%VARNM='tp'
+      META(1)%VARNL='wave peak period'
+      META(1)%VARNS='sea_surface_wave_peak_period'
+      META(1)%VARNG='dominant_wave_period'
+      META(1)%VMIN = 0 
+      META(1)%VMAX = 50
 !
 !---------- GROUP 3 ----------------
 !

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -39,6 +39,7 @@
 !/    03-Nov-2020 : Moved NetCDF metadata to separate   ( version 7.12 )
 !/                  module.
 !/    09-Dec-2020 : Set fixed values for VARID indices  ( version 7.12 )
+!/    15-Jan-2021 : Added TP, WNDDIR and CURDIR outputs ( version 7.12 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -842,7 +843,7 @@
       REAL, ALLOCATABLE       :: X1(:,:), X2(:,:), XX(:,:), XY(:,:),   &
                                  XK(:,:,:), XXK(:,:,:), XYK(:,:,:),    & 
                                  MX1R(:,:), MXXR(:,:), MYYR(:,:),      &
-                                 MXYR(:,:)
+                                 MXYR(:,:), AUX1(:), AUX2(:)
 !
       DOUBLE PRECISION        :: OUTJULDAY
       DOUBLE PRECISION        :: SXD, SYD, X0D, Y0D
@@ -858,6 +859,7 @@
       CHARACTER, SAVE         :: TIMEID*16 = '0000000000000000'
 !
       LOGICAL                 :: FLFRQ, FLDIR, FEXIST, FREMOVE
+      LOGICAL                 :: FLAGCURN = .FALSE., FLAGWURN=.FALSE.
       LOGICAL                 :: CUSTOMFRQ=.FALSE.
 !/T      LOGICAL                 :: LTEMP(NGRPP)
 !/RTD ! RTDL == False for a standard lat-lon grid. Will be set to True if the
@@ -902,6 +904,7 @@
         ALLOCATE(MX1(NX,NY), MXX(NX,NY), MYY(NX,NY), MXY(NX,NY), MAPOUT(NX,NY))
         ALLOCATE(MX1R(NX,NY), MXXR(NX,NY), MYYR(NX,NY), MXYR(NX,NY))
       ENDIF ! SMCGRD
+      ALLOCATE(AUX1(1:NSEA), AUX2(1:NSEA))
 
       X1     = UNDEF
       X2     = UNDEF
@@ -1018,11 +1021,14 @@
                                                             , MAPSF, X1 )
               ENDIF
 
-            ! Surface current
+            ! Surface current (U/V)
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 2 ) THEN
               !! Note - CX and CY read in from .ww3 file are X-Y vectors
 !/RTD              ! Rotate x,y vector back to standard pole
-!/RTD              IF ( FLAGUNR ) CALL W3XYRTN(NSEA, CX(1:NSEA), CY(1:NSEA), AnglD)
+!/RTD              IF ( FLAGUNR .AND. .NOT. FLAGCURN ) THEN
+!/RTD                CALL W3XYRTN(NSEA, CX(1:NSEA), CY(1:NSEA), AnglD)
+!/RTD                FLAGCURN = .TRUE.
+!/RTD              ENDIF
               IF( SMCGRD ) THEN
 !/SMC                 CALL W3S2XY_SMC( CX(1:NSEA), XX )
 !/SMC                 CALL W3S2XY_SMC( CY(1:NSEA), XY )
@@ -1034,11 +1040,14 @@
               ENDIF
               NFIELD=2
 !
-            ! Wind
+            ! Wind (U/V)
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 3 ) THEN
               !! Note - UA and UD read in from .ww3 file are UX,UY
 !/RTD              ! Rotate x,y vector back to standard pole
-!/RTD              IF ( FLAGUNR ) CALL W3XYRTN(NSEA, UA(1:NSEA), UD(1:NSEA), AnglD)
+!/RTD              IF ( FLAGUNR .AND. .NOT. FLAGWURN )  THEN
+!/RTD                CALL W3XYRTN(NSEA, UA(1:NSEA), UD(1:NSEA), AnglD)
+!/RTD                FLAGWURN = .TRUE.
+!/RTD              ENDIF
               
               IF( SMCGRD ) THEN
 !/SMC                 CALL W3S2XY_SMC( UA(1:NSEA), XX )
@@ -1075,7 +1084,7 @@
               ELSE
                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, ICE(1:NSEA), MAPSF, X1 )
               ENDIF
-
+!
             ! Icebergs_damping
             ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 7 ) THEN
               IF( SMCGRD ) THEN
@@ -1085,19 +1094,59 @@
               ENDIF
               WHERE ( X1.NE.UNDEF) X1 = X1*0.1
 !
+            ! Surface current (speed/dir)
+            ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 8 ) THEN
+              !! Note - CX and CY read in from .ww3 file are X-Y vectors
+!/RTD              ! Rotate x,y vector back to standard pole
+!/RTD              IF ( FLAGUNR .AND. .NOT. FLAGCURN ) THEN
+!/RTD                CALL W3XYRTN(NSEA, CX(1:NSEA), CY(1:NSEA), AnglD)
+!/RTD                FLAGCURN = .TRUE.
+!/RTD              ENDIF
+
+              CALL UV_TO_MAG_DIR(CX(1:NSEA), CY(1:NSEA), AUX1, AUX2,   &
+                                 TOLERANCE=0.05, CONV='O')
+              IF( SMCGRD ) THEN
+!/SMC                 CALL W3S2XY_SMC( AUX1, XX, .TRUE. )
+!/SMC                 CALL W3S2XY_SMC( AUX2, XY, .TRUE. )
+              ELSE
+                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, AUX1, MAPSF, XX )
+                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, AUX2, MAPSF, XY )
+              ENDIF
+              NFIELD=2
+!
+            ! Wind (speed/dir)
+            ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 9 ) THEN
+              !! Note - UA and UD read in from .ww3 file are UX,UY
+!/RTD              ! Rotate x,y vector back to standard pole
+!/RTD              IF ( FLAGUNR .AND. .NOT. FLAGWURN )  THEN
+!/RTD                CALL W3XYRTN(NSEA, UA(1:NSEA), UD(1:NSEA), AnglD)
+!/RTD                FLAGWURN = .TRUE.
+!/RTD              ENDIF
+              
+              CALL UV_TO_MAG_DIR(UA(1:NSEA), UD(1:NSEA), AUX1, AUX2,   &
+                                 TOLERANCE=1.0, CONV='N')
+              IF( SMCGRD ) THEN
+!/SMC                 CALL W3S2XY_SMC( UA(1:NSEA), AUX1, .TRUE. )
+!/SMC                 CALL W3S2XY_SMC( UD(1:NSEA), AUX2, .TRUE. )
+              ELSE ! IF(SMCGRD)
+                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, AUX1, MAPSF, XX )
+                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, AUX2, MAPSF, XY )
+              ENDIF
+              NFIELD=2
+!
 !/BT4 ! Krumbein phi scale
-!/BT4 ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 8 ) THEN
+!/BT4 ELSE IF ( IFI .EQ. 1 .AND. IFJ .EQ. 10 ) THEN
 !/BT4              CALL W3S2XY ( NSEA, NSEA, NX+1, NY, SED_D50   , MAPSF, X1 )
 !/BT4              WHERE ( X1.NE.UNDEF) X1 = -LOG(X1/0.001)/LOG2    
 !/BT4              NFIELD=1
 !
 !/IS2 ! Ice thickness
-!/IS2 ELSE IF (IFI .EQ. 1 .AND. IFJ .EQ. 9 ) THEN
+!/IS2 ELSE IF (IFI .EQ. 1 .AND. IFJ .EQ. 11 ) THEN
 !/IS2              CALL W3S2XY (NSEA, NSEA, NX+1, NY, ICEH(1:NSEA), MAPSF, X1 )
 !/IS2              NFIELD=1
 !
 !/IS2 ! Maximum ice floe diameter
-!/IS2 ELSE IF (IFI .EQ. 1 .AND. IFJ .EQ. 10 ) THEN
+!/IS2 ELSE IF (IFI .EQ. 1 .AND. IFJ .EQ. 12 ) THEN
 !/IS2              CALL W3S2XY (NSEA, NSEA, NX+1, NY, ICEF(1:NSEA), MAPSF, X1 )
 !/IS2              NFIELD=1
 
@@ -1251,6 +1300,21 @@
               ELSE
                  CALL W3S2XY ( NSEA, NSEA, NX+1, NY, WBT, MAPSF, X1 )
               END IF
+
+            ! Wave peak period (derived from peak freq field)
+            ELSE IF ( IFI .EQ. 2 .AND. IFJ .EQ. 18 ) THEN
+              DO I=1,NSEA
+                IF(FP0(I) .NE. UNDEF) THEN
+                  AUX1(I) = 1.0 / FP0(I)
+                ELSE
+                  AUX1(I) = UNDEF
+                ENDIF
+              ENDDO
+              IF( SMCGRD ) THEN
+!/SMC                CALL W3S2XY_SMC(AUX1, X1)
+              ELSE
+                 CALL W3S2XY ( NSEA, NSEA, NX+1, NY, AUX1, MAPSF, X1 )
+              ENDIF
 !
             ! Wave elevation spectrum
             ELSE IF ( IFI .EQ. 3 .AND. IFJ .EQ. 1 ) THEN
@@ -3737,6 +3801,87 @@
 
       END SUBROUTINE W3CRNC 
 
+!/ ------------------------------------------------------------------- /
+      SUBROUTINE UV_TO_MAG_DIR(U, V, MAG, DIR, TOLERANCE, CONV)
+!/
+!/                  +-----------------------------------+
+!/                  | WAVEWATCH III           NOAA/NCEP |
+!/                  |           C. Bunney               |
+!/                  |                        FORTRAN 90 |
+!/                  | Last update :         15-Jan-2021 |
+!/                  +-----------------------------------+
+!/
+!/    15-Jan-2021 : Creation                            ( version 7.12 )
+!/
+!  1. Purpose :
+!
+!     Converts seapoint arrays formulated as U/V vectors into magnitude
+!     and direction arrays.
+!
+!  2. Parameters
+!
+!     Parameter list
+!     ----------------------------------------------------------------
+!       U/V       R.Arr  I  Array of U/V components
+!       MAG       R.Arr  O  Magnitude array
+!       DIR       R.Arr  O  Direction array (degrees)
+!       TOLERANCE Real   I  Minimum allowed magnitude  (Optional)
+!       CONV      Char   I  Ouput direciton convention (Optional)
+!     ----------------------------------------------------------------
+!
+!  3. Remarks
+!
+!     Optional CONV specifies direction convention. Must be one of:
+!       'N'=Nautical     : North=0, clockwise, direction-from (default)
+!       'O'=Oceangraphic : North=0, clockwise, direction-to
+!       'C'=Cartesian    : North=90, counter-clockwise, direction-to
+!
+!/ ------------------------------------------------------------------- /
+      IMPLICIT NONE
+ 
+      REAL, INTENT(IN) :: U(:), V(:)
+      REAL, INTENT(OUT) :: MAG(:), DIR(:)
+      REAL, INTENT(IN), OPTIONAL :: TOLERANCE
+      CHARACTER, INTENT(IN), OPTIONAL :: CONV
+!/ ------------------------------------------------------------------- /
+!/ Local parameters
+!
+      REAL :: TOL, SGN, OFFSET
+      CHARACTER :: DIRCONV
+      INTEGER :: ISEA
+
+      DIRCONV = 'N'
+      TOL = 1.0
+      IF(PRESENT(TOLERANCE)) TOL = TOLERANCE
+      IF(PRESENT(CONV)) DIRCONV = CONV
+
+      SELECT CASE (CONV)
+        CASE('N')
+          OFFSET = 630.
+          SGN = -1.
+        CASE('O')
+          OFFSET = 450.
+          SGN = -1.
+        CASE('C')
+          OFFSET = 360.
+          SGN = 1.
+        CASE DEFAULT
+          WRITE(NDSE,*) "UV_TO_MAG_DIR: UNKNOWN DIR CONVENTION: ", DIRCONV
+          CALL EXTCDE(1)
+      END SELECT
+
+      DO ISEA=1, NSEA
+        MAG(ISEA) = SQRT(U(ISEA)**2 + V(ISEA)**2)
+        IF(MAG(ISEA) .GE. TOL) THEN
+          DIR(ISEA) = MOD(OFFSET + (SGN * RADE * ATAN2(V(ISEA), U(ISEA))), 360.)
+        ELSE
+          MAG(ISEA) = UNDEF
+          DIR(ISEA) = UNDEF
+        END IF
+      END DO
+
+     END SUBROUTINE UV_TO_MAG_DIR
+
 !==============================================================================
 
       SUBROUTINE CHECK_ERROR(IRET, ILINE)
@@ -3762,13 +3907,7 @@
 
 !==============================================================================
 
-
 !/
 !/ End of W3OUNF ----------------------------------------------------- /
 !/
       END PROGRAM W3OUNF
-
-
-
-
-


### PR DESCRIPTION
Reference issue #296 

This PR adds 3 new gridded output fields to WW3 that are derived from existing internal fields:
  - `CURDIR` : Surface current direction and speed (from UA/UD)
  - `WNDDIR` : Wind speed and direction (from CX/CY)
  - `TP` : Peak wave period (from FP0)

As these outputs can be derived from existing internal fields in `w3adatmd`, there is no extra memory requirement or additional I/O performed by `w3iogomd`. The new outputs are calculated entirely in the relevant gridded post-processing program.

**Currently, this is only implemented for ww3_ounf. I am raising this PR as a draft to get preliminary acceptance before implementing in the other post-processing programs**

_NOTE: This PR is going to clash with @ukmo-juan-castillo 's #285 as both add additional fields to group 1 outputs. One of us will have to modify our PR depending on whose is merged first!_