### PR TITLE
Fix incorrect field index for ICEF

### DIFF
--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -2613,7 +2613,7 @@
 #endif
 !
 #ifdef W3_MPI
-              IF ( FLGRDALL( 1, 9) ) THEN
+              IF ( FLGRDALL( 1, 12) ) THEN
                   IH     = IH + 1
                   IT     = IT + 1
       CALL MPI_SEND_INIT (ICEF (IAPROC), 1, WW3_FIELD_VEC,    &
@@ -4021,7 +4021,7 @@
 #endif
 !
 #ifdef W3_MPI
-                IF ( FLGRDALL( 1, 9) ) THEN
+                IF ( FLGRDALL( 1, 12) ) THEN
                     IH     = IH + 1
                     IT     = IT + 1
       CALL MPI_RECV_INIT (ICEF (I0),1,WW3_FIELD_VEC, IFROM, IT,  &
@@ -5533,7 +5533,7 @@
 #endif
 !
 #ifdef W3_MPI
-              IF ( FLOGRR( 1, 9) ) THEN
+              IF ( FLOGRR( 1, 12) ) THEN
                 IH     = IH + 1
                 IT     = IT0 + 6
                 CALL MPI_SEND_INIT (ICEF(IAPROC), 1, WW3_FIELD_VEC, &
@@ -5930,7 +5930,7 @@
 #endif
 !
 #ifdef W3_MPI
-                  IF ( FLOGRR( 1, 9) ) THEN
+                  IF ( FLOGRR( 1, 12) ) THEN
                     IH     = IH + 1
                     IT     = IT0 + 6
                     CALL MPI_RECV_INIT (ICEF (I0),1,WW3_FIELD_VEC, &

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -984,7 +984,7 @@
                     WRITE(NDSR,ERR=803,IOSTAT=IERR) CX(1:NSEA)
                     WRITE(NDSR,ERR=803,IOSTAT=IERR) CY(1:NSEA)
                   ENDIF
-                  IF ( FLOGRR(1,9) )                                  &
+                  IF ( FLOGRR(1,12) )                                 &
                     WRITE(NDSR,ERR=803,IOSTAT=IERR) ICEF(1:NSEA)
                   IF ( FLOGRR(2,1) )                                  &
                     WRITE(NDSR,ERR=803,IOSTAT=IERR) HS(1:NSEA)
@@ -1181,7 +1181,7 @@
 #ifdef W3_DEBUGINIT
          WRITE(740+IAPROC,*) 'Before reading ICEF'
 #endif
-              IF ( FLOGOA(1,9) ) THEN
+              IF ( FLOGOA(1,12) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) ICEF(1:NSEA)
               ENDIF
 #ifdef W3_DEBUGINIT


### PR DESCRIPTION
# Pull Request Summary
The field index for `ICEF` is incorrect in `w3iorsmd` and `w3initmd`

## Description
The `ICEF` index is set as 9 in w3iorsmd and w3initmd, but it should be 12.

This fix could result in a change in a generated restart file if `RHO` was requested as an extra restart output as this would have incorrectly output the "ICEF" field to `restart.ww3`.

Currently, this only affects the ww3_tp2.14 regtest.

### Issue(s) addressed
- fixes #514 

### Commit Message
Fix incorrect field index for ICEF.

### Check list  
- [✔] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [✔] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **Regression tests.**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **Yes**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **Cray XC HPC; GFortran compiler**

Regression test results: [matrixComp_badfieldnum.zip](https://github.com/NOAA-EMC/WW3/files/7728651/matrixComp_badfieldnum.zip)

Summary of differences:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (7 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (12 files differ)
ww3_tp2.14/./work_OASACM4                         (1 files differ)
```

**Expected differences:**
 - **ww3_tp2.14/OASACM4**: restart file is different due to previously incorrect output of ICEF field, as described above.
 - **mww3_test_03**: Known non-b4b.

