### PR TITLE
Fix Github Action builds

### DIFF
--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -2,7 +2,7 @@ name: GNU Linux Build
 on: [push, pull_request]
 
 env:
-  cache_key: gnu3
+  cache_key: gnu4
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10
@@ -44,7 +44,7 @@ jobs:
           spack env create ww3-gnu ww3/model/ci/spack.yaml
           spack env activate ww3-gnu
           spack compiler find
-          spack external find m4 cmake pkgconf openssl
+          spack external find
           spack add mpich@3.4.2
           spack concretize
           spack install --dirty -v
@@ -55,11 +55,12 @@ jobs:
           source spack/share/spack/setup-env.sh
           spack env activate ww3-gnu
           export WWATCH3_DIR=${GITHUB_WORKSPACE}/ww3/model
+          export OASIS_INPUT_PATH=${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/oasis3-mct
+          export OASIS_WORK_PATH=${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/work_oasis3-mct
           cd ww3/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir
-          mkdir build && cd build
-          cmake ..
+          cmake .
           make VERBOSE=1
-          cp -r ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/work_oasis3-mct ${GITHUB_WORKSPACE}
+          cp -r ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/work_oasis3-mct ${GITHUB_WORKSPACE}
 
   build:
     needs: setup

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -9,7 +9,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel4
+  cache_key: intel5
   CC: icc
   FC: ifort
   CXX: icpc
@@ -64,7 +64,7 @@ jobs:
           spack env create ww3-intel ww3/model/ci/spack.yaml
           spack env activate ww3-intel
           spack compiler find
-          spack external find m4 cmake pkgconf openssl
+          spack external find
           spack add intel-oneapi-mpi
           spack concretize
           spack install --dirty -v
@@ -75,11 +75,12 @@ jobs:
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel
           export WWATCH3_DIR=${GITHUB_WORKSPACE}/ww3/model
+          export OASIS_INPUT_PATH=${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/oasis3-mct
+          export OASIS_WORK_PATH=${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/work_oasis3-mct
           cd ww3/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir
-          mkdir build && cd build
-          cmake ..
+          cmake .
           make
-          cp -r ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/work_oasis3-mct ${GITHUB_WORKSPACE}
+          cp -r ${GITHUB_WORKSPACE}/ww3/regtests/ww3_tp2.14/input/work_oasis3-mct ${GITHUB_WORKSPACE}
 
   build:
     needs: setup

--- a/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/make.inc
+++ b/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/make.inc
@@ -10,6 +10,6 @@
 # Note: Choose one of these includes files and modify it according to your
 #       local settings. Replace the currently active file with your own.
 #
-include  <oasis_input_path>/util/make_dir/cmplr
+include  $(OASIS_INPUT_PATH)/util/make_dir/cmplr
 #
 ### End User configurable options ###

--- a/regtests/ww3_tp2.14/input/toy/Makefile
+++ b/regtests/ww3_tp2.14/input/toy/Makefile
@@ -1,5 +1,5 @@
 #
-include <oasis_input_path>/util/make_dir/make.inc
+include $(OASIS_INPUT_PATH)/util/make_dir/make.inc
 #
 LIBPSMILE = $(ARCHDIR)/lib/libpsmile.${CHAN}.a $(ARCHDIR)/lib/libmct.a $(ARCHDIR)/lib/libmpeu.a $(ARCHDIR)/lib/libscrip.a
 #

--- a/regtests/ww3_tp2.14/input_oasacm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasacm2/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm2/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasacm4/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm4/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasacm5/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm5/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasacm6/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm6/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasicm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasicm/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out

--- a/regtests/ww3_tp2.14/input_oasocm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasocm/prep_env.sh
@@ -34,7 +34,6 @@ echo '   Setup oasis cmplr file'
 cd $path_w/oasis3-mct/util/make_dir
 
 echo '   setup oasis make.inc file'
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" make.inc.tmpl > make.inc
 
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
@@ -44,8 +43,6 @@ make
 
 echo '   setup toy Makefile'
 cd $path_w/toy
-sed -e "s:<oasis_input_path>:$path_w/oasis3-mct:" Makefile.tmpl > Makefile
-
 
 echo '   compile toy model'
 make clean > $path_w/toy_clean.out


### PR DESCRIPTION
# Pull Request Summary

Fix Github Action builds. The OASIS directory layout changed and the workflows had to be updated.

## Description
The OASIS directory layout changed and the workflows had to be updated. Instead of using sed to find and replace the values in the makefile, use the environment variables directly. 

@JessicaMeixner-NOAA @mickaelaccensi 

### Issue(s) addressed

Fix #631 

### Commit Message

Single commit that doesn't need to be squashed

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

The Actions complete successfully. See https://github.com/kgerheiser/WW3/actions/runs/1911148044

