### PR TITLE
Fixes to solve issue #377

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -758,7 +758,7 @@
 !/OASACM           J = 1
 !/OASOCM         CASE('OHS')
 !/OASOCM           I = 2
-!/OASACM           J = 1
+!/OASOCM           J = 1
       CASE('HS')
         I = 2
         J = 1
@@ -902,7 +902,7 @@
 !/OASACM           J = 2
 !/OASOCM         CASE('OCHA')
 !/OASOCM           I = 5
-!/OASACM           J = 2
+!/OASOCM           J = 2
       CASE('CHA')
         I = 5
         J = 2


### PR DESCRIPTION
# Pull Request Summary
  
Fix to oasis compilation switches.

## Description

Fix a small bug in the oasis switches, changing two instances of OASACM to OASOCM. It fixes atmosphere/wave and ocean/wave (but not atmosphere/ocean/wave) coupled configurations, when coupling the Charnock coefficient and/or the wave height, which made OASIS crash because the these fields were not properly identified as coupling fields.

### Issue(s) addressed
* Is there an issue associated with this development (bug fix, enhancement, new feature)?    

- fixes #377 
- fixes noaa-emc/ww3/issues/377

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)?
YES

* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop), [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Reviewers: @aliabdolali @ukmo-ccbunney 


### Testing
* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* If a new feature was added, was a new regression test added?
* Have regression tests been run?
* Which compiler / HPC you used to run the regression tests in the PR? 
* Please provide the summary output of matrix.comp (_matrix.Diff.out_, _matrixCompFull.out_ and _matrixCompSummary.out_):    
Please indicate the expected changes in the outputs ([excluding the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).










