### PR TITLE
Small bigfix to variable INTENT

### DIFF
--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -940,9 +940,9 @@
 !
 !/ ------------------------------------------------------------------- /
       IMPLICIT NONE
-      INTEGER, INTENT(IN)               :: NDMI
-      TYPE(META_T), INTENT(IN), POINTER :: META
-      INTEGER, INTENT(INOUT)            :: ILINE
+      INTEGER, INTENT(IN)                  :: NDMI
+      TYPE(META_T), INTENT(INOUT), POINTER :: META
+      INTEGER, INTENT(INOUT)               :: ILINE
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !


### PR DESCRIPTION
# Pull Request Summary [SEE #499]
Fixes issue where some compilers generate an error relating to the INTENT of an subroutine parameter in w3ounfmeta.ftn

Issue #489 describes.

## Description
Some compilers (e.g. the Cray compiler at version 8.3.4) complain about the `INTENT(IN)` of the `META` parameter in the `READ_META_PAIRS` subroutine in w3oundmeta.ftn.

An easy fix is to make change the intent to `INTENT(INOUT)`.
 
### Issue(s) addressed
- fixes #489 

### Commit Message
* Small bugfix to INTENT of subroutine parameter in w3ounfmeta.

### Testing
* How were these changes tested? Regtests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* If a new feature was added, was a new regression test added? N/A
* Have regression tests been run? Yes
* Which compiler / HPC you used to run the regression tests in the PR? Cray/GNU/Intel compiler. Cray HPC

No differences in regression tests other than known non-B4B regtest `mww3_test_03`:

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (7 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (11 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
```

[matrixDiff_issue489.zip](https://github.com/NOAA-EMC/WW3/files/7304158/matrixDiff_issue489.zip)

