### PR TITLE
allow mask variables to be retrieved from nems.configure

### DIFF
--- a/model/src/wmesmfmd.F90
+++ b/model/src/wmesmfmd.F90
@@ -772,6 +772,34 @@
             if (ESMF_LogFoundError(rc, PASSTHRU)) return
           end if
         end if
+
+        call NUOPC_CompAttributeGet(gcomp, name="mask_value_water", &
+          value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        if (isPresent .and. isSet) then
+          maskvaluewater = ESMF_UtilString2Int(cvalue, rc=rc)
+          if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          if (verbosity.gt.0) then
+            write(logmsg,*) maskvaluewater
+            call ESMF_LogWrite(trim(cname)//': mask_value_water = '// &
+              trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+            if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          end if
+        end if
+
+        call NUOPC_CompAttributeGet(gcomp, name="mask_value_land", &
+          value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        if (isPresent .and. isSet) then
+          maskvalueland = ESMF_UtilString2Int(cvalue, rc=rc)
+          if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          if (verbosity.gt.0) then
+            write(logmsg,*) maskvalueland
+            call ESMF_LogWrite(trim(cname)//': mask_value_land = '// &
+              trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+            if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          end if
+        end if
       end if
 !
 ! -------------------------------------------------------------------- /


### PR DESCRIPTION
# Pull Request Summary

Retrieves ``mask_value_water`` and ``mask_value_land`` if present in nems.configure and ``med_present`` is true.

## Description

Currently, when used in UWM, wmesmf sets the import and export mask values for the grid from the default values.

```
! --- Default Mask Convention for import/export fields
      INTEGER, PARAMETER :: DEFAULT_MASK_WATER =  0
      INTEGER, PARAMETER :: DEFAULT_MASK_LAND  =  1
```

These values are opposite the normal interpretation and CMEPS is then forced to set the dstMaskValue and srcMaskValues used for RH creation opposite to their normal sense. In med_map_mod, the currently used values in CMEPS for HAFS are (``n1`` is the source side and ``n2`` is the destination side)

```
       elseif (n1 == compatm .and. n2 == compwav) then
          dstMaskValue = 1
       elseif (n1 == compwav .and. n2 == compatm) then
          srcMaskValue = 1
          dstMaskValue = ispval_mask
       endif
```

Both the ``dstMaskValue`` when the destination is compwav and the ``srcMaskValue`` when compwav is the source are reversed. That is, the dstMaskValue should indicate where the wave grid is masked when it is the destination. It should be 0 (ie, don't interpolate to the land points). The srcMaskValue should indicate what points to ignore when wave is the source. It should be  0 (ie, don't interpolate from land points on the wave grid). 


When HAFS is switched to the new cap, the mask values will be set with the correct interpretation for CMEPS. A PR for CMEPS [# 266](https://github.com/ESCOMP/CMEPS/pull/266) is the first step in implementing the new wave cap in UWM. In order for the existing cap to continue to work for HAFS, it is required to allow non-default mask values to be set from nems.configure:

```
  mask_value_water = 1
  mask_value_land = 0
```

These will be consistent with the ``dstMaskValue`` and ``srcMaskValue`` used by CMEPS. 

These configuration variables will not be added to the HAFS nems.configure in UWM until CMEPS is also updated.

<!--
Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

### Issue(s) addressed

- related to, but does not close, https://github.com/ufs-community/ufs-weather-model/issues/739. 
   This PR allows the current wmesmf cap to continue to function for UFS HAFS apps during the transition to a CMEPS cap for both S2SW and HAFS. 

### Commit Message

Retrieve mask_value_water and mask_value_land if present in nems.configure and med_present is true.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) ufs-weather-model branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

Baselines were run on both Cheyenne.intel and Cheyenne.gnu using a feature branch of CMEPS incorporating changes required for S2SW coupling. All baselines were B4B. Tested hash #f297618 of [FB updcmeps_wavcpl](https://github.com/DeniseWorthen/ufs-weather-model/tree/feature/updcmeps_wavcpl)

* How were these changes tested? 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    
* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

