### PR TITLE
add coupling field for mean direction without projection

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -813,6 +813,9 @@
       CASE('WNM')
         I = 2
         J = 19
+!/OASOCM      CASE('THM')
+!/OASOCM        I = 2
+!/OASOCM        J = 20
 !
 ! Group 3
 !

--- a/model/ftn/w3oacpmd.ftn
+++ b/model/ftn/w3oacpmd.ftn
@@ -947,6 +947,12 @@
 !/OASOCM            ID_NB_SND = ID_NB_SND +1
 !/OASOCM            SND(ID_NB_SND)%CL_FIELD_NAME='WW3_SDIR'
 !
+!/OASOCM         CASE('THM')
+!/OASOCM            ! THM / wave_thm : mean direction (n/a)
+!/OASOCM            ! exchange the mean direction instead of cos/sin projection
+!/OASOCM            ID_NB_SND = ID_NB_SND +1
+!/OASOCM            SND(ID_NB_SND)%CL_FIELD_NAME='WW3__DIR'
+!
 !/OASOCM         CASE('BHD')
 !/OASOCM            ! BHD / wave_bhd : wave-induced Bernoulli head pressure (bhd in N.m-1)
 !/OASOCM            ID_NB_SND = ID_NB_SND +1

--- a/model/ftn/w3odatmd.ftn
+++ b/model/ftn/w3odatmd.ftn
@@ -699,6 +699,7 @@
 ! 2) Standard mean wave parameters
 !
       NOGE(2) = 19
+!/OASOCM      NOGE(2) = 20
 !
       IDOUT( 2, 1)  = 'Wave height         '
       IDOUT( 2, 2)  = 'Mean wave length    '
@@ -719,6 +720,7 @@
       IDOUT( 2, 17)  = 'Dominant wave bT   '
       IDOUT( 2, 18)  = 'Peak prd. (from fp)'
       IDOUT( 2, 19)  = 'Mean wave number   '
+!/OASOCM  IDOUT( 2, 20) = 'Mean wave dir. norot'
 !      IDOUT( 2,10)  = 'Mean wave dir. a2b2'
 !      IDOUT( 2,11)  = 'Mean dir. spr. a2b2'
 !      IDOUT( 2,12)  = 'Windsea height(Sin)'

--- a/model/ftn/w3ogcmmd.ftn
+++ b/model/ftn/w3ogcmmd.ftn
@@ -195,7 +195,6 @@
          ! Cosinus of Mean wave direction (cos(theta) in radians)
          ! ---------------------------------------------------------------------
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
-         ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_CDIR') THEN
             TMP(1:NSEAL) = 0.0
             WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=COS(THM(1:NSEAL))
@@ -206,11 +205,20 @@
          ! Sinus of Mean wave direction (sin(theta) in radians)
          ! ---------------------------------------------------------------------
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
-         ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_SDIR') THEN
             TMP(1:NSEAL) = 0.0
             WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=SIN(THM(1:NSEAL))
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
+            CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
+         ENDIF
+         !
+         ! Mean wave direction theta in radians
+         ! ---------------------------------------------------------------------
+         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__DIR') THEN
+            TMP(1:NSEAL) = 0.0
+            WHERE(THM /= UNDEF) TMP=THM
+            RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
          !

--- a/model/ftn/w3ogcmmd.ftn
+++ b/model/ftn/w3ogcmmd.ftn
@@ -194,7 +194,7 @@
          !
          ! Cosinus of Mean wave direction (cos(theta) in radians)
          ! ---------------------------------------------------------------------
-         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         ! dir : nautical convention (GRIDDED files) - 0 degree from north, 90 from east 
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_CDIR') THEN
             TMP(1:NSEAL) = 0.0
             WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=COS(THM(1:NSEAL))
@@ -204,7 +204,7 @@
          !
          ! Sinus of Mean wave direction (sin(theta) in radians)
          ! ---------------------------------------------------------------------
-         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         ! dir : nautical convention (GRIDDED files) - 0 degree from north, 90 from east 
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_SDIR') THEN
             TMP(1:NSEAL) = 0.0
             WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=SIN(THM(1:NSEAL))
@@ -214,7 +214,7 @@
          !
          ! Mean wave direction theta in radians
          ! ---------------------------------------------------------------------
-         ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
+         ! dir : nautical convention (GRIDDED files) - 0 degree from north, 90 from east 
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__DIR') THEN
             TMP(1:NSEAL) = 0.0
             WHERE(THM /= UNDEF) TMP=THM

--- a/model/ftn/ww3_bound.ftn
+++ b/model/ftn/ww3_bound.ftn
@@ -335,7 +335,7 @@
         ALLOCATE(LATS(NBO2),LONS(NBO2))
         DO IP=1,NBO2
           OPEN(200+IP,FILE=SPECFILES(IP),status='old',iostat=IERR)
-          IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,I5,3A,I5)') 'IP, file, I/O error:',IP,', ',       &
+          IF (VERBOSE.EQ.1) WRITE(NDSO,'(A,I5,3A,I5)') 'IP, file, I/O stat:',IP,', ',       &
                                   TRIM(SPECFILES(IP)),', ',IERR
           IF (IERR.NE.0) WRITE(NDSE,*) 'File do not exist:',SPECFILES(IP)
           READ(200+IP,'(A1,A22,A1,X,2I6)',iostat=IERR)  &

--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -187,7 +187,7 @@
                   isIdentical=0; let "numNotInComp += 1"
                   echo "     $file not in compare directory" >> $home_dir/fulldiff.tmp
                 else
-                  files_2=`echo $files_2 | sed "s#$escapedfilename##g" | sed "s#  # #g"`
+                  files_2=`echo "$files_2" | sed "s#\b$escapedfilename\b##g" | sed "s#  # #g"`
 
                   if [[ $skipfiles =~ (^|[[:space:]])"$file"($|[[:space:]]) ]]
                   then
@@ -316,7 +316,7 @@
 #             echo "files_2 = [$files_2]"
               done
 
-# 5.d Fils in compare directpry only
+# 5.d Files in compare directory only
             for file in $files_2
             do
               echo "     $file in comp directory only" >> $home_dir/fulldiff.tmp; isIdentical=0 ; let "numInCompOnly += 1"

--- a/regtests/ww3_tp2.17/input/ww3_multi_grdset_a1.inp
+++ b/regtests/ww3_tp2.17/input/ww3_multi_grdset_a1.inp
@@ -6,7 +6,7 @@ $
 $'points'
 $
 $
- 'inla'  'native' 'native' 'native' 'no' 'no' 'no' 'no'   1  1  0.00 1.00  F
+ 'inla'  'native' 'native' 'native' 'no' 'no' 'no' 'no' 'no' 'no'   1  1  0.00 1.00  F
 $ 
  20151214 020000 20151214 040000
 $

--- a/regtests/ww3_tp2.17/input/ww3_multi_grdset_c1.inp
+++ b/regtests/ww3_tp2.17/input/ww3_multi_grdset_c1.inp
@@ -6,7 +6,7 @@ $
 $'points'
 $
 $
- 'inlc'  'native' 'native' 'native' 'no' 'no' 'no' 'no'   1  1  0.00 1.00  F
+ 'inlc'  'native' 'native' 'native' 'no' 'no' 'no' 'no' 'no' 'no'   1  1  0.00 1.00  F
 $ 
  20151214 020000 20151214 040000
 $


### PR DESCRIPTION
# Pull Request Summary
add coupling field for mean direction without projection

## Description
this PR is about exchanging the mean direction instead of the cos and sin of the direction. This useful when the ww3 grid is rotated.

### Issue(s) addressed
linked to issue #459 
also solve issue #457 (only typo)
also solve issue #463 (matrix.comp not behaving correctly on ww3_tp2.18)
also solve issue #442 (incorrect statements in inp file in ww3_tp2.17)

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)? yes
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Please list appropriate labels code managers should add for this PR:   
_new feature_
 
* Reviewers: @ukmo-ccbunney  @aliabdolali 

### Commit Message
exchange the mean direction directly as a coupled field instead of the projected cos and sin of the direction

### Testing
* How were these changes tested? matrix
* Are the changes covered by regression tests? no
* If a new feature was added, was a new regression test added? no
* Have regression tests been run? yes
* Which compiler / HPC you used to run the regression tests in the PR? intel
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):   
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7116764/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7116765/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7116766/matrixDiff.txt)

Please indicate the expected changes in the outputs ([excluding the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).

no changes expected except usual not b4b regtest
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
ww3_tp2.17/./work_mc1                     (1 files differ)
ww3_tp2.17/./work_ma1                     (1 files differ)
ww3_tp2.18/./work_TIDE                     (0 files differ)
ww3_tp2.18/./work_TIDE_MPI                     (0 files differ)





