### PR TITLE
Memory leak: w3iorsmd.F90

### DIFF
--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -335,7 +335,6 @@
       CHARACTER(LEN=26)       :: IDTST
       CHARACTER(LEN=30)       :: TNAME
       CHARACTER(LEN=15)       :: TIMETAG
-
       LOGICAL                 :: UNITOPEN
 !/
 !/ ------------------------------------------------------------------- /
@@ -608,15 +607,13 @@
 #ifdef W3_T
               WRITE (NDST,9005) TYPE
 #endif
+              ! Clean up file handles and allocated arrays                  
+              INQUIRE (UNIT=NDSR, OPENED=UNITOPEN)
+              IF (UNITOPEN)             CLOSE(NDSR)
+              IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
+              IF (ALLOCATED(TMP))       DEALLOCATE(TMP)
+              IF (ALLOCATED(TMP2))      DEALLOCATE(TMP2)
 
-!!!MTM0
-                  ! Clean up file handles and allocated arrays                  
-                  INQUIRE (UNIT=NDSR, OPENED=UNITOPEN)
-                  IF (UNITOPEN)             CLOSE(NDSR)
-                  IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
-                  IF (ALLOCATED(TMP))       DEALLOCATE(TMP)
-                  IF (ALLOCATED(TMP2))      DEALLOCATE(TMP2)
-!!!MTM0              
               RETURN
             ELSE IF ( IAPROC.LE.NAPROC .OR. IAPROC.EQ. NAPRST ) THEN
 #ifdef W3_DEBUGIO
@@ -1497,7 +1494,6 @@
   ELSE
      CLOSE ( NDSR )
   END IF
-  
 !
 #ifdef W3_DEBUGIO
         WRITE(740+IAPROC,*)  'W3IORS, step 9'

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -328,6 +328,7 @@
 
       LOGICAL                 :: WRITE, IOSFLG
       LOGICAL                 :: FLOGOA(NOGRP,NGRPP)
+      LOGICAL                 :: NDSROPN      
       CHARACTER(LEN=4)        :: TYPE
       CHARACTER(LEN=10)       :: VERTST
 !      CHARACTER(LEN=21)       :: FNAME
@@ -335,7 +336,6 @@
       CHARACTER(LEN=26)       :: IDTST
       CHARACTER(LEN=30)       :: TNAME
       CHARACTER(LEN=15)       :: TIMETAG
-      LOGICAL                 :: UNITOPEN
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -608,8 +608,8 @@
               WRITE (NDST,9005) TYPE
 #endif
               ! Clean up file handles and allocated arrays                  
-              INQUIRE (UNIT=NDSR, OPENED=UNITOPEN)
-              IF (UNITOPEN)             CLOSE(NDSR)
+              INQUIRE (UNIT=NDSR, OPENED=NDSROPN)
+              IF (NDSROPN)              CLOSE(NDSR)
               IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
               IF (ALLOCATED(TMP))       DEALLOCATE(TMP)
               IF (ALLOCATED(TMP2))      DEALLOCATE(TMP2)

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -335,6 +335,8 @@
       CHARACTER(LEN=26)       :: IDTST
       CHARACTER(LEN=30)       :: TNAME
       CHARACTER(LEN=15)       :: TIMETAG
+
+      LOGICAL                 :: UNITOPEN
 !/
 !/ ------------------------------------------------------------------- /
 !/

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -606,6 +606,15 @@
 #ifdef W3_T
               WRITE (NDST,9005) TYPE
 #endif
+
+!!!MTM0
+                  ! Clean up file handles and allocated arrays                  
+                  INQUIRE (UNIT=NDSR, OPENED=UNITOPEN)
+                  IF (UNITOPEN)             CLOSE(NDSR)
+                  IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
+                  IF (ALLOCATED(TMP))       DEALLOCATE(TMP)
+                  IF (ALLOCATED(TMP2))      DEALLOCATE(TMP2)
+!!!MTM0              
               RETURN
             ELSE IF ( IAPROC.LE.NAPROC .OR. IAPROC.EQ. NAPRST ) THEN
 #ifdef W3_DEBUGIO
@@ -1479,9 +1488,14 @@
 !
 ! Close file --------------------------------------------------------- *
 !
+  IF (WRITE) THEN        
       IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST ) THEN
         CLOSE ( NDSR )
       END IF
+  ELSE
+     CLOSE ( NDSR )
+  END IF
+  
 !
 #ifdef W3_DEBUGIO
         WRITE(740+IAPROC,*)  'W3IORS, step 9'


### PR DESCRIPTION
# Pull Request Summary
Fixes memory leaks in `w3iorsmd.F90`.

## Description
Provide a detailed description of what this PR does.
* Fixes memory leaks in the restart module, `w3iorsmd.F90`, related to `ALLOCATED` arrays as well as `OPEN`ed file units (closing these releases associated IO buffers).
  * `DEALLOCATE` and `CLOSE` statements are added before a 'bail out' `RETURN` statement.
  * The same logic around the `OPEN` statement for the restart file unit, `NDSR`, is reproduced before the main `RETURN` statement.


What bug does it fix, or what feature does it add?
* This addresses (but does not close at this time) WW3 issue #579,  which was created due to [UFS issue #779](https://github.com/ufs-community/ufs-weather-model/discussions/779).  I believe #579 should remain open as two additional leaks reported by valgrind are investigated.

Is a change of answers expected from this PR?
* No.

Please also include the following information: 
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR? 
  * No.  This fix passed the UFS cpld_bmark_p7 regtest, as well as matrix.comp.

### Issue(s) addressed
* Addresses (does not close) #579, as well as [UFS issue #779](https://github.com/ufs-community/ufs-weather-model/discussions/779). 

### Commit Message
w3iorsmd:  fixes memory leaks

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * UFS regression test `cpld_bmark_p7` was run with the fix and passed.  
  * The same test was also run with WW3 develop for comparison.  Each of these runs had ESMF memory profiling turned on.  This plot compares the mean memory use for both runs at each timestep.
    
![cpld_bmark_p7_mean_pet](https://user-images.githubusercontent.com/86749872/149673024-23afe8b1-3319-4846-88ff-535aaba0f98b.png)
 
   * Lastly the full matrix was run for develop and fix.  Matrix.comp returned only the expected differences for the non-identical cases.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * Yes.  A new feature is not being added.  Memory leaks were fixed, so running these changes against develop in the full matrix confirms that answers have not changed.
 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  Hera/Intel.
 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):   
   * [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7873197/matrixCompSummary.txt)
   * [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7873198/matrixCompFull.txt)
   * [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7873199/matrixDiff.txt)
 
* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
  *  The only changes are within the list of expected differences. 

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (7 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (5 files differ)
ww3_ufs1.1/./work_d                     (0 files differ)
ww3_ufs1.2/./work_b                     (0 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```
