### PR TITLE
[ww3_ounp] TIMESPLIT=0 support

### DIFF
--- a/model/inp/ww3_ounp.inp
+++ b/model/inp/ww3_ounp.inp
@@ -18,7 +18,7 @@ $ mandatory end of list
 $
 $--------------------------------------------------------------------- $
 $ file prefix
-$ number of characters in date [4(yearly),6(monthly),8(daily),10(hourly)]
+$ number of characters in date [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 $ netCDF version [3,4]
 $ points in same file [T] or not [F] 
 $                    and max number of points to be processed in one pass

--- a/model/nml/ww3_ounp.nml
+++ b/model/nml/ww3_ounp.nml
@@ -12,7 +12,7 @@
 !     POINT%TIMESTART            = '19000101 000000'  ! Stop date for the output field
 !     POINT%TIMESTRIDE           = '0'                ! Time stride for the output field
 !     POINT%TIMECOUNT            = '1000000000'       ! Number of time steps
-!     POINT%TIMESPLIT            = 6                  ! [4(yearly),6(monthly),8(daily),10(hourly)]
+!     POINT%TIMESPLIT            = 6                  ! [0(nodate),4(yearly),6(monthly),8(daily),10(hourly)]
 !     POINT%LIST                 = 'all'              ! List of points index ['all'|'1 2 3']
 !     POINT%SAMEFILE             = T                  ! All the points in the same file
 !     POINT%BUFFER               = 150                ! Number of points to process per pass

--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -665,12 +665,9 @@
 
 
 ! 5.2 Creates filename listing
-      WRITE(EXT,'(A)') ''
       SEP = '_'
-      IF(S3 .EQ. 0) THEN
-        ! Don't add "_" separator if there is no datetime string.
-        SEP = ''
-      ENDIF
+      IF(S3 .EQ. 0) SEP = '' ! No "_" separator if no datetime string.
+      WRITE(EXT,'(A)') ''
       IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.2)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
       IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.3)) WRITE(EXT,'(A,A)') TRIM(SEP), 'spec.nc'
       IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.4)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'

--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -55,6 +55,7 @@
 !/    18-Jun-2020 : Support for 360-day calendar.       ( version 7.08 )
 !/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/    06-Sep-2021 : scale factor on spectra output      ( version 7.12 )
+!/    05-Jan-2022 : Added S3=0 support                  ( version 7.13 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -249,6 +250,7 @@
       CHARACTER(LEN=8)             :: EXT
       CHARACTER(LEN=128)           :: NCNAME
       CHARACTER(LEN=25)            :: IDSRCE(7)
+      CHARACTER                    :: SEP
 !
       CHARACTER(LEN=100),ALLOCATABLE      :: POINTLIST(:)
       CHARACTER(LEN=128),ALLOCATABLE      :: NCFILE(:)
@@ -600,16 +602,18 @@
 ! 4.3 Output type
 !
       ! S3 defines the number of characters in the date for the filename
-      ! S3=4-> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
+      ! S3=0 -> empty, S3=4 -> YYYY, S3=6 -> YYYYMM, S3=10 -> YYYYMMDDHH
 !
       ! Setups min and max date format
-      IF (S3.LT.4) S3=4
+      IF (S3.GT.0 .AND. S3.LT.4) S3=4
       IF (S3.GT.10) S3=10
 !
       ! Defines the format of FILETIME as ISO8601 convention
       S5=S3-8
       ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHMMSSZ'
-      IF (S3.EQ.10) THEN
+      IF (S3.EQ.0) THEN
+        FILETIME = ''
+      ELSE IF (S3.EQ.10) THEN
         WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
         WRITE (FILETIME,FORMAT1) TIME(1), 'T', &
                FLOOR(REAL(TIME(2))/NINT(10.**(6-S5))), 'Z'
@@ -662,13 +666,18 @@
 
 ! 5.2 Creates filename listing
       WRITE(EXT,'(A)') ''
-      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.2)) WRITE(EXT,'(A)') '_tab.nc'
-      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.3)) WRITE(EXT,'(A)') '_spec.nc'
-      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.4)) WRITE(EXT,'(A)') '_tab.nc'
-      IF  (ITYPE .EQ. 2)                     WRITE(EXT,'(A)') '_tab.nc'
-      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.2)) WRITE(EXT,'(A)') '_tab.nc'
-      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.3)) WRITE(EXT,'(A)') '_tab.nc'
-      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.4)) WRITE(EXT,'(A)') '_src.nc'
+      SEP = '_'
+      IF(S3 .EQ. 0) THEN
+        ! Don't add "_" separator if there is no datetime string.
+        SEP = ''
+      ENDIF
+      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.2)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
+      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.3)) WRITE(EXT,'(A,A)') TRIM(SEP), 'spec.nc'
+      IF ((ITYPE .EQ. 1) .AND. (OTYPE.EQ.4)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
+      IF  (ITYPE .EQ. 2)                     WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
+      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.2)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
+      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.3)) WRITE(EXT,'(A,A)') TRIM(SEP), 'tab.nc'
+      IF ((ITYPE .EQ. 3) .AND. (OTYPE.EQ.4)) WRITE(EXT,'(A,A)') TRIM(SEP), 'src.nc'
       ! checks if extension exists
       IF (LEN_TRIM(EXT).EQ.0) THEN
         WRITE (NDSE,1006)
@@ -720,7 +729,9 @@
 
 ! 5.6.1 Redefines the filetime when it's a new date defined by the date division S3
         ! if S3=>YYYYMMDDHH then filetime='YYYYMMDDTHHMMSSZ'
-        IF (S3.EQ.10) THEN
+        IF (S3.EQ.0) THEN
+          FILETIME = ''
+        ELSE IF (S3.EQ.10) THEN
           WRITE(FORMAT1,'(A,I1,A,I1,A)') '(I8.8,A1,I',S5,'.',S5,',A1)'
           WRITE (FILETIME,FORMAT1) TIME(1), 'T', &
                  NINT(REAL(TIME(2))/NINT(10.**(6-S5))), 'Z'

--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -55,7 +55,7 @@
 !/    18-Jun-2020 : Support for 360-day calendar.       ( version 7.08 )
 !/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
 !/    06-Sep-2021 : scale factor on spectra output      ( version 7.12 )
-!/    05-Jan-2022 : Added S3=0 support                  ( version 7.13 )
+!/    05-Jan-2022 : Added TIMESPLIT=0 (nodate) support  ( version 7.14 )
 !/
 !/    Copyright 2009 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights


### PR DESCRIPTION
# Pull Request Summary
Add TIMESPLIT=0 (no date string) support for `ww3_ounp`, as per `ww3_ounf`

## Description
This PR adds support for a zero length datetime string (`TIMESPLIT=0` in the namelist) for `ww3_ounp`.
This brings it in-line with ww3_ounf.

When TIMESPLIT=0, the output file will simply be `ww3.spec.nc` for combined files or `ww3.<field>_spec.nc` for split files.

### Commit Message
Add TIMESPLIT=0 (no date string) support for ww3_ounp.

### Check list  

- [✔] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [✔] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ n/a ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ n/a ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Local testing, regression tests.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * Yes 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes; Cray HPC, GNU Fortran

### Regression tests results

Full results: [matrixComp_ounp_nodate.zip](https://github.com/NOAA-EMC/WW3/files/7820828/matrixComp_ounp_nodate.zip)

Only the usual known non-b4b results:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (9 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
```

