### PR TITLE
Default endian

### DIFF
--- a/model/src/constants.F90
+++ b/model/src/constants.F90
@@ -1,4 +1,9 @@
 #include "w3macros.h"
+!
+#ifndef ENDIANNESS
+#define ENDIANNESS "native"
+#endif
+!
 !/ ------------------------------------------------------------------- /
       MODULE CONSTANTS
 !/


### PR DESCRIPTION
# Pull Request Summary
Added CPP directives to set default value for `ENDIANNESS` in `constants.f90` if not defined by build system.
Default value is "native".

Please also include the following information: 
* Add any suggestions for a reviewer @aronroland @JessicaMeixner-NOAA 
* Are answer changes expected from this PR? **No changes expected.**

### Issue(s) addressed
- fixes #742 

### Commit Message
Set default ENDIANNESS="native"  in constants.F90

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [N/A] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [N/A] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regtests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes
* Please indicate the expected changes in the regression test output: No changes expected.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Regtests show only the known differences
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (18 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
```
