### PR TITLE
Feat/w3wave scaling

### DIFF
--- a/model/src/w3parall.F90
+++ b/model/src/w3parall.F90
@@ -1204,28 +1204,23 @@
 #ifdef W3_S
       CALL STRACE (IENT, 'INIT_GET_JSEA_ISPROC')
 #endif
-!!/DEBUG      WRITE(740+IAPROC,*) 'PDLIB=', PDLIB
-!!/DEBUG      WRITE(740+IAPROC,*) 'GTYPE=', GTYPE, ' UNGTYPE=', UNGTYPE
-!!/DEBUG      FLUSH(740+IAPROC)
-      IF (.NOT. LPDLIB) THEN
-        JSEA   = 1 + (ISEA-1)/NAPROC
-        ISPROC = ISEA - (JSEA-1)*NAPROC
-      ELSE
+
 #ifdef W3_PDLIB
-      IF (GTYPE .ne. UNGTYPE) THEN
-        JSEA   = 1 + (ISEA-1)/NAPROC
-        ISPROC = ISEA - (JSEA-1)*NAPROC
+      IF ((.NOT. LPDLIB ).or.(GTYPE .ne. UNGTYPE)) THEN
+#endif
+         JSEA   = 1 + (ISEA-1)/NAPROC
+         ISPROC = ISEA - (JSEA-1)*NAPROC
+#ifdef W3_PDLIB
       ELSE
-        IP_glob = MAPSF(ISEA,1)
-        IF (IAPROC .le. NAPROC) THEN
-          JSEA   = ISEA_TO_JSEA(ISEA)
-        ELSE
-          JSEA   = -1
-        END IF
-        ISPROC = IPGL_TO_PROC(IP_glob)
+         IP_glob = MAPSF(ISEA,1)
+         IF (IAPROC .le. NAPROC) THEN
+            JSEA   = ISEA_TO_JSEA(ISEA)
+         ELSE
+            JSEA   = -1
+         END IF
+         ISPROC = IPGL_TO_PROC(IP_glob)
       ENDIF
 #endif
-      ENDIF
 !/
 !/ End of JACOBI_INIT ------------------------------------------------ /
 !/

--- a/model/src/w3parall.F90
+++ b/model/src/w3parall.F90
@@ -1212,13 +1212,13 @@
          ISPROC = ISEA - (JSEA-1)*NAPROC
 #ifdef W3_PDLIB
       ELSE
-         IP_glob = MAPSF(ISEA,1)
-         IF (IAPROC .le. NAPROC) THEN
-            JSEA   = ISEA_TO_JSEA(ISEA)
-         ELSE
-            JSEA   = -1
-         END IF
-         ISPROC = IPGL_TO_PROC(IP_glob)
+        IP_glob = MAPSF(ISEA,1)
+        IF (IAPROC .le. NAPROC) THEN
+          JSEA   = ISEA_TO_JSEA(ISEA)
+        ELSE
+          JSEA   = -1
+        END IF
+        ISPROC = IPGL_TO_PROC(IP_glob)
       ENDIF
 #endif
 !/

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -16,7 +16,7 @@
 !/                  | WAVEWATCH III           NOAA/NCEP |
 !/                  |           H. L. Tolman            |
 !/                  |                        FORTRAN 90 |
-!/                  | Last update :         22-Mar-2021 |
+!/                  | Last update :         13-Sep-2022 |
 !/                  +-----------------------------------+
 !/
 !/    04-Feb-2000 : Origination.                        ( version 2.00 )
@@ -95,7 +95,9 @@
 !/    22-Mar-2021 : Update TAUA, RHOA                   ( version 7.13 )
 !/    06-May-2021 : Use ARCTC and SMCTYPE options. JGLi ( version 7.13 )
 !/    19-Jul-2021 : Momentum and air density support    ( version 7.14 )
-!/    11-Nov-2021 : Remove XYB since it is obsolete     ( version 7.xx ) 
+!/    11-Nov-2021 : Remove XYB since it is obsolete     ( version 7.xx )
+!/    13-Sep-2022 : Add OMP for W3NMIN loops. Hide
+!/                  W3NMIN in W3_DEBUGRUN for scaling.  ( version 7.xx )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -162,7 +164,10 @@
 !                Subr.          Basic MPI routines.
 !     ----------------------------------------------------------------
 !
-!  5. Remarks :
+!  5. Remarks : Call to W3NMIN hidden behind W3_DEBUGRUN. This call
+!               currently only serves to warn when one or more procs
+!               have no active seapoints. It has been hid as this
+!               dramatically increases runtime performance.
 !
 !  6. Switches :
 !

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -4442,6 +4442,10 @@
 !
       NMIN   = NSEA
 !
+#ifdef W3_OMPG
+!$OMP PARALLEL PRIVATE (IPROC,NLOC,ISEA,JSEA,ISPROC,IXY,NMIN)
+!$OMP DO SCHEDULE (DYNAMIC,1)
+#endif
       DO IPROC=1, NAPROC
         NLOC   = 0
         DO ISEA=1, NSEA
@@ -4462,6 +4466,10 @@
 #endif
         NMIN   = MIN ( NMIN , NLOC )
         END DO
+#ifdef W3_OMPG
+!$OMP END DO
+!$OMP END PARALLEL
+#endif
 !
       FLAG0  = NMIN .EQ. 0
 #ifdef W3_T

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1715,9 +1715,14 @@
 #ifdef W3_PR3
               CALL W3MAPT
 #endif
-            END IF  !! GTYPE 
+            END IF  !! GTYPE
+
+!! Hides call to W3NMIN, which currently only serves to warn when
+!! one or more procs have zero active seapoints.
+#ifdef W3_DEBUGRUN
               CALL W3NMIN ( MAPSTA, FLAG0 )
               IF ( FLAG0 .AND. IAPROC.EQ.NAPERR ) WRITE (NDSE,1030) IMOD
+#endif
               FLMAP  = .FALSE.
           END IF
 !


### PR DESCRIPTION
# Pull Request Summary
Addresses the performance bottleneck found in subroutine W3NMIN.

## Description
Provide a detailed description of what this PR does.
  * Removes the bottleneck identified in W3NMIN.  The body of W3NMIN is a nested loop over all processors, and all global sea points, scaling inversely as ~(`NAPROC` x `NSEA`).  
  * Two methods to remove this are included.
      * The first adds OMP parallel statements around the loops.  This method provides no reduction when OMP threads are not used.  It does retain a warning message for the case when a processor has no active seapoints.  This is the only functionality currently provided by calling W3NMIN, so we have added it but hid it behind a `DEBUGRUN` `#ifdef` statement.
      * The second comments out the call to W3NMIN, completely removing the bottleneck.

Is a change of answers expected from this PR?
  * No.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * Performance gains from the '`W3NMIN`' fix are shown by comparison alongside the current `develop` runtime
 ![dev_w3nmin_warm_t1_inr](https://user-images.githubusercontent.com/86749872/190305472-12c7ec69-e0f4-44e2-81ec-02ce0266287c.png)

 
* Mention any labels that should be added: 
  * _enhancement_.

* Are answer changes expected from this PR? 
  * No.

* Co-authors
  * @GeorgeVandenberghe-NOAA, @JessicaMeixner-NOAA, @DeniseWorthen, @mvertens. 

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
  * Addresses #775, though will remain open while remaining testing completes. 

### Commit Message
W3NMIN bottleneck fix

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Full matrix run against develop.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No.  The changes do not add a feature to be tested.  

* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes. Orion / Intel.

* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * There are no changes, except those known to be non-identical.

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```bash
**********************************************************************        
********************* non-identical cases ****************************        
**********************************************************************        
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)       
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)        
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)      
mww3_test_03/./work_PR3_UQ_MPI_d2                     (17 files differ)       
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (19 files differ)    
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)     
mww3_test_03/./work_PR1_MPI_d2                     (23 files differ)          
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)      
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)       
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)      
ww3_ta1/./work_UPD0F_U                     (0 files differ)                   
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)               
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)               
ww3_tp2.17/./work_ma                     (1 files differ)                     
ww3_tp2.17/./work_mc1                     (1 files differ)                    
ww3_tp2.17/./work_mc                     (1 files differ)                     
ww3_tp2.17/./work_a                     (1 files differ)                      
ww3_tp2.17/./work_b                     (1 files differ)                      
ww3_tp2.17/./work_mb                     (1 files differ)                     
ww3_tp2.17/./work_c                     (1 files differ)                      
ww3_tp2.17/./work_ma1                     (1 files differ)                    
ww3_tp2.6/./work_pdlib                     (1 files differ)                   
ww3_ufs1.3/./work_a                     (1 files differ)                                                                                              
**********************************************************************        
************************ identical cases *****************************        
**********************************************************************
```

  * [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/9571287/matrixDiff.txt)
  * [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/9571288/matrixCompFull.txt)
  * [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/9571289/matrixCompSummary.txt)
 