### PR TITLE
Bugfix/gmake endian

### DIFF
--- a/model/bin/ad3.tmpl
+++ b/model/bin/ad3.tmpl
@@ -210,9 +210,10 @@
        CPPFLAGS+=("-DW3_$sw")
     done 
 
-	CPPFLAGS+=("-DENDIANNESS='<endian>'")
-
     CPPFLAGS+=("-D__WW3_SWITCHES__='$sw_str'")
+
+    # Also set endianness:
+    CPPFLAGS+=("-DENDIANNESS='<endian>'")
 
     <comp_seq> "${CPPFLAGS[@]}" <cppad3procflag> <cppad3flag2>  $path_i/$name.F90 <cppad3flag3> $name.F90
     <cppad3flag4> mv $name.i $name.F90

--- a/model/bin/ad3.tmpl
+++ b/model/bin/ad3.tmpl
@@ -210,6 +210,8 @@
        CPPFLAGS+=("-DW3_$sw")
     done 
 
+	CPPFLAGS+=("-DENDIANNESS='<endian>'")
+
     CPPFLAGS+=("-D__WW3_SWITCHES__='$sw_str'")
 
     <comp_seq> "${CPPFLAGS[@]}" <cppad3procflag> <cppad3flag2>  $path_i/$name.F90 <cppad3flag3> $name.F90

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -36,6 +36,9 @@
 err_pattern='[[:space:]]error[[:space:]]'
 warn_pattern='warn'
 
+# Binary I/O defaults to native endian:
+endian='native'
+
 # disable listing done by the compiler
 list='no'
 
@@ -63,8 +66,10 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || [ "$cmplr" == "mpt_pr
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias'
+  optc='-c -module $path_m -no-fma -ip -g -i4 -real-size 32 -fp-model precise -assume byterecl -fno-alias -fno-fnalias'
   optl='-o $prog -g'
+
+  endian='big_endian'
 
   # list options
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
@@ -145,8 +150,10 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -module $path_m -no-fma -ip -g -traceback -i4 -real-size 32 -fp-model precise -assume byterecl -convert big_endian -fno-alias -fno-fnalias -sox'
+  optc='-c -module $path_m -no-fma -ip -g -traceback -i4 -real-size 32 -fp-model precise -assume byterecl -fno-alias -fno-fnalias -sox'
   optl='-o $prog -g'
+
+  endian='big_endian'
 
   # list options
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
@@ -252,8 +259,10 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || [ "$cmplr" == "gnu_pr
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
-  optc='-c -J$path_m -g -fno-second-underscore -ffree-line-length-none -fconvert=big-endian'
+  optc='-c -J$path_m -g -fno-second-underscore -ffree-line-length-none'
   optl='-o $prog -g'
+
+  endian='big_endian'
 
   # omp options
   optomp='-fopenmp'

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -394,7 +394,7 @@ then
        [ "$cmplr" == "ukmo_cray_gnu" ] || [ "$cmplr" == "ukmo_cray_gnu_debug" ]     || \
        [ "$cmplr" == "ukmo_cray_intel" ] || [ "$cmplr" == "ukmo_cray_intel_debug" ]; then
      source $path_b/cmplr.env
-     sed -e "s/<comp_seq>/$comp_seq/" -e "s/<cppad3procflag>/$cppad3procflag/" -e "s/<cppad3flag2>/$cppad3flag2/" -e "s/<cppad3flag3>/$cppad3flag3/" -e "s/<cppad3flag4>/$cppad3flag4/" $path_b/ad3.tmpl > $path_b/ad3
+     sed -e "s/<comp_seq>/$comp_seq/" -e "s/<cppad3procflag>/$cppad3procflag/" -e "s/<cppad3flag2>/$cppad3flag2/" -e "s/<cppad3flag3>/$cppad3flag3/" -e "s/<cppad3flag4>/$cppad3flag4/" -e "s/<endian>/${endian}/" $path_b/ad3.tmpl > $path_b/ad3
     echo "      sed $path_b/ad3.tmpl => $path_b/ad3"
   else
     errmsg "$path_b/ad3.$cmplr not found"

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -1259,7 +1259,14 @@ then
         else
            inputs="`ls $path_i/$prog*.inp 2>/dev/null`"
         fi
-        inputs_tmp=`( ls ${path_i}/${prog}${gu}* )`
+
+        if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
+          then
+          inputs_tmp=`( ls ${path_i}/${prog}${gu}*nml)`
+        else
+          inputs_tmp=`( ls ${path_i}/${prog}${gu}*inp)`
+        fi
+         
         if [ ! -z "$inputs_tmp" ];then
            inputs=$inputs_tmp
         fi


### PR DESCRIPTION
# Pull Request Summary
Fixes broken gmake build after PR #680 

## Description
The `gmake` build is broken after PR #680 - the ENDIANNESS string is not being replaced by the pre-processor in `constants.ftn`.

This PR adds a choice of endian in the `cmplr.env` file. I have set this to default to "native".
I have removed instances of compiler flags that set the endianness and have set this via the new `endian` environment variable in `cmplr.env` instead.

No changes are expected in the output files or regression tests.

### Issue(s) addressed

- fixes #720


### Commit Message
Added choice of endian for binaray I/O when building with gmake

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regtests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) No
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Cray HPC; GNU Fortran

### Regtest results
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_02/./work_PR2_UNO_MPI_c                     (53 files differ)
mww3_test_02/./work_PR2_UNO_MPI_d                     (3 files differ)
mww3_test_02/./work_PR2_UNO_MPI_b                     (53 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
```

`mww3_test_02` differences are due to PR #716 - my baseline regression tests were taken from commit feb333dd60ff4bd8a7b9d04ed6d6d7b4a00f58b7 where the gmake build was last working.