### PR TITLE
Fix for arctic grib files 

### DIFF
--- a/model/ftn/ww3_grib.ftn
+++ b/model/ftn/ww3_grib.ftn
@@ -620,6 +620,9 @@
 !       (17) Projection center flag
 !       (18) Scanning mode
 !
+!  Projection for PolarStereo grid was changed from 
+!  KGDS( 1) = 6 to KGDS( 1) = 5 (Earth assumed represented by WGS84)
+!/NCEP2        KGDS( 1) = 5
 !/NCEP2        X0 = MOD(XGRD(1,1) + 360.,360.)
 !/NCEP2        XN = MOD(XGRD(NY,NX) + 360., 360.)
 !/NCEP2        X0N = MOD(XGRD(NY,1) + 360., 360.)

--- a/model/ftn/ww3_grib.ftn
+++ b/model/ftn/ww3_grib.ftn
@@ -621,7 +621,8 @@
 !       (18) Scanning mode
 !
 !  Projection for PolarStereo grid was changed from 
-!  KGDS( 1) = 6 to KGDS( 1) = 5 (Earth assumed represented by WGS84)
+!  KGDS( 1) = 6 to KGDS( 1) = 5 (Earth assumed represented by WGS84 -
+!  Octet No 15 Table 3.2)
 !/NCEP2        KGDS( 1) = 5
 !/NCEP2        X0 = MOD(XGRD(1,1) + 360.,360.)
 !/NCEP2        XN = MOD(XGRD(NY,NX) + 360., 360.)


### PR DESCRIPTION
# Pull Request Summary
Update way polar stenographic grid is encoded in ww3_grib 

## Description
When GDTN = 20 in ww3_grib for polar sterographic grids, we should use the "Earth assumed represented by WGS84" option which requires changing KGDS( 1) = 6 to setting KGDS( 1) = 5. 

### Issue(s) addressed
* This will fix the issue reported by the Alaska region for the Aleutian Islands appearing shifted. 
* See issue #345 for more details. 

### Testing
* ww3_grib was tested on WCOSS via v16 global-workflow 


Fix made with help from:  @aliabdolali @arunchawla-NOAA @BoiVuong-NOAA @GeorgeGayno-NOAA 








