### PR TITLE
updates for build on wcoss2

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -111,6 +111,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
    [ "$cmplr" == "datarmor_intel" ] || [ "$cmplr" == "datarmor_intel_debug" ] || [ "$cmplr" == "datarmor_intel_prof" ] || \
    [ "$cmplr" == "wcoss_cray" ]     || [ "$cmplr" == "wcoss_dell_p3" ]  || [ "$cmplr" == "cheyenne.intel" ]      || \
    [ "$cmplr" == "gaea.intel" ]     || [ "$cmplr" == "jet.intel" ]      || \
+   [ "$cmplr" == "wcoss2" ]         || \
    [ "$cmplr" == "hera.intel" ]     || [ "$cmplr" == "orion.intel" ]    || [ "$cmplr" == "stampede.intel" ] ; then
 
 
@@ -121,7 +122,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   comp_mpi='mpiifort'
 
   # cray compiler
-  if [ ! -z "$(echo $cmplr | grep wcoss_cray)" ]  || [ "$cmplr" == "gaea.intel" ]; then
+  if [ ! -z "$(echo $cmplr | grep wcoss_cray)" ]  || [ "$cmplr" == "gaea.intel" ] || [ "$cmplr" == "wcoss2" ]; then
     comp_seq='ftn'
     comp_mpi='ftn'
   fi
@@ -159,7 +160,7 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   # omp options
   if [ ! -z "$(echo $cmplr | grep datarmor)" ] || [ "$cmplr" == "hera.intel" ] || [ "$cmplr" == "orion.intel" ] || \
      [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ] || [ "$cmplr" == "cheyenne.intel" ] || \
-     [ "$cmplr" == "gaea.intel" ] || [ "$cmplr" == "jet.intel" ] || \
+     [ "$cmplr" == "gaea.intel" ] || [ "$cmplr" == "jet.intel" ] || [ "$cmplr" == "wcoss2" ] \
      [ "$cmplr" == "stampede.intel" ]; then
      optomp="-qopenmp"
   else

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -417,6 +417,7 @@ then
        [ "$cmplr" == "hera.intel" ] || [ "$cmplr" == "orion.intel" ]                || \
        [ "$cmplr" == "hera.gnu" ]   || [ "$cmplr" == "jet.intel" ]                  || \
        [ "$cmplr" == "stampede.intel" ] || [ "$cmplr" == "gaea.intel" ]             || \
+       [ "$cmplr" == "wcoss2" ] || \
        [ "$cmplr" == "cheyenne.intel" ] || [ "$cmplr" == "cheyenne.gnu" ]           || \
        [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]              || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \
@@ -445,6 +446,7 @@ then
        [ "$cmplr" == "hera.intel" ] || [ "$cmplr" == "orion.intel" ]                || \
        [ "$cmplr" == "hera.gnu" ]   || [ "$cmplr" == "jet.intel" ]                  || \
        [ "$cmplr" == "stampede.intel" ] || [ "$cmplr" == "gaea.intel" ]             || \
+       [ "$cmplr" == "wcoss2" ] || \
        [ "$cmplr" == "cheyenne.intel" ] || [ "$cmplr" == "cheyenne.gnu" ]           || \
        [ "$cmplr" == "wcoss_cray" ] || [ "$cmplr" == "wcoss_dell_p3" ]              || \
        [ "$cmplr" == "datarmor_gnu" ] || [ "$cmplr" == "datarmor_gnu_debug" ]       || \

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -39,7 +39,7 @@ else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","Intel" "hera.intel" "orion.inte
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)", "cheyenne.intel" "stampede.intel"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_cray" "wcoss_dell_p3" "gaea.intel"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_cray" "wcoss_dell_p3" "gaea.intel" "wcoss2"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","intel" "datarmor_intel" "datarmor_intel_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian


### PR DESCRIPTION
# Pull Request Summary
This adds the WCOSS2 platform to the list of build platforms for WW3.

## Description
Allows WW3 and UFS coupled system to build and run on Acorn (WCOSS2 test system)

### Issue(s) addressed

- fixes noaa-emc/ww3/issues/369
 
### Testing
This compiles and runs on WCOSS2 with the UFS cpld_bmarkfrac_wave_v16 test. I have not run any WW3-specific tests, so if there are some that should be done, let me know. 










