### PR TITLE
Fixes for issue #417

### DIFF
--- a/model/ftn/w3initmd.ftn
+++ b/model/ftn/w3initmd.ftn
@@ -3737,8 +3737,7 @@
 !
 !/MPIT          WRITE (NDST,9020)
 !
-!/MPI          IF ( IAPROC.LE.NAPROC ) THEN
-!/MPI            IF ( IAPROC.NE.NAPRST ) THEN
+!/MPI          IF ( IAPROC.NE.NAPRST .AND. IAPROC.LE.NAPROC ) THEN
 !
 !/MPI              IH     = IH + 1
 !/MPI              IT     = IT0 + 1
@@ -3757,9 +3756,34 @@
 !/MPI              CALL MPI_SEND_INIT (FPIS(IAPROC), 1, WW3_FIELD_VEC, &
 !/MPI                       IROOT, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
 !/MPIT      WRITE (NDST,9021) IH, 'S FP', IROOT, IT, IRQRS(IH), IERR
+!
+!/MPI          ELSE IF ( IAPROC .EQ. NAPRST ) THEN
+!/MPI              DO I0=1, NAPROC
+!/MPI                IFROM  = I0 - 1
+!/MPI                IF ( I0 .NE. IAPROC ) THEN
+!
+!/MPI                    IH     = IH + 1
+!/MPI                    IT     = IT0 + 1
+!/MPI                    CALL MPI_RECV_INIT (UST (I0),1,WW3_FIELD_VEC, &
+!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
+!/MPIT      WRITE (NDST,9021) IH, 'R U*', IFROM, IT, IRQRS(IH), IERR
+!
+!/MPI                    IH     = IH + 1
+!/MPI                    IT     = IT0 + 2
+!/MPI                    CALL MPI_RECV_INIT (USTDIR(I0),1,WW3_FIELD_VEC, &
+!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
+!/MPIT      WRITE (NDST,9021) IH, 'R UD', IFROM, IT, IRQRS(IH), IERR
+!
+!/MPI                    IH     = IH + 1
+!/MPI                    IT     = IT0 + 3
+!/MPI                    CALL MPI_RECV_INIT (FPIS(I0),1,WW3_FIELD_VEC, &
+!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
+!/MPIT      WRITE (NDST,9021) IH, 'R FP', IFROM, IT, IRQRS(IH), IERR
+!/MPI                END IF
+!/MPI              END DO
 !/MPI            END IF
 !
-!/MPI            IF (OARST) THEN
+!/MPI          IF (OARST) THEN
 !/MPI              IF ( FLOGRR( 1, 2) ) THEN
 !/MPI                IH     = IH + 1
 !/MPI                IT     = IT0 + 4
@@ -3980,38 +4004,13 @@
 !/MPI                         IROOT, IT, MPI_COMM_WAVE, IRQRS(IH), IERR)
 !/MPIT        WRITE (NDST,9021) IH, 'S T2', IROOT, IT, IRQRS(IH), IERR
 !/MPI              END IF
-!/MPI            ENDIF
 !
 !/MPI            IF ( IAPROC .EQ. NAPRST ) THEN
-!/MPI              IF (OARST) THEN
 !/MPI                IF (NAPRST .NE. NAPFLD) CALL W3XDMA ( IMOD, NDSE, NDST, FLOGRR )
 !/MPI                CALL W3XETA ( IMOD, NDSE, NDST )
-!/MPI              ENDIF
 !
-!/MPI              DO I0=1, NAPROC
-!/MPI                IFROM  = I0 - 1
-!/MPI                IF ( I0 .NE. IAPROC ) THEN
-!
-!/MPI                    IH     = IH + 1
-!/MPI                    IT     = IT0 + 1
-!/MPI                    CALL MPI_RECV_INIT (UST (I0),1,WW3_FIELD_VEC, &
-!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
-!/MPIT      WRITE (NDST,9021) IH, 'R U*', IFROM, IT, IRQRS(IH), IERR
-!
-!/MPI                    IH     = IH + 1
-!/MPI                    IT     = IT0 + 2
-!/MPI                    CALL MPI_RECV_INIT (USTDIR(I0),1,WW3_FIELD_VEC, &
-!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
-!/MPIT      WRITE (NDST,9021) IH, 'R UD', IFROM, IT, IRQRS(IH), IERR
-!
-!/MPI                    IH     = IH + 1
-!/MPI                    IT     = IT0 + 3
-!/MPI                    CALL MPI_RECV_INIT (FPIS(I0),1,WW3_FIELD_VEC, &
-!/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
-!/MPIT      WRITE (NDST,9021) IH, 'R FP', IFROM, IT, IRQRS(IH), IERR
-!/MPI                END IF
-!
-!/MPI                IF (OARST) THEN
+!/MPI                DO I0=1, NAPROC
+!/MPI                  IFROM  = I0 - 1
 !/MPI                  IF ( FLOGRR( 1, 2) ) THEN
 !/MPI                    IH     = IH + 1
 !/MPI                    IT     = IT0 + 4
@@ -4232,11 +4231,9 @@
 !/MPI                       IFROM, IT, MPI_COMM_WAVE, IRQRS(IH), IERR )
 !/MPIT      WRITE (NDST,9021) IH, 'R T2', IFROM, IT, IRQRS(IH), IERR
 !/MPI                  END IF
-!/MPI                END IF
+!/MPI                END DO
 !
-!/MPI              END DO
-!
-!/MPI              IF (OARST) CALL W3SETA ( IMOD, NDSE, NDST )
+!/MPI                CALL W3SETA ( IMOD, NDSE, NDST )
 !/MPI            END IF
 !/MPI          END IF
 !


### PR DESCRIPTION
# Pull Request Summary   
Please describe the PR summary
It was reported that, after merging some branches containing changes for oasis coupling, the results of some multi grid configurations, and of some mww3_test_03 regtests changed.


## Description
This branch aims to address the change of answers after merging branches containing changes for oasis coupling. The problem was traced to the setting up of MPI communicators in the subroutine W3MPIO, where some if conditions where modified to add communication for extra fields to be written in the restart file. These if conditions for the original fields in the restart file were reverted, and appropriate new conditions were written for the extra restart fields.

A change of answers is expected to match the results of the code before the oasis coupling changes were introduced.

### Issue(s) addressed
* Is there an issue associated with this development (bug fix, enhancement, new feature)?    
YES

- fixes #417 
- fixes noaa-emc/ww3/issues/417

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)?
YES
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
DONE
* Reviewers: @aliabdolali  @JessicaMeixner-NOAA @ukmo-ccbunney 

### Testing
* How were these changes tested?
Compared mww3_test_04 and ww3_tp2.14 test between commits:

commit 9735c7d (HEAD)
Author: Mickael Accensi 49198861+mickaelaccensi@users.noreply.github.com
Date: Fri Oct 23 16:40:22 2020 +0200

commit e756361 (HEAD)
Author: Chris Bunney 48915820+ukmo-ccbunney@users.noreply.github.com
Date: Thu Nov 5 16:08:39 2020 +0000

The Met Office atmosphere+ocean+wave coupled configuration in the UKV domain was also tested to make sure that no changes in results took place in coupled configurations.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
YES - reviewers are encouraged to run further tests to make sure that the differences in results they observed disappear
* If a new feature was added, was a new regression test added?
N/A
* Have regression tests been run?
YES - output will be attached to the request once they are completed
* Which compiler / HPC you used to run the regression tests in the PR?
Cray compiler in the CRAYXC40 machinge at the Met Office 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    

Expecting changes in the mww3_test_03 test, PR1_MPI_e and PR1_MPI_d2


