### PR TITLE
Manual PDF build errors

### DIFF
--- a/manual/manual.bib
+++ b/manual/manual.bib
@@ -1663,7 +1663,7 @@ year={2019},
 
 @article{art:sikiric2013,
   title={Coupling of the Regional Ocean Modeling System (ROMS) and Wind Wave Model},
-  author={Sikiri{\'c}, Mathieu Dutour and Roland, Aron and Janekovi{\'c}, Ivica and Tomaz̆i{\'c}, Igor and Kuzmi{\'c}, Milivoj},
+  author={Sikiri{\'c}, Mathieu Dutour and Roland, Aron and Janekovi{\'c}, Ivica and Tomazi{\'c}, Igor and Kuzmi{\'c}, Milivoj},
   journal=OMOD,
   volume={72},
   pages={59--73},

--- a/manual/num/space_SMC.tex
+++ b/manual/num/space_SMC.tex
@@ -186,7 +186,7 @@ sub-grid group but boundary condition will still be limited to whole spectral
 exchange.  The original lat-lon grid boundary interpolation is not enabled. 
 This simplification reduces MPI communication load but may lose some accuracy
 if their boundary cell centres are not aligned.  See the regression test    
-\emph{regtests/mww3_test\_09} for an exmple of SMC sub-grids for the Great
+\emph{regtests/mww3\_test\_09} for an exmple of SMC sub-grids for the Great
 Lakes.  It covers the Lake Michigan, Huron and Superior in 3 SMC levels 
 (0.5-1-2 km) with minimized boundary links.
   
@@ -194,7 +194,7 @@ Hybrid parallelization is supported for SMC grids and it could reduce the total
 elapsed time by half when it is run on the Cray XC40 supercomputer with 3 or 6
 OpenMP threads. Further increase of OpenMP threads seems no much effect.  The 
 combined hybrid and multi-grid parallelization may extend the computer usage
-to over 100 nodes for the 3 Great Lake sub-grids in \emph{mww3_test\_09}.
+to over 100 nodes for the 3 Great Lake sub-grids in \emph{mww3\_test\_09}.
 
 It is recommended to read the smc\_docs/SMC\_Grid\_Guide.pdf or the
 conference paper \citep{tol:LiS17} at conference web page: 

--- a/manual/run.tex
+++ b/manual/run.tex
@@ -4,7 +4,7 @@
 \input{run/design}
 \input{run/core}
 \input{run/das}
-\input{run/aux}
+\input{run/sup}
 \input{run/ww3_grid.tex}
 \input{run/ww3_strt.tex}
 \input{run/ww3_bound.tex}

--- a/manual/sys.tex
+++ b/manual/sys.tex
@@ -17,7 +17,7 @@ to the source code itself, which is fully documented.
 \pb
 \input{sys/files_wm}
 \input{sys/das}
-\input{sys/aux}
+\input{sys/sup}
 \input{sys/optim}
 \pb
 \input{sys/store}

--- a/model/inp/ww3_shel.inp
+++ b/model/inp/ww3_shel.inp
@@ -354,7 +354,7 @@ $
 $ Homogeneous field data --------------------------------------------- $
 $ Homogeneous fields can be defined by a list of lines containing an ID
 $ string 'LEV' 'CUR' 'WND', date and time information (yyyymmdd
-$ hhmmss), value (S.I. units), direction (current and wind, oceanogr.
+$ hhmmss), value (S.I. units), direction (current and wind, meteorol.
 $ convention degrees)) and air-sea temperature difference (degrees C).
 $ 'STP' is mandatory stop string.
 $ Also defined here are the speed with which the grid is moved


### PR DESCRIPTION
# Pull Request Summary
Fixed some typos and filename changes (aux => sup) that were causing the manual PDF build to fail.

## Description
Two sets of errors were causing the manual PDF compilation to fail:
  - Missing escape `\` for underscores in "mww3_test_09" strings (`num/space_SMC.tex`)
  - References to old filenames `run/aux.tex` and `sys/aux.tex` (renamed `sup.tex`)

A correction for #177 is also included in this PR
 
* Reviewers: @aliabdolali 

### Fixes
 fixes: #177

### Commit Message
* Fixed some typos and filename changes (aux => sup) that were causing the manual PDF build to fail. Also fix incorrect direction convention comment in ww3_shel.tex

### Testing
* How were these changes tested? **Build of PDF manual**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **n/a**
* If a new feature was added, was a new regression test added? **n/a**
* Have regression tests been run? **n/a**
* Which compiler / HPC you used to run the regression tests in the PR? **n/a**


