### PR TITLE
Multiple build directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ manual/*.toc
 manual/*.out
 manual/*.dvi
 manual/*.pdf
+model/build*
+regtests/list*
+regtests/before
 regtests/matrix*
 regtests/*/work*
 regtests/*/input*/*.nc

--- a/model/bin/ad3
+++ b/model/bin/ad3
@@ -100,7 +100,9 @@
 
   source $(dirname $0)/w3_setenv
   main_dir=$WWATCH3_DIR
-  temp_dir=$WWATCH3_TMP
+  build_dir=${WWATCH3_BUILD:-$WWATCH3_DIR}
+  #temp_dir=$WWATCH3_TMP
+  temp_dir=$build_dir/tmp
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
 
@@ -110,8 +112,10 @@
   path_b="$main_dir/bin"
   path_w="$( cd $temp_dir && pwd )"
   path_i="$main_dir/ftn"
-  path_o="$main_dir/obj"
-  path_m="$main_dir/mod"
+  #path_o="$main_dir/obj"
+  #path_m="$main_dir/mod"
+  path_o="$build_dir/obj"
+  path_m="$build_dir/mod"
   path_e="$main_dir/exe"
   if [ -n "`echo $name | grep scrip_ 2>/dev/null`" ]
   then

--- a/model/bin/ad3
+++ b/model/bin/ad3
@@ -101,7 +101,6 @@
   source $(dirname $0)/w3_setenv
   main_dir=$WWATCH3_DIR
   build_dir=${WWATCH3_BUILD:-$WWATCH3_DIR}
-  #temp_dir=$WWATCH3_TMP
   temp_dir=$build_dir/tmp
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
@@ -112,8 +111,6 @@
   path_b="$main_dir/bin"
   path_w="$( cd $temp_dir && pwd )"
   path_i="$main_dir/ftn"
-  #path_o="$main_dir/obj"
-  #path_m="$main_dir/mod"
   path_o="$build_dir/obj"
   path_m="$build_dir/mod"
   path_e="$main_dir/exe"

--- a/model/bin/link.tmpl
+++ b/model/bin/link.tmpl
@@ -37,20 +37,23 @@
 
   source $(dirname $0)/w3_setenv
   main_dir=$WWATCH3_DIR
-  temp_dir=$WWATCH3_TMP
+  build_dir=${WWATCH3_BUILD:-${WWATCH3_DIR}}
+  temp_dir=$build_dir/tmp
+  obj_dir=$build_dir/obj
+  exe_dir=$build_dir/exe
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
 
 
 # 1.c Initial clean-up - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
-  rm -f $main_dir/exe/$prog
+  rm -f ${exe_dir}/$prog
 
 # --------------------------------------------------------------------------- #
 # 2. Check objects                                                            #
 # --------------------------------------------------------------------------- #
 
-  cd $main_dir/obj
+  cd $obj_dir
   objects=$NULL
   error='n'
   set $input
@@ -182,7 +185,7 @@
       rm -f link.???
       exit 1
     else
-      mv $prog $main_dir/exe/.
+      mv $prog ${exe_dir}/
       rm -f link.???
     fi
   fi

--- a/model/bin/make_makefile.sh
+++ b/model/bin/make_makefile.sh
@@ -59,8 +59,8 @@
 
   source $(dirname $0)/w3_setenv
   main_dir=$WWATCH3_DIR
-  #temp_dir=$WWATCH3_TMP
-  temp_dir=$WWATCH3_BUILD/tmp
+  build_dir=${WWATCH3_BUILD:-${WWATCH3_DIR}}
+  temp_dir=$build_dir/tmp
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
 

--- a/model/bin/make_makefile.sh
+++ b/model/bin/make_makefile.sh
@@ -59,7 +59,8 @@
 
   source $(dirname $0)/w3_setenv
   main_dir=$WWATCH3_DIR
-  temp_dir=$WWATCH3_TMP
+  #temp_dir=$WWATCH3_TMP
+  temp_dir=$WWATCH3_BUILD/tmp
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
 

--- a/model/bin/w3_clean
+++ b/model/bin/w3_clean
@@ -391,4 +391,19 @@ EOF
     fi
   fi
 
+
+# --------------------------------------------------------------------------- #
+# 6. Cleanup files specific to optional build dir
+# --------------------------------------------------------------------------- #
+  if [ -d $WWATCH3_BUILD -a "$(ls -d $WWATCH_BUILD)" != "$(ls -d $main_dir)" ] ; then
+
+    rm -f $WWATCH3_BUILD/makefile*
+    rm -f $WWATCH3_BUILD/switch*
+
+    if [ $(ls -A ${WWATCH3_BUILD} | wc -l) -eq 0 ]; then
+      echo "   Removing build dir $WWATCH3_BUILD"
+      rmdir ${WWATCH3_BUILD}
+    fi
+  fi
+
 # End of w3_clean ----------------------------------------------------------- #

--- a/model/bin/w3_clean
+++ b/model/bin/w3_clean
@@ -103,9 +103,14 @@ EOF
   # source again in case of updated wwatch3.env
   source $(dirname $0)/w3_setenv 
   main_dir=$WWATCH3_DIR
-  temp_dir=$WWATCH3_TMP
+  build_dir=${WWATCH3_BUILD:-${WWATCH3_DIR}}
+  temp_dir=$build_dir/tmp
+  obj_dir=$build_dir/obj
+  mod_dir=$build_dir/mod
+  exe_dir=$build_dir/exe
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
+
 
 # --------------------------------------------------------------------------- #
 # 2. Scratch directory                                                        #
@@ -282,26 +287,32 @@ EOF
         done
       fi
     done
+  else
+    echo "   Directory does not exist: $main_dir"
+  fi
+
+
+  if [ -d $build_dir ]
+  then
     # clean up work & mod & obj & tmp
     for folder in work mod obj tmp
     do
-      if [ -d $main_dir/$folder ] || [ -L $main_dir/$folder ]
+      if [ -d $build_dir/$folder ] || [ -L $build_dir/$folder ]
       then
-        echo "   Remove $main_dir/$folder"
-        rm -fr $main_dir/$folder
+        echo "   Remove $build_dir/$folder"
+        rm -fr $build_dir/$folder
       fi
       for type in DIST SHRD OMP HYB MPI SEQ
       do
-        if [ -d $main_dir/${folder}_${type} ]
+        if [ -d $build_dir/${folder}_${type} ]
         then
-          echo "   Remove $main_dir/${folder}_${type}"
-          rm -fr $main_dir/${folder}_${type}
+          echo "   Remove $build_dir/${folder}_${type}"
+          rm -fr $build_dir/${folder}_${type}
         fi
       done
    done
-
   else
-    echo "   Directory does not exist: $main_dir"
+    echo "   Directory does not exist: $build_dir"
   fi
 
 # --------------------------------------------------------------------------- #
@@ -319,26 +330,32 @@ EOF
         rm -f w3adc w3list w3prnt w3split
         rm -f comp link switch
       fi
-    # clean up exe
-    for folder in exe
-    do
-      if [ -d $main_dir/$folder ] || [ -L $main_dir/$folder ]
-      then
-        echo "   Remove $main_dir/$folder"
-        rm -fr $main_dir/$folder
-      fi
-      for type in DIST SHRD OMP HYB MPI SEQ
-      do
-        if [ -d $main_dir/${folder}_${type} ]
-        then
-          echo "   Remove $main_dir/${folder}_${type}"
-          rm -fr $main_dir/${folder}_${type}
-        fi
-      done
-   done
-
     else
       echo "   Directory does not exist: $main_dir"
+    fi
+
+
+    if [ -d $build_dir ]
+    then
+      # clean up exe
+      for folder in exe
+      do
+        if [ -d $build_dir/$folder ] || [ -L $build_dir/$folder ]
+        then
+          echo "   Remove $build_dir/$folder"
+          rm -fr $build_dir/$folder
+        fi
+        for type in DIST SHRD OMP HYB MPI SEQ
+        do
+          if [ -d $build_dir/${folder}_${type} ]
+          then
+            echo "   Remove $build_dir/${folder}_${type}"
+            rm -fr $build_dir/${folder}_${type}
+            fi
+        done
+      done
+    else
+      echo "   Directory does not exist: $build_dir"
     fi
   fi
 

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -56,12 +56,19 @@
 # 1.c Get data from setup file - - - - - - - - - - - - - - - - - - - - - - - - 
 
   source $(dirname $0)/w3_setenv
+  build_dir=$WWATCH3_BUILD
   main_dir=$WWATCH3_DIR
-  temp_dir=$WWATCH3_TMP
+  #temp_dir=$WWATCH3_TMP
+  temp_dir=$WWATCH3_BUILD/tmp
+  obj_dir=$build_dir/obj
+  mod_dir=$build_dir/mod
+
+
   source=$WWATCH3_SOURCE
   list=$WWATCH3_LIST
 
   echo "Main directory    : $main_dir"
+  echo "Build directory   : $build_dir"
   echo "Scratch directory : $temp_dir"
   echo "Save source codes : $source"
   echo "Save listings     : $list"
@@ -277,8 +284,10 @@
     fi
   fi
 
-  rm -rf $main_dir/obj
-  rm -rf $main_dir/mod
+  #rm -rf $main_dir/obj
+  #rm -rf $main_dir/mod
+  rm -rf $obj_dir $mod_dir
+
   if [ -f ${switch_file_old}_$pres_type ] ; then
      cp ${switch_file_old}_$pres_type $switch_file_old
   fi
@@ -286,9 +295,15 @@
     cp ${makefile}_$pres_type $makefile
   fi
   cd $main_dir
-  mkdir -p obj_$pres_type mod_$pres_type
-  ln -sf obj_$pres_type obj
-  ln -sf mod_$pres_type mod
+
+
+  #mkdir -p obj_$pres_type mod_$pres_type
+  #ln -sf obj_$pres_type obj
+  #ln -sf mod_$pres_type mod
+
+  mkdir -p ${obj_dir}_${pres_type} ${mod_dir}_${pres_type}
+  ln -sf ${obj_dir}_${pres_type} ${obj_dir}
+  ln -sf ${mod_dir}_${pres_type} ${mod_dir}
   cd $here
 
 
@@ -554,8 +569,10 @@ EOF
 # 1.f Export paths - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
   aPb="$main_dir/bin"     # path containing shell scripts
-  aPo="$main_dir/obj"     # path containing .o files
-  aPm="$main_dir/mod"     # path containing .mod files
+  #aPo="$main_dir/obj"     # path containing .o files
+  #aPm="$main_dir/mod"     # path containing .mod files
+  aPo="$obj_dir"          # path containing .o files
+  aPm="$mod_dir"          # path containing .mod files
   aPe="$main_dir/exe"     # path containing executables
 
   export aPb aPo aPm aPe
@@ -692,7 +709,8 @@ EOF
       sed -n "/$prog/!p" tempfile > $exec_type_file
       rm -f tempfile
 
-      path_m=$main_dir/mod
+      #path_m=$main_dir/mod
+      path_m=$mod_dir
       export path_m
       # WW3_PARCOMPN is an environment variable to set the parallel make tasks
       # it defaults to 4
@@ -711,11 +729,15 @@ EOF
         mkfile=$main_dir/nuopc.mk
         if [ -n "`grep OMP $switch_file`" ]
         then
-          mod_dir=$main_dir/mod_HYB
-          obj_dir=$main_dir/obj_HYB
+          #mod_dir=$main_dir/mod_HYB
+          #obj_dir=$main_dir/obj_HYB
+          mod_dir=${mod_dir}_HYB
+          obj_dir=${obj_dir}_HYB
         else 
-          mod_dir=$main_dir/mod_MPI
-          obj_dir=$main_dir/obj_MPI
+          #mod_dir=$main_dir/mod_MPI
+          #obj_dir=$main_dir/obj_MPI
+          mod_dir=${mod_dir}_MPI
+          obj_dir=${obj_dir}_MPI
         fi 
         rm -f $mkfile
         touch $mkfile

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -286,8 +286,6 @@
     fi
   fi
 
-  #rm -rf $main_dir/obj
-  #rm -rf $main_dir/mod
   rm -rf $obj_dir $mod_dir
 
   if [ -f ${switch_file_old}_$pres_type ] ; then
@@ -297,11 +295,6 @@
     cp ${makefile}_$pres_type $makefile
   fi
   cd $main_dir
-
-
-  #mkdir -p obj_$pres_type mod_$pres_type
-  #ln -sf obj_$pres_type obj
-  #ln -sf mod_$pres_type mod
 
   mkdir -p ${obj_dir}_${pres_type} ${mod_dir}_${pres_type}
   ln -sf ${obj_dir}_${pres_type} ${obj_dir}
@@ -527,11 +520,10 @@ EOF
 
 # 1.e Prepare makefile - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-  # CB - makefile will now go in build directory
   make_make='y'
   if test -f $switch_file_old
   then
-    #CB if test -f $main_dir/ftn/makefile && \
+    # ChrisB: makefile will now go in build directory
     if test -f $build_dir/makefile && \
        test -z "`diff $switch_file $switch_file_old`"
     then
@@ -577,8 +569,6 @@ EOF
 # 1.f Export paths - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
   aPb="$main_dir/bin"     # path containing shell scripts
-  #aPo="$main_dir/obj"     # path containing .o files
-  #aPm="$main_dir/mod"     # path containing .mod files
   aPo="$obj_dir"          # path containing .o files
   aPm="$mod_dir"          # path containing .mod files
   aPe="$exe_dir"         # path containing executables
@@ -717,7 +707,6 @@ EOF
       sed -n "/$prog/!p" tempfile > $exec_type_file
       rm -f tempfile
 
-      #path_m=$main_dir/mod
       path_m=$mod_dir
       export path_m
       # WW3_PARCOMPN is an environment variable to set the parallel make tasks
@@ -737,13 +726,9 @@ EOF
         mkfile=$main_dir/nuopc.mk
         if [ -n "`grep OMP $switch_file`" ]
         then
-          #mod_dir=$main_dir/mod_HYB
-          #obj_dir=$main_dir/obj_HYB
           mod_dir=${mod_dir}_HYB
           obj_dir=${obj_dir}_HYB
         else 
-          #mod_dir=$main_dir/mod_MPI
-          #obj_dir=$main_dir/obj_MPI
           mod_dir=${mod_dir}_MPI
           obj_dir=${obj_dir}_MPI
         fi 

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -56,12 +56,12 @@
 # 1.c Get data from setup file - - - - - - - - - - - - - - - - - - - - - - - - 
 
   source $(dirname $0)/w3_setenv
-  build_dir=$WWATCH3_BUILD
   main_dir=$WWATCH3_DIR
-  #temp_dir=$WWATCH3_TMP
-  temp_dir=$WWATCH3_BUILD/tmp
+  build_dir=${WWATCH3_BUILD:-$WWATCH3_DIR}
+  temp_dir=$build_dir/tmp
   obj_dir=$build_dir/obj
   mod_dir=$build_dir/mod
+  exe_dir=$build_dir/exe
 
 
   source=$WWATCH3_SOURCE
@@ -85,9 +85,9 @@
   fi
 
   # exe dir
-  if [ ! -d $main_dir/exe ]
+  if [ ! -d $exe_dir ]
   then
-    mkdir -p $main_dir/exe
+    mkdir -p $exe_dir
   fi
 
   # switch file
@@ -102,7 +102,7 @@
     echo "        Please run $main_dir/bin/w3_setup <main_dir> -c <comp> -s <switch>"
     exit 1
   fi
-  cp  $switch_file $main_dir/exe/
+  cp  $switch_file $exe_dir
 
   # comp file
   comp_file=$main_dir/bin/comp
@@ -125,7 +125,9 @@
   fi
 
   # ftn dir
-  makefile=$main_dir/ftn/makefile
+  # ChrisB: Makefile now goes in build directory
+  #makefile=$main_dir/ftn/makefile
+  makefile=${build_dir}/makefile
   if [ ! -d $main_dir/ftn ]
   then
     echo ' '
@@ -262,7 +264,7 @@
   flag_OMPH=`grep OMPH $switch_file | wc -l | awk '{ print $1}'`
 
   switch_file_old=$main_dir/bin/switch.old
-  exec_type_file=$main_dir/exe/exec_type
+  exec_type_file=$exe_dir/exec_type
 
   here=`pwd`
 
@@ -525,10 +527,12 @@ EOF
 
 # 1.e Prepare makefile - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  # CB - makefile will now go in build directory
   make_make='y'
   if test -f $switch_file_old
   then
-    if test -f $main_dir/ftn/makefile && \
+    #CB if test -f $main_dir/ftn/makefile && \
+    if test -f $build_dir/makefile && \
        test -z "`diff $switch_file $switch_file_old`"
     then
       make_make='n'
@@ -538,6 +542,7 @@ EOF
   if test "$make_make" = 'y'
   then
     echo 'Making makefile ...'
+    cd $build_dir  # ChrisB: makefile goes in build directory
     if $main_dir/bin/make_makefile.sh
     then
       if [ "$flag_SHRD" -gt '0' ]
@@ -565,6 +570,9 @@ EOF
     fi
   fi
   echo ' '
+  
+  # CB - go back to ftn dir
+  cd $main_dir/ftn
 
 # 1.f Export paths - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
 
@@ -573,7 +581,7 @@ EOF
   #aPm="$main_dir/mod"     # path containing .mod files
   aPo="$obj_dir"          # path containing .o files
   aPm="$mod_dir"          # path containing .mod files
-  aPe="$main_dir/exe"     # path containing executables
+  aPe="$exe_dir"         # path containing executables
 
   export aPb aPo aPm aPe
 
@@ -703,7 +711,7 @@ EOF
         exec_type=`grep $prog $exec_type_file | tail -1 | awk '{ print $2}'`
       fi
       if [ "$exec_type" != "$pres_type" ] ; then
-          rm -f $main_dir/exe/$prog  ; fi
+          rm -f $exe_dir/$prog  ; fi
 
       cp $exec_type_file tempfile
       sed -n "/$prog/!p" tempfile > $exec_type_file
@@ -761,8 +769,8 @@ EOF
 
 # 2.d copy comp and link 
 
-  cp  $main_dir/bin/comp $main_dir/exe/
-  cp  $main_dir/bin/link $main_dir/exe/
+  cp  $main_dir/bin/comp $exe_dir/
+  cp  $main_dir/bin/link $exe_dir/
  
 # --------------------------------------------------------------------------- #
 # 3. End of program ID.                                                       #

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -134,7 +134,12 @@ fi
 path_bin="`cd $path_bin 1>/dev/null 2>&1 && pwd`"
 
 echo ' '
-if [ -e $path_bin/wwatch3.env ]
+if [ ! -z ${WWATCH3_ENV} ]
+then
+  ww3_env=${WWATCH3_ENV}
+  echo "[INFO] user defined env file wwatch3.env found in $ww3_env"
+elif [ -e $path_bin/wwatch3.env ]
+#if [ -e $path_bin/wwatch3.env ]
 then
   ww3_env=$path_bin/wwatch3.env
   echo "[INFO] local env file wwatch3.env found in $ww3_env"
@@ -143,10 +148,10 @@ then
   cp ${HOME}/.wwatch3.env $path_bin/wwatch3.env
   ww3_env=$path_bin/wwatch3.env
   echo "[INFO] global env file wwatch3.env copied in $ww3_env"
-elif [ ! -z ${WWATCH3_ENV} ]
-then
-  ww3_env=${WWATCH3_ENV}
-  echo "[INFO] user defined env file wwatch3.env found in $ww3_env"
+#elif [ ! -z ${WWATCH3_ENV} ]
+#then
+#  ww3_env=${WWATCH3_ENV}
+#  echo "[INFO] user defined env file wwatch3.env found in $ww3_env"
 else
   ww3_env=$path_bin/wwatch3.env
   echo "[INFO] local env file wwatch3.env created in $ww3_env"

--- a/regtests/bin/matrix_divider.sh
+++ b/regtests/bin/matrix_divider.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# --------------------------------------------------------------------------- #
+# matrix_divider simply divides the main matrix into subsets with a given     #
+# number of test (i.e. maxlist1 for mpi tests and maxlist2 for serial tests)  #
+#                                                                             #
+# Remarks:                                                                    #
+# - Once the matrix is generated, this script can be execute. The user should #
+#   define the maxlist and this script divide the matrix into matrix? and     #
+#   submit the job using sbatch.                                              #
+#                                                                             #
+#                                                      Ali Abdolali           #
+#                                                      August 2018            #
+#                                                      March 2021             #
+#                                                                             #
+#    Copyright 2013 National Weather Service (NWS),                           #
+#       National Oceanic and Atmospheric Administration.  All rights          #
+#       reserved.  WAVEWATCH III is a trademark of the NWS.                   #
+#       No unauthorized use without permission.                               #
+#                                                                             #
+# --------------------------------------------------------------------------- #
+# --------------------------------------------------------------------------- #
+# 1.  clean up and definitions                                                #
+# --------------------------------------------------------------------------- #
+rm -r ../model/build*
+cp matrix matrix.tmp
+
+maxlist1=48
+maxlist2=91
+
+#Put the job requirement/spec in "before"
+sed -e "/run_test/,\$d" matrix.tmp > before
+#Put the list of tests in "list"
+command egrep 'ww3_tp2.14|ww3_tp2.17' matrix.tmp | cat >> list_heavy
+awk '!/ww3_tp2.14/' matrix.tmp > tmpfile && mv tmpfile matrix.tmp
+awk '!/ww3_tp2.17/' matrix.tmp > tmpfile && mv tmpfile matrix.tmp
+command egrep 'mpirun|mpiexec|MPI_LAUNCH' matrix.tmp | cat >> list_mpi
+awk '!/mpirun|mpiexec|MPI_LAUNCH/' matrix.tmp > tmpfile && mv tmpfile matrix.tmp
+split -dl $maxlist1 list_mpi list_mpi_
+rm list_mpi
+matrixno1=$(ls list_mpi_* | wc -l)
+echo "Total nummber of matrix with parallel tests = $(($matrixno1 + 1)); each includes $maxlist1 tests"
+command egrep 'run_test' matrix.tmp | cat >> list_serial
+split -dl $maxlist2 list_serial list_serial_
+rm list_serial
+matrixno2=$(ls list_serial_* | wc -l)
+echo "Total nummber of matrix with serial test = $matrixno2; each includes $maxlist2 tests"
+rm matrix.tmp
+
+# --------------------------------------------------------------------------- #
+# 2.  Divide and dump in subsets                                              #
+# --------------------------------------------------------------------------- #
+# parallel jobs
+count=0
+  for i in `seq -f '%02g' 0 "$((matrixno1 - 1))"`; do
+#echo $i
+#Replace matrix.out > matrix?.out, model > model?
+  (( count = count + 1 ))
+  cat before >> matrix$count
+  cat list_mpi_$i >> matrix$count
+  sed -i 's/'matrix.out'/'matrix${count}.out'/gI' matrix$count
+  sed -i 's/'model'/'model\ \-B\ build${count}'/gI' matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo '     *  end of WAVEWATCH III matrix$count of regression tests     *'"   >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "rm -r ../model/build$count"                                                     >> matrix$count
+  echo " matrix$count prepared"
+ done
+
+#serial jobs
+ for i in `seq -f '%02g' 0 "$((matrixno2 - 1))"`; do
+#echo $i
+#Replace matrix.out > matrix?.out, model > model?
+  (( count = count + 1 ))
+  cat before >> matrix$count
+  cat list_serial_$i >> matrix$count
+  sed -i 's/'matrix.out'/'matrix${count}.out'/gI' matrix$count
+  sed -i 's/'model'/'model\ \-B\ build${count}'/gI' matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo '     *  end of WAVEWATCH III matrix$count of regression tests     *'"   >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "rm -r ../model/build$count"                                                     >> matrix$count
+  echo " matrix$count prepared"
+ done
+
+#ww3_tp2.14 is separated, as it has dependency. 
+#ww3_tp2.17 is separated, as it takes a long time to finish
+  (( count = count + 1 ))
+  cat before >> matrix$count
+  cat list_heavy >> matrix$count
+  cp -r ../model ../model$count
+  sed -i 's/'matrix.out'/'matrix${count}.out'/gI' matrix$count
+  sed -i 's/'model'/'model\ \-B\ build${count}'/gI' matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo '     *  end of WAVEWATCH III matrix$count of regression tests     *'"   >> matrix$count
+  echo "  echo '     **************************************************************'"   >> matrix$count
+  echo "  echo ' '"                                                                     >> matrix$count
+  echo "rm -r ../model/build$count"                                                     >> matrix$count
+  echo " matrix$count prepared"
+
+
+
+rm before
+rm list*
+
+  echo "file matrix is divided into $count subsets ...."
+
+# --------------------------------------------------------------------------- #
+# End to matrix_divider                                                       #
+# --------------------------------------------------------------------------- #
+

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -3,11 +3,13 @@
 #                                                                             #
 # Script for running WW-III tests.                                            #
 #                                                                             #
-#                    Last update :         04-May-2020                        #
+#                    Last update :         12-Mar-2020                        #
 # --------------------------------------------------------------------------- #
 #    Modification history
 #    27-Jan-2014 : Adapts ww3_ounf section for multigrid            ( version 4.18 )
 #    04-May-2020 : F. Ardhuin added step 3.b2 for CDL input files   ( version 7.XX ) 
+#    12-Mar-2020 : Added -B flag to use alternative build directory ( version 7.12 )
+#                   
 #
 # Limitations:
 #  - For each ww3_grid_*.inp, run_test process *all* ww3_prep_*.inp files.

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -41,7 +41,7 @@ errmsg ()
 
 # 1.b Usage function
 myname="`basename $0`"  #name of script
-optstr="a:b:c:C:defg:Ghi:m:n:No:Op:q:r:s:t:STw:"  #option string for getopt function
+optstr="a:b:B:c:C:defg:Ghi:m:n:No:Op:q:r:s:t:STw:"  #option string for getopt function
 usage ()
 {
 
@@ -56,6 +56,7 @@ Options:
                    :   *default is <source_dir>/bin/wwatch3.env
                    :   *file will be created if it does not already exist
   -b batchq        : optional setting to determine batch queue type (for slurm now)
+  -B build_dir     : optional build directory (relative to source_dir)
   -c cmplr         : setup comp & link files for specified cmplr
   -C coupl         : invoke test using <coupl> coupled application
                    :   OASIS : OASIS3-mct ww3_shel coupled application
@@ -129,6 +130,7 @@ ARGS=$args
 exit_p=none
 exec_p=none
 batchq=none
+blddir=none
 multi=0
 dist=0
 inpdir=input
@@ -141,6 +143,7 @@ do
   case "$1" in
   -a) shift; ww3_env="$1" ;;
   -b) shift; batchq="$1" ;;
+  -B) shift; blddir="$1" ;;
   -c) shift; cmplr="$1" ;;
   -C) shift; coupl="$1" ;;
   -d) use_gdb=1 ;;
@@ -268,7 +271,22 @@ else
 fi
 
 # 2.h Paths to source subdirectories
-path_e="$path_s/exe"
+if [ $blddir != "none" ]; then
+    # If using a separate build directory, ensure that the switch
+    # file goes here instead of the bin directory to avoid it being
+    # clobbered.
+    path_bld="$path_s/$blddir"
+    echo "Using build directory: $path_bld"
+    mkdir -p $path_bld
+    export WWATCH3_BUILD=${path_bld}
+    export switch_file=${path_bld}/switch
+else
+    path_bld="$path_s"
+    unset WWATCH3_BUILD
+    unset switch_file
+fi
+
+path_e="$path_bld/exe"
 path_a="$path_s/aux"
 path_b="$path_s/bin"
 if [ ! -d $path_a ]
@@ -396,7 +414,7 @@ fi
 #  exit 1
 #fi  
 #
-#if [ ! -e $path_b/switch ]
+#if [ ! -e $path_bld/switch ]
 #then
 #  $path_b/w3_setup $path_s -s $file_c -q
 #fi
@@ -485,20 +503,22 @@ then
   echo '+--------------------+'
   echo ' '
 
+  echo "BUILD PATH: $path_bld"
+
   if [ $force_shrd ]
   then # build pre- & post-processing programs with SHRD only
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_b/switch
+                  sed 's/B4B //' > $path_bld/switch
   else
-    \cp -f $file_c $path_b/switch
+    \cp -f $file_c $path_bld/switch
   fi
   if [ $testST ] 
   then #add S T switches 
-    \cp -f $path_b/switch $path_b/switch_noST
-    cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-    rm $path_b/switch_noST
+    \cp -f $path_bld/switch $path_bld/switch_noST
+    cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+    rm $path_bld/switch_noST
   fi
 
   if [ $time_count ]
@@ -543,7 +563,6 @@ then
     else
       ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
     fi
-
 
     if [ ! -f $path_e/$prog ]
     then
@@ -638,16 +657,16 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_b/switch
+                  sed 's/B4B //' > $path_bld/switch
 
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
 
     if [ $time_count ]
@@ -775,15 +794,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_b/switch
+                  sed 's/B4B //' > $path_bld/switch
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
   
     if [ $time_count ]
@@ -910,15 +929,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_b/switch
+                    sed 's/B4B //' > $path_bld/switch
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
   
     if [ $time_count ]
@@ -1044,15 +1063,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_b/switch
+                    sed 's/B4B //' > $path_bld/switch
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
 
     if [ $time_count ]
@@ -1186,15 +1205,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_b/switch
+                    sed 's/B4B //' > $path_bld/switch
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
 
     runprog=$runcmd
@@ -1211,7 +1230,7 @@ then
         fi
       fi
     fi
-    if [ -n "$(grep SHRD $path_b/switch)" ] 
+    if [ -n "$(grep SHRD $path_bld/switch)" ] 
     then
       runprog=''
     fi
@@ -1343,12 +1362,12 @@ then
     echo '+---------------------------------+'
     echo ' '
 
-    \cp -f $file_c $path_b/switch
+    \cp -f $file_c $path_bld/switch
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
 
     runprog=$runcmd
@@ -1542,12 +1561,12 @@ then
     echo '+--------------------+'
     echo ' '
   
-    \cp -f $file_c $path_b/switch
+    \cp -f $file_c $path_bld/switch
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
   
     if [ $time_count ]
@@ -1735,15 +1754,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_b/switch
+                  sed 's/B4B //' > $path_bld/switch
     else
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
   
     if [ $time_count ]
@@ -1878,15 +1897,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                       sed 's/OMPG //'    | sed 's/OMPX //'  | \
                       sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                      sed 's/B4B //' > $path_b/switch
+                      sed 's/B4B //' > $path_bld/switch
       else
-        \cp -f $file_c $path_b/switch
+        \cp -f $file_c $path_bld/switch
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_b/switch $path_b/switch_noST
-        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-        rm $path_b/switch_noST
+        \cp -f $path_bld/switch $path_bld/switch_noST
+        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+        rm $path_bld/switch_noST
       fi
     
       if [ $time_count ]
@@ -2098,15 +2117,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                       sed 's/OMPG //'    | sed 's/OMPX //'  | \
                       sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                      sed 's/B4B //' > $path_b/switch
+                      sed 's/B4B //' > $path_bld/switch
       else
-        \cp -f $file_c $path_b/switch
+        \cp -f $file_c $path_bld/switch
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_b/switch $path_b/switch_noST
-        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-        rm $path_b/switch_noST
+        \cp -f $path_bld/switch $path_bld/switch_noST
+        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+        rm $path_bld/switch_noST
       fi
 
       if [ $time_count ]
@@ -2259,15 +2278,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_b/switch
+                    sed 's/B4B //' > $path_bld/switch
       else
-        \cp -f $file_c $path_b/switch
+        \cp -f $file_c $path_bld/switch
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_b/switch $path_b/switch_noST
-        cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-        rm $path_b/switch_noST
+        \cp -f $path_bld/switch $path_bld/switch_noST
+        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+        rm $path_bld/switch_noST
       fi
 
       if [ $time_count ]
@@ -2421,20 +2440,20 @@ then
     echo '+-------------------------+'
     echo ' '
 
-      \cp -f $file_c $path_b/switch
+      \cp -f $file_c $path_bld/switch
 #  if [ $force_shrd ]
 #  then # build pre- & post-processing programs with SHRD only
 #    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
 #                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-#                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_b/switchh
+#                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_bld/switchh
 #  else
-#    \cp -f $file_c $path_b/switch
+#    \cp -f $file_c $path_bld/switch
 #  fi  
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch 
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch 
+      rm $path_bld/switch_noST
     fi
 
     if [ $time_count ]
@@ -2568,12 +2587,12 @@ then
     echo '+-------------------------+'
     echo ' '
   
-    \cp -f $file_c $path_b/switch
+    \cp -f $file_c $path_bld/switch
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_b/switch $path_b/switch_noST
-      cat $path_b/switch_noST | sed 's/F90/F90 S T /' > $path_b/switch
-      rm $path_b/switch_noST
+      \cp -f $path_bld/switch $path_bld/switch_noST
+      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
+      rm $path_bld/switch_noST
     fi
   
     if [ $time_count ]

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -275,15 +275,17 @@ if [ $blddir != "none" ]; then
     # If using a separate build directory, ensure that the switch
     # file goes here instead of the bin directory to avoid it being
     # clobbered.
+    # Note: `switch_file` is used by w3_make.
     path_bld="$path_s/$blddir"
     echo "Using build directory: $path_bld"
     mkdir -p $path_bld
     export WWATCH3_BUILD=${path_bld}
     export switch_file=${path_bld}/switch
 else
+    # Default build path (model directory)
     path_bld="$path_s"
+    export switch_file=${path_s}/bin/switch
     unset WWATCH3_BUILD
-    unset switch_file
 fi
 
 path_e="$path_bld/exe"
@@ -414,7 +416,7 @@ fi
 #  exit 1
 #fi  
 #
-#if [ ! -e $path_bld/switch ]
+#if [ ! -e ${switch_file} ]
 #then
 #  $path_b/w3_setup $path_s -s $file_c -q
 #fi
@@ -510,15 +512,15 @@ then
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_bld/switch
+                  sed 's/B4B //' > ${switch_file}
   else
-    \cp -f $file_c $path_bld/switch
+    \cp -f $file_c ${switch_file}
   fi
   if [ $testST ] 
   then #add S T switches 
-    \cp -f $path_bld/switch $path_bld/switch_noST
-    cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-    rm $path_bld/switch_noST
+    \cp -f ${switch_file} ${switch_file}_noST
+    cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+    rm ${switch_file}_noST
   fi
 
   if [ $time_count ]
@@ -657,16 +659,16 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_bld/switch
+                  sed 's/B4B //' > ${switch_file}
 
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
 
     if [ $time_count ]
@@ -794,15 +796,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_bld/switch
+                  sed 's/B4B //' > ${switch_file}
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
   
     if [ $time_count ]
@@ -929,15 +931,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_bld/switch
+                    sed 's/B4B //' > ${switch_file}
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
   
     if [ $time_count ]
@@ -1063,15 +1065,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_bld/switch
+                    sed 's/B4B //' > ${switch_file}
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
 
     if [ $time_count ]
@@ -1205,15 +1207,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_bld/switch
+                    sed 's/B4B //' > ${switch_file}
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
 
     runprog=$runcmd
@@ -1230,7 +1232,7 @@ then
         fi
       fi
     fi
-    if [ -n "$(grep SHRD $path_bld/switch)" ] 
+    if [ -n "$(grep SHRD ${switch_file})" ] 
     then
       runprog=''
     fi
@@ -1362,12 +1364,12 @@ then
     echo '+---------------------------------+'
     echo ' '
 
-    \cp -f $file_c $path_bld/switch
+    \cp -f $file_c ${switch_file}
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
 
     runprog=$runcmd
@@ -1561,12 +1563,12 @@ then
     echo '+--------------------+'
     echo ' '
   
-    \cp -f $file_c $path_bld/switch
+    \cp -f $file_c ${switch_file}
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
   
     if [ $time_count ]
@@ -1754,15 +1756,15 @@ then
       cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                   sed 's/OMPG //'    | sed 's/OMPX //'  | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                  sed 's/B4B //' > $path_bld/switch
+                  sed 's/B4B //' > ${switch_file}
     else
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
     fi
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
   
     if [ $time_count ]
@@ -1897,15 +1899,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                       sed 's/OMPG //'    | sed 's/OMPX //'  | \
                       sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                      sed 's/B4B //' > $path_bld/switch
+                      sed 's/B4B //' > ${switch_file}
       else
-        \cp -f $file_c $path_bld/switch
+        \cp -f $file_c ${switch_file}
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_bld/switch $path_bld/switch_noST
-        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-        rm $path_bld/switch_noST
+        \cp -f ${switch_file} ${switch_file}_noST
+        cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+        rm ${switch_file}_noST
       fi
     
       if [ $time_count ]
@@ -2117,15 +2119,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                       sed 's/OMPG //'    | sed 's/OMPX //'  | \
                       sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                      sed 's/B4B //' > $path_bld/switch
+                      sed 's/B4B //' > ${switch_file}
       else
-        \cp -f $file_c $path_bld/switch
+        \cp -f $file_c ${switch_file}
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_bld/switch $path_bld/switch_noST
-        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-        rm $path_bld/switch_noST
+        \cp -f ${switch_file} ${switch_file}_noST
+        cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+        rm ${switch_file}_noST
       fi
 
       if [ $time_count ]
@@ -2278,15 +2280,15 @@ do
         cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
                     sed 's/OMPG //'    | sed 's/OMPX //'  | \
                     sed 's/OMPH //'    | sed 's/PDLIB //' | \
-                    sed 's/B4B //' > $path_bld/switch
+                    sed 's/B4B //' > ${switch_file}
       else
-        \cp -f $file_c $path_bld/switch
+        \cp -f $file_c ${switch_file}
       fi
       if [ $testST ]
       then #add S T switches 
-        \cp -f $path_bld/switch $path_bld/switch_noST
-        cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-        rm $path_bld/switch_noST
+        \cp -f ${switch_file} ${switch_file}_noST
+        cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+        rm ${switch_file}_noST
       fi
 
       if [ $time_count ]
@@ -2440,20 +2442,20 @@ then
     echo '+-------------------------+'
     echo ' '
 
-      \cp -f $file_c $path_bld/switch
+      \cp -f $file_c ${switch_file}
 #  if [ $force_shrd ]
 #  then # build pre- & post-processing programs with SHRD only
 #    cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //' | \
 #                  sed 's/OMPG //'    | sed 's/OMPX //'| \
-#                  sed 's/OMPH //'    | sed 's/PDLIB //'  > $path_bld/switchh
+#                  sed 's/OMPH //'    | sed 's/PDLIB //'  > ${switch_file}h
 #  else
-#    \cp -f $file_c $path_bld/switch
+#    \cp -f $file_c ${switch_file}
 #  fi  
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch 
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file} 
+      rm ${switch_file}_noST
     fi
 
     if [ $time_count ]
@@ -2587,12 +2589,12 @@ then
     echo '+-------------------------+'
     echo ' '
   
-    \cp -f $file_c $path_bld/switch
+    \cp -f $file_c ${switch_file}
     if [ $testST ]
     then #add S T switches 
-      \cp -f $path_bld/switch $path_bld/switch_noST
-      cat $path_bld/switch_noST | sed 's/F90/F90 S T /' > $path_bld/switch
-      rm $path_bld/switch_noST
+      \cp -f ${switch_file} ${switch_file}_noST
+      cat ${switch_file}_noST | sed 's/F90/F90 S T /' > ${switch_file}
+      rm ${switch_file}_noST
     fi
   
     if [ $time_count ]


### PR DESCRIPTION
This PR updates the WW3 build scripts and regression test `run_test` script to allow the user to provide an optional "build" directory via the `WWATCH3_BUILD` environment variable.

If an optional build directory is specified, the following following directories/files will be relocated to the build directory rather than the base `model` directory:
  - obj*
  - mod*
  - exe
  - tmp
  - makefile*
 
This enables multiple jobs to build WW3 executables from the same model directory without clobbering each other.

The `regtests/bin/run_test` script has also been update to include a new `-B build_dir` option. If set, this ensures that the regression test is built using a named build directory. This allows multiple regression tests to be run in parallel. The switch file is copied to the build directory (and specified with the existing `switch_file` environment variable) to ensure the file does not get clobbered in `model/bin`