### PR TITLE
Use the hash of the spack.yaml as part of the Github Action cache key

### DIFF
--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -1,11 +1,17 @@
 name: GNU Linux Build
 on: [push, pull_request]
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
-  cache_key: gnu4
+  cache_key: gnu5
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10
+
 
 # Split into a steup step, and a WW3 build step which
 # builds multiple switches in a matrix. The setup is run once and 
@@ -16,6 +22,11 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+      - name: checkout-ww3
+        if: steps.cache-env.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with: 
+            path: ww3
       # Cache spack, OASIS, and compiler
       # No way to flush Action cache, so key may have # appended
       - name: cache-env
@@ -26,13 +37,7 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
-
-      - name: checkout-ww3
-        if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
-        with: 
-            path: ww3
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
@@ -83,7 +88,7 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
 
       - name: build-ww3
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,6 +1,11 @@
 name: Intel Linux Build
 on: [push, pull_request]
 
+# Cancel in-progress workflows when pushing to a branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 # Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
 # without having to do it in manually every step
 defaults:
@@ -9,7 +14,7 @@ defaults:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel5
+  cache_key: intel6
   CC: icc
   FC: ifort
   CXX: icpc
@@ -25,6 +30,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+
+      - name: checkout-ww3
+        if: steps.cache-env.outputs.cache-hit != 'true'
+        uses: actions/checkout@v2
+        with: 
+            path: ww3
+
       # Cache spack, OASIS, and compiler
       # No way to flush Action cache, so key may have # appended
       - name: cache-env
@@ -36,7 +48,7 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -47,12 +59,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
           echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
-
-      - name: checkout-ww3
-        if: steps.cache-env.outputs.cache-hit != 'true'
-        uses: actions/checkout@v2
-        with: 
-            path: ww3
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
@@ -108,7 +114,7 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
 
       - name: build-ww3
         run: |


### PR DESCRIPTION
# Pull Request Summary

Now, whenver the spack.yaml changes the CI will rebuild the dependencies. 

Currently they can go stale unless the cache key is manually changed.

Also, cancel in-progress workflows when pushing to a branch to avoid duplicate workflow runs.

### Issue(s) addressed
Fix #751 

### Commit Message

```
Use the hash of the spack.yaml as part of the Github Action cache key
Cancel in-progress workflows when pushing to a branch to avoid duplicate workflow runs.
```
### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* Only changes the CI build. The checks should pass when the builds complete.

