### PR TITLE
Feature/gint ice mask

### DIFF
--- a/model/src/ww3_gint.F90
+++ b/model/src/ww3_gint.F90
@@ -26,7 +26,7 @@
 !/                  | WAVEWATCH-III           NOAA/NCEP |
 !/                  |             A. Chawla             |SX
 !/                  |                        FORTRAN 90 |
-!/                  | Last update :         02-Jun-2021 |
+!/                  | Last update :         25-Jul-2022 |
 !/                  +-----------------------------------+
 !/
 !/    15-Mar-2007 : Origination.                        ( version 3.13 )
@@ -42,8 +42,7 @@
 !/    26-Jan-2021 : Added TP field (derived from FP)    ( version 7.12 )
 !/    22-Mar-2021 : New coupling fields output          ( version 7.13 )
 !/    02-Jun-2021 : Bug fix (*SUMGRD; Q. Liu)           ( version 7.13 )
-!/    18-Feb-2021 : Modify to keep ice points active    ( version 7.12 )
-!/                  unless masked (B. Pouliot, CMC)
+!/    25-Jul-2022 : Keep ice points active (B. Pouliot) ( version 7.14 )
 !/
 !   1. Purpose : 
 !
@@ -956,6 +955,7 @@
 !/    30-Apr-2014 : Add group 3                         ( version 5.00 )
 !/    27-Aug-2015 : ice thick. and floe added as output ( version 5.10 )
 !/    22-Mar-2021 : New coupling fields output          ( version 7.13 )
+!/    25-Jul-2022 : Add PNR. ACTIVE label for ice       ( version 7.14 )
 !/
 !   1. Purpose :
 !
@@ -1036,7 +1036,7 @@
         REAL          :: PHSAUX(0:NOSWLL_MIN), PTPAUX(0:NOSWLL_MIN),   &
                          PLPAUX(0:NOSWLL_MIN), PSIAUX(0:NOSWLL_MIN),   &
                          PWSAUX(0:NOSWLL_MIN), PDIRAUX1(0:NOSWLL_MIN), &
-                         PWSTAUX, PDIRAUX2(0:NOSWLL_MIN),              &
+                         PWSTAUX, PNRAUX, PDIRAUX2(0:NOSWLL_MIN),      &
                          PTHP0AUX1(0:NOSWLL_MIN),                      &
                          PTHP0AUX2(0:NOSWLL_MIN),                      &
                          PQPAUX(0:NOSWLL_MIN), PPEAUX(0:NOSWLL_MIN),   &
@@ -1380,6 +1380,7 @@
                 PSIAUX      = UNDEF
                 PWSAUX      = UNDEF
                 PWSTAUX     = UNDEF
+                PNRAUX      = UNDEF
                 PTHP0AUX1   = UNDEF
                 PTHP0AUX2   = UNDEF
                 PQPAUX      = UNDEF
@@ -2055,6 +2056,17 @@
                         PWSTAUX = WADATS(IGRID)%PWST(GSEA)*WT
                       ELSE
                         PWSTAUX = PWSTAUX + WADATS(IGRID)%PWST(GSEA)*WT
+                      END IF
+                    END IF
+                  END IF
+!
+                  IF ( FLOGRD(4,17) .AND. ACTIVE ) THEN
+                    IF ( WADATS(IGRID)%PNR(GSEA) .NE. UNDEF ) THEN
+                        SUMWT4(17,0) = SUMWT4(17,0) + WT
+                      IF ( PNRAUX .EQ. UNDEF ) THEN
+                        PNRAUX = WADATS(IGRID)%PNR(GSEA)*WT
+                      ELSE
+                        PNRAUX = PNRAUX + WADATS(IGRID)%PNR(GSEA)*WT
                       END IF
                     END IF
                   END IF
@@ -2957,6 +2969,15 @@
                     PWST(ISEA) = PWSTAUX / REAL( SUMGRD )
                   ELSE
                     PWST(ISEA) = PWST(ISEA) + PWSTAUX / REAL( SUMGRD )
+                  END IF
+                END IF
+!
+                IF ( PNRAUX .NE. UNDEF ) THEN
+                  PNRAUX = PNRAUX / SUMWT4(17,0)
+                  IF ( PNR(ISEA) .EQ. UNDEF )  THEN
+                    PNR(ISEA) = PNRAUX / REAL( SUMGRD )
+                  ELSE
+                    PNR(ISEA) = PNR(ISEA) + PNRAUX / REAL( SUMGRD )
                   END IF
                 END IF
 !

--- a/model/src/ww3_gint.F90
+++ b/model/src/ww3_gint.F90
@@ -42,6 +42,8 @@
 !/    26-Jan-2021 : Added TP field (derived from FP)    ( version 7.12 )
 !/    22-Mar-2021 : New coupling fields output          ( version 7.13 )
 !/    02-Jun-2021 : Bug fix (*SUMGRD; Q. Liu)           ( version 7.13 )
+!/    18-Feb-2021 : Modify to keep ice points active    ( version 7.12 )
+!/                  unless masked (B. Pouliot, CMC)
 !/
 !   1. Purpose : 
 !
@@ -1221,7 +1223,6 @@
           MAPINT = MOD(MAPST2(IY,IX)/16,2) 
           MAPST2(IY,IX) = MAPST2(IY,IX) - MAPICE - 2*MAPDRY - 4*MAPLND         &
                           - 8*MAPMSK
-          ACTIVE =  (MAPICE .NE. 1 .AND. MAPDRY .NE. 1)
 !
           IF ( MAPINT .EQ. 0 ) THEN
 !
@@ -1271,7 +1272,7 @@
               IF ( NMAPDRY .GT. 50 ) MAPDRYT = 1
               IF ( NMAPLND .GT. 50 ) MAPLNDT = 1
               IF ( NMAPMSK .GT. 50 ) MAPMSKT = 1
-              ACTIVE =  (MAPICET .NE. 1 .AND. MAPDRYT .NE. 1 .AND.             &
+              ACTIVE =  (MAPDRYT .NE. 1 .AND.                          &
                          MAPLNDT .NE. 1 .AND. MAPMSKT .NE. 1)
               IF ( ACTIVE ) THEN
                 USEGRID(IG) = .TRUE.

--- a/model/src/ww3_ounf.F90
+++ b/model/src/ww3_ounf.F90
@@ -2898,11 +2898,8 @@
 ! NFIELD=3
             IF (NCVARTYPE.EQ.2) THEN
               IF ( NFIELD.EQ.3 ) THEN
-                IF (SMCGRD) THEN
-#ifdef W3_SMC
                   DO IX=IX1, IXN
                     DO IY=IY1, IYN
-                      ! TODO: Find some other way to access MAPSTA
                       IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                         MXX(IX,IY) = MFILL
                         MYY(IX,IY) = MFILL
@@ -2914,6 +2911,7 @@
                       END IF
                     END DO
                   END DO
+#ifdef W3_SMC
                   IF(SMCOTYPE .EQ. 1) THEN
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                         MXX(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
@@ -2925,6 +2923,7 @@
                         MXY(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                     call CHECK_ERR(IRET)
                   ELSE
+#endif
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                         MXX(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                     call CHECK_ERR(IRET)
@@ -2934,42 +2933,15 @@
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+3),               &
                         MXY(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                     call CHECK_ERR(IRET)
+#ifdef W3_SMC
                   ENDIF
 #endif
-                ELSE ! IF(SMCGRD)
-                  DO IX=IX1, IXN
-                    DO IY=IY1, IYN
-                      IF ( X1(IX,IY) .EQ. UNDEF ) THEN
-                        MXX(IX,IY) = MFILL
-                        MYY(IX,IY) = MFILL
-                        MXY(IX,IY) = MFILL
-                      ELSE
-                        MXX(IX,IY) = NINT(X1(IX,IY)/META(1)%FSC)
-                        MYY(IX,IY) = NINT(X2(IX,IY)/META(2)%FSC)
-                        MXY(IX,IY) = NINT(XY(IX,IY)/META(3)%FSC)
-                      END IF
-                    END DO
-                  END DO
-
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),              &
-                          MXX(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),            &
-                          MYY(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+3),            &
-                          MXY(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                ENDIF ! SMCGRD
 ! NFIELD=2
               ELSE IF (NFIELD.EQ.2 ) THEN
 ! EXTRADIM=0
                 IF (EXTRADIM.EQ.0) THEN
-                  IF (SMCGRD) THEN
-#ifdef W3_SMC
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        ! TODO: Find some other way to access MAPSTA
                         IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                           MXX(IX,IY) = MFILL
                           MYY(IX,IY) = MFILL
@@ -2979,6 +2951,7 @@
                         END IF
                       END DO
                     END DO
+#ifdef W3_SMC
                     IF(SMCOTYPE .EQ. 1) THEN
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MXX(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
@@ -2987,46 +2960,23 @@
                           MYY(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                       call CHECK_ERR(IRET)
                     ELSE
+#endif
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MXX(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),               &
                           MYY(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
+#ifdef W3_SMC
                     ENDIF
 #endif
-                  ELSE ! IF(SMCGRD)
-                    DO IX=IX1, IXN
-                      DO IY=IY1, IYN
-                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
-                          MXX(IX,IY) = MFILL
-                          MYY(IX,IY) = MFILL
-                        ELSE
-                    !PRINT*,XX(IX,IY),XY(IX,IY)
-                    !STOP
-                          MXX(IX,IY) = NINT(XX(IX,IY)/META(1)%FSC)
-                          MYY(IX,IY) = NINT(XY(IX,IY)/META(2)%FSC)
-                        END IF
-                      END DO
-                    END DO
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),             &
-                              MXX(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),           &
-                            MYY(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                  ENDIF ! SMCGRD
 ! EXTRADIM=1
                 ELSE
                   START(3+1-COORDTYPE)=0
                   DO IK=I1F,I2F
-                    START(3+1-COORDTYPE)=START(3+1-COORDTYPE)+1
-
-                    IF (SMCGRD) THEN
-#ifdef W3_SMC
+                      START(3+1-COORDTYPE)=START(3+1-COORDTYPE)+1
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          ! TODO: Find some other way to access MAPSTA
                           IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MXX(IX,IY) = MFILL
                             MYY(IX,IY) = MFILL
@@ -3036,6 +2986,7 @@
                           END IF
                         END DO
                       END DO
+#ifdef W3_SMC
                       IF(SMCOTYPE .EQ. 1) THEN
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),                     &
                             MXX(IX1:IXN,IY1:IYN),(/START(1), START(3), START(4)/), &
@@ -3046,39 +2997,22 @@
                             (/COUNT(1), COUNT(3), COUNT(4)/))
                         call CHECK_ERR(IRET)
                       ELSE
+#endif
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                             MXX(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
-                        IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
+                        IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),               &
                             MXX(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
+#ifdef W3_SMC
                       ENDIF
 #endif
-                    ELSE ! IF(SMCGRD)
-                      DO IX=IX1, IXN
-                        DO IY=IY1, IYN
-                          IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
-                            MXX(IX,IY) = MFILL
-                            MYY(IX,IY) = MFILL
-                          ELSE
-                            MXX(IX,IY) = NINT(XXK(IX,IY,IK)/META(1)%FSC)
-                            MYY(IX,IY) = NINT(XYK(IX,IY,IK)/META(2)%FSC)
-                          END IF
-                        END DO
-                      END DO
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                              MXX(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),             &
-                              MYY(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                    ENDIF ! SMCGRD
                   END DO
                 END IF  ! EXTRADIM
 ! NFIELD=1
               ELSE
 ! EXTRADIM=0
                 IF (EXTRADIM.EQ.0) THEN
-                  IF (SMCGRD) THEN
-#ifdef W3_SMC
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
                         ! TODO: Find some other way to access MAPSTA
@@ -3089,41 +3023,26 @@
                         END IF
                       END DO
                     END DO
+#ifdef W3_SMC
                     IF(SMCOTYPE .EQ. 1) THEN
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MX1(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                       call CHECK_ERR(IRET)
                     ELSE
+#endif
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MX1(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
+#ifdef W3_SMC
                     ENDIF
 #endif
-                  ELSE ! IF(SMCGRD)
-                    DO IX=IX1, IXN
-                      DO IY=IY1, IYN
-                        IF ( X1(IX,IY) .EQ. UNDEF ) THEN
-                          MX1(IX,IY) = MFILL
-                        ELSE
-                          MX1(IX,IY) = NINT(X1(IX,IY)/META(1)%FSC)
-                        END IF
-                      END DO
-                    END DO
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                  ENDIF ! SMCGRD
 ! EXTRADIM=1
                 ELSE
                   START(3+1-COORDTYPE)=0
                   DO IK=I1F,I2F
-                    START(3+1-COORDTYPE)=START(3+1-COORDTYPE)+1
-
-                    IF (SMCGRD) THEN
-#ifdef W3_SMC
+                      START(3+1-COORDTYPE)=START(3+1-COORDTYPE)+1
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          ! TODO: Find some other way to access MAPSTA
                           IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MX1(IX,IY) = MFILL
                           ELSE
@@ -3131,30 +3050,20 @@
                           END IF
                         END DO
                       END DO
+#ifdef W3_SMC
                       IF(SMCOTYPE .EQ. 1) THEN
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
+                            MX1(IX1:IXN,IY1:IYN),(/START(1), START(3), START(4)/), &
+                            (/COUNT(1), COUNT(3), COUNT(4)/))
                         call CHECK_ERR(IRET)
                       ELSE
+#endif
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
+                            MX1(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
+#ifdef W3_SMC
                       ENDIF
 #endif
-                    ELSE ! IF(SMCGRD)
-                      DO IX=IX1, IXN
-                        DO IY=IY1, IYN
-                          IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
-                            MX1(IX,IY) = MFILL
-                          ELSE
-                            MX1(IX,IY) = NINT(XK(IX,IY,IK)/META(1)%FSC)
-                          END IF
-                        END DO
-                      END DO
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                          MX1(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                      CALL CHECK_ERR(IRET)
-                    ENDIF ! SMCGRD
                   END DO
                 END IF   ! EXTRADIM
               END IF   ! NFIELD
@@ -3163,11 +3072,8 @@
 !
             ELSE
               IF ( NFIELD.EQ.3 ) THEN
-                IF (SMCGRD) THEN
-#ifdef W3_SMC
                   DO IX=IX1, IXN
                     DO IY=IY1, IYN
-                      ! TODO: Find some other way to access MAPSTA
                       IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                         MXXR(IX,IY) = MFILLR
                         MYYR(IX,IY) = MFILLR
@@ -3179,6 +3085,7 @@
                       END IF
                     END DO
                   END DO
+#ifdef W3_SMC
                   IF(SMCOTYPE .EQ. 1) THEN
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                         MXXR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
@@ -3190,6 +3097,7 @@
                         MXYR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                     call CHECK_ERR(IRET)
                   ELSE
+#endif
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                         MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                     call CHECK_ERR(IRET)
@@ -3199,42 +3107,15 @@
                     IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+3),               &
                         MXYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                     call CHECK_ERR(IRET)
+#ifdef W3_SMC
                   ENDIF
 #endif
-                ELSE ! IF(SMCGRD)
-                  DO IX=IX1, IXN
-                    DO IY=IY1, IYN
-                      IF ( X1(IX,IY) .EQ. UNDEF ) THEN
-                        MXXR(IX,IY) = MFILLR
-                        MYYR(IX,IY) = MFILLR
-                        MXYR(IX,IY) = MFILLR
-                      ELSE
-                        MXXR(IX,IY) = X1(IX,IY)
-                        MYYR(IX,IY) = X2(IX,IY)
-                        MXYR(IX,IY) = XY(IX,IY)
-                      END IF
-                    END DO
-                  END DO
-
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),              &
-                          MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),            &
-                          MYYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                  IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+3),            &
-                          MXYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                  CALL CHECK_ERR(IRET)
-                ENDIF ! SMCGRD
 ! NFIELD=2
               ELSE IF (NFIELD.EQ.2 ) THEN
 ! EXTRADIM=0
                 IF (EXTRADIM.EQ.0) THEN
-                  IF (SMCGRD) THEN
-#ifdef W3_SMC
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        ! TODO: Find some other way to access MAPSTA
                         IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                           MXXR(IX,IY) = MFILLR
                           MYYR(IX,IY) = MFILLR
@@ -3244,6 +3125,7 @@
                         END IF
                       END DO
                     END DO
+#ifdef W3_SMC
                     IF(SMCOTYPE .EQ. 1) THEN
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MXXR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
@@ -3252,44 +3134,23 @@
                           MYYR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                       call CHECK_ERR(IRET)
                     ELSE
+#endif
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),               &
                           MYYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
+#ifdef W3_SMC
                     ENDIF
 #endif
-                  ELSE ! IF SMCGRD
-                    DO IX=IX1, IXN
-                      DO IY=IY1, IYN
-                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
-                          MXXR(IX,IY) = MFILLR
-                          MYYR(IX,IY) = MFILLR
-                        ELSE
-                          MXXR(IX,IY) = XX(IX,IY)
-                          MYYR(IX,IY) = XY(IX,IY)
-                        END IF
-                      END DO
-                    END DO
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),             &
-                              MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),           &
-                            MYYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                  ENDIF ! SMCGRD
-  ! EXTRADIM=1
+! EXTRADIM=1
                 ELSE
                   START(4-COORDTYPE)=0
                   DO IK=I1F,I2F
-                    START(4-COORDTYPE)=START(4-COORDTYPE)+1
-
-                    IF (SMCGRD) THEN
-#ifdef W3_SMC
+                      START(4-COORDTYPE)=START(4-COORDTYPE)+1
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          ! TODO: Find some other way to access MAPSTA
                           IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MXXR(IX,IY) = MFILLR
                             MYYR(IX,IY) = MFILLR
@@ -3299,50 +3160,35 @@
                           END IF
                         END DO
                       END DO
+#ifdef W3_SMC
                       IF(SMCOTYPE .EQ. 1) THEN
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MXXR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
+                            MXXR(IX1:IXN,IY1:IYN),(/START(1), START(3), START(4)/), &
+                            (/COUNT(1), COUNT(3), COUNT(4)/))
                         call CHECK_ERR(IRET)
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),               &
-                            MYYR(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
+                            MYYR(IX1:IXN,IY1:IYN),(/START(1), START(3), START(4)/), &
+                            (/COUNT(1), COUNT(3), COUNT(4)/))
                         call CHECK_ERR(IRET)
                       ELSE
+#endif
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MXXR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
+                            MXXR(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),               &
-                            MYYR(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
+                            MYYR(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
+#ifdef W3_SMC
                       ENDIF
 #endif
-                    ELSE ! IF SMCGRD
-                      DO IX=IX1, IXN
-                        DO IY=IY1, IYN
-                          IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
-                            MXXR(IX,IY) = MFILLR
-                            MYYR(IX,IY) = MFILLR
-                          ELSE
-                            MXXR(IX,IY) = XXK(IX,IY,IK)
-                            MYYR(IX,IY) = XYK(IX,IY,IK)
-                          END IF
-                        END DO
-                      END DO
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                              MXXR(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+2),             &
-                              MYYR(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                    ENDIF ! SMCGRD
                   END DO
                 END IF  ! EXTRADIM
 ! NFIELD=1
               ELSE
 ! EXTRADIM=0
                 IF (EXTRADIM.EQ.0) THEN
-                  IF (SMCGRD) THEN
-#ifdef W3_SMC
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        ! TODO: Find some other way to access MAPSTA
                         IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                           MX1R(IX,IY) = MFILLR
                         ELSE
@@ -3350,40 +3196,26 @@
                         END IF
                       END DO
                     END DO
+#ifdef W3_SMC
                     IF(SMCOTYPE .EQ. 1) THEN
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MX1R(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
                       call CHECK_ERR(IRET)
                     ELSE
+#endif
                       IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
                           MX1R(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
                       call CHECK_ERR(IRET)
+#ifdef W3_SMC
                     ENDIF
 #endif
-                  ELSE ! IF SMCGRD
-                    DO IX=IX1, IXN
-                      DO IY=IY1, IYN
-                        IF ( X1(IX,IY) .EQ. UNDEF ) THEN
-                          MX1R(IX,IY) = MFILLR
-                        ELSE
-                          MX1R(IX,IY) = X1(IX,IY)
-                        END IF
-                      END DO
-                    END DO
-                    IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1R(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
-                    CALL CHECK_ERR(IRET)
-                  ENDIF ! SMCGRD
 ! EXTRADIM=1
                 ELSE
                   START(4-COORDTYPE)=0
                   DO IK=I1F,I2F
-                    START(4-COORDTYPE)=START(4-COORDTYPE)+1
-                    IF (SMCGRD) THEN
-#ifdef W3_SMC
+                      START(4-COORDTYPE)=START(4-COORDTYPE)+1
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          ! TODO: Find some other way to access MAPSTA
                           IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MX1R(IX,IY) = MFILLR
                           ELSE
@@ -3391,30 +3223,20 @@
                           END IF
                         END DO
                       END DO
+#ifdef W3_SMC
                       IF(SMCOTYPE .EQ. 1) THEN
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1R(IX1:IXN,IY1:IYN),(/START(1), START(3)/),(/COUNT(1), COUNT(3)/))
+                            MX1R(IX1:IXN,IY1:IYN),(/START(1), START(3), START(4)/), &
+                            (/COUNT(1), COUNT(3), COUNT(4)/))
                         call CHECK_ERR(IRET)
                       ELSE
+#endif
                         IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                            MX1R(IX1:IXN,IY1:IYN),(/START(1:3)/),(/COUNT(1:3)/))
+                            MX1R(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
                         call CHECK_ERR(IRET)
+#ifdef W3_SMC
                       ENDIF
 #endif
-                    ELSE ! IF SMCGRD
-                      DO IX=IX1, IXN
-                        DO IY=IY1, IYN
-                          IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
-                            MX1R(IX,IY) = MFILLR
-                          ELSE
-                            MX1R(IX,IY) = XK(IX,IY,IK)
-                          END IF
-                        END DO
-                      END DO
-                      IRET=NF90_PUT_VAR(NCID,VARID(IVAR1+1),               &
-                          MX1R(IX1:IXN,IY1:IYN),(/START(1:4)/),(/COUNT(1:4)/))
-                      CALL CHECK_ERR(IRET)
-                    END IF ! SMCGRD
                   END DO
                 END IF   ! EXTRADIM
               END IF   ! NFIELD

--- a/model/src/ww3_ounf.F90
+++ b/model/src/ww3_ounf.F90
@@ -2939,7 +2939,7 @@
                 ELSE ! IF(SMCGRD)
                   DO IX=IX1, IXN
                     DO IY=IY1, IYN
-                      IF ( MAPSTA(IY,IX) .LE. 0 .OR. X1(IX,IY) .EQ. UNDEF ) THEN
+                      IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                         MXX(IX,IY) = MFILL
                         MYY(IX,IY) = MFILL
                         MXY(IX,IY) = MFILL
@@ -2998,7 +2998,7 @@
                   ELSE ! IF(SMCGRD)
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR. XX(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                           MXX(IX,IY) = MFILL
                           MYY(IX,IY) = MFILL
                         ELSE
@@ -3057,7 +3057,7 @@
                     ELSE ! IF(SMCGRD)
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          IF ( MAPSTA(IY,IX) .LE. 0 .OR.XXK(IX,IY,IK) .EQ. UNDEF ) THEN
+                          IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MXX(IX,IY) = MFILL
                             MYY(IX,IY) = MFILL
                           ELSE
@@ -3102,7 +3102,7 @@
                   ELSE ! IF(SMCGRD)
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR.X1(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                           MX1(IX,IY) = MFILL
                         ELSE
                           MX1(IX,IY) = NINT(X1(IX,IY)/META(1)%FSC)
@@ -3144,7 +3144,7 @@
                     ELSE ! IF(SMCGRD)
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          IF ( MAPSTA(IY,IX) .LE. 0 .OR.XK(IX,IY,IK) .EQ. UNDEF ) THEN
+                          IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MX1(IX,IY) = MFILL
                           ELSE
                             MX1(IX,IY) = NINT(XK(IX,IY,IK)/META(1)%FSC)
@@ -3204,7 +3204,7 @@
                 ELSE ! IF(SMCGRD)
                   DO IX=IX1, IXN
                     DO IY=IY1, IYN
-                      IF ( MAPSTA(IY,IX) .LE. 0 .OR. X1(IX,IY) .EQ. UNDEF ) THEN
+                      IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                         MXXR(IX,IY) = MFILLR
                         MYYR(IX,IY) = MFILLR
                         MXYR(IX,IY) = MFILLR
@@ -3263,7 +3263,7 @@
                   ELSE ! IF SMCGRD
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR. XX(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                           MXXR(IX,IY) = MFILLR
                           MYYR(IX,IY) = MFILLR
                         ELSE
@@ -3318,7 +3318,7 @@
                     ELSE ! IF SMCGRD
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          IF ( MAPSTA(IY,IX) .LE. 0 .OR.XXK(IX,IY,IK) .EQ. UNDEF ) THEN
+                          IF ( XXK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MXXR(IX,IY) = MFILLR
                             MYYR(IX,IY) = MFILLR
                           ELSE
@@ -3363,7 +3363,7 @@
                   ELSE ! IF SMCGRD
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR.X1(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                           MX1R(IX,IY) = MFILLR
                         ELSE
                           MX1R(IX,IY) = X1(IX,IY)
@@ -3404,7 +3404,7 @@
                     ELSE ! IF SMCGRD
                       DO IX=IX1, IXN
                         DO IY=IY1, IYN
-                          IF ( MAPSTA(IY,IX) .LE. 0 .OR.XK(IX,IY,IK) .EQ. UNDEF ) THEN
+                          IF ( XK(IX,IY,IK) .EQ. UNDEF ) THEN
                             MX1R(IX,IY) = MFILLR
                           ELSE
                             MX1R(IX,IY) = XK(IX,IY,IK)

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -2319,8 +2319,7 @@
 !
                 DO IX=IX1, IXN
                   DO IY=IY1, IYN
-                    IF ( MAPSTA(IY,IX) .GT. 0 .AND.                   &
-                         X1(IX,IY) .NE. UNDEF ) THEN
+                    IF ( X1(IX,IY) .NE. UNDEF ) THEN
                         NINGRD = NINGRD + 1
                         XMIN   = MIN ( XMIN , X1(IX,IY) )
                         XMAX   = MAX ( XMAX , X1(IX,IY) )
@@ -2409,8 +2408,7 @@
                   IF ( FLTRI ) THEN
                    DO IX=IX1, IXN
                      DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR.                &
-                             XX(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                             MXX(IX,IY) = MFILL
                             MYY(IX,IY) = MFILL
                             MXY(IX,IY) = MFILL
@@ -2449,8 +2447,7 @@
                   IF ( FLTWO .OR. FLDIR ) THEN
                     DO IX=IX1, IXN
                      DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR.                &
-                             XX(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( XX(IX,IY) .EQ. UNDEF ) THEN
                             MXX(IX,IY) = MFILL
                             MYY(IX,IY) = MFILL
                           ELSE
@@ -2489,8 +2486,7 @@
                   ELSE
                     DO IX=IX1, IXN
                       DO IY=IY1, IYN
-                        IF ( MAPSTA(IY,IX) .LE. 0 .OR.                &
-                             X1(IX,IY) .EQ. UNDEF ) THEN
+                        IF ( X1(IX,IY) .EQ. UNDEF ) THEN
                             MX1(IX,IY) = MFILL
                           ELSE
                             MX1(IX,IY) = NINT(X1(IX,IY)/FSC)


### PR DESCRIPTION
# Pull Request Summary

In gint, do not automatically set points as inactive if sea ice concentration > CICEN. Add PNR.

## Description

In ww3_gint, forcings parameters (winds, ice, etc) are masked where ice concentration is greater than CICEN.

This is not the case for output directly out of ww3_shel, where we get wind and ice output even for points where ice concentration is greater than CICEN. This PR makes gint behave the same way as shel.

This does not change behaviour for wave fields which continue to be masked where ice concentration is greater than CICEN.

Add PNR.

Please also include the following information: 
* Add any suggestions for a reviewer @aliabdolali @JessicaMeixner-NOAA @mickaelaccensi 
* Mention any labels that should be added:  _enhancement_
* Are answer changes expected from this PR? _Regression test_


### Issue(s) addressed

- fixes #316


### Commit Message

In gint: do not automatically set points as inactive if sea ice concentration > CICEN. Add PNR.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? No
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

