### PR TITLE
revert comet porting

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -110,7 +110,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
    [ "$cmplr" == "so_intel" ]       || [ "$cmplr" == "so_intel_debug" ] || [ "$cmplr" == "so_intel_prof" ] || \
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] || [ "$cmplr" == "datarmor_intel_prof" ] || \
    [ "$cmplr" == "wcoss_phase2" ]   || [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_dell_p3" ]  || \
-   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] || [ "$cmplr" == "comet" ] ; then
+   [ "$cmplr" == "theia" ]          || [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] ; then
 
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -151,7 +151,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] || [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ] || [ "$cmplr" == "comet" ] ; then
+  if [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ] || [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]; then
      optomp="-qopenmp"
   else
      optomp="-openmp"

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -417,7 +417,6 @@ then
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
        [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ]                            || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
-       [ "$cmplr" == "comet" ]                                                      || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
        [ "$cmplr" == "datarmor_pgi" ] || [ "$cmplr" == "datarmor_pgi_debug" ]       || \
@@ -444,7 +443,6 @@ then
        [ "$cmplr" == "theia" ] || [ "$cmplr" == "wcoss_cray" ]                      || \
        [ "$cmplr" == "hera" ] || [ "$cmplr" == "orion" ]                            || \
        [ "$cmplr" == "wcoss_phase2" ] || [ "$cmplr" == "wcoss_dell_p3" ]            || \
-       [ "$cmplr" == "comet" ]                                                      || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
        [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ]                         || \
        [ "$cmplr" == "datarmor_pgi" ] || [ "$cmplr" == "datarmor_pgi_debug" ]       || \

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -35,7 +35,7 @@ ifeq ($(WW3_COMP),Portland)
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","pgi" "datarmor_pgi" "datarmor_pgi_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -byteswapio
 # intel
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel" "hera" "orion" "comet"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","theia" "Intel" "hera" "orion"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_phase2" "wcoss_cray" "wcoss_dell_p3"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian


### PR DESCRIPTION
# Pull Request Summary
Temporarily revert comet porting 

## Description
This branch needs to match what is in production so that the changes we implement are accepted by NCO.  The changes for comet porting need to be discussed at a later time.  Issue https://github.com/NOAA-EMC/WW3/issues/343 was created to keep track. 