### PR TITLE
Fix for coupling time step different from driving data update frequency

### DIFF
--- a/model/src/ww3_shel.F90
+++ b/model/src/ww3_shel.F90
@@ -2261,10 +2261,16 @@
             END IF
 #ifdef W3_OASIS
           ELSE 
-            ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TIME ))
-            IF ( (DTOUT(7).NE.0) .AND.                               &
-                 (MOD(ID_OASIS_TIME, NINT(DTOUT(7))) .EQ. 0 ) .AND. &
-                 (DSEC21 (TIME, TIMEEND) .GT. 0.0)) DTTST=0.
+            IF ( DTOUT(7).NE.0 ) THEN
+              IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN
+                ID_OASIS_TIME = 0
+                DTTST=0.
+              ELSE
+                ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TFN(:,J) ))
+                IF ( NINT(MOD(DSEC21(TIME00,TIME), DTOUT(7))) .EQ. 0 .AND. &
+                     DSEC21 (TFN(:,J), TIMEEND) .GT. 0.0 ) DTTST=0.
+              ENDIF
+            ENDIF
 #endif
           END IF
 !

--- a/model/src/ww3_shel.F90
+++ b/model/src/ww3_shel.F90
@@ -2262,6 +2262,7 @@
 #ifdef W3_OASIS
           ELSE 
             IF ( DTOUT(7).NE.0 ) THEN
+              ! TFN not initialized at TIME=TIME00, using TIME instead
               IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN
                 ID_OASIS_TIME = 0
                 DTTST=0.

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -436,7 +436,8 @@ fi
 
 if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
 then
-  if $path_i/prep_env.sh $path_i $path_w $cmplr $swtstr
+  ww3_dir=${path_s}/..
+  if $path_i/prep_env.sh $path_i $path_w $cmplr $swtstr $ww3_dir
   then :
   else
     errmsg "Error occured during WW3 $prog build"


### PR DESCRIPTION
# Pull Request Summary
Allow coupling time steps to happen at times different to the update of driving data.

## Description
This change only affects coupled configurations, and modifies the calculation of the variables that specify when driving data coming via coupling is taking place, and what the next coupling time is. Before these times where overwritten by the times when driving data update was taking place.

Suggested reviewers: ukmo-chris-bunney JessicaMeixner

Suggested labels: _enhancement_

No answer changes expected.

### Issue(s) addressed
- fixes #651 
- fixes noaa-emc/ww3/issues/651

### Commit Message
Allow coupling time steps to happen at times different to the update of driving data.

### Check list  

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [N/A] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [N/A] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Multiple Met Office regional configurations, coupled and uncoupled. See issue description for details
* Are the changes covered by regression tests? No, as the configuration that failed was not tested before; if needed, it would be easy to add a new test
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes, but could not run the ww3_tp2.14 tests at the Met Office CrayXC40, GNU compiler. This is due to the change to cmake compilation and the way the netcdf libraries are installed. I recommend the reviewers to test ww3_tp2.14 because the changes may only affect these, but this is not expected.
* Please indicate the expected changes in the regression test output ([Note the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).
None
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/8417816/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/8417819/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/8417820/matrixDiff.txt)

