### PR TITLE
reintegrate dev/ufs-weather-model

### DIFF
--- a/model/src/wmesmfmd.F90
+++ b/model/src/wmesmfmd.F90
@@ -187,7 +187,7 @@
 !/
 !/ Public module methods
 !/
-      public SetServices
+      public SetServices, SetVM
 !/
 !/ Private module parameters
 !/
@@ -770,6 +770,34 @@
           if (verbosity.gt.0) then
             write(logmsg,*) flds_scalar_index_ny
             call ESMF_LogWrite(trim(cname)//': flds_scalar_index_ny = '// &
+              trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+            if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          end if
+        end if
+
+        call NUOPC_CompAttributeGet(gcomp, name="mask_value_water", &
+          value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        if (isPresent .and. isSet) then
+          maskvaluewater = ESMF_UtilString2Int(cvalue, rc=rc)
+          if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          if (verbosity.gt.0) then
+            write(logmsg,*) maskvaluewater
+            call ESMF_LogWrite(trim(cname)//': mask_value_water = '// &
+              trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
+            if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          end if
+        end if
+
+        call NUOPC_CompAttributeGet(gcomp, name="mask_value_land", &
+          value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+        if (ESMF_LogFoundError(rc, PASSTHRU)) return
+        if (isPresent .and. isSet) then
+          maskvalueland = ESMF_UtilString2Int(cvalue, rc=rc)
+          if (ESMF_LogFoundError(rc, PASSTHRU)) return
+          if (verbosity.gt.0) then
+            write(logmsg,*) maskvalueland
+            call ESMF_LogWrite(trim(cname)//': mask_value_land = '// &
               trim(logmsg), ESMF_LOGMSG_INFO, rc=rc)
             if (ESMF_LogFoundError(rc, PASSTHRU)) return
           end if

--- a/model/src/wmesmfmd.F90
+++ b/model/src/wmesmfmd.F90
@@ -187,7 +187,7 @@
 !/
 !/ Public module methods
 !/
-      public SetServices, SetVM
+      public SetServices
 !/
 !/ Private module parameters
 !/


### PR DESCRIPTION
# Pull Request Summary

- Retrieves mask_value_water and `mask_value_land` if present in nems.configure and `med_present` is true.

## Description
Currently, when used in UWM, wmesmf sets the import and export mask values for the grid from the default values.

```
! --- Default Mask Convention for import/export fields
      INTEGER, PARAMETER :: DEFAULT_MASK_WATER =  0
      INTEGER, PARAMETER :: DEFAULT_MASK_LAND  =  1
```

These values are opposite the normal interpretation and CMEPS is then forced to set the dstMaskValue and srcMaskValues used for RH creation opposite to their normal sense. In med_map_mod, the currently used values in CMEPS for HAFS are (``n1`` is the source side and ``n2`` is the destination side)

```
       elseif (n1 == compatm .and. n2 == compwav) then
          dstMaskValue = 1
       elseif (n1 == compwav .and. n2 == compatm) then
          srcMaskValue = 1
          dstMaskValue = ispval_mask
       endif
```

Both the ``dstMaskValue`` when the destination is compwav and the ``srcMaskValue`` when compwav is the source are reversed. That is, the dstMaskValue should indicate where the wave grid is masked when it is the destination. It should be 0 (ie, don't interpolate to the land points). The srcMaskValue should indicate what points to ignore when wave is the source. It should be  0 (ie, don't interpolate from land points on the wave grid). 


When HAFS is switched to the new cap, the mask values will be set with the correct interpretation for CMEPS. A PR for CMEPS [# 266](https://github.com/ESCOMP/CMEPS/pull/266) is the first step in implementing the new wave cap in UWM. In order for the existing cap to continue to work for HAFS, it is required to allow non-default mask values to be set from nems.configure:

```
  mask_value_water = 1
  mask_value_land = 0
```

These will be consistent with the ``dstMaskValue`` and ``srcMaskValue`` used by CMEPS. 

These configuration variables will not be added to the HAFS nems.configure in UWM until CMEPS is also updated.


- related to, but does not close, https://github.com/ufs-community/ufs-weather-model/issues/739. 
   This PR allows the current wmesmf cap to continue to function for UFS HAFS apps during the transition to a CMEPS cap for both S2SW and HAFS. 

authors: @DeniseWorthen  
### Commit Message

- Retrieve mask_value_water and mask_value_land if present in nems.configure and med_present is true.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [N/A ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [N/A] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? run regtests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) NA
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, On Hera using intel compiler
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    
* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7922310/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7922311/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7922312/matrixDiff.txt)

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (5 files differ)
ww3_ufs1.1/./work_d                     (0 files differ)
ww3_ufs1.2/./work_b                     (0 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)


```
