### PR TITLE
Bugfix/cmake netcdf find

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,10 @@ endif()
 
 set(MULTI_ESMF OFF CACHE BOOL "Build ww3_multi_esmf library")
 set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
+set(EXCLUDE_FIND "" CACHE STRING "Don't try and search for these libraries (assumd to be handled by the compiler/wrapper)")
+
+# make sure all "exclude_find" entries are lower case
+list(TRANSFORM EXCLUDE_FIND TOLOWER)
 
 # Make Find modules visible to CMake
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/model/README.md
+++ b/model/README.md
@@ -82,6 +82,16 @@ If a library is located in a non-standard location CMake will search
 multiple locations including `CMAKE_PREFIX_PATH` (a semi-colon
 separated list) or `<name>_ROOT`. 
 
+Note: If your system provides the paths to libraries and include directories
+automatically (e.g. via a compiler wrapper script, as is the case with the
+Cray Compiler Environment), then you might wish to stop CMake from trying
+to automatically finding particular libraries. This can be achieved by
+passing a list of libraries to ignore via the `EXCLUDE_FIND` option to
+CMake (currently only implemented for the netCDF library). E.g:
+```
+cmake .. -DEXCLUDE_FIND="netcdf"
+```
+
 ### Can set the compiler to MPI wrappers to find MPI
 ```
 export CC=mpicc
@@ -134,7 +144,7 @@ Append to [src_list.cmake](./src/cmake/src_list.cmake)
 
 Compiler flags are set per compiler in [CMakeLists.txt](./src/CMakeLists.txt)
 
-Supported compilers are Intel, GNU, and PGI.
+Supported compilers are Intel, GNU, PGI and Cray.
 
 ### How to build a single target?
 

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -71,6 +71,12 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "PGI")
   if(${CMAKE_Fortran_COMPILER_VERSION} VERSION_GREATER_EQUAL 10)
     target_compile_options(ww3_lib PUBLIC -fallow-argument-mismatch -fallow-invalid-boz)
   endif()
+
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
+  # TODO: Where do we set -homp for OpenMP compiles?
+  set(compile_flags -g -sdefault32 -eg)
+  set(compile_flags_release -O3)
+  set(compile_flags_debug -O0 -Rbcps -Ktrap=fp)
 endif()
 
 target_compile_options(ww3_lib PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
@@ -90,12 +96,21 @@ if("OASIS" IN_LIST switches)
 endif()
 
 if(NETCDF)
-  find_package(NetCDF REQUIRED COMPONENTS Fortran)
+  if("netcdf" IN_LIST EXCLUDE_FIND)
+    # NetCDF library flags provided by compiler or wrapper script: don't search
+    set(NetCDF_Fortran_FOUND TRUE)
+	message(WARNING "Not searching for NetCDF library - please ensure correct flags are provided by your compiler/wrapper")
+  else()
+    find_package(NetCDF REQUIRED COMPONENTS Fortran)
+  endif()
 endif()
 
 if(NetCDF_Fortran_FOUND)
   target_sources(ww3_lib PRIVATE w3ounfmetamd.F90)
-  target_link_libraries(ww3_lib PUBLIC NetCDF::NetCDF_Fortran)
+  if(NOT "netcdf" IN_LIST EXCLUDE_FIND)
+    # NetCDF library flags provided by compiler or wrapper script: don't add as dependency
+    target_link_libraries(ww3_lib PUBLIC NetCDF::NetCDF_Fortran)
+  endif()
   list(APPEND programs ${netcdf_programs})
 endif()
 

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -99,7 +99,7 @@ if(NETCDF)
   if("netcdf" IN_LIST EXCLUDE_FIND)
     # NetCDF library flags provided by compiler or wrapper script: don't search
     set(NetCDF_Fortran_FOUND TRUE)
-	message(WARNING "Not searching for NetCDF library - please ensure correct flags are provided by your compiler/wrapper")
+    message(WARNING "Not searching for NetCDF library - please ensure correct flags are provided by your compiler/wrapper")
   else()
     find_package(NetCDF REQUIRED COMPONENTS Fortran)
   endif()

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -107,7 +107,7 @@ endif()
 
 if(NetCDF_Fortran_FOUND)
   target_sources(ww3_lib PRIVATE w3ounfmetamd.F90)
-  if(NOT "netcdf" IN_LIST EXCLUDE_FIND)
+  if(TARGET NetCDF::NetCDF_Fortran)
     # NetCDF library flags provided by compiler or wrapper script: don't add as dependency
     target_link_libraries(ww3_lib PUBLIC NetCDF::NetCDF_Fortran)
   endif()

--- a/regtests/bin/matrix_cmake_ukmo_cray
+++ b/regtests/bin/matrix_cmake_ukmo_cray
@@ -1,0 +1,174 @@
+#!/bin/bash
+# --------------------------------------------------------------------------- #
+# matrix_ukmo_cray: Run matrix of regression tests on Cray XC architecture    #
+#   as currently used at the UK Met Office.                                   #
+#
+# This version runs the CMake compilation version
+#                                                                             #
+# Remarks:                                                                    #
+#   Currently, programs using the PDLIB switch (METIS library) crash when     #
+#   compiled with the Cray CCE compiler. For those regtests that use PDLIB    #
+#   it is required to use the GNU compiler.                                   #
+#                                                                             #
+#                                                      Chris Bunney           #
+#                                                      April 2022             #
+#                                                                             #
+#                                                      Hendrik L. Tolman      #
+#                                                      August 2013            #
+#                                                      December 2013          #
+#                                                      April 2018             #
+#                                                                             #
+#    Copyright 2013 National Weather Service (NWS),                           #
+#       National Oceanic and Atmospheric Administration.  All rights          #
+#       reserved.  WAVEWATCH III is a trademark of the NWS.                   #
+#       No unauthorized use without permission.                               #
+#                                                                             #
+# --------------------------------------------------------------------------- #
+# 0. Environment file
+
+  source $(dirname $0)/../../model/bin/w3_setenv
+  main_dir=$WWATCH3_DIR
+  temp_dir=$WWATCH3_TMP
+  source=$WWATCH3_SOURCE
+  list=$WWATCH3_LIST
+
+  echo "Main directory    : $main_dir"
+  echo "Scratch directory : $temp_dir"
+  echo "Save source codes : $source"
+  echo "Save listings     : $list"
+
+  # Set Cray compiler variant: CCE (Cray Compiler Environment) or GNU.
+  #  - ukmo_cray[_debug]       : Cray Fortan (Cray Compiler Environment)
+  #  - ukmo_cray_gnu[_dubug]   : GNU Fortran using cray wrapper
+  #  - ukmo_cray_intel[_dubug] : Ifort using cray wrapper
+  # Note: currently, Cray Fortran fails with some PDLIB regrests
+  cmplr="ukmo_cray_gnu"
+  export cmplOption='y'
+
+# 1. Set up for compilation environemnt on Cray XC (broadwell processors)
+  echo '#!/bin/bash'                                         > matrix.head
+  echo ' '                                                  >> matrix.head
+
+# Run everything on single node in shared queue (compilation on compute
+# nodes via parallel queue is inefficient and wasteful of resources):
+  echo '#PBS -l ncpus=16'                                   >> matrix.head
+  echo '#PBS -l mem=16GB'                                   >> matrix.head
+  echo '#PBS -q shared'                                     >> matrix.head
+  echo '#PBS -l walltime=04:00:00'                          >> matrix.head
+  echo '#PBS -N ww3_regtest'                                >> matrix.head
+  echo '#PBS -j oe'                                         >> matrix.head
+  echo '#PBS -o matrix.out'                                 >> matrix.head
+  echo ' '                                                  >> matrix.head
+
+  echo "  cd $(dirname $main_dir)/regtests"                 >> matrix.head
+  echo ' '                                                  >> matrix.head
+
+if [[ $cmplr == "ukmo_cray" ]] || [[ $cmplr == "ukmo_cray_debug" ]]; then
+  # Load targetted versions of Cray Development Tools (bug in Fortran StreamIO
+  # for older versions) and netCDF/HDF5 modules:
+    echo "module load  cdt/18.12"                         >> matrix.head
+    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
+    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
+    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS"  >> matrix.head
+
+elif [[ $cmplr == ukmo_cray_gnu* ]]; then
+    # ParMETIS library not currently working with Cray compiler.
+    # Use GNU compiler for programs that use PDLIB.
+    echo "module switch PrgEnv-cray PrgEnv-gnu/5.2.82"    >> matrix.head
+    echo "module load cray-netcdf"                        >> matrix.head
+    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS_GNU" >> matrix.head
+
+elif [[ $cmplr == ukmo_cray_intel* ]]; then
+    echo "module switch PrgEnv-cray PrgEnv-intel"         >> matrix.head
+    echo "module swap intel/15.0.0.090 intel/18.0.5.274"  >> matrix.head
+    echo "module load cdt/18.12"                          >> matrix.head
+    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
+    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
+
+else
+    echo "Unknown compiler for UKMO regression tests: $cmplr"
+    exit 1
+fi
+
+# Need newer cmake version on the XC
+  echo "module load cmake/3.21.3"                         >> matrix.head
+
+# SNP Launcher 7.7.4 allows -np switch:
+  echo "module load cray-snplauncher/7.7.4"               >> matrix.head
+  echo "export NETCDF_CONFIG=\$(which nc-config)"         >> matrix.head
+
+# On the Cray XC, we need to stop CMake from searching for
+# the NetCDF libraries - they are provided by the ftn wrapper.
+  echo "export CMAKE_OPTIONS=-DEXCLUDE_FIND=\"netcdf\"" >> matrix.head
+
+# Resources:
+  export  mpi='mpiexec'
+  export   np='16'
+  export   nr='4'
+  export  nth='4'
+
+  if [ "$cmplOption" = 'y' ]
+  then
+     export rtst="./bin/run_cmake_test -o both -c $cmplr -S"
+  else
+     export rtst="./bin/run_cmake_test -o both -S"
+  fi
+
+  export  ww3='../model'
+
+# 1.b Flags to do course selection - - - - - - - - - - - - - - - - - - - - - -
+#     Addition selection by commenting out lines as below
+
+  export       shrd='y' # Do shared architecture tests
+  export       dist='y' # Do distributed architecture (MPI) tests
+  export        omp='y' # Threaded (OpenMP) tests
+  export       hybd='y' # Hybrid options
+
+  export     prop1D='y' # 1-D propagation tests (ww3_tp1.X)
+  export     prop2D='y' # 2-D propagation tests (ww3_tp2.X)
+  export       time='y' # time linmited growth
+  export      fetch='y' # fetch linmited growth
+  export     hur1mg='y' # Hurricane with one moving grid
+  export      shwtr='y' # shallow water tests
+  export      unstr='y' # unstructured grid tests
+  export      pdlib='y' # unstr with pdlib for domain decomposition and implicit solver
+  export      smcgr='y' # SMC grid test
+  export        rtd='y' # Rotated pole test
+  export     mudice='y' # Mud/Ice and wave interaction tests 
+  export     infgrv='y' # Second harmonic generation tests
+  export       uost='y' # ww3_ts4 Unresolved Obstacles Source Term (UOST)
+  export      assim='y' # Restart spectra update
+  export      oasis='y' # Atmosphere, ocean, and ice coupling using oasis
+  export   calendar='y' # Calendar type 
+  export   confignc='y' # Configurable netCDF meta data (ww3_ounf)
+
+  export    multi01='y' # mww3_test_01 (wetting and drying)
+  export    multi02='y' # mww3_test_02 (basic two-way nesting test))
+  export    multi03='y' # mww3_test_03 (three high and three low res grids).
+  export    multi04='y' # mww3_test_04 (swell on sea mount and/or current)
+  export    multi05='y' # mww3_test_05 (three-grid moving hurricane)
+  export    multi06='y' # mww3_test_06 (curvilinear grid tests)
+  export    multi07='y' # mww3_test_07 (unstructured grid tests)
+  export    multi08='y' # mww3_test_08 (wind and ice tests)
+  export    multi09='y' # mww3_test_09 (SMC multi grid test)
+  export        ufs='n' # The Unified Forecast System
+  export  ufscoarse='n' # Option for small PCs
+  export       grib='n' # grib file field output
+  export  rstrt_b4b='y' # Restart Reproducibility
+  export    npl_b4b='y' # MPI task Reproducibility
+  export    nth_b4b='y' # Thread Reproducibility
+  export       esmf='n' # ESMF coupling
+# export   filter='PR3 ST2 UQ'
+                      # The filter does a set of consecutinve greps on the 
+                      # command lines generated by filter.base with the above
+                      # selected options.
+
+# --------------------------------------------------------------------------- #
+# 2.  Execute matrix.base ...                                                 #
+# --------------------------------------------------------------------------- #
+             
+  $main_dir/../regtests/bin/matrix.base
+
+# --------------------------------------------------------------------------- #
+# End to the matrix                                                           #
+# --------------------------------------------------------------------------- #

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -427,7 +427,7 @@ then
 
   echo "Switch file is $path_build/switch with switches:" >> $ofile 
   cat $path_build/switch >> $ofile
-  cmake $path_cmake -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1  
+  cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1
   rc=$?
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in cmake."
@@ -458,7 +458,7 @@ then
   \cp -f $file_c $path_build/switch
   echo "Switch file is $path_build/switch with switches:" >> $ofile 
   cat $path_build/switch >> $ofile  
-  cmake $path_cmake -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile  2>&1 
+  cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile  2>&1
   rc=$?
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in cmake."
@@ -495,7 +495,7 @@ else
   fi
   echo "Switch file is $path_build/switch with switches:" >> $ofile
   cat $path_build/switch >> $ofile
-  cmake $path_cmake -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1 
+  cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1
   rc=$?
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in cmake."

--- a/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/CMakeLists.txt
+++ b/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/CMakeLists.txt
@@ -13,10 +13,10 @@ if("netcdf" IN_LIST EXCLUDE_FIND)
   message(WARNING "Not seaching for NetCDF library")
 else()
   find_package(NetCDF MODULE REQUIRED COMPONENTS Fortran)
+  list(REVERSE NetCDF_LIBRARIES)
+  string(REPLACE ";" " " NetCDF_LIBRARIES_STR "${NetCDF_LIBRARIES}")
+  set(NetCDF_INCLUDES_STR "-I${NetCDF_C_INCLUDE_DIRS} -I${NetCDF_Fortran_INCLUDE_DIRS}")
 endif()
-
-list(REVERSE NetCDF_LIBRARIES)
-string(REPLACE ";" " " NetCDF_LIBRARIES_STR "${NetCDF_LIBRARIES}")
 
 set(WWATCH3_DIR $ENV{WWATCH3_DIR})
 set(comp_mpi ${MPI_Fortran_COMPILER})

--- a/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/CMakeLists.txt
+++ b/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/CMakeLists.txt
@@ -3,10 +3,17 @@ cmake_minimum_required(VERSION 3.15)
 project(oasis3-mct
   LANGUAGES C Fortran)
 
+set(EXCLUDE_FIND "" CACHE STRING "Don't try and search for these libraries (assumd to be handled by the compiler/wrapper)")
+list(TRANSFORM EXCLUDE_FIND TOLOWER)
+
 list(APPEND CMAKE_MODULE_PATH "$ENV{WWATCH3_DIR}/../cmake")
 
 find_package(MPI REQUIRED COMPONENTS Fortran)
-find_package(NetCDF MODULE REQUIRED COMPONENTS Fortran)
+if("netcdf" IN_LIST EXCLUDE_FIND)
+  message(WARNING "Not seaching for NetCDF library")
+else()
+  find_package(NetCDF MODULE REQUIRED COMPONENTS Fortran)
+endif()
 
 list(REVERSE NetCDF_LIBRARIES)
 string(REPLACE ";" " " NetCDF_LIBRARIES_STR "${NetCDF_LIBRARIES}")

--- a/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/cmplr.tmpl
+++ b/regtests/ww3_tp2.14/input/oasis3-mct/util/make_dir/cmplr.tmpl
@@ -30,7 +30,7 @@ COUPLE          = @oasis_input_path@
 ARCHDIR         = @oasis_work_path@
 #
 # NetCDF library
-NETCDF_INCLUDE  = -I@NetCDF_C_INCLUDE_DIRS@ -I@NetCDF_Fortran_INCLUDE_DIRS@
+NETCDF_INCLUDE  = @NetCDF_INCLUDES_STR@
 NETCDF_LIBRARY  = @NetCDF_LIBRARIES_STR@
 #
 # Compilers and options

--- a/regtests/ww3_tp2.14/input_oasacm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasacm2/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm2/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasacm4/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm4/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasacm5/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm5/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasacm6/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasacm6/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasicm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasicm/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'

--- a/regtests/ww3_tp2.14/input_oasocm/prep_env.sh
+++ b/regtests/ww3_tp2.14/input_oasocm/prep_env.sh
@@ -38,7 +38,7 @@ echo '   setup oasis make.inc file'
 echo '   compile oasis coupler'
 # Build OASIS with CMake wrapper
 rm -rf Makefile CMakeCache.txt  CMakeFiles  cmake_install.cmake cmplr src tmp
-cmake .
+cmake . ${CMAKE_OPTIONS:-}
 make
 
 echo '   setup toy Makefile'


### PR DESCRIPTION
# Pull Request Summary
Provides an update to CMake allowing it to avoid searching for a particular library (currently only netCDF).

## Description
Adds the `-D EXCLUDE_FIND="list"` option to CMakeLists.txt.

Specifying a library with `EXCLUDE_FIND` will stop CMake from searching for that library with `find_package`.

This is useful for systems where a compiler wrapper is used (such as the Cray) that automatically sets the compiler flags for library dependencies based on the current compiler environment loaded; in these cases CMake can fail to find the library or select an incorrect one.

The addition of the `CMAKE_OPTIONS` environment variable to `run_cmake_test`  is to allow extra options (like the `-DEXCLUDE_FIND`) to be passed to cmake from the matrix files.

No changes to regression tests expected.

### Issue(s) addressed
Fixes #656 

### Commit Message
Provides an update to CMake allowing it to avoid searching for a particular library 

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested? Regression tests.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes (no change expected)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Cray XC HPC; GNU Fortran.

**Matrix results **
Usual known non-b4b tests (mww3_test_03 and ww3_tp2.10)
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (14 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
```


