### PR TITLE
wmesmfmd: init tauwx/y

### DIFF
--- a/model/src/wmesmfmd.F90
+++ b/model/src/wmesmfmd.F90
@@ -6192,6 +6192,8 @@
             llws(:) = .true.
             ustar = zero
             ustdr = zero
+            tauwx = zero
+            tauwy = zero
             call w3spr3( va(:,jsea), cg(1:nk,isea), wn(1:nk,isea),   &
                          emean, fmean, fmean1, wnmean, amax,         &
                          u10(isea), u10d(isea), ustar, ustdr, tauwx, &
@@ -6201,6 +6203,8 @@
             llws(:) = .true.
             ustar = zero
             ustdr = zero
+            tauwx = zero
+            tauwy = zero
             call w3spr4( va(:,jsea), cg(1:nk,isea), wn(1:nk,isea),   &
                          emean, fmean, fmean1, wnmean, amax,         &
                          u10(isea), u10d(isea), ustar, ustdr, tauwx, &
@@ -6332,6 +6336,8 @@
               llws(:) = .true.
               ustar = zero
               ustdr = zero
+              tauwx = zero
+              tauwy = zero
               call w3spr3( va(:,jsea), cg(1:nk,isea), wn(1:nk,isea),   &
                            emean, fmean, fmean1, wnmean, amax,         &
                            u10(isea), u10d(isea), ustar, ustdr, tauwx, &
@@ -6341,6 +6347,8 @@
               llws(:) = .true.
               ustar = zero
               ustdr = zero
+              tauwx = zero
+              tauwy = zero
               call w3spr4( va(:,jsea), cg(1:nk,isea), wn(1:nk,isea),   &
                            emean, fmean, fmean1, wnmean, amax,         &
                            u10(isea), u10d(isea), ustar, ustdr, tauwx, &


### PR DESCRIPTION
# Pull Request Summary
Initializes variables `tauwx`, `tauwy` in the ESMF cap.


## Description
Provide a detailed description of what this PR does.
* The local variables `tauwx`, `tauwy` in the subroutines `CalcRoughl( )` and `CalcCharnk( )` of module `wmesmfmd` are  initialized to zero.  These initializations occur in one place for switch `SW3` and one for `SW4`.  Both are enclosed in an if-block for the first time through the routine, and looped over for all seapoints, `jsea`. 


What bug does it fix, or what feature does it add?
* It fixes the bug of using the variable `tauwx` and `tauwy` values before they have been initialized.  In both `CalcCharnk( )` and `CalcRoughl( )` they are declared local variables and then passed into subroutines `W3SPR3` and `W3SPR4`.  In each case they are `INTENT(in)` input parameters  (for `W3SPR3` and `W3SPR4`) whose values are used in the statement `TAUW = SQRT(TAUWX**2+TAUWY**2)`, without a prior assignment statement.


Is a change of answers expected from this PR?
* Within WW3 the answers will not change because the edits are restricted to the ESMF cap, `wmesmfmd.F90`.  So no changes to any regtests since `wmesmfmd` is never called.  The code in question is executed when WW3 is used as a component in an ESMF application (ex., UFS).  Running the UFS S2SW app RT `cpld_control_p8` on Hera with the Intel compiler the uninitialized values were found to be set to a value very  close, but not equal to, zero. So in this case answers are not expected to change.  However using within ESMF for different machines/compilers, answer changes couldn't be ruled out. If there are answer changes though then it is a good step because previous answers would have been based on uninitialized values.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * Note:  in an offline conversation @aliabdolali was curious about potential other calls to `W3SPR3` and `W3SPR4`.  There were a handful of other occurrences, all of them initialized tauwx, tauwy to zero in the outer routine.  From this we know there aren't other calls out there needing to initialize tauwx,tauwy, and also that we are doing it in the correct place (vs. moving the initialization within W3SPR3/4).

* Mention any labels that should be added:  
  * _bug_ .

* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply.
  * No.

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
  * Addresses #525, and originating issue [UFS \#225](https://github.com/ufs-community/ufs-weather-model/issues/229), though an additional fix is needed to close them.



### Commit Message
wmesmfmd:  init tauwx,tauwy

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * **UFS**
    * ran all WAV compiles in the RT suite (S2SW, HAFSW, ATMW), with DEBUG=OFF.  All tests passed.
    * ran `cpld_control_p8` RT with DEBUG=ON.  I was able to successfully complete simulations, and create/match a baseline, though not 100% of the time.  This fix is necessary for running in Debug Mode under UFS, but likely an additional fix is needed as well.
  * **WW3**
    * ran the full matrix for develop and fix.  Only the expected differences.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No, the ESMF cap is not called during any WW3 regtest.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  Hera / Intel.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    
  * [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/7937534/matrixCompSummary.txt)
  * [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/7937537/matrixCompFull.txt)
  * [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/7937538/matrixDiff.txt)

* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
  * No expected changes outside of the known list. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```bash                                                                                                                                         
**********************************************************************         
********************* non-identical cases ****************************         
**********************************************************************         
mww3_test_03/./work_PR2_UQ_MPI_d2                     (8 files differ)         
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (8 files differ)      
mww3_test_03/./work_PR3_UNO_MPI_d2                     (10 files differ)       
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)        
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)            
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)       
mww3_test_03/./work_PR3_UQ_MPI_d2                     (8 files differ)         
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)                
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)                
ww3_ufs1.1/./work_d                     (0 files differ)                       
ww3_ufs1.2/./work_b                     (0 files differ)                       
ww3_ufs1.3/./work_a                     (1 files differ)                                
**********************************************************************         
************************ identical cases *****************************         
**********************************************************************
```
