### PR TITLE
Add support for Application Level Placement Scheduler (ALPS) in regtest

### DIFF
--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -8,6 +8,7 @@
 #    Modification history
 #    27-Jan-2014 : Adapts ww3_ounf section for multigrid            ( version 4.18 )
 #    04-May-2020 : F. Ardhuin added step 3.b2 for CDL input files   ( version 7.XX ) 
+#    21-May-2021 : C. Bunney add support for ALPS job placement     ( version 7.12 )
 #
 # Limitations:
 #  - For each ww3_grid_*.inp, run_test process *all* ww3_prep_*.inp files.
@@ -55,7 +56,7 @@ Options:
   -a ww3_env       : use WW3 environment setup file <ww3_env>
                    :   *default is <source_dir>/bin/wwatch3.env
                    :   *file will be created if it does not already exist
-  -b batchq        : optional setting to determine batch queue type (for slurm now)
+  -b batchq        : optional setting to determine batch queue type (slurm or alps)
   -c cmplr         : setup comp & link files for specified cmplr
   -C coupl         : invoke test using <coupl> coupled application
                    :   OASIS : OASIS3-mct ww3_shel coupled application
@@ -1202,7 +1203,7 @@ then
     then
       if [ $nproc ]
       then
-        if [ $batchq = "slurm" ]
+        if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
         then
           runprog="$runprog -n $nproc"
 
@@ -1356,7 +1357,7 @@ then
     then
       if [ $nproc ]
       then
-        if [ $batchq = "slurm" ]
+        if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
         then 
           runprog="$runprog -n $nproc"
         else
@@ -1627,10 +1628,9 @@ then
     then
       if [ $nproc ]
       then
-        if [ -z $batchq ] && [ $batchq = "slurm" ]
+        if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
         then 
           runprog="$runprog -n $nproc"
-        
         else
           runprog="$runprog -np $nproc"
         fi
@@ -1639,6 +1639,9 @@ then
       then
         if ( which omplace ) ; then
           runprog="$runprog omplace -nt $nthrd"
+        elif [ $batchq = "alps" ]
+        then
+          runprog="$runprog -d $nthrd /usr/bin/env OMP_NUM_THREADS=$nthrd"
         else
           runprog="$runprog /usr/bin/env OMP_NUM_THREADS=$nthrd"
         fi
@@ -2478,10 +2481,10 @@ then
     then
       if [ $nproc ]
       then
-        if [ $batchq = "slurm" ]
+        if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
         then
           runprog="$runprog -n $nproc"
-  
+
         else
           runprog="$runprog -np $nproc"
         fi
@@ -2622,7 +2625,7 @@ then
      then
        if [ $nproc ]
        then
-         if [ $batchq = "slurm" ]
+         if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
          then
            runprog="$runprog -n $nproc"
          else


### PR DESCRIPTION
# Pull Request Summary
Adds support for Application Level Placement Scheduler (ALPS) in regtests.


## Description
Adds support for Application Level Placement Scheduler (ALPS; used on Cray systems) when running regtests to launch MPI jobs with correctly formatted "aprun" command.

This change adds an extra `alps` option to the `-b` switch of `run_test`. When this is specified, the correct aprun options are passed to the `runcmd`. Specifically, it ensures that the `-d` flag (depth) is set when calling aprun when using multiple threads.


### Testing
* How were these changes tested?
  * Tested on Met Office Cray using multinode compute placement using "aprun" and an hybrid OMPH regtest.
  * No affect on any of the existing regtests.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No - specific to launching of MPI jobs on Cray.
* If a new feature was added, was a new regression test added?
  *  N/A - is specific to Cray/ALPS systems.
* Have regression tests been run?
  * Yes. See below.
* Which compiler / HPC you used to run the regression tests in the PR? 
  * Cray XC, GNU compiler


## Results of regressions tests:
All test b4b comparible with `develop` branch, except the usual suspects:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (7 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (8 files differ)
ww3_tp2.18/./work_TIDE_MPI                     (1 files differ)
```










