### PR TITLE
Fix/add o all

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -48,7 +48,6 @@ main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
 
   cmplr=intel
   export cmplOption='y'
-  export o_opt='y'
 
   #Module Versions from HPC-Stack that are common for all platforms 
   modnetcdf='netcdf/4.7.4'
@@ -163,25 +162,19 @@ main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
     export  mpi='mpirun'
   fi
 
-# output option
-  if [ "$o_opt" = 'y' ]
-  then
-     opt="-o all"
-  fi
-
 # Compile option
   if [ "$cmplOption" = 'y' ]
   then
-     opt="-c $cmplr -S -T $opt"
+     opt="-o all -c $cmplr -S -T"
   else
-     opt="-S $opt"
+     opt="-o all -S"
   fi
+
 # Batch queue option
   if [ "$batchq" = 'slurm' ]
   then
      opt="-b $batchq $opt"
   fi
-
 
 # Base run_test command line
   export rtst="./bin/run_cmake_test $opt"

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -48,6 +48,7 @@ main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
 
   cmplr=intel
   export cmplOption='y'
+  export o_opt='y'
 
   #Module Versions from HPC-Stack that are common for all platforms 
   modnetcdf='netcdf/4.7.4'
@@ -162,18 +163,25 @@ main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
     export  mpi='mpirun'
   fi
 
+# output option
+  if [ "$o_opt" = 'y' ]
+  then
+     opt="-o all"
+  fi
+
 # Compile option
   if [ "$cmplOption" = 'y' ]
   then
-     opt="-c $cmplr -S -T"
+     opt="-c $cmplr -S -T $opt"
   else
-     opt="-S"
+     opt="-S $opt"
   fi
 # Batch queue option
   if [ "$batchq" = 'slurm' ]
   then
      opt="-b $batchq $opt"
   fi
+
 
 # Base run_test command line
   export rtst="./bin/run_cmake_test $opt"

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -406,7 +406,7 @@ then
   if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ; 
   then 
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
-                  sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' \
+                  sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
                   sed 's/B4B //' > $path_build/switch
   else 


### PR DESCRIPTION
# Pull Request Summary
add `-o all` to matrix*ncep

## Description
The -o all option was supposed to be brought to the matrix files, but was not put in matrix*ncep or unintentionally dropped.

Please also include the following information: 
* Add any suggestions for a reviewer @JessicaMeixner-NOAA 

### Issue(s) addressed

* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #643
- closes #643


### Commit Message
add -o all option to matrix_cmake_ncep

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? to be updated
* Are the changes covered by regression tests? n/a
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Hera/intel
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):  to be updated
* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
to be updated

