### PR TITLE
Fixed uninitialised variable in mod_oasis_namcouple.F90

### DIFF
--- a/regtests/ww3_tp2.14/input/oasis3-mct/lib/psmile/src/mod_oasis_namcouple.F90
+++ b/regtests/ww3_tp2.14/input/oasis3-mct/lib/psmile/src/mod_oasis_namcouple.F90
@@ -1680,6 +1680,7 @@ SUBROUTINE inipar_alloc()
   clhead   = ' $MODINFO'
   clprint  = ' $NLOGPRT'
   clcal    = ' $CALTYPE'
+  clinfo   = 'no'
 
   !* Initialize some variables 
   ntime = 0 ; niter = 5 


### PR DESCRIPTION
# Pull Request Summary
Fixed uninitialised  variable in `mod_oasis_namcouple.F90`

## Description
Fixed uninitialised `clinfo` variable in `mod_oasis_namcouple.F90` that was causing differences when comparing outputs in regtest ww3_t2.14.

The `clinfo` variable is now initialised to the string value `"no"`. 

I have only run the ww3_tp2.14 regression tests as this change does not affect the main model code (just the OASIS coupler interface). The `nout.000000` files are showing differences as expected due to the now initialised variable, e.g.:
```
***
/home/d02/frey/WW3/UKMO_WW3/regtests/output/ww3_tp2.14/work_OASACM/nout.000000_diff.txt
***
46c46
< * ===>>> : The information mode is activated ? ==> no
---
> * ===>>> : The information mode is activated ? ==> h\H
```


### Issue(s) addressed
- fixes #737 

### Commit Message
Fix uninitialised variable in mod_oasis_namcouple.F90

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regtests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Just ww3_tp2.14

Regtest summary below:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
ww3_tp2.14/./work_OASACM                     (1 files differ)
ww3_tp2.14/./work_OASACM6                     (1 files differ)
ww3_tp2.14/./work_OASACM2                     (1 files differ)
ww3_tp2.14/./work_OASACM5                     (1 files differ)
ww3_tp2.14/./work_OASACM4                     (1 files differ)
ww3_tp2.14/./work_OASOCM                     (1 files differ)
ww3_tp2.14/./work_OASICM                     (1 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
ww3_tp2.14/./work_OASACM3
```
