### PR TITLE
cmplr.env: err_pattern fix for scrip_errormod false positive

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -33,7 +33,7 @@
 ## Set some defaults (can be overriden by individual compiler sections)
 
 # grep pattern for errors/warnings in compiler output:
-err_pattern='error'
+err_pattern='[[:space:]]error[[:space:]]'
 warn_pattern='warn'
 
 # disable listing done by the compiler


### PR DESCRIPTION
# Pull Request Summary
During building, in addition to _error_ messages, _remarks_ and _warning_ outputs, along with the file name, can appear in the files' `.err` output.  In the case of `scrip_errormod.f90`, this can lead to termination of the build due to `comp` `grep`ing for the word 'error', and finding it as a substring of the file name.

## Description
This PR addresses a potential bug in the build scripts where `.err` files are `grep`ed for the word '_error_'.  If the name of the file contains the word _error_, it could unnecessarily trigger a compile to abort based only on finding it as a substring in the name.  I used _potential_ because this error was discovered while using non-WW3 (UFS) debug flags to compile, though that does not mean it can't occur otherwise.   This fix works by adding to the `err_pattern` the requirement of whitespace (space, tab, newline, carriage return) on either side of the word _error_.  This means that the use of _error_ in a variable name, file name, etc. will not be flagged as a problem by `comp`.  This is not expected to change answers.


Please also include the following information: 
* Add any suggestions for a reviewer
  *  N/A
* Mention any labels that should be added: 
  *  _bug_
* Are answer changes expected from this PR?
  * No answers are expected to change.
* Co-author
  * @JessicaMeixner-NOAA 

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close.
  * fixes noaa-emc/ww3/issues/[554](https://github.com/NOAA-EMC/WW3/issues/554)

### Commit Message
scrip_errormod.f90: fixes build failure due to 'error' substring in file name

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * (1) The fix was run in debug mode with the UFS flags that cause the build error. In this case the compile succeeded and the run completed successfully.  The current develop branch was run in the same way, but without the fix.  In this case the compile failed as documented in the issue: [#554](https://github.com/NOAA-EMC/WW3/issues/554).
  * (2) Both the fix and develop branches were run for the full matrix, with the normal (WW3) debug flags present, though using the standard Intel compiler (vs. `intel_debug`).  Then running `matrix.comp` the only differences were those of the known issues.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No.  WW3 is not normally run in debug mode.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  `hera.intel`.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):      
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7663435/matrixCompSummary.txt)
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7663437/matrixCompFull.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7663439/matrixDiff.txt)


* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
  * Only files in the known list are present.
```bash
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (7 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (7 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (8 files differ)
mww3_test_07/./work_PR3_UQ                     (3 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_ufs1.1/./work_d                     (0 files differ)
ww3_ufs1.2/./work_b                     (0 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```
