### PR TITLE
Updates for Jet/HAFS

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -192,6 +192,9 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   elif [ ! -z "$(echo $cmplr | grep wcoss_dell_p3)" ] ; then
     optc="$optc -xHOST"
     optl="$optl -xHOST"
+  elif [ ! -z "$(echo $cmplr | grep jet.intel)" ] ; then
+    optc="$optc -axSSE4.2,AVX,CORE-AVX2,CORE-AVX512 -align array64byte -ip"
+    optl="$optl -axSSE4.2,AVX,CORE-AVX2,CORE-AVX512 -align array64byte -ip"
   elif [[ $cmplr == ukmo_cray* ]]; then
     : # processor type set by ftn wrapper script.
   elif [ ! -z "$(echo $cmplr | grep s4)" ] ; then


### PR DESCRIPTION
# Pull Request Summary
Add compiler specific flags for jet 

## Description
After issues that were discussed here: https://github.com/hafs-community/HAFS/pull/107#issuecomment-967214429 it was determined that compiler specific flags were needed for jet.  

### Issue(s) addressed
* No WW3 issue was created.  See other issue/PR: https://github.com/hafs-community/HAFS/pull/107

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)? yes
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Please list appropriate labels code managers should add for this PR:   
 _bug_, _documentation_, _enhancement_, _new feature_, ..
 
* Reviewers: @BinLiu-NOAA @aliabdolali @MatthewMasarik-NOAA 

### Commit Message
* Update for jet specific compiler flags 

### Testing
* How were these changes tested? By @BinLiu-NOAA within HAFS
* Are the changes covered by regression tests? We do not run WW3 standalone regtests on Jet. 
* If a new feature was added, was a new regression test added? no
* Have regression tests been run? no
* Which compiler / HPC you used to run the regression tests in the PR?  no regtests were run as this was a platform specific update 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    
Please indicate the expected changes in the outputs ([excluding the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
* Please list which labels code managers should add to indicate code changes:    
_mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_, ...

