### PR TITLE
Updated version number to 7.14

### DIFF
--- a/manual/defs.tex
+++ b/manual/defs.tex
@@ -1,4 +1,4 @@
-\newcommand{\WWver}{7.13}
+\newcommand{\WWver}{7.14}
 \newcommand{\guidever}{1.2}
 \newcommand{\guideref}{tol:MMABguide}
 \newcommand{\genever}{1.5}

--- a/manual/intro/about.tex
+++ b/manual/intro/about.tex
@@ -79,6 +79,9 @@ and code-structure modifications made in \ws\ \WWver since the previous release.
       and NCC switches, removed experimental and supplemental switches (XX0, XXX, FLXX, PRX, 
       STX, NLX, BTX, DBX, TRX, BSX) and modularized and cleaned up the build (model version 7.13).
 
+\item Changed from WW3 preprocessor and ftn source code directory to using CPP preprocessors and
+      src for the source code directory (model version 7.14).  
+
 \end{list}
 
 \vspace{\baselineskip} \noindent 

--- a/model/src/gx_outp.F90
+++ b/model/src/gx_outp.F90
@@ -40,7 +40,7 @@
 !/    26-Dec-2012 : Modified obsolete declarations.     ( version 4.11 )
 !/    27-Aug-2015 : Sice add as additional output       ( version 5.10 )
 !/                  (in source terms)
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/w3fldsmd.F90
+++ b/model/src/w3fldsmd.F90
@@ -1013,7 +1013,7 @@
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
 !/    25-Sep-2020 : Receive coupled fields at T+0       ( version 7.10 )
 !/    22-Mar-2021 : adds momentum and density input     ( version 7.13 )
-!/    13-Aug-2021 : Allow scalar fields to be time      ( version 7.xx )
+!/    13-Aug-2021 : Allow scalar fields to be time      ( version 7.14 )
 !/                  interpolated
 !/
 !  1. Purpose :

--- a/model/src/w3flx5md.F90
+++ b/model/src/w3flx5md.F90
@@ -12,7 +12,7 @@
 !/                  | Last update :         01-Jul-2021 |
 !/                  +-----------------------------------+
 !/
-!/    22-Mar-2021 : Origination.                        ( version 7.xx )
+!/    22-Mar-2021 : Origination.                        ( version 7.14 )
 !/    22-Mar-2021 : Enable direct use of atmospheric model wind stress
 !/                  by source terms ST6
 !/    01-Jul-2021 : Enable direct use of atmospheric model wind stress
@@ -73,7 +73,7 @@
 !/                  | Last update :         01-Jul-2021 |
 !/                  +-----------------------------------+
 !/
-!/    22-Mar-2021 : Origination.                        ( version 7.xx )
+!/    22-Mar-2021 : Origination.                        ( version 7.14 )
 !/    22-Mar-2021 : Enable direct use of atmospheric model wind stress
 !/                  by source terms ST6
 !/    01-Jul-2021 : Enable direct use of atmospheric model wind stress

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -112,7 +112,7 @@
 !/    27-May-2021 : Updates for IC5 (Q. Liu)            ( version 7.12 )
 !/    27-May-2021 : Moved to a subroutine               ( version 7.13 )
 !/    07-Jun-2021 : S_{nl} GKE NL5 (Q. Liu)             ( version 7.13 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -112,7 +112,7 @@
       PUBLIC
 !/
       REAL, PARAMETER                :: CRITOS = 15.
-      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.13  '
+      CHARACTER(LEN=10), PARAMETER   :: WWVER  = '7.14  '
       CHARACTER(LEN=512), PARAMETER  :: SWITCHES  = &
                     __WW3_SWITCHES__ 
 !/

--- a/model/src/w3iogrmd.F90
+++ b/model/src/w3iogrmd.F90
@@ -149,7 +149,7 @@
 !/    18-Jun-2020 : Adds 360-day calendar option        ( version 7.08 )
 !/    19-Oct-2020 : Add AIRCMIN, AIRGB parameters       ( version 7.08 )
 !/    07-07-2021  : S_{nl} GKE NL5 (Q. Liu)             ( version 7.12 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/w3iopomd.F90
+++ b/model/src/w3iopomd.F90
@@ -617,7 +617,7 @@
 !/                  (Jian-Guo Li)                       ( version 4.06 )
 !/    01-Mar-2018 : Add option to unrotate spectra      ( version 6.02 )
 !/                  from RTD grid models
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !  1. Purpose :
 !
@@ -1033,7 +1033,7 @@
 !/    27-Jun-2006 : Adding file name preamble.          ( version 3.09 )
 !/    25-Jul-2006 : Adding grid ID per point.           ( version 3.10 )
 !/    27-Aug-2015 : Adding interpolation for the ice.   ( version 5.10 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !  1. Purpose :
 !

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -48,7 +48,7 @@
 !/                  internal fields. (C. Bunney, UKMO)
 !/    22-Mar-2021 : Add extra coupling variables        ( version 7.13 )
 !/    07-Jun-2021 : S_{nl} GKE NL5 (Q. Liu)             ( version 7.13 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/w3src4md.F90
+++ b/model/src/w3src4md.F90
@@ -102,7 +102,7 @@
 !/    13-Jun-2011 : Adds f_m0,-1 as FMEAN in the outout ( version 4.04 )
 !/    08-Jun-2018 : use STRACE and FLUSH                ( version 6.04 )
 !/    22-Feb-2020 : Merge Romero (2019) and cleanup     ( version 7.06 )
-!/    22-Jun-2021 : Add FLX5 to use stresses with the ST( version 7.xx )
+!/    22-Jun-2021 : Add FLX5 to use stresses with the ST( version 7.14 )
 !/
 !  1. Purpose :
 !
@@ -1673,7 +1673,7 @@
 !/    13-Nov-2013 : Reduced frequency range with IG1 switch 
 !/    06-Jun-2018 : Add optional DEBUGSRC              ( version 6.04 )
 !/    22-Feb-2020 : Option to use Romero (GRL 2019)    ( version 7.06 )
-!/    13-Aug-2021 : Consider DAIR a variable           ( version x.xx )
+!/    13-Aug-2021 : Consider DAIR a variable           ( version 7.14 )
 !/
 !  1. Purpose :
 !

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -125,7 +125,7 @@
 !/    26-Aug-2018 : UOST (Mentaschi et al. 2015, 2018)  ( version 6.06 )
 !/    22-Mar-2021 : Add extra fields used in coupling   ( version 7.13 )
 !/    07-Jun-2021 : S_{nl5} GKE NL5 (Q. Liu)            ( version 7.13 ) 
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/w3updtmd.F90
+++ b/model/src/w3updtmd.F90
@@ -2496,7 +2496,7 @@
 !/                  +-----------------------------------+
 !/
 !/    22-Mar-2021 : First implementation                ( version 7.13 )
-!/    13-Aug-2021 : Enable time interpolation           ( version 7.xx )
+!/    13-Aug-2021 : Enable time interpolation           ( version 7.14 )
 !/
 !  1. Purpose :
 !

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -84,7 +84,7 @@
 !/                  defunct OMPX switches.
 !/    22-Mar-2021 : Update TAUA, RHOA                   ( version 7.13 )
 !/    06-May-2021 : Use ARCTC and SMCTYPE options. JGLi ( version 7.13 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -36,7 +36,7 @@
 !/    26-Jul-2018 : Adding polar stereographic grid     ( version 6.05 ) 
 !/                  (J.H. Alves)
 !/    22-Mar-2021 : New coupling fields output          ( version 7.13 )
-!/    09-Jun-2021 : remove grib1 support (NCEP1)        ( version X.XX )
+!/    09-Jun-2021 : remove grib1 support (NCEP1)        ( version 7.14 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights

--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -53,7 +53,7 @@
 !/    15-May-2018 : Add namelist feature                ( version 6.05 )
 !/    18-Aug-2018 : S_{ice} IC5 (Q. Liu)                ( version 6.06 )
 !/    18-Jun-2020 : Support for 360-day calendar.       ( version 7.08 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/    06-Sep-2021 : scale factor on spectra output      ( version 7.12 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),

--- a/model/src/ww3_outp.F90
+++ b/model/src/ww3_outp.F90
@@ -59,7 +59,7 @@
 !/                  (in source terms)
 !/    27-Jun-2017 : Expanding WMO table to 2 digits JHA ( version 6.02 )
 !/    18-Aug-2018 : S_{ice} IC5 (Q. Liu)                ( version 6.06 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -1024,7 +1024,7 @@
 !/                  from 3.15 (HLT).                    ( version 4.08 )
 !/    26-Dec-2012 : Modified obsolete declarations.     ( version 4.11 )
 !/    06-Feb-2014 : Fix header format in part. files.   ( version 4.18 )
-!/    19-Jul-2021 : Momentum and air density support    ( version 7.xx )
+!/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/
 !  1. Purpose :
 !

--- a/model/src/ww3_uprstr.F90
+++ b/model/src/ww3_uprstr.F90
@@ -1248,7 +1248,7 @@
 !/                  +-----------------------------------+
 !/
 !/    16-Oct-2018 : Original Code                       ( version 6.06 )
-!/    24-Oct-2018 : Update by Andy Saulter              ( version x.xx )
+!/    24-Oct-2018 : Update by Andy Saulter              ( version 7.14 )
 !/
 !/    Copyright 2010 National Weather Service (NWS),
 !/    National Oceanic and Atmospheric Administration.  All rights


### PR DESCRIPTION
# Pull Request Summary
Update version number to 7.14

## Description
Updates the wave model code to version 7.14 after the conversion of ftn/*.ftn to src/*.F90. 

### Issue(s) addressed
* no issue

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)? yes 
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) version number checklist was completed 
* Please list appropriate labels code managers should add for this PR:   
no label exists for version number updates
 
* Reviewers: @aliabdolali 

### Commit Message
* Updated version number to 7.14

### Testing
* How were these changes tested? matrix_ncep (and 2 tests of ufs-weather-model) 
* Are the changes covered by regression tests? yes 
* If a new feature was added, was a new regression test added? no new feature
* Have regression tests been run? yes
* Which compiler / HPC you used to run the regression tests in the PR?  hera.intel matrix_ncep 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    

[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7454720/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7454721/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7454722/matrixDiff.txt)

Only the expected differences: 

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
mww3_test_04/./work_PR3_UQ_MPI_NC_b_c                     (1 files differ)
mww3_test_07/./work_PR3_UQ                     (3 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (3 files differ)
ww3_ufs1.1/./work_d                     (0 files differ)
ww3_ufs1.2/./work_b                     (0 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
```

For ufs-weather-model, both the cpld_control_wave_p7 and cpld_bmark_p7 passed

* Please list which labels code managers should add to indicate code changes:    
Version Number is updated. (no label exists) 
