### PR TITLE
Cmake run_test and debug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,11 @@ project(
 
 get_directory_property(hasParent PARENT_DIRECTORY)
 if(hasParent)
-  # Unset flags that come from UFS because they (-r8/-r4) conflict
-  # with Ww3
+  # Unset flags that come from Parent (ie UFS or other coupled build) 
+  # for potential (-r8/-r4) conflict
   set(CMAKE_Fortran_FLAGS "")
   set(CMAKE_C_FLAGS "")
+  remove_definitions(-DDEBUG)
 endif()
 
 set(MULTI_ESMF OFF CACHE BOOL "Build ww3_multi_esmf library")

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -367,6 +367,15 @@ fi
 
 mkdir -p $path_w
 
+cd $path_w
+
+if [ $stub ] && [ -f finished ]
+then
+  echo " Test already finished, skipping ..."
+  echo ' '
+  exit 0
+fi
+
 if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
 then
   ww3_dir=${path_s}/..
@@ -406,7 +415,7 @@ then
   if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ; 
   then 
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
-                  sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' \
+                  sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
                   sed 's/B4B //' > $path_build/switch
   else 
@@ -546,13 +555,6 @@ echo ' '
 echo " Input directory: $path_i"
 echo " Switch file: $file_c"
 echo ' '
-
-if [ $stub ] && [ -f finished ]
-then
-  echo " Test already finished, skipping ..."
-  echo ' '
-  exit 0
-fi
 
 # 3.b2 Preprocess cdl files into nc files ----------------------------------- #
 


### PR DESCRIPTION
# Pull Request Summary
This provides a bug fix for CMAKE debug option when running with ufs-weather-model and makes sure when you are running with the -S option that run_cmake_test exists before building the code. 

## Description
Updates for cmake: 
* Fix from @kgerheiser for making sure CMAKE debug flags are cleared when WW3 is built from a parent repo, such as the ufs-weather-model 
* bug fix for run_cmake_test so that you will exit out before building the model if the -S option is used and the test has already been completed.  This will make any resubmission of matrix regression tests significantly faster and was an oversight in the creation of run_cmake_test

### Issue(s) addressed
-fixes #646

### Commit Message

Update run_cmake test to exit if test is completed before building and clear debug flags in cmake if built from a parent repo. 

co-author: @kgerheiser 

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? The ufs-weather-model was run for the debug fix and then I ran the matrix, stopped after a test had completed, and then re-submitted the matrix to ensure that the test was then in fact skipped (before building) as expected. 
* Are the changes covered by regression tests? In the ufs-weather-model  
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? no
