### PR TITLE
non interactive ww3_from_ftp.sh 

### DIFF
--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -10,13 +10,28 @@ curr_dir=`pwd`
 # Set WW3 code version
 ww3ver=v7.12.6
 
-interactive='y'
-if [ $# -eq 3 ] ; then
-  interactive='n'
-  ww3dir=$1  # [ '../../']
-  wnew=$2    # ['y']
-  wnew2=$3   # ['y']
+interactive='n'
+keep='n'
+if [ $# -eq 1 ] ; then
+  if [ "$1" = "-i" ] ; then
+    interactive='y'
+  elif [ "$1" = "-k" ] ; then
+    keep='y'
+  else
+    echo '[ERROR] input argument not recognized'
+    echo '        use -i for interactive mode'
+    echo '        use -k to keep tar files'
+    exit 1
+  fi
+elif [ $# -gt 1 ] ; then
+  echo '[ERROR] only one input argument accepted'
+  echo '        use -i for interactive mode'
+  echo '        use -k to keep tar files'
+  exit 1
 fi
+
+model_dir=$(cd $(dirname $(dirname $0)) > /dev/null && pwd -P)
+echo $model_dir
 
 #Get top level directory of ww3 from user: 
 echo -e "\n\n This script will download data from the ftp for WAVEWATCH III "
@@ -25,13 +40,13 @@ echo -e "be '../../' if in the model/bin directory or '.' if already in the "
 echo -e "top/main directory:"
 if [ "$interactive" = "n" ]
 then
-  echo $ww3dir
+  echo $model_dir
 else
-  read ww3dir 
+  read model_dir 
 fi
 
 #Move to top level directory of ww3: 
-cd $ww3dir 
+cd $model_dir 
 
 #Download from ftp and uptar: 
 echo -e "Downloading and untaring file from ftp:" 
@@ -75,11 +90,11 @@ cp -r data_regtests/ww3_ufs1.3/input/*nc   regtests/ww3_ufs1.3/input/
 echo -e "\n\n Do you want to delete the tar file ww3_from_ftp.${ww3ver}.tar.gz [y|n]: "
 if [ "$interactive" = "n" ]
 then
-  echo $wnew
+  echo $keep
 else
-  read wnew
+  read keep
 fi
-if [ "${wnew}" = "Y" ] || [ "${wnew}" = "y" ]
+if [ "${keep}" = "Y" ] || [ "${keep}" = "y" ]
 then
   echo -e '\n Deleting tar file ww3_from_ftp.${ww3ver}.tar.gz'
   rm ww3_from_ftp.${ww3ver}.tar.gz
@@ -91,11 +106,11 @@ echo -e "\n\n Files were copied from the data_regtests to the regtests folder."
 echo -e "Do you want to delete the data_regtests folder? [y|n]: "
 if [ "$interactive" = "n" ]
 then
-  echo $wnew2
+  echo $keep
 else
-  read wnew2
+  read keep
 fi
-if [ "${wnew2}" = "Y" ] || [ "${wnew2}" = "y" ]
+if [ "${keep}" = "Y" ] || [ "${keep}" = "y" ]
 then
   echo -e '\n Deleting the data_regtests folder'
   rm -rf data_regtests

--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -43,23 +43,23 @@ elif [ $# -gt 1 ] ; then
   exit 1
 fi
 
-model_dir=$(cd $(dirname $(dirname $0)) > /dev/null && pwd -P)
-echo $model_dir
-
+dir0=$(cd $(dirname $0) > /dev/null && pwd -P)
+ww3dir=$(dirname $(dirname $dir0))
+ 
 #Get top level directory of ww3 from user: 
 echo -e "\n\n This script will download data from the ftp for WAVEWATCH III "
 if [ "$interactive" = "n" ]
 then
-  echo $model_dir
+  echo $ww3dir
 else
-echo -e "Enter the absolute or relative path to the model directory, "
+echo -e "Enter the absolute or relative path to the main/top directory, "
 echo -e "this would be '../../' if in the model/bin directory "
 echo -e "or './' if already in the top/main directory:"
-  read model_dir 
+  read ww3dir 
 fi
 
 #Move to top level directory of ww3: 
-cd $model_dir 
+cd $ww3dir 
 
 #Download from ftp and uptar: 
 echo -e "Downloading and untaring file from ftp:" 
@@ -107,7 +107,7 @@ then
 else
   read keep
 fi
-if [ "${keep}" = "Y" ] || [ "${keep}" = "y" ]
+if [ "${keep}" = "N" ] || [ "${keep}" = "n" ]
 then
   echo -e '\n Deleting tar file ww3_from_ftp.${ww3ver}.tar.gz'
   rm ww3_from_ftp.${ww3ver}.tar.gz
@@ -123,7 +123,7 @@ then
 else
   read keep
 fi
-if [ "${keep}" = "Y" ] || [ "${keep}" = "y" ]
+if [ "${keep}" = "N" ] || [ "${keep}" = "n" ]
 then
   echo -e '\n Deleting the data_regtests folder'
   rm -rf data_regtests

--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # --------------------------------------------------------------------------- #
 #                                                                             #
 # Script for downloading data from ftp                                        #
@@ -10,19 +10,32 @@ curr_dir=`pwd`
 # Set WW3 code version
 ww3ver=v7.12.6
 
+interactive='y'
+if [ $# -eq 3 ] ; then
+  interactive='n'
+  ww3dir=$1  # [ '../../']
+  wnew=$2    # ['y']
+  wnew2=$3   # ['y']
+fi
+
 #Get top level directory of ww3 from user: 
 echo -e "\n\n This script will download data from the ftp for WAVEWATCH III "
 echo -e "Enter the relative path to the main/top level directory, this would "
 echo -e "be '../../' if in the model/bin directory or '.' if already in the "
 echo -e "top/main directory:"
-read ww3dir 
+if [ "$interactive" = "n" ]
+then
+  echo $ww3dir
+else
+  read ww3dir 
+fi
 
 #Move to top level directory of ww3: 
 cd $ww3dir 
 
 #Download from ftp and uptar: 
 echo -e "Downloading and untaring file from ftp:" 
-wget https://ftp.emc.ncep.noaa.gov/static_files/public/WW3/ww3_from_ftp.${ww3ver}.tar.gz
+wget --no-check-certificate https://ftp.emc.ncep.noaa.gov/static_files/public/WW3/ww3_from_ftp.${ww3ver}.tar.gz
 tar -xvzf ww3_from_ftp.${ww3ver}.tar.gz
 
 #Move regtest info from data_regtests to regtests:
@@ -60,7 +73,12 @@ cp -r data_regtests/ww3_ufs1.2/input/*     regtests/ww3_ufs1.2/input/
 cp -r data_regtests/ww3_ufs1.3/input/*nc   regtests/ww3_ufs1.3/input/
 #Do you want to clean up (aka delete tar file, delete the data_regtests directory) 
 echo -e "\n\n Do you want to delete the tar file ww3_from_ftp.${ww3ver}.tar.gz [y|n]: "
-read wnew
+if [ "$interactive" = "n" ]
+then
+  echo $wnew
+else
+  read wnew
+fi
 if [ "${wnew}" = "Y" ] || [ "${wnew}" = "y" ]
 then
   echo -e '\n Deleting tar file ww3_from_ftp.${ww3ver}.tar.gz'
@@ -71,7 +89,12 @@ fi
 
 echo -e "\n\n Files were copied from the data_regtests to the regtests folder."
 echo -e "Do you want to delete the data_regtests folder? [y|n]: "
-read wnew2
+if [ "$interactive" = "n" ]
+then
+  echo $wnew2
+else
+  read wnew2
+fi
 if [ "${wnew2}" = "Y" ] || [ "${wnew2}" = "y" ]
 then
   echo -e '\n Deleting the data_regtests folder'

--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -5,6 +5,18 @@
 #                                                    Created 0ct 10, 2017     #
 # --------------------------------------------------------------------------- #
 
+usage()
+{
+    echo ''
+    echo ' Usage : ./ww3_from_ftp.sh [options]'
+    echo ''
+    echo ' Options : '
+    echo '           -h : print usage'
+    echo '           -i : interactive mode'
+    echo '           -k : keep tar files'
+    echo ''
+}
+
 curr_dir=`pwd`
 
 # Set WW3 code version
@@ -13,20 +25,21 @@ ww3ver=v7.12.6
 interactive='n'
 keep='n'
 if [ $# -eq 1 ] ; then
-  if [ "$1" = "-i" ] ; then
+  if [ "$1" = "-h" ] ; then
+    usage
+    exit 0
+  elif [ "$1" = "-i" ] ; then
     interactive='y'
   elif [ "$1" = "-k" ] ; then
     keep='y'
   else
     echo '[ERROR] input argument not recognized'
-    echo '        use -i for interactive mode'
-    echo '        use -k to keep tar files'
+    usage
     exit 1
   fi
 elif [ $# -gt 1 ] ; then
   echo '[ERROR] only one input argument accepted'
-  echo '        use -i for interactive mode'
-  echo '        use -k to keep tar files'
+  usage
   exit 1
 fi
 

--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -35,13 +35,13 @@ echo $model_dir
 
 #Get top level directory of ww3 from user: 
 echo -e "\n\n This script will download data from the ftp for WAVEWATCH III "
-echo -e "Enter the relative path to the main/top level directory, this would "
-echo -e "be '../../' if in the model/bin directory or '.' if already in the "
-echo -e "top/main directory:"
 if [ "$interactive" = "n" ]
 then
   echo $model_dir
 else
+echo -e "Enter the absolute or relative path to the model directory, "
+echo -e "this would be '../../' if in the model/bin directory "
+echo -e "or './' if already in the top/main directory:"
   read model_dir 
 fi
 


### PR DESCRIPTION
# Pull Request Summary
change default behavior to automatically download tar files and detect main directory
add options : 
   -h : print usage
   -i : interactive mode
   -k : keep tar files

add download option --no-check-certificate

## Description
solve issue #578 
the new way to use it is to add arguments in the command line : 
`cd WW3/model/bin/ww3_from_ftp.sh`

### Issue(s) addressed
fixes #578 

### Commit Message
non interactive ww3_from_ftp.sh 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [X] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [X] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
by running the bash script itself

