### PR TITLE
[ww3_shel.nml] Fixed incorrect ordering of TAU and RHOAIR

### DIFF
--- a/model/nml/ww3_shel.nml
+++ b/model/nml/ww3_shel.nml
@@ -103,11 +103,11 @@
 !  T  T  1     5   WLV        WLV   Water levels.
 !  T  T  1     6   ICE        ICE   Ice concentration.
 !  T  T  1     7   IBG        IBG   Iceberg-induced damping.
-!  T  T  1     8   D50        D50   Median sediment grain size.
-!  T  T  1     9   IC1        IC1   Ice thickness.
-!  T  T  1    10   IC5        IC5   Ice flow diameter.
-$  T  T  1    11   TAUA       TAU   Atm. momentum. 
-$  T  T  1    12   RHOAIR     RHO   Air density. 
+!  T  T  1     8   TAUA       TAU   Atm. momentum.
+!  T  T  1     9   RHOAIR     RHO   Air density.
+!  T  T  1    10   D50        D50   Median sediment grain size.
+!  T  T  1    11   IC1        IC1   Ice thickness.
+!  T  T  1    12   IC5        IC5   Ice flow diameter.
 !   -------------------------------------------------
 !        2                          Standard mean wave Parameters
 !   -------------------------------------------------


### PR DESCRIPTION
# Pull Request Summary
Fixed incorrect ordering of TAU and RHOAIR fields in ww3_shel.nml field output table.

## Description
The `TAU` and `RHOAIR` fields were incorrectly listed as fields 11 and 12 in `ww3_shel.nml`.
This has been corrected to reorder them as fields 8 and 9 as per `w3iogomd`.

This is a documentation change only so no regression tests have been run.

### Issue(s) addressed
- fixes #514 

### Commit Message
Fixed incorrect ordering of TAU and RHOAIR fields in ww3_shel.nml field output table.

### Check list  

- [✔] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [✔] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [**N/A**] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [**N/A**] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **Not required - documentation change only**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **N/A**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **N/A**

