### PR TITLE
Doc/doxygen no errors

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2151,7 +2151,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # C-preprocessor directives found in the sources and include files.
 # The default value is: YES.
 
-ENABLE_PREPROCESSING   = YES
+ENABLE_PREPROCESSING   = NO
 
 # If the MACRO_EXPANSION tag is set to YES, doxygen will expand all macro names
 # in the source code. If set to NO, only conditional compilation will be

--- a/model/src/w3idatmd.F90
+++ b/model/src/w3idatmd.F90
@@ -155,34 +155,64 @@
 !/
 !/ Data structure INPUT
 !/
-      TYPE INPUT
-        INTEGER               :: TFN(2,-7:10), TC0(2), TW0(2),        &
-                                 TU0(2), TR0(2), TDN(2), TG0(2)
-        REAL                  :: GA0, GD0, GAN, GDN
+      TYPE, PUBLIC :: INPUT
+         INTEGER               :: TFN(2,-7:10)
+         INTEGER               :: TC0(2)
+         INTEGER               :: TW0(2)
+         INTEGER               :: TU0(2)
+         INTEGER               :: TR0(2)
+         INTEGER               :: TDN(2)
+         INTEGER               :: TG0(2)
+         REAL                  :: GA0
+         REAL                  :: GD0
+         REAL                  :: GAN
+         REAL                  :: GDN
 #ifdef W3_WRST
-        REAL, POINTER         :: WXNwrst(:,:),WYNwrst(:,:)
+         REAL, POINTER         :: WXNwrst(:,:)
+         REAL, POINTER         :: WYNwrst(:,:)
 #endif
-        REAL, POINTER         :: WX0(:,:), WY0(:,:), DT0(:,:),        &
-                                 WXN(:,:), WYN(:,:), DTN(:,:),        &
-                                 CX0(:,:), CY0(:,:), CXN(:,:),        &
-                                 CYN(:,:), WLEV(:,:), ICEI(:,:),      &
-                                 UX0(:,:), UY0(:,:), UXN(:,:),        &
-                                 UYN(:,:), RH0(:,:), RHN(:,:),        &
-                                 BERGI(:,:), MUDT(:,:), MUDV(:,:),    &
-                                 MUDD(:,:), ICEP1(:,:), ICEP2(:,:),   &
-                                 ICEP3(:,:), ICEP4(:,:), ICEP5(:,:)
+         REAL, POINTER         :: WX0(:,:)
+         REAL, POINTER         :: WY0(:,:)
+         REAL, POINTER         :: DT0(:,:)
+         REAL, POINTER         :: WXN(:,:)
+         REAL, POINTER         :: WYN(:,:)
+         REAL, POINTER         :: DTN(:,:)
+         REAL, POINTER         :: CX0(:,:)
+         REAL, POINTER         :: CY0(:,:)
+         REAL, POINTER         :: CXN(:,:)
+         REAL, POINTER         :: CYN(:,:)
+         REAL, POINTER         :: WLEV(:,:)
+         REAL, POINTER         :: ICEI(:,:)
+         REAL, POINTER         :: UX0(:,:)
+         REAL, POINTER         :: UY0(:,:)
+         REAL, POINTER         :: UXN(:,:)
+         REAL, POINTER         :: UYN(:,:)
+         REAL, POINTER         :: RH0(:,:)
+         REAL, POINTER         :: RHN(:,:)
+         REAL, POINTER         :: BERGI(:,:)
+         REAL, POINTER         :: MUDT(:,:)
+         REAL, POINTER         :: MUDV(:,:)
+         REAL, POINTER         :: MUDD(:,:)
+         REAL, POINTER         :: ICEP1(:,:)
+         REAL, POINTER         :: ICEP2(:,:)
+         REAL, POINTER         :: ICEP3(:,:)
+         REAL, POINTER         :: ICEP4(:,:)
+         REAL, POINTER         :: ICEP5(:,:)
+                                 
 #ifdef W3_TIDE
- REAL, POINTER         ::  CXTIDE(:,:,:,:), CYTIDE(:,:,:,:),    &
-                           WLTIDE(:,:,:,:)
+         REAL, POINTER         :: CXTIDE(:,:,:,:)
+         REAL, POINTER         :: CYTIDE(:,:,:,:)
+         REAL, POINTER         :: WLTIDE(:,:,:,:)
 #endif
-        LOGICAL               :: IINIT
+         LOGICAL               :: IINIT
 #ifdef W3_WRST
-        LOGICAL               :: WRSTIINIT=.FALSE.
+         LOGICAL               :: WRSTIINIT=.FALSE.
 #endif
 ! note that if size of INFLAGS1 is changed, then TFLAGS in wminitmd.ftn
 !    also must be resized.
-        LOGICAL               :: INFLAGS1(-7:14), FLAGSC(-7:14),      &
-                                 INFLAGS2(-7:14)
+         LOGICAL               :: INFLAGS1(-7:14)
+         LOGICAL               :: FLAGSC(-7:14)
+         LOGICAL               :: INFLAGS2(-7:14)
       END TYPE INPUT
 !/
 !/ Data storage


### PR DESCRIPTION
# Pull Request Summary
Fixes the existing doxygen errors prior to submitting doxygen marked-up code.

## Description
Doxygen scans and generates some amount of documentation for code even without adding doxygen markup to it.  It's possible for legal code to cause the doxygen parser to become confused and produce an error.  It was suggested by @edwardhartnett to remove all errors from a code base, then going forward require all submissions to be doxygen-error free.  This PR removes the remaining doxygen errors in the code base.  

Please also include the following information: 
* Add any suggestions for a reviewer 
  * N/A. 
* Mention any labels that should be added:  
  *  _documentation_.
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply:
  * No answers are expected to change.  There were edits to the source code, but only to express the same statements in a slightly different way to satisfy the doxygen parser.  The meaning of both expressions is identical. 

### Issue(s) addressed
N/A.

### Commit Message
doxygen:  remove existing doxygen errors prior to markup

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * The full matrix was run against current develop.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No.  The changes are for documentation purposes, not functionality. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  hera.intel. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_): 
  * [matrixCompSummary(1).txt](https://github.com/NOAA-EMC/WW3/files/8064458/matrixCompSummary.1.txt)
  * [matrixCompFull(1).txt](https://github.com/NOAA-EMC/WW3/files/8064460/matrixCompFull.1.txt)
  * [matrixDiff(1).txt](https://github.com/NOAA-EMC/WW3/files/8064461/matrixDiff.1.txt)

* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
  * Only entries in the list of known non-identical cases.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```bash
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (5 files differ)
ww3_ufs1.1/./work_d                     (0 files differ)
ww3_ufs1.2/./work_b                     (0 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```
