### PR TITLE
Clear flags that come from UFS when building as submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ project(
   VERSION ${pVersion}
   LANGUAGES C Fortran)
 
+get_directory_property(hasParent PARENT_DIRECTORY)
+if(hasParent)
+  # Unset flags that come from UFS because they (-r8/-r4) conflict
+  # with Ww3
+  set(CMAKE_Fortran_FLAGS "")
+  set(CMAKE_C_FLAGS "")
+endif()
+
 set(MULTI_ESMF OFF CACHE BOOL "Build ww3_multi_esmf library")
 set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
 

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -159,10 +159,13 @@ if("TIDE" IN_LIST switches)
   list(APPEND programs ww3_prtide)
 endif()
 
-foreach(program ${programs})
-  add_executable(${program} ${program}.F90)
-  target_link_libraries(${program} PRIVATE ww3_lib)
-endforeach()
+# Executables are not needed when building ww3_multi_esmf library
+if(NOT MULTI_ESMF)
+  foreach(program ${programs})
+    add_executable(${program} ${program}.F90)
+    target_link_libraries(${program} PRIVATE ww3_lib)
+  endforeach()
+endif()
 
 install(
   TARGETS ${programs} ww3_lib

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -89,17 +89,6 @@ if("OASIS" IN_LIST switches)
   target_link_libraries(ww3_lib PUBLIC OASIS::OASIS)
 endif()
 
-if(MULTI_ESMF)
-  # Don't search for ESMF if target already exists (when build WW3 as UFS submodule)
-  if (NOT TARGET esmf)
-    find_package(ESMF MODULE REQUIRED)
-  endif()
-  
-  target_sources(ww3_lib PRIVATE wmesmfmd.F90)
-  target_link_libraries(ww3_lib PUBLIC esmf)
-  set_target_properties(ww3_lib PROPERTIES OUTPUT_NAME "ww3_multi_esmf")
-endif() 
-
 if(NETCDF)
   find_package(NetCDF REQUIRED COMPONENTS Fortran)
 endif()
@@ -109,6 +98,19 @@ if(NetCDF_Fortran_FOUND)
   target_link_libraries(ww3_lib PUBLIC NetCDF::NetCDF_Fortran)
   list(APPEND programs ${netcdf_programs})
 endif()
+
+if(MULTI_ESMF)
+  # Don't search for ESMF if target already exists (when build WW3 as UFS submodule)
+  if (NOT TARGET esmf)
+    find_package(ESMF MODULE REQUIRED)
+  endif()
+  
+  target_sources(ww3_lib PRIVATE wmesmfmd.F90)
+  target_link_libraries(ww3_lib PUBLIC esmf)
+  set_target_properties(ww3_lib PROPERTIES OUTPUT_NAME "ww3_multi_esmf")
+  # Don't build executables when building WW3 ESMF library
+  set(programs "")
+endif() 
 
 set_property(SOURCE w3initmd.F90
   APPEND
@@ -160,12 +162,10 @@ if("TIDE" IN_LIST switches)
 endif()
 
 # Executables are not needed when building ww3_multi_esmf library
-if(NOT MULTI_ESMF)
-  foreach(program ${programs})
-    add_executable(${program} ${program}.F90)
-    target_link_libraries(${program} PRIVATE ww3_lib)
-  endforeach()
-endif()
+foreach(program ${programs})
+  add_executable(${program} ${program}.F90)
+  target_link_libraries(${program} PRIVATE ww3_lib)
+endforeach()
 
 install(
   TARGETS ${programs} ww3_lib


### PR DESCRIPTION
# Pull Request Summary
Fix ufs-weather-model integration with CMake build

## Description
Conflicting flags from UFS would enter WW3 build. Check if building as subdirectory and then clear CMAKE_Fortran_FLAGS

### Issue(s) addressed
Fix #627 

### Commit Message
```
Clear flags that come from UFS when building as submodule

Conflicting flags from UFS would enter WW3 build. Check if building as subdirectory and then clear CMAKE_<lang>_FLAGS
```

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

@JessicaMeixner-NOAA tested the fix by running UFS wave tests

