### PR TITLE
Cmmb

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -234,6 +234,8 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || [ "$cmplr" == "gnu_pr
 
   # COMPILER - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
+  _GCC_VER="$(echo $(gcc --version | head -1 | cut -d ' ' -f 3 | cut -d '.' -f 1))"
+
   # Only match `error` and `warn` at beginning of line:
   err_pattern='^error'
   warn_pattern='^warn'
@@ -252,7 +254,12 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || [ "$cmplr" == "gnu_pr
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -J$path_m -g -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+  if [ ${_GCC_VER:-0} -ge 10 ] ; then
+    #optc='-c -J$path_m -p -g -fallow-argument-mismatch -fallow-invalid-boz -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+    optc='-c -J$path_m -p -g -fallow-argument-mismatch -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+  else
+    optc='-c -J$path_m -p -g -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+  fi
   optl='-o $prog -g'
 
   # omp options


### PR DESCRIPTION
# Pull Request Summary
Workaround to compile with gfortran >= 10; argument mismatch errors when compiling with gfortran >= 10

## Description
This fix degrades argument mismatch in procedures from errors to warnings when WW3 is compiled using gcc/gfortran >= 10.
It passes the flag "-fallow-argument-mismatch" to gfortran if gfortran >= 10.
This is an an _enhancement_ to the GNU build system.

Please see the list of affected files:

================================================================================

w3iorsmd.F90:507:38:

  493 |                                       ( NRQ, IRQRSS, IERR_MPI )
      |                                             2
......
  507 |                                ( NRQ, IRQRSS(IH), IERR_MPI )
      |                                      1
Warning: Element of assumed-shape or pointer array as actual argument at (1) cannot correspond to actual argument at (2)
w3iorsmd.F90:528:32:

  493 |                                       ( NRQ, IRQRSS, IERR_MPI )
      |                                             2
......
  528 |                            ( 1, IRQRSS(IB), IERR_MPI )
      |                                1
Warning: Element of assumed-shape or pointer array as actual argument at (1) cannot correspond to actual argument at (2)
w3iorsmd.F90:611:30:

  503 |                            ( NRQ, IRQRSS(IH), STAT1, IERR_MPI )
      |                                  2
......
  611 |                      ( NRQRS, IRQRS , STAT2, IERR_MPI )
      |                              1
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)

================================================================================


================================================================================

w3iosfmd.F90:476:26:

  470 |           CALL MPI_SEND ( ICPRT, ICSIZ, MPI_REAL, NAPPRT-1, IT,  &
      |                          2
......
  476 |                         ( DTPRT, 6*DTSIZ, MPI_REAL, NAPPRT-1,    &
      |                          1
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(4)/INTEGER(4)).
w3iosfmd.F90:513:28:

  504 |             CALL MPI_RECV ( ICP, ICSIZ, MPI_REAL, JAPROC-1, IT,  &
      |                            2
......
  513 |                           ( DTP, DIMP*DTSIZ, MPI_REAL, JAPROC-1, &
      |                            1
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(4)/INTEGER(4)).

================================================================================


================================================================================

w3wavemd.F90:1316:38:

 1316 |            CALL MPI_STARTALL ( NRQGO, IRQGO , IERR_MPI )
      |                                      1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2    
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1323:39:

 1323 |            CALL MPI_STARTALL ( NRQGO2, IRQGO2, IERR_MPI )
      |                                       1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2     
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1335:47:

 1335 |                     CALL MPI_STARTALL ( NRQPO, IRQPO1, IERR_MPI )
      |                                               1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2             
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1343:47:

 1343 |                     CALL MPI_STARTALL ( NRQRS, IRQRS , IERR_MPI )
      |                                               1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2             
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1351:48:

 1351 |                     CALL MPI_STARTALL ( NRQBP , IRQBP1, IERR_MPI )
      |                                                1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2              
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1360:46:

 1360 |                     CALL MPI_STARTALL (NRQBP2,IRQBP2,IERR_MPI)
      |                                              1
......
 1887 |            MPI_STARTALL ( NRQSG2, IRQSG2(IOFF,2), IERR_MPI )
      |                                  2            
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1388:43:

 1388 |                                  ( NRQGO2, IRQGO2, STATIO, IERR_MPI )
      |                                           1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1420:42:

 1420 |                                 ( NRQBP2, IRQBP2,STATIO, IERR_MPI )
      |                                          1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1459:38:

 1459 |                              ( NRQGO, IRQGO , STATIO, IERR_MPI )
      |                                      1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1461:38:

 1461 |                              ( NRQPO, IRQPO1, STATIO, IERR_MPI )
      |                                      1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1463:38:

 1463 |                              ( NRQRS, IRQRS , STATIO, IERR_MPI )
      |                                      1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)
w3wavemd.F90:1465:38:

 1465 |                              ( NRQBP, IRQBP1, STATIO, IERR_MPI )
      |                                      1
......
 1913 |                      MPI_WAITALL ( NRQSG2, IRQSG2(IOFF,2),       &
      |                                           2
Warning: Rank mismatch between actual argument at (1) and actual argument at (2) (scalar and rank-1)

================================================================================


================================================================================

wmgridmd.F90:284:30:

  271 |              CALL MPI_BCAST ( GRIDS(I)%MAPSTA(1,1), NXYG,        &
      |                              2
......
  284 |              CALL MPI_BCAST ( GRIDS(I)%CLATIS(1), NSEA, MPI_REAL, 0,&
      |                              1
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (REAL(4)/INTEGER(4)).

================================================================================


================================================================================

wminiomd.F90:531:33:

  531 |                 CALL MPI_IRECV ( BPSTGE(IMOD,J)%VTIME, 2,        &
      |                                 1
......
 1948 |                         CALL MPI_IRECV ( SEQL(1,I,IA),           &
      |                                         2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/REAL(4)).
wminiomd.F90:243:35:

  243 |                   CALL MPI_ISEND ( BPSTGE(J,IMOD)%STIME, 2,  &
      |                                   1
......
 1742 |               CALL MPI_ISEND ( SEQL(1,I), NSPEC, MPI_REAL, IP-1, &
      |                               2    
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/REAL(4)).

================================================================================


================================================================================

wminitmd.F90:4769:29:

 4760 |             CALL MPI_BCAST ( TOUTP(1,I), 2, MPI_INTEGER, 0,      &
      |                             2
......
 4769 |             CALL MPI_BCAST ( FLAGLL,1, MPI_LOGICAL, 0,           &
      |                             1
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (LOGICAL(4)/INTEGER(4)).

================================================================================


================================================================================

wmwavemd.F90:1392:32:

 1392 |                 CALL MPI_SEND ( DATA, NR, MPI_INTEGER, IP-1,     &
      |                                1
......
 1528 |             CALL MPI_SEND ( DUMMY, 1, MPI_INTEGER, IP-1,         &
      |                            2    
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/REAL(4)).
wmwavemd.F90:1402:26:

 1402 |           CALL MPI_RECV ( DATA, NR, MPI_INTEGER, CROOT-1, ITAG,  &
      |                          1
......
 1537 |           CALL MPI_RECV ( DUMMY, 1, MPI_INTEGER, 0, ITAG,        &
      |                          2
Warning: Type mismatch between actual argument at (1) and actual argument at (2) (INTEGER(4)/REAL(4)).

================================================================================


### Commit Message
Workaround to compile with gfortran >= 10; argument mismatch errors when compiling with gfortran >= 10

### Check list  
<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  Locally with gfortran v8.3 and gfortran v10.3.1



