### PR TITLE
COMSTR for ww3_shel.nml

### DIFF
--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -554,6 +554,9 @@
 !
 ! 1.c Local parameters
 !
+! Default COMSTR to "$" (for when using nml input files)
+      COMSTR = "$"
+!
 ! inferred from context: these flags (FL) are to indicate that the last (LST) 
 !   field has been read from a file.
       FLLSTL = .FALSE. ! This is associated with J.EQ.1 (wlev)


### PR DESCRIPTION
Added default value for COMSTR in `ww3_shel.ftn` so comment lines can be processed in the `points.list` file when using the ww3_shel.nml input file.

Resolves #313 (raised by @CarstenHansen)