### PR TITLE
[w3ounfmeta] fix overlapping internal write

### DIFF
--- a/model/src/w3ounfmetamd.F90
+++ b/model/src/w3ounfmetamd.F90
@@ -1778,6 +1778,7 @@
       INTEGER :: I, J, ISN
       TYPE(PART_TMPL_T), POINTER :: P
       CHARACTER(LEN=64) :: TMPL
+      CHARACTER(LEN=256) :: TMP
 
       ISN = IPART + 1
       IF(PTMETH .LE. 3) THEN
@@ -1790,7 +1791,8 @@
       I = INDEX(INSTR, IPART_TOKEN)
       J = I + LEN_TRIM(IPART_TOKEN)
       IF(I .GT. 0) THEN
-        WRITE(INSTR,'(A,I1,A)') INSTR(1:I-1), IPART, INSTR(J:LEN(INSTR))
+        WRITE(TMP, '(A,I1,A)') INSTR(1:I-1), IPART, INSTR(J:LEN(INSTR))
+        INSTR = TMP
       ENDIF
 
       ! Set standard name string (built-in SPART template)

--- a/model/src/w3ounfmetamd.F90
+++ b/model/src/w3ounfmetamd.F90
@@ -1777,8 +1777,7 @@
 !/
       INTEGER :: I, J, ISN
       TYPE(PART_TMPL_T), POINTER :: P
-      CHARACTER(LEN=64) :: TMPL
-      CHARACTER(LEN=512) :: TMP
+      CHARACTER(LEN=512) :: TMPL
 
       ISN = IPART + 1
       IF(PTMETH .LE. 3) THEN
@@ -1791,8 +1790,8 @@
       I = INDEX(INSTR, IPART_TOKEN)
       J = I + LEN_TRIM(IPART_TOKEN)
       IF(I .GT. 0) THEN
-        WRITE(TMP, '(A,I1,A)') INSTR(1:I-1), IPART, INSTR(J:LEN(INSTR))
-        INSTR = TMP
+        WRITE(TMPL, '(A,I1,A)') INSTR(1:I-1), IPART, INSTR(J:LEN(INSTR))
+        INSTR = TMPL
       ENDIF
 
       ! Set standard name string (built-in SPART template)

--- a/model/src/w3ounfmetamd.F90
+++ b/model/src/w3ounfmetamd.F90
@@ -1778,7 +1778,7 @@
       INTEGER :: I, J, ISN
       TYPE(PART_TMPL_T), POINTER :: P
       CHARACTER(LEN=64) :: TMPL
-      CHARACTER(LEN=256) :: TMP
+      CHARACTER(LEN=512) :: TMP
 
       ISN = IPART + 1
       IF(PTMETH .LE. 3) THEN


### PR DESCRIPTION
# Pull Request Summary
Fix overlapping internal write

## Description
There is an internal Fortran write statement (formatted write to a string variable) in `w3ounfmeta` where the target string is written with data from itself, i.e.

```fortran
WRITE(INSTR,'(A,I1,A)') INSTR(1:I-1), IPART, INSTR(J:LEN(INSTR)
```

This is causing unpredictable behavior as the data in `INSTR` is being overwritten at the same time it is trying to be read (`INSTR` appears as both the target for the `WRITE` statement and as arguments to it).

The solution is to simply write to a temporary variable first and the assign this to `INSTR`.


### Issue(s) addressed
- fixes #451 


### Commit Message
Fix overlapping internal write of INSTR in w3ounfmetamd.

### Check list  

- [yes ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ yes] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? ww3_tnc1 and full regression test  suite.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, GNU compiler; Cray XC HPC.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    

**Regression tests results:** [matrixComp_ounfpartno.zip](https://github.com/NOAA-EMC/WW3/files/7693508/matrixComp_ounfpartno.zip)

All tests bit-4-bit apart from the usual:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (9 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (7 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (11 files differ)
```

