### PR TITLE
Fix PGI 19.10 compilation error

### DIFF
--- a/model/ftn/w3gridmd.ftn
+++ b/model/ftn/w3gridmd.ftn
@@ -5972,7 +5972,7 @@
  4972 FORMAT ( '       Spectrum of Uss             :',3I4)
  4973 FORMAT ( '       Frequency spectrum          :',3I4)
  4974 FORMAT ( '       Partions of Uss             :',2I4)
- 4975 FORMAT ( '       Partition wavenumber #',I02,'   : ',1F6.3)
+ 4975 FORMAT ( '       Partition wavenumber #',I2,'   : ',1F6.3)
 
 !
  4980 FORMAT (/'  Coastal / iceberg reflection  ',A/                   &


### PR DESCRIPTION
# Pull Request Summary
This PR fixes a very minor syntax issue that causes an error when compiling with PGI 19.10

## Description
`I02` format specifier is changed to `I2` in `w3gridmd.ftn`

### Issue(s) addressed
Fixes #422



