### PR TITLE
updates to porting to WCOSS2

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -177,6 +177,9 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   elif [ ! -z "$(echo $cmplr | grep wcoss_cray)" ] ; then
     optc="$optc -xCORE-AVX2"
     optl="$optl -xCORE-AVX2"
+  elif [ ! -z "$(echo $cmplr | grep wcoss2)" ] ; then
+    optc="$optc"
+    optl="$optl"
   elif [ ! -z "$(echo $cmplr | grep wcoss_dell_p3)" ] ; then
     optc="$optc -xHOST"
     optl="$optl -xHOST"

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -37,8 +37,12 @@ else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","Intel" "hera.intel" "orion.inte
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)", "cheyenne.intel" "stampede.intel"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
-else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_cray" "wcoss_dell_p3" "gaea.intel" "wcoss2"))
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss_cray" "wcoss_dell_p3" "gaea.intel"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
+else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","wcoss2"))
+ ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
+ WW3_CC=cc
+ WW3_F90=ftn
 else ifeq ("$(WW3_COMP)",$(filter "$(WW3_COMP)","intel" "datarmor_intel" "datarmor_intel_debug"))
  ESMF_F90COMPILEOPTS := $(ESMF_F90COMPILEOPTS) -convert big_endian
 # mpt


### PR DESCRIPTION

# Pull Request Summary
Updates porting to WCOSS2

## Description
This PR
- remove any xhost compile flags
- define in makefile for esmf to use ftn instead of gfortran


### Issue(s) addressed
* Is there an issue associated with this development (bug fix, enhancement, new feature)?    
Please add a reference to a related issue(s) in WW3 repository (Follow [link](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)).
Link the issues to be closed with this PR, whether in this repository, or in another repository.
(Remember, issues should always be created before starting work on a PR branch!).  
Note that properly "linked issues" (either automatic links, or manual ones using the correct keywords) will be automatically closed when the PR is merged.

- fixes #472 (Most of this was actually taken care of in PR#370)

Co-author: @DusanJovic-NOAA

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)?
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Please list appropriate labels code managers should add for this PR:   
 _bug_, _documentation_, _enhancement_, _new feature_, ..
 
* Reviewers: @DusanJovic-NOAA @aliabdolali 

### Commit Message
Updates porting for WCOSS2
- remove any xhost compile flags
- define in esmf makefile to use ftn instead of gfortran 


### Testing
* How were these changes tested? were not tested with develop yet, these changes work for other branches
* Are the changes covered by regression tests? No, not currently running standalone tests on wcoss2
* If a new feature was added, was a new regression test added?
* Have regression tests been run? no

