### PR TITLE
Debug_Cleanup

### DIFF
--- a/model/src/pdlib_field_vec.F90
+++ b/model/src/pdlib_field_vec.F90
@@ -486,21 +486,9 @@ MODULE PDLIB_FIELD_VEC
       CALL STRACE (IENT, 'VA_SETUP_IOBPD')
 #endif
       !
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'UNST_PDLIB_READ, Beginning of function'
-     FLUSH(740+IAPROC)
-#endif
       LRECL  = MAX ( LRB*NSPEC ,                                      &
                      LRB*(6+(25/LRB)+(9/LRB)+(29/LRB)+(3/LRB)) )
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'UNST_PDLIB_READ, LRB=', LRB, ' LRECL=', LRECL
-     FLUSH(740+IAPROC)
-#endif
       IF (IAPROC .gt. NAPROC) THEN
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'Leaving bc rank IAPROC > NAPROC=', NAPROC
-     FLUSH(740+IAPROC)
-#endif
         RETURN
       END IF
       ListFirst(1)=0
@@ -528,10 +516,6 @@ MODULE PDLIB_FIELD_VEC
        CALL PRINT_MY_TIME("Beginning of iBlock value treatment")
 #endif
 
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'R : iBlock=', iBlock, '/', nbBlock, 'iFirst=', iFirst, 'iEnd=', iEnd
-     FLUSH(740+IAPROC)
-#endif
 !    Let's try to get the indexes right.
 !    We have 1 <= IB <= len = iEnd + 1 - iFirst
 !    We have iFirst - 1 = (iBlock - 1)*BlockSize
@@ -553,11 +537,6 @@ MODULE PDLIB_FIELD_VEC
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("After data reading")
 #endif
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After the block of reads'
-     WRITE(740+IAPROC,*) 'iBlock=', iBlock, '/', nbBlock, ' sum(DATAread)=', sum(DATAread)
-     FLUSH(740+IAPROC)
-#endif
           DO iProc=2,NAPROC
             NbMatch=0
             DO IPloc=1,ListNPA(iProc)
@@ -566,10 +545,6 @@ MODULE PDLIB_FIELD_VEC
                 NbMatch = NbMatch+1
               END IF
             END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'Sending to iProc=', iProc, ' NbMatch=', NbMatch
-     FLUSH(740+IAPROC)
-#endif
             IF (NbMatch .gt. 0) THEN
               allocate(ArrSend(NSPEC,NbMatch), stat=istat)
               ArrSend = 0.
@@ -604,10 +579,6 @@ MODULE PDLIB_FIELD_VEC
               NbMatch = NbMatch+1
             END IF
           END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'Receiving NbMatch=', NbMatch
-     FLUSH(740+IAPROC)
-#endif
           IF (NbMatch .gt. 0) THEN
             allocate(ArrSend(NSPEC,NbMatch), stat=istat)
             CALL MPI_RECV(ArrSend,NSPEC*NbMatch,MPI_REAL, 0, 37, MPI_COMM_WAVE, istatus, ierr)
@@ -629,14 +600,6 @@ MODULE PDLIB_FIELD_VEC
       IF (IAPROC .eq. 1) THEN
         deallocate(DATAread)
       END IF
-#ifdef W3_DEBUGIO
-     IF (IAPROC .le. NAPROC) THEN
-       WRITE(740+IAPROC,*) 'iBlock=', iBlock, '/', nbBlock, ' sum(VA)=', sum(VA)
-       FLUSH(740+IAPROC)
-     END IF
-     WRITE(740+IAPROC,*) 'Exiting READ_FROM_FILE'
-     FLUSH(740+IAPROC)
-#endif
       END SUBROUTINE
 !/ ------------------------------------------------------------------- /
       SUBROUTINE UNST_PDLIB_WRITE_TO_FILE(NDWRITE)
@@ -733,50 +696,20 @@ MODULE PDLIB_FIELD_VEC
 #ifdef W3_S
       CALL STRACE (IENT, 'VA_SETUP_IOBPD')
 #endif
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'Beginning of UNST_PDLIB_WRITE_TO_FILE IAPROC=', IAPROC, 'NAPRST=', NAPRST
-      FLUSH(740+IAPROC)
-      WRITE(740+IAPROC,*) 'sum(VA)=', sum(VA)
-      FLUSH(740+IAPROC)
-#endif
       ListFirst(1) = 0
       DO IPROC=2,NAPROC
         ListFirst(iProc)=ListFirst(iProc-1) + ListNPA(iProc-1)
       END DO
       !
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'NX=', NX, ' NY=', NY, ' NSEA=', NSEA
-      WRITE(740+IAPROC,*) 'NAPROC=', NAPROC, ' NTPROC=', NTPROC
-#endif
       LRECL  = MAX ( LRB*NSPEC ,                                      &
                      LRB*(6+(25/LRB)+(9/LRB)+(29/LRB)+(3/LRB)) )
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'UNST_PDLIB_WRITE, LRB=', LRB, ' LRECL=', LRECL
-      WRITE(740+IAPROC,*) 'NDWRITE=', NDWRITE, 'NAPROC=', NAPROC, 'NTPROC=', NTPROC
-      FLUSH(740+IAPROC)
-#endif
       nbBlock=NSEA / BlockSize + 1
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'NSEA=', NSEA, ' BlockSize=', BlockSize
-#endif
       DO iBlock=1,nbBlock
         iFirst= 1 + (iBlock - 1)*BlockSize
         iEnd= MIN(iBlock * BlockSize, NSEA)
         len=iEnd + 1 - iFirst
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'W : iBlock=', iBlock, '/', nbBlock, 'iFirst=', iFirst, 'iEnd=', iEnd, ' len=', len
-      FLUSH(740+IAPROC)
-#endif
         IF (IAPROC .eq. NAPRST) THEN
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'The Node is a restart writing node'
-      FLUSH(740+IAPROC)
-#endif
           IF (IAPROC .le. NAPROC) THEN
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'It is also a running node'
-      FLUSH(740+IAPROC)
-#endif
             DO JSEA=1,NSEAL
               CALL INIT_GET_ISEA(ISEA, JSEA)
               IF ((iFirst .le. ISEA).and.(ISEA .le. iEnd)) THEN
@@ -785,21 +718,9 @@ MODULE PDLIB_FIELD_VEC
               END IF
             END DO
           END IF
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'Now iterating over all the nodes for RECV'
-      FLUSH(740+IAPROC)
-#endif
           DO iProc=1,NAPROC
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'iProc=', iProc, ' / ', NAPROC
-      FLUSH(740+IAPROC)
-#endif
             IF (iProc .ne. IAPROC) THEN
               NPAloc=ListNPA(iProc)
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'We found NPAloc=', NPAloc
-     FLUSH(740+IAPROC)
-#endif
               NbMatch=0
               DO IPloc=1,NPAloc
                 IPglob = ListIPLG(ListFirst(iProc) + IPloc)
@@ -809,15 +730,7 @@ MODULE PDLIB_FIELD_VEC
               END DO
               IF (NbMatch .gt. 0) THEN
                 allocate(DATArecv(NSPEC, NbMatch), stat=istat)
-#ifdef W3_DEBUGIO
-       WRITE(740+IAPROC,*) 'After allocation and before reception, istat=', istat
-       FLUSH(740+IAPROC)
-#endif
                 CALL MPI_RECV(DATArecv,NSPEC*NbMatch,MPI_REAL, iProc-1, 101, MPI_COMM_WAVE, istatus, ierr)
-#ifdef W3_DEBUGIO
-       WRITE(740+IAPROC,*) 'After reception, ierr=', ierr
-       FLUSH(740+IAPROC)
-#endif
                 idx=0
                 DO IPloc=1,NPAloc
                   IPglob = ListIPLG(IPloc + ListFirst(iProc))
@@ -828,23 +741,10 @@ MODULE PDLIB_FIELD_VEC
                     DATAwrite(:, pos) = DATArecv(:, idx)
                   END IF
                 END DO
-#ifdef W3_DEBUGIO
-       WRITE(740+IAPROC,*) 'After assignation'
-       FLUSH(740+IAPROC)
-#endif
                 deallocate(DATArecv, stat=istat)
-#ifdef W3_DEBUGIO
-       WRITE(740+IAPROC,*) 'After assignation istat=', istat
-       FLUSH(740+IAPROC)
-#endif
               END IF
             END IF
           END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'Before the actual write down'
-     WRITE(740+IAPROC,*) 'iBlock=', iBlock, '/', nbBlock, 'Sum DATAwrite=', sum(DATAwrite)
-     FLUSH(740+IAPROC)
-#endif
           DO ISEA=iFirst,iEnd
             idx  = ISEA - iFirst + 1
             NREC = ISEA + 2
@@ -855,20 +755,8 @@ MODULE PDLIB_FIELD_VEC
             WRITEBUFF(1:NSPEC) = DATAwrite(1:NSPEC, idx)
             WRITE(NDWRITE, POS=RPOS) WRITEBUFF
           END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After the write down'
-     FLUSH(740+IAPROC)
-#endif
         ELSE
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'We are a node different from NAPRST'
-     FLUSH(740+IAPROC)
-#endif
           IF (IAPROC .le. NAPROC) THEN
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'We are a computing node'
-     FLUSH(740+IAPROC)
-#endif
             NbMatch=0
             DO IPloc=1,ListNPA(IAPROC)
               IPglob = ListIPLG(ListFirst(IAPROC) + IPloc)
@@ -876,21 +764,8 @@ MODULE PDLIB_FIELD_VEC
                 NbMatch=NbMatch+1
               END IF
             END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'NbMatch=', NbMatch
-     FLUSH(740+IAPROC)
-#endif
             IF (NbMatch .gt. 0) THEN
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'We are actually a computing node so we have something to send'
-     WRITE(740+IAPROC,*) 'Sending message of length NSEAL=', NSEAL
-     FLUSH(740+IAPROC)
-#endif
               allocate(DATAsend(NSPEC,NbMatch), stat=istat)
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After allocation of DATAsend, istat=', istat
-     FLUSH(740+IAPROC)
-#endif
               idx=0
               DO IPloc=1,ListNPA(IAPROC)
                 IPglob = ListIPLG(ListFirst(IAPROC) + IPloc)
@@ -899,35 +774,12 @@ MODULE PDLIB_FIELD_VEC
                   DATAsend(:,idx)=VA(:,IPloc)
                 END IF
               END DO
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After assignation of DATAsend'
-     FLUSH(740+IAPROC)
-#endif
               CALL MPI_SEND(DATAsend,NSPEC*NbMatch,MPI_REAL, NAPRST-1, 101, MPI_COMM_WAVE, ierr)
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After sending of DATAsend, ierr=', ierr
-     FLUSH(740+IAPROC)
-#endif
               deallocate(DATAsend, stat=istat)
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After deallocation of DATAsend, istat=', istat
-     FLUSH(740+IAPROC)
-#endif
             END IF
           END IF
-#ifdef W3_DEBUGIO
-     WRITE(740+IAPROC,*) 'After the IAPROC test'
-     FLUSH(740+IAPROC)
-#endif
         END IF
       END DO
-!!/DEBUGIO     WRITE(740+IAPROC,*) 'Before the MPI_BARRIER'
-!!/DEBUGIO     FLUSH(740+IAPROC)
-!      CALL MPI_BARRIER(MPI_COMM_WAVE, IERR_MPI)
-#ifdef W3_DEBUGIO
-      WRITE(740+IAPROC,*) 'Exiting the UNST_PDLIB_WRITE_TO_FILE'
-      FLUSH(740+IAPROC)
-#endif
       END SUBROUTINE
 !/ ------------------------------------------------------------------- /
       SUBROUTINE DO_OUTPUT_EXCHANGES(IMOD)
@@ -1023,11 +875,6 @@ MODULE PDLIB_FIELD_VEC
       INTEGER                 :: eEnt(1), IPROC
       INTEGER                 :: TheSize, NSEAL_loc
       INTEGER, SAVE           :: indexOutput
-#ifdef W3_DEBUGOUTPUT
-      WRITE(740+IAPROC,*) 'Beginning of output, indexOutput=', indexOutput
-      WRITE(740+IAPROC,*) 'NAPROC=', NAPROC, ' NAPFLD=', NAPFLD
-      FLUSH(740+IAPROC)
-#endif
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -1040,17 +887,9 @@ MODULE PDLIB_FIELD_VEC
       NRQGO2 = 0
       IT0    = NSPEC
       IROOT  = NAPFLD - 1
-#ifdef W3_DEBUGOUTPUT
-      WRITE(740+IAPROC,*) 'Entering DO_OUTPUT_EXCHANGES'
-      FLUSH(740+IAPROC)
-#endif
       IF ( FLOUT(1) .OR. FLOUT(7) ) THEN
         CALL GET_ARRAY_SIZE(TheSize)
         IF ( IAPROC .LE. NAPROC ) THEN
-#ifdef W3_DEBUGOUTPUT
-          WRITE(740+IAPROC,*) 'Allocating and filling'
-          FLUSH(740+IAPROC)
-#endif
           allocate(ARRexch(TheSize, NSEAL), ARRpos(NSEAL))
           DO JSEA=1,NSEAL
             CALL INIT_GET_ISEA(ISEA, JSEA)
@@ -1454,10 +1293,6 @@ MODULE PDLIB_FIELD_VEC
             END DO
           END DO
         END IF
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'Before assigning field values'
-        FLUSH(740+IAPROC)
-#endif
 !
 !  Now synchronizing the data
 !  It must be possible to ensure that the output
@@ -1471,71 +1306,21 @@ MODULE PDLIB_FIELD_VEC
             END DO
           END IF
         END IF
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'Before ARRexch operations'
-        FLUSH(740+IAPROC)
-#endif
         IF ((IAPROC .le. NAPROC).and.(IAPROC.ne.NAPFLD)) THEN
-#ifdef W3_DEBUGOUTPUT
-            WRITE(740+IAPROC,*) 'Case 1'
-            WRITE(740+IAPROC,*) 'NSEAL=', NSEAL
-            WRITE(740+IAPROC,*) 'IAPROC=', IAPROC, ' NAPFLD=', NAPFLD
-            FLUSH(740+IAPROC)
-#endif
           eEnt(1)=NSEAL
           CALL MPI_SEND(eEnt,1,MPI_INTEGER, NAPFLD-1, 23, MPI_COMM_WAVE, ierr)
-#ifdef W3_DEBUGOUTPUT
-            WRITE(740+IAPROC,*) 'After MPI_SEND 1'
-            FLUSH(740+IAPROC)
-#endif
           CALL MPI_SEND(ARRpos,NSEAL,MPI_INTEGER, NAPFLD-1, 29, MPI_COMM_WAVE, ierr)
-#ifdef W3_DEBUGOUTPUT
-            WRITE(740+IAPROC,*) 'After MPI_SEND 2'
-            FLUSH(740+IAPROC)
-#endif
           CALL MPI_SEND(ARRexch,NSEAL*TheSize,MPI_REAL, NAPFLD-1, 37, MPI_COMM_WAVE, ierr)
-#ifdef W3_DEBUGOUTPUT
-            WRITE(740+IAPROC,*) 'After MPI_SEND 3'
-            FLUSH(740+IAPROC)
-#endif
           deallocate(ARRpos, ARRexch)
         END IF
-#ifdef W3_DEBUGOUTPUT
-            WRITE(740+IAPROC,*) 'Case 2'
-            FLUSH(740+IAPROC)
-#endif
         IF (IAPROC .eq. NAPFLD) THEN
-#ifdef W3_DEBUGOUTPUT
-              WRITE(740+IAPROC,*) 'Case 2a'
-              FLUSH(740+IAPROC)
-#endif
             DO IPROC=1,NAPROC
               IF (IPROC .ne. IAPROC) THEN
-#ifdef W3_DEBUGOUTPUT
-                WRITE(740+IAPROC,*) 'IPROC=', IPROC
-                FLUSH(740+IAPROC)
-#endif
                 CALL MPI_RECV(eEnt,1,MPI_INTEGER, IPROC-1, 23, MPI_COMM_WAVE, istatus, ierr)
-#ifdef W3_DEBUGOUTPUT
-                WRITE(740+IAPROC,*) 'After MPI_RECV 1'
-                FLUSH(740+IAPROC)
-#endif
                 NSEAL_loc=eEnt(1)
-#ifdef W3_DEBUGOUTPUT
-                WRITE(740+IAPROC,*) 'NSEAL_loc=', NSEAL_loc
-                FLUSH(740+IAPROC)
-#endif
                 allocate(ARRpos_loc(NSEAL_loc), ARRexch_loc(TheSize, NSEAL_loc))
                 CALL MPI_RECV(ARRpos_loc,NSEAL_loc,MPI_INTEGER, IPROC-1, 29, MPI_COMM_WAVE, istatus, ierr)
-#ifdef W3_DEBUGOUTPUT
-                WRITE(740+IAPROC,*) 'After MPI_RECV 2'
-                FLUSH(740+IAPROC)
-#endif
                 CALL MPI_RECV(ARRexch_loc,NSEAL_loc*TheSize,MPI_INTEGER, IPROC-1, 37, MPI_COMM_WAVE, istatus, ierr)
-#ifdef W3_DEBUGOUTPUT
-                WRITE(740+IAPROC,*) 'After MPI_RECV 3'
-                FLUSH(740+IAPROC)
-#endif
                 DO I=1,NSEAL_loc
                   ARRtotal(:,ARRpos_loc(I)) = ARRexch_loc(:,I)
                 END DO
@@ -1543,18 +1328,8 @@ MODULE PDLIB_FIELD_VEC
               END IF
             END DO
         END IF
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'After ARRexch operations'
-        FLUSH(740+IAPROC)
-        WRITE(740+IAPROC,*) 'NAPFLD=', NAPFLD
-        FLUSH(740+IAPROC)
-#endif
         IF ( IAPROC .EQ. NAPFLD ) THEN
 !              CALL W3XDMA ( IMOD, NDSE, NDST, FLGRDALL )
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'Call W3XETA from DO_OUTPUT_EXCHANGES'
-        FLUSH(740+IAPROC)
-#endif
               CALL W3XETA ( IMOD, NDSE, NDST )
               IH     = 0
               IF ( FLGRDALL( 2, 1) ) THEN
@@ -1955,15 +1730,7 @@ MODULE PDLIB_FIELD_VEC
               END DO
               CALL W3SETA ( IMOD, NDSE, NDST )
         END IF
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'After IAPROC = NAPFLD test'
-        FLUSH(740+IAPROC)
-#endif
       END IF
-#ifdef W3_DEBUGOUTPUT
-        WRITE(740+IAPROC,*) 'Ending of output, indexOutput=', indexOutput
-        FLUSH(740+IAPROC)
-#endif
       indexOutput=indexOutput+1
       END SUBROUTINE DO_OUTPUT_EXCHANGES
 !/ ------------------------------------------------------------------- /

--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -1061,21 +1061,11 @@
 ! For the 3D arrays: the allocation is performed only if these arrays are allowed
 !                    by specific variables defined through the mod_def file 
 !                    and read by w3iogr, which is called before W3DIMA. 
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before the EF allocation'
-      WRITE(740+IAPROC,*) 'E3DF=', E3DF(1,1)
-#endif
       IF (  E3DF(1,1).GT.0 ) THEN
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) 'Now the allocation'
-#endif
           ALLOCATE(WADATS(IMOD)%EF(NSEALM,E3DF(2,1):E3DF(3,1)),    &
                    STAT=ISTAT )
           CHECK_ALLOC_STATUS ( ISTAT )
         END IF
-#ifdef W3_DEBUGINIT
-      FLUSH(740+IAPROC)
-#endif
       IF (  E3DF(1,2).GT.0 ) THEN
           ALLOCATE(WADATS(IMOD)%TH1M(NSEALM,E3DF(2,2):E3DF(3,2)),  &
                    STAT=ISTAT )

--- a/model/src/w3fldsmd.F90
+++ b/model/src/w3fldsmd.F90
@@ -200,9 +200,7 @@
       USE W3SERVMD, ONLY: STRACE
 #endif
 !
-#ifdef W3_DEBUGFLS
       USE W3ODATMD, only : IAPROC
-#endif
       USE CONSTANTS, ONLY: file_endian
 
       IMPLICIT NONE
@@ -350,37 +348,19 @@
 !
 ! Open file ---------------------------------------------------------- *
 !
-#ifdef W3_DEBUGFLS
-      WRITE(740+IAPROC,*) 'W3FLDSMD 1 : WRITE=', WRITE
-#endif
       IF ( WRITE ) THEN
-#ifdef W3_DEBUGFLS
-        WRITE(740+IAPROC,*) 'W3FLDSMD 2 : WRITE=', WRITE
-#endif
         IF ( PRESENT(FPRE) ) THEN
-#ifdef W3_DEBUGFLS
-          WRITE(740+IAPROC,*) '1 : W3FLDSMD FNAME=', FNAME(:I)
-#endif
           OPEN (NDS,FILE=FPRE//FNAME(:I),FORM=FORM, convert=file_endian, &
                 ERR=803, IOSTAT=IERR)
         ELSE
-#ifdef W3_DEBUGFLS
-          WRITE(740+IAPROC,*) '2 : W3FLDSMD FNAME=', FNAME(:I)
-#endif
           OPEN (NDS,FILE=FNAME(:I),FORM=FORM,convert=file_endian, & 
                 ERR=803,IOSTAT=IERR)
         END IF
       ELSE
         IF ( PRESENT(FPRE) ) THEN
-#ifdef W3_DEBUGFLS
-          WRITE(740+IAPROC,*) '3 : W3FLDSMD FNAME=', FNAME(:I)
-#endif
           OPEN (NDS,FILE=FPRE//FNAME(:I),FORM=FORM,convert=file_endian, &
                 STATUS='OLD',ERR=803,IOSTAT=IERR)
         ELSE
-#ifdef W3_DEBUGFLS
-          WRITE(740+IAPROC,*) '4 : W3FLDSMD FNAME=', FNAME(:I)
-#endif
           OPEN (NDS,FILE=FNAME(:I),FORM=FORM,convert=file_endian,       &
                     STATUS='OLD',ERR=803,IOSTAT=IERR)
         END IF
@@ -388,9 +368,6 @@
 !
 ! Process test data -------------------------------------------------- *
 !
-#ifdef W3_DEBUGFLS
-      WRITE(740+IAPROC,*) 'WRITE=', WRITE
-#endif
       IF ( WRITE ) THEN
           IF ( FDHDR ) THEN
              IF ( FORM .EQ. 'UNFORMATTED' ) THEN
@@ -409,22 +386,9 @@
           IF ( FORM .EQ. 'UNFORMATTED' ) THEN
               READ (NDS,END=806,ERR=805,IOSTAT=IERR)                  &
                     TSSTR, TSFLD, NXT, NYT, GTYPET, FILLER(1:2), TIDEFLAG
-#ifdef W3_DEBUGFLS
-       WRITE(740+IAPROC,*) '1: NXT=', NXT, ' NYT=', NYT
-       WRITE(740+IAPROC,*)            '1: TSSTR=', TSSTR
-       WRITE(740+IAPROC,*)            '1: TSFLD=', TSFLD
-       WRITE(740+IAPROC,*)            '1: NXT=', NXT, ' NYT=', NYT
-       WRITE(740+IAPROC,*)            '1: GTYPET=', GTYPET
-       WRITE(740+IAPROC,*)            '1: FILLER=', FILLER
-       WRITE(740+IAPROC,*)            '1: TIDEFLAG=', TIDEFLAG
-#endif
           ELSE
               READ (NDS,900,END=806,ERR=805,IOSTAT=IERR)              &
                     TSSTR, TSFLD, NXT, NYT, GTYPET, FILLER(1:2), TIDEFLAG
-#ifdef W3_DEBUGFLS
-       WRITE(740+IAPROC,*) '2: NXT=', NXT, ' NYT=', NYT
-       WRITE(740+IAPROC,*) '2: NXT=', NXT, ' NYT=', NYT
-#endif
           END IF
           IF ((FILLER(1).NE.0.OR.FILLER(2).NE.0).AND.TIDEFLAG.GE.0) TIDEFLAG=0
           IF (TIDEFLAG.NE.0.AND.(.NOT.TIDEOK)) THEN     
@@ -442,11 +406,6 @@
           IF ( IDFLD .NE. TSFLD ) GOTO 808
           IF ( IDFLD(1:2) .NE. 'DT' ) THEN
             IF ( NX.NE.NXT .OR. NY.NE.NYT ) THEN 
-#ifdef W3_DEBUGFLS
-       WRITE(740+IAPROC,*) 'Dimension error'
-       WRITE(740+IAPROC,*) 'NX =', NX , ' NY =', NY
-       WRITE(740+IAPROC,*) 'NXT=', NXT, ' NYT=', NYT
-#endif
               GOTO 809
             ELSE
               NX     = NXT

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -3978,13 +3978,6 @@
         CALL READMSH(NDSG,FNAME)
         ALLOCATE(ZBIN(NX, NY),OBSX(NX,NY),OBSY(NX,NY))
         ZBIN(:,1) = VSC * ZB(:)
-#ifdef W3_DEBUGSTP
-        WRITE(740,*) 'VSC=', VSC
-        WRITE(740,*) 'Printing ZBIN 1'
-        DO IX=1,NX
-          WRITE(740,*) 'IX/ZBIN=', IX, ZBIN(IX,1)
-        END DO
-#endif
 !
 ! subgrid obstructions are not yet handled in unstructured grids
 !
@@ -3998,12 +3991,6 @@
       ALLOCATE ( TMPSTA(NY,NX), TMPMAP(NY,NX) )
       TMPSTA = 0
 !
-#ifdef W3_DEBUGSTP
-          WRITE(740,*) 'Printing ZBIN 2'
-          DO IX=1,NX
-            WRITE(740,*) 'IX/ZBIN=', IX, ZBIN(IX,1)
-          END DO
-#endif
       IF (GTYPE .EQ. UNGTYPE) THEN
         TMPSTA = 1
       ELSE
@@ -4433,12 +4420,6 @@
         CALL READMSHOBC(NDSG,UGOBCFILE,TMPSTA,UGOBCOK)
        IF ((GTYPE.EQ.UNGTYPE).AND.UGOBCAUTO.AND.(.NOT.UGOBCOK))  &
           CALL UG_GETOPENBOUNDARY(TMPSTA,ZBIN,UGOBCDEPTH)
-#ifdef W3_DEBUGSTP
-          WRITE(740,*) 'Printing ZBIN 4'
-          DO IX=1,NX
-            WRITE(740,*) 'IX/ZBIN=', IX, ZBIN(IX,1)
-          END DO
-#endif
 !
 ! 8.b Determine where to get the data
 !
@@ -4898,12 +4879,6 @@
                    1, NX, IX3, 1, NY, IY3, 'Zb', 'm')
 #endif
 !
-#ifdef W3_DEBUGSTP
-          WRITE(740,*) 'Printing ZBIN 5'
-          DO IX=1,NX
-            WRITE(740,*) 'IX/ZBIN=', IX, ZBIN(IX,1)
-          END DO
-#endif
       TRNX   = 0.
       TRNY   = 0.
 !
@@ -4954,12 +4929,6 @@
 
           END DO
         END DO
-#ifdef W3_DEBUGSTP
-        DO ISEA=1,NSEA
-          WRITE(740,*) 'ISEA,ZB=', ISEA, ZB(ISEA)
-        END DO
-        FLUSH(740)
-#endif
 !
 #ifdef W3_SMC
  !!Li SMC grid definition of mapping arrays.

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -643,13 +643,6 @@
       ! STK_WN are the decays for Stokes drift partitions
       REAL                    :: STK_WN(25)
 
-#ifdef W3_DEBUGGRID
-       INTEGER     :: nbCase1, nbCase2, nbCase3,           &
-                      nbCase4, nbCase5, nbCase6,           &
-                      nbCase7, nbCase8
-       INTEGER     :: nbTMPSTA0, nbTMPSTA1, nbTMPSTA2
-       INTEGER     :: IAPROC
-#endif
 !
 #ifdef W3_LN1
       REAL                    :: CLIN, RFPM, RFHF
@@ -1160,9 +1153,6 @@
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 2.  IO set-up.
 !
-#ifdef W3_DEBUGGRID
-      IAPROC = 1
-#endif
       NDSI   = 10
       NDSS   = 99
       NDSM   = 20
@@ -4468,9 +4458,6 @@
 !
 ! ... Data to be read in parts
 !
-#ifdef W3_DEBUGGRID
-             WRITE(740+IAPROC,*) 'FROM=', TRIM(FROM)
-#endif
       IF ( FROM .EQ. 'PART' ) THEN
 !
 ! 8.b Update TMPSTA with input boundary data (ILOOP=1)
@@ -4482,16 +4469,6 @@
           'TO READ DATA IN PARTS. STOPPING NOW (107).'
           CALL EXTCDE ( 107 )
         END IF
-#ifdef W3_DEBUGGRID
-       nbCase1=0
-       nbCase2=0
-       nbCase3=0
-       nbCase4=0
-       nbCase5=0
-       nbCase6=0
-       nbCase7=0
-       nbCase8=0
-#endif
         DO ILOOP=1, 2
 !
           I = 1
@@ -4531,12 +4508,6 @@
               CALL NEXTLN ( COMSTR , NDSI , NDSE )
               READ (NDSI,*,END=2001,ERR=2002) IX, IY, CONNCT
             END IF
-#ifdef W3_DEBUGGRID
-  		 WRITE(740+IAPROC,*) 'read IX=', IX
-  		 WRITE(740+IAPROC,*) 'read IY=', IY
-  		 WRITE(740+IAPROC,*) 'read CONNCT=', CONNCT
-#endif
-
 !
 ! ... Check if last point reached.
 !
@@ -4553,10 +4524,6 @@
 !
 ! ... Check if intermediate points are to be added.
 !
-#ifdef W3_DEBUGGRID
-  		 WRITE(740+IAPROC,*) 'CONNCT=', CONNCT
-  		 WRITE(740+IAPROC,*) 'FIRST=', FIRST
-#endif
             IF ( CONNCT .AND. .NOT.FIRST ) THEN
                 IDX    = IX - IXO
                 IDY    = IY - IYO
@@ -4589,9 +4556,6 @@
 ! ... Check if point itself is to be added
 !
             IF ( TMPSTA(IY,IX).EQ.1 .OR. J.EQ.2 ) THEN
-#ifdef W3_DEBUGGRID
-                nbCase2=nbCase2+1
-#endif
               TMPSTA(IY,IX) = NSTAT
             END IF
 !
@@ -4653,9 +4617,6 @@
               IY1    = IY
 !
               JJ     = TMPSTA(IY,IX)
-#ifdef W3_DEBUGGRID
-             nbCase3=nbCase3 + 1
-#endif
               TMPSTA(IY,IX) = NSTAT
               DO
                 NBT    = 0
@@ -4665,36 +4626,24 @@
                       IF (IX.GT.1) THEN
                         IF (TMPSTA(IY  ,IX-1).EQ.NSTAT           &
                             .AND. TMPMAP(IY  ,IX-1).EQ.JJ ) THEN
-#ifdef W3_DEBUGGRID
-               nbCase4=nbCase4 + 1
-#endif
                           TMPSTA(IY,IX) = NSTAT
                         END IF
                       END IF
                       IF (IX.LT.NX) THEN
                         IF (TMPSTA(IY  ,IX+1).EQ.NSTAT           &
                             .AND. TMPMAP(IY  ,IX+1).EQ.JJ ) THEN
-#ifdef W3_DEBUGGRID
-               nbCase5=nbCase5 + 1
-#endif
                           TMPSTA(IY,IX) = NSTAT
                         END IF
                       END IF
                       IF (IY.LT.NY) THEN
                         IF (TMPSTA(IY+1,IX  ).EQ.NSTAT           &
                             .AND. TMPMAP(IY+1,IX  ).EQ.JJ ) THEN
-#ifdef W3_DEBUGGRID
-  	          nbCase6=nbCase6 + 1
-#endif
                           TMPSTA(IY,IX) = NSTAT
                         END IF
                       END IF
                       IF (IY.GT.1) THEN
                         IF (TMPSTA(IY-1,IX  ).EQ.NSTAT           &
                            .AND. TMPMAP(IY-1,IX  ).EQ.JJ ) THEN
-#ifdef W3_DEBUGGRID
-               nbCase7=nbCase7 + 1
-#endif
                           TMPSTA(IY,IX) = NSTAT
                         END IF
                       END IF
@@ -4734,31 +4683,6 @@
 ! ... Branch back input / excluded points ( ILOOP in 8.b )
 !
         END DO
-#ifdef W3_DEBUGGRID
-      WRITE(740+IAPROC,*) 'nbCase1=', nbCase1
-      WRITE(740+IAPROC,*) 'nbCase2=', nbCase2
-      WRITE(740+IAPROC,*) 'nbCase3=', nbCase3
-      WRITE(740+IAPROC,*) 'nbCase4=', nbCase4
-      WRITE(740+IAPROC,*) 'nbCase5=', nbCase5
-      WRITE(740+IAPROC,*) 'nbCase6=', nbCase6
-      WRITE(740+IAPROC,*) 'nbCase7=', nbCase7
-      WRITE(740+IAPROC,*) 'nbCase8=', nbCase8
-      nbTMPSTA0=0
-      nbTMPSTA1=0
-      nbTMPSTA2=0
-      DO IX=1,NX
-        DO IY=1,NY
-          WRITE(740+IAPROC,*) 'IX/IY/TMPSTA=', IX, IY, TMPSTA(IY,IX)
-          IF (TMPSTA(IY,IX) .eq. 0) nbTMPSTA0=nbTMPSTA0+1
-          IF (TMPSTA(IY,IX) .eq. 1) nbTMPSTA1=nbTMPSTA1+1
-          IF (TMPSTA(IY,IX) .eq. 2) nbTMPSTA2=nbTMPSTA2+1
-        END DO
-      END DO
-      WRITE(740+IAPROC,*) 'nbTMPSTA0=', nbTMPSTA0
-      WRITE(740+IAPROC,*) 'nbTMPSTA1=', nbTMPSTA1
-      WRITE(740+IAPROC,*) 'nbTMPSTA2=', nbTMPSTA2
-      FLUSH(740+IAPROC)
-#endif
 !
         ELSE ! FROM .EQ. PART
 !

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -532,12 +532,6 @@
 #ifdef W3_UOST
       CALL UOST_SETGRID(IMOD)
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Beginning of W3INIT'
-      WRITE(740+IAPROC,*) '  FLGR2(10,1)=', FLGR2(10,1)
-      WRITE(740+IAPROC,*) '  FLGR2(10,2)=', FLGR2(10,2)
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("Case 2")
 #endif
@@ -679,16 +673,10 @@
       J      = LEN_TRIM(FNMPRE)
 !
       IF ( OUTPTS(IMOD)%IAPROC .EQ. OUTPTS(IMOD)%NAPLOG )             &
-#ifdef W3_DEBUGINIT
-       WRITE(*,*) '1: w3initmd f=', TRIM(FNMPRE(:J)//LFILE(:IFL))
-#endif
           OPEN (MDS(1),FILE=FNMPRE(:J)//LFILE(:IFL),ERR=888,IOSTAT=IERR)
 !
       IF ( MDS(3).NE.MDS(1) .AND. MDS(3).NE.MDS(4) .AND. TSTOUT ) THEN
           INQUIRE (MDS(3),OPENED=OPENED)
-#ifdef W3_DEBUGINIT
-       WRITE(*,*) '2: w3initmd f=', TRIM(FNMPRE(:J)//TFILE(:IFT))
-#endif
           IF ( .NOT. OPENED ) OPEN                                    &
                (MDS(3),FILE=FNMPRE(:J)//TFILE(:IFT),ERR=889,IOSTAT=IERR)
         END IF
@@ -773,12 +761,6 @@
 #endif
 
 #ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Before PDLIB_INIT'
-#endif
-#endif
-
-#ifdef W3_PDLIB
       CALL PDLIB_INIT(IMOD)
 #endif
 
@@ -786,15 +768,6 @@
        WRITE(10000+IAPROC,*) 'memcheck_____:', 'WW3_INIT SECTION 2c'
        call getMallocInfo(mallinfos)
        call printMallInfo(10000+IAPROC,mallInfos)
-#endif
-
-#ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'After set up of NSEAL, NSEALM=', NSEALM
-     WRITE(740+IAPROC,*) 'After PDLIB_INIT'
-     WRITE(740+IAPROC,*) 'allocated(ISEA_TO_JSEA)=', allocated(ISEA_TO_JSEA)
-     FLUSH(740+IAPROC)
-#endif
 #endif
 
 #ifdef W3_TIMINGS
@@ -822,11 +795,6 @@
 #endif
 
 ! Update of output parameter flags based on mod_def parameters (for 3D arrays)
-
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before W3FLGRDUPDT'
-      FLUSH(740+IAPROC)
-#endif
 
       CALL W3FLGRDUPDT ( NDSO, NDSE, FLGRD, FLGR2, FLGD, FLG2 )
 
@@ -867,16 +835,6 @@
        call getMallocInfo(mallinfos)
        call printMallInfo(10000+IAPROC,mallInfos)
 #endif
-!
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'After set up of NSEAL, NSEAL=', NSEAL
-     WRITE(740+IAPROC,*) 'After set up of NSEAL, NSEALM=', NSEALM
-     WRITE(740+IAPROC,*) 'NSEA=', NSEA, ' NSPEC=', NSPEC
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_DEBUGMPI
-     CALL TEST_MPI_STATUS("Case 11")
-#endif
 
 #ifdef W3_DIST
         IF ( NSEA .LT. NAPROC ) GOTO 820
@@ -885,31 +843,14 @@
         END IF
 #endif
 
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Before PDLIB related allocations'
-     FLUSH(740+IAPROC)
-#endif
-
 #ifdef W3_PDLIB
          IF ((IAPROC .LE. NAPROC).and.(GTYPE .eq. UNGTYPE)) THEN
-#endif
-
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) 'After test 1'
-        FLUSH(740+IAPROC)
-        WRITE(740+IAPROC,*) 'Before BLOCK_SOLVER_INIT'
-        FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_PDLIB
             CALL BLOCK_SOLVER_INIT(IMOD)
             CALL PDLIB_IOBP_INIT(IMOD)
             CALL SET_IOBPA_PDLIB
-#endif
-
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) 'After BLOCK_SOLVER_INIT'
-        FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_PDLIB
@@ -927,19 +868,11 @@
       call getMallocInfo(mallinfos)
       call printMallInfo(10000+IAPROC,mallInfos)
 #endif
-
-#ifdef W3_DEBUGMPI
-      CALL TEST_MPI_STATUS("Case 12")
-#endif
 !
 !
 ! 2.c.2 Allocate arrays
 !
       IF ( IAPROC .LE. NAPROC ) THEN
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Calling W3DIMW at W3INIT, case 1'
-     FLUSH(740+IAPROC)
-#endif
           CALL W3DIMW ( IMOD, NDSE, NDST )
 #ifdef W3_MEMCHECK
       WRITE(10000+IAPROC,*) 'memcheck_____:', 'WW3_INIT SECTION 2h'
@@ -947,10 +880,6 @@
       call printMallInfo(10000+IAPROC,mallInfos)
 #endif
         ELSE
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Calling W3DIMW at W3INIT, case 2'
-     FLUSH(740+IAPROC)
-#endif
           CALL W3DIMW ( IMOD, NDSE, NDST, .FALSE. )
 #ifdef W3_MEMCHECK
       WRITE(10000+IAPROC,*) 'memcheck_____:', 'WW3_INIT SECTION 2i'
@@ -958,11 +887,6 @@
       call printMallInfo(10000+IAPROC,mallInfos)
 #endif
         END IF
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) ' 1: NSEAL=', NSEAL
-     WRITE(740+IAPROC,*) ' maxval(UST)=', maxval(UST)
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("After W3DIMW")
 #endif
@@ -1103,34 +1027,14 @@
         END DO
     END IF
 #endif
-!
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 4'
-     FLUSH(740+IAPROC)
-#endif
       DEALLOCATE ( NT )
 !
 ! 3.  Model initialization ------------------------------------------- /
 ! 3.a Read restart file
 !
       VA(:,:) = 0.
-#ifdef W3_DEBUGMPI
-     CALL TEST_MPI_STATUS("Case 15")
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 4.0'
-     WRITE(740+IAPROC,*) ' 1: min/max/sum(VA)=', minval(VA), maxval(VA), sum(VA)
-     WRITE(740+IAPROC,*) ' 1: NSEAL=', NSEAL
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before W3IORS call", 1)
-#endif
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) ' After ALL_VA_INTEGRAL_PRINT'
-     FLUSH(740+IAPROC)
 #endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("Before W3IORS")
@@ -1145,20 +1049,8 @@
       call printMallInfo(10000+IAPROC,mallInfos)
 #endif
 
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) ' 2: min/max/sum(VA)=', minval(VA), maxval(VA), sum(VA)
-     WRITE(740+IAPROC,*) ' 2: NSEAL=', NSEAL
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After W3IORS call", 1)
-#endif
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 4.1'
-     WRITE(740+IAPROC,*) '    sum(VA)=', sum(VA)
-     FLUSH(740+IAPROC)
 #endif
       FLCOLD = RSTYPE.LE.1  .OR. RSTYPE.EQ.4
       IF ( IAPROC .EQ. NAPLOG ) THEN
@@ -1172,14 +1064,8 @@
               WRITE (NDSO,930) 'full restart.'
             END IF
         END IF
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 4.2'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 4.2", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("After restart inits")
@@ -1203,14 +1089,8 @@
       call printMallInfo(10000+IAPROC,mallInfos)
 #endif
 !
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 4.3'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 4.3", 1)
-#endif
 #endif
 !
 ! 3.b2 Set MAPSTA associated to PDLIB
@@ -1230,14 +1110,8 @@
 !
 ! 3.d Initialization with calm conditions
 !
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 5'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 5", 1)
-#endif
 #endif
       IF ( RSTYPE .EQ. 4 ) THEN
           VA(:,:) = 0.
@@ -1256,22 +1130,12 @@
 !
       IF ( .NOT. FLCUR ) FLCK = .FALSE.
 #ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT definition of FSREFR and FRFREQ'
-     WRITE(740+IAPROC,*) 'FSTOTALIMP=', FSTOTALIMP
-     WRITE(740+IAPROC,*) 'FSREFRACTION=', FSREFRACTION
-     WRITE(740+IAPROC,*) 'FSFREQSHIFT=', FSFREQSHIFT
-     WRITE(740+IAPROC,*) 'Before FLCTH=', FLCTH, 'FLCK=', FLCK
-#endif
         IF (FSTOTALIMP .and. FSREFRACTION) THEN
           FLCTH = .FALSE.
         END IF
         IF (FSTOTALIMP .and. FSFREQSHIFT) THEN
           FLCK = .FALSE.
         END IF
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) ' After FLCTH=', FLCTH, 'FLCK=', FLCK
-#endif
 #endif
 !
 ! 4.  Set-up output times -------------------------------------------- *
@@ -1310,14 +1174,8 @@
           FLOUT(1) = FLOUT(1) .OR. FLOGRD(J,K)
         END DO
       END DO
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 6'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 6", 1)
-#endif
 #endif
 !
       FLOUT(7) = .FALSE.
@@ -1358,17 +1216,8 @@
 !
 !      WRITE(*,*) 'We set NOTYPE=0 just for DEBUGGING'
 !      NOTYPE=0 ! ONLY FOR DEBUGGING PURPOSE
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 7'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 7", 1)
-#endif
-#endif
-#ifdef W3_DEBUGINIT
-      WRITE(*,*) 'Starting the NOTYPE loop, takes time'
 #endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("Before NOTYPE loop")
@@ -1485,20 +1334,11 @@
        call printMallInfo(10000+IAPROC,mallInfos)
 #endif
 
-#ifdef W3_DEBUGINIT
-      WRITE(*,*) 'Ending the NOTYPE loop, takes time'
-#endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("After NOTYPE loop")
 #endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 8'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 8.1", 1)
-#endif
 #endif
 !
 ! 4.d Preprocessing for point output.
@@ -1527,14 +1367,6 @@
 !
       MAPTST = MOD(MAPST2/2,2)
       MAPST2 = MAPST2 - 2*MAPTST
-#ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Before INIT_GET_JSEA_ISPROC call'
-     WRITE(740+IAPROC,*) 'allocated(ISEA_TO_JSEA)=', allocated(ISEA_TO_JSEA)
-     WRITE(740+IAPROC,*) 'NAPROC=', NAPROC
-     FLUSH(740+IAPROC)
-#endif
-#endif
 
 !
 !Li   For multi-resolution SMC grid, these 1-NX and 1-NY nested loops
@@ -1544,13 +1376,7 @@
 !Li   DO IY=1, NY
 !Li     DO IX=1, NX
 !Li       ISEA   = MAPFS(IY,IX)
-#ifdef W3_DEBUGSTP
-    WRITE(740+IAPROC,*) 'Debugging the SETUP / WLV'
-#endif
       DO ISEA=1, NSEA
-#ifdef W3_DEBUGSTP
-    WRITE(740+IAPROC,*) 'ISEA/WLV/ZB=', ISEA, WLV(ISEA), ZB(ISEA)
-#endif
         IX = MAPSF(ISEA,1)
         IY = MAPSF(ISEA,2)
 #ifdef W3_T
@@ -1603,48 +1429,20 @@
 #endif
 
 !
-#ifdef W3_DEBUGSTP
-    FLUSH(740+IAPROC)
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9'
-     FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 8.2", 1)
 #endif
-#endif
 
 !
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.1'
-     WRITE(740+IAPROC,*) ' allocated(MAPTST)=', allocated(MAPTST)
-     WRITE(740+IAPROC,*) 'NY=', NY, ' NX=', NX
-     FLUSH(740+IAPROC)
-#endif
       MAPST2 = MAPST2 + 2*MAPTST
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.2'
-     FLUSH(740+IAPROC)
-#endif
 !
       DEALLOCATE ( MAPTST )
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.3'
-     FLUSH(740+IAPROC)
-#endif
-
 #ifdef W3_MEMCHECK
        WRITE(10000+IAPROC,*) 'memcheck_____:', 'WW3_INIT SECTION 6'
        call getMallocInfo(mallinfos)
        call printMallInfo(10000+IAPROC,mallInfos)
 #endif
 !
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.4'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_T
       WRITE (NDST,9050)
       NX0    = 1
@@ -1666,15 +1464,7 @@
 !
 ! 5.b Fill wavenumber and group velocity arrays.
 !
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.5'
-     FLUSH(740+IAPROC)
-#endif
       DO IS=0, NSEA
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'IS=', IS
-     FLUSH(740+IAPROC)
-#endif
         IF (IS.GT.0) THEN
           DEPTH  = MAX ( DMIN , DW(IS) )
         ELSE
@@ -1697,10 +1487,6 @@
           END DO
         END DO
 
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.6'
-     FLUSH(740+IAPROC)
-#endif
 !
 ! 6.  Initialize arrays ---------------------------------------------- /
 !     Some initialized in W3IORS
@@ -1714,10 +1500,6 @@
 !
       AS    (0) = 0.
       DW    (0) = 0.
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.7'
-     FLUSH(740+IAPROC)
-#endif
 !
 ! 7.  Write info to log file ----------------------------------------- /
 !
@@ -1813,10 +1595,6 @@
           WRITE (NDSO,984)
 !
         END IF
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.8'
-     FLUSH(740+IAPROC)
-#endif
 !
       IF ( NOPTS .EQ. 0 ) FLOUT(2) = .FALSE.
 
@@ -1825,27 +1603,15 @@
        call getMallocInfo(mallinfos)
        call printMallInfo(10000+IAPROC,mallInfos)
 #endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.9'
-     FLUSH(740+IAPROC)
-#endif
 !
 ! Boundary set up for the directions
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 8.3", 1)
 #endif
-#endif
 !!/PDLIB         CALL VA_SETUP_IOBPD
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3INIT, step 8.4", 1)
-#endif
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'W3INIT, aft BLOCK_SOLVER_INIT, step 9.10'
-     FLUSH(740+IAPROC)
 #endif
 !
 ! 8.  Final MPI set up ----------------------------------------------- /
@@ -1853,29 +1619,15 @@
 #ifdef W3_MPI
       CALL W3MPII ( IMOD )
 #endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'After W3MPII'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
       CALL W3MPIO ( IMOD )
-#endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'After W3MPIO'
-     FLUSH(740+IAPROC)
 #endif
 #ifdef W3_MPI
       IF ( FLOUT(2) ) CALL W3MPIP ( IMOD )
 #endif
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'After W3MPIP'
-     FLUSH(740+IAPROC)
-#endif
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGINIT
          CALL PRINT_WN_STATISTIC("W3INIT leaving")
-#endif
 #endif
 #ifdef W3_TIMINGS
        CALL PRINT_MY_TIME("Leaving W3INIT")
@@ -2178,49 +1930,25 @@
 !
 ! 1.  Set up derived data types -------------------------------------- /
 !
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
       NXXXX  = NSEALM * NAPROC
 !
 #ifdef W3_MPI
       CALL MPI_TYPE_VECTOR ( NSEALM, 1, NAPROC, MPI_REAL,        &
                              WW3_FIELD_VEC, IERR_MPI )
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
       CALL MPI_TYPE_VECTOR ( NSEALM, 1, NSPEC, MPI_REAL,         &
                              WW3_SPEC_VEC, IERR_MPI )
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
       CALL MPI_TYPE_COMMIT ( WW3_FIELD_VEC, IERR_MPI )
-#endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
 #endif
 #ifdef W3_MPI
       CALL MPI_TYPE_COMMIT ( WW3_SPEC_VEC, IERR_MPI )
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_MPIT
       WRITE (NDST,9010) WW3_FIELD_VEC, WW3_SPEC_VEC
-#endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
 #endif
 !
 #ifdef W3_MPI
@@ -2236,10 +1964,6 @@
           RETURN
         END IF
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 !
 ! 2.  Set up scatters and gathers for W3WAVE ------------------------- /
 !     ( persistent communication calls )
@@ -2253,10 +1977,6 @@
         IF ( IAPPRO(ISP) .EQ. IAPROC ) NSPLOC = NSPLOC + 1
         END DO
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_MPI
       NRQSG1 = NSPEC - NSPLOC
@@ -2264,16 +1984,9 @@
       IRQSG1 => WADATS(IMOD)%IRQSG1
       IH     = 0
 #endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_MPIT
       WRITE (NDST,9021)
-#endif
-#ifdef W3_DEBUGINIT
-          WRITE(*,*) 'Before VA MPI_SEND/RECV_INIT inits'
 #endif
 #ifdef W3_MPI
       DO ISP=1, NSPEC
@@ -2293,16 +2006,9 @@
           END IF
         END DO
 #endif
-#ifdef W3_DEBUGINIT
-           WRITE(*,*) 'After VA MPI_SEND/RECV_INIT inits'
-#endif
 #ifdef W3_MPIT
       WRITE (NDST,9023)
       WRITE (NDST,9020) NRQSG1
-#endif
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3MPII, step 1'
-      FLUSH(740+IAPROC)
 #endif
 !
 ! 3.  Set up scatters and gathers for W3SCAT and W3GATH -------------- /

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1284,18 +1284,6 @@
 #ifdef W3_S
       CALL STRACE (IENT, 'W3OUTG')
 #endif
-!
-#ifdef W3_DEBUGSTP
-    WRITE(740+IAPROC,*) 'NTH=', NTH
-    WRITE(740+IAPROC,*) 'NK=', NK
-    WRITE(740+IAPROC,*) 'NSPEC=', NSPEC
-    WRITE(740+IAPROC,*) 'NSEAL=', NSEAL
-    WRITE(740+IAPROC,*) 'W3OUTG, initial A printing'
-    WRITE(740+IAPROC,*) 'size(A,1)=', size(A,1)
-    WRITE(740+IAPROC,*) 'size(A,2)=', size(A,2)
-    WRITE(740+IAPROC,*) 'size(A,3)=', size(A,3)
-    FLUSH(740+IAPROC)
-#endif
       DO I=1,NOGRP
         DO J=1,NGRPP
           FLOLOC(I,J) =   &

--- a/model/src/w3iogrmd.F90
+++ b/model/src/w3iogrmd.F90
@@ -328,10 +328,6 @@
       CALL STRACE (IENT, 'W3IOGR')
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 1'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 1'
        call getMallocInfo(mallinfos)
@@ -489,10 +485,6 @@
       FNAMEP = TNAMEP
       FNAMEG = TNAMEG
       FNAMEI = TNAMEI
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 2'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       FLTEST = .TRUE.
@@ -521,10 +513,6 @@
           CALL EXTCDE ( 1 )
         END IF
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 3'
-     FLUSH(740+IAPROC)
-#endif
       WRITE  = INXOUT .EQ. 'WRITE'
 !
 #ifdef W3_T
@@ -534,10 +522,6 @@
       CALL W3SETO ( IGRD, NDSE, NDST )
       CALL W3SETG ( IGRD, NDSE, NDST )
       FILEXT = TEMPXT
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 4'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 2'
        call getMallocInfo(mallinfos)
@@ -559,10 +543,6 @@
         ENDIF
 !
       REWIND ( NDSM )
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 5, WRITE=', WRITE
-     FLUSH(740+IAPROC)
-#endif
 !
 ! Dimensions and test information --------------------------------------
 !
@@ -700,10 +680,6 @@
 #endif
 !
         ENDIF
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 6'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 3'
        call getMallocInfo(mallinfos)
@@ -715,10 +691,6 @@
 !                                                   Module W3GDAT GRID
 !
       ALLOCATE ( MAPTMP(NY,NX) )
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7'
-     FLUSH(740+IAPROC)
-#endif
 !
       IF ( WRITE ) THEN
           MAPTMP = MAPSTA + 8*MAPST2
@@ -803,10 +775,6 @@
 !!        WRITE(NDSM)                                                 &
 !!             COUG_2D, COUG_RAD3D, COUG_US3D
         ELSE
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.1'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 4'
        call getMallocInfo(mallinfos)
@@ -815,10 +783,6 @@
 
           READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
                GTYPE, FLAGLL, ICLOSE
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.2'
-     FLUSH(740+IAPROC)
-#endif
 !!Li      IF (.NOT.GINIT) CALL W3DIMX ( IGRD, NX, NY, NSEA, NDSE, NDST )
           IF (.NOT.GINIT) CALL W3DIMX ( IGRD, NX, NY, NSEA, NDSE, NDST &
 #ifdef W3_SMC
@@ -826,10 +790,6 @@
                                  , NARC, NBAC, NSPEC              &
 #endif
                                       )
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.3'
-     FLUSH(740+IAPROC)
-#endif
 !
 ! Reads different kind of information depending on grid type
 !
@@ -855,10 +815,6 @@
               X0 = HUGE(X0); Y0 = HUGE(Y0)
               SX = HUGE(SX); SY = HUGE(SY)
             CASE (UNGTYPE) 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.4'
-     FLUSH(740+IAPROC)
-#endif
               READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                 & 
                 FSN, FSPSI,FSFCT,FSNIMP,FSTOTALIMP,FSTOTALEXP,        &
                 FSBCCFL, FSREFRACTION, FSFREQSHIFT, FSSOURCE,         &
@@ -876,15 +832,7 @@
                 B_JGS_NORM_THR,                                       &
                 B_JGS_NLEVEL,                                         &
                 B_JGS_SOURCE_NONLINEAR
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.5, GUGINIT=', GUGINIT
-     FLUSH(740+IAPROC)
-#endif
               IF (.NOT. GUGINIT) THEN
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'Before call to W3DIMUG from W3IOGR'
-     FLUSH(740+IAPROC)
-#endif
                 CALL W3DIMUG ( IGRD, NTRI, NX, COUNTOT, NNZ, NDSE, NDST )
               END IF
 #ifdef W3_MEMCHECK
@@ -892,20 +840,12 @@
        call getMallocInfo(mallinfos)
        call printMallInfo(IAPROC,mallInfos)
 #endif
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.6'
-     FLUSH(740+IAPROC)
-#endif
               READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                 &
                 X0, Y0, SX, SY, DXYMAX, XGRD, YGRD, TRIGP, TRIA,             &
                 LEN, IEN, ANGLE0, ANGLE, SI, MAXX, MAXY,   &
                 DXYMAX, INDEX_CELL, CCON, COUNTCON, IE_CELL,  &
                 POS_CELL, IOBP, IOBPA, IOBDP, IOBPD, IAA, JAA, POSI
 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.6.4'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 6'
        call getMallocInfo(mallinfos)
@@ -913,27 +853,11 @@
 #endif
 
 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.7'
-     FLUSH(740+IAPROC)
-#endif
             END SELECT !GTYPE
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.8'
-     FLUSH(740+IAPROC)
-#endif
           IF (GTYPE.NE.UNGTYPE) CALL W3GNTX ( IGRD, NDSE, NDST ) 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.9'
-     FLUSH(740+IAPROC)
-#endif
           READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
                ZB, MAPTMP, MAPFS, MAPSF, TRFLAG
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.10'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_SMC
         IF( GTYPE .EQ. SMCTYPE ) THEN
@@ -962,17 +886,9 @@
         ENDIF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.11'
-     FLUSH(740+IAPROC)
-#endif
           MAPSTA = MOD(MAPTMP+2,8) - 2
           MAPST2 = (MAPTMP-MAPSTA) / 8
           MAPSF(:,3) = MAPSF(:,2) + (MAPSF(:,1)-1)*NY
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.12'
-     FLUSH(740+IAPROC)
-#endif
           IF ( TRFLAG .NE. 0 ) THEN
               READ (NDSM,END=801,ERR=802,IOSTAT=IERR) TRNX, TRNY
             END IF
@@ -983,10 +899,6 @@
           TRNY = 1
 #endif
 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.13'
-     FLUSH(740+IAPROC)
-#endif
           READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
                DTCFL, DTCFLI, DTMAX, DTMIN, DMIN, CTMAX,              &
                FICE0, FICEN, FICEL, PFMOVE, FLDRY, FLCX, FLCY,        &
@@ -995,22 +907,10 @@
                IICEDISP, ICESCALES(1:4), CALTYPE, CMPRTRCK, IICEHFAC, &
                IICEDDISP, IICEHDISP, IICEFDISP, BTBETA,               &
                AAIRCMIN, AAIRGB
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.14'
-     FLUSH(740+IAPROC)
-#endif
 
               READ(NDSM,END=801,ERR=802,IOSTAT=IERR)GRIDSHIFT
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.15'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_SEC1
          READ (NDSM) NITERSEC1
-#endif
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.16'
-     FLUSH(740+IAPROC)
 #endif
 !
 #ifdef W3_RTD
@@ -1019,10 +919,6 @@
 
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 7.17'
-     FLUSH(740+IAPROC)
-#endif
         END IF
 
 #ifdef W3_MEMCHECK
@@ -1032,10 +928,6 @@
 #endif
 
 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 8'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9010) GTYPE, FLAGLL, ICLOSE, SX, SY, X0, Y0, TRFLAG
@@ -1063,10 +955,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 9'
-     FLUSH(740+IAPROC)
-#endif
       DEALLOCATE ( MAPTMP )
 !
 #ifdef W3_T
@@ -1095,10 +983,6 @@
                FTF, FTWN, FTTR, FTWL, FACTI1, FACTI2, FACHFA, FACHFE
         END IF
 
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 10'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9030) (MAPWN(I),I=1,8), (MAPTH(I),I=1,8), DTH*RADE, &
@@ -1122,10 +1006,6 @@
           CLOSE (NDSM)
           RETURN
         END IF
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 11'
-     FLUSH(740+IAPROC)
-#endif
 !
 ! Parameters for output boundary points ------------------------------ *
 !                                                 Module W3ODATMD OUT5
@@ -1138,10 +1018,6 @@
           READ (NDSM,END=801,ERR=802,IOSTAT=IERR)                     &
                XBPO, YBPO, RDBPO, IPBPO, ISBPO
         END IF
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 12'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9020)
@@ -1167,10 +1043,6 @@
                 IHMAX, HSPMIN, WSMULT, WSCUT, FLCOMB, NOSWLL,         &
                 PTMETH, PTFCUT
         END IF
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 13'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9025) IHMAX, HSPMIN, WSMULT, WSCUT, FLCOMB, NOSWLL
@@ -1252,10 +1124,6 @@
                 IC5PARS
 #endif
         END IF
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 14'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9040) FACP, XREL, XFLT, FXFM, FXPM, XFT, XFC,    &
@@ -1295,10 +1163,6 @@
       IF ( FLTEST ) WRITE (NDST,9048) NITTIN, CAP_ID, CINXSI, CD_MAX
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 15'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_FLX4
       IF ( WRITE ) THEN
           WRITE (NDSM)                            FLX4A0
@@ -1350,10 +1214,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 16'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_ST2
       IF ( FLTEST ) WRITE (NDST,9050)                            &
            ZWIND, FSWELL, CDSA0, CDSA1, CDSA2,                   &
@@ -1383,10 +1243,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 17'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_ST4
       IF ( WRITE ) THEN
           CALL INSIN4(.TRUE.)
@@ -1420,10 +1276,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 18'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_ST6
       IF ( WRITE ) THEN
           WRITE (NDSM) SIN6A0, SDS6ET, SDS6A1, SDS6A2,           &
@@ -1439,10 +1291,6 @@
 !
 ! ... Nonlinear interactions
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 19'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_NL1
       IF ( WRITE ) THEN
           WRITE (NDSM)                                           &
@@ -1472,10 +1320,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 20'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_NL2
       IF ( FLTEST ) WRITE (NDST,9051) IQTPE, NLTAIL, NDPTHS
       IF ( FLTEST ) WRITE (NDST,9151) DPTHNL
@@ -1506,10 +1350,6 @@
         END IF
 #endif
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 21'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_NL3
       IF ( FLTEST ) WRITE (NDST,9051) SNLNQ, SNLMSC, SNLNSC,     &
                                       SNLSFD, SNLSFS
@@ -1577,10 +1417,6 @@
 !
 ! Layered barriers needed for file management in xnl_init
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 22'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
       IF ( FLSNL2 .AND. .NOT.WRITE ) THEN
           DO IP=1, IAPROC-1
@@ -1626,10 +1462,6 @@
 !
 ! ... Depth induced breaking ...
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 23'
-     FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WIOGR SECTION 8'
        call getMallocInfo(mallinfos)
@@ -1689,10 +1521,6 @@
 !
 ! Propagation scheme ------------------------------------------------- *
 !                                                 Module W3GDATMD PROP
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 24'
-     FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_PR2
       IF ( WRITE ) THEN
@@ -1753,10 +1581,6 @@
 ! Interpolation tables ( fill locally ) ----------------------------- *
 !                                                      Module W3DISPMD
 !
-#ifdef W3_DEBUGIOGR
-     WRITE(740+IAPROC,*) 'W3IOGR, step 25'
-     FLUSH(740+IAPROC)
-#endif
       IF ( .NOT.WRITE .AND. .NOT.FLDISP ) THEN
 #ifdef W3_T
           WRITE (NDST,9070)

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -349,11 +349,6 @@
 !  UNFORMATTED files in OPEN
 !
 !     NDSR = 525
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'Beginning of W3IORS subroutine'
-        WRITE(740+IAPROC,*)  'W3IORS, step 1'
-        FLUSH(740+IAPROC)
-#endif
 
       IOSFLG = IOSTYP .GT. 0
 !
@@ -392,10 +387,6 @@
 !
 ! initializations ---------------------------------------------------- *
 !
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 2'
-        FLUSH(740+IAPROC)
-#endif
       IF ( .NOT.DINIT ) THEN
           IF ( IAPROC .LE. NAPROC ) THEN
               CALL W3DIMW ( IMOD, NDSE, NDST )
@@ -403,20 +394,12 @@
               CALL W3DIMW ( IMOD, NDSE, NDST, .FALSE. )
             END IF
         END IF
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 3'
-        FLUSH(740+IAPROC)
-#endif
 !
       IF ( IAPROC .LE. NAPROC ) VA(:,0) = 0.
 !
       LRECL  = MAX ( LRB*NSPEC ,                                      &
                      LRB*(6+(25/LRB)+(9/LRB)+(29/LRB)+(3/LRB)) )
       NSIZE  = LRECL / LRB
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, LRECL=', LRECL, ' NSIZE=', NSIZE
-        FLUSH(740+IAPROC)
-#endif
 !     --- Allocate buffer array with zeros (used to
 !         fill bytes up to size LRECL). ---
       ALLOCATE(WRITEBUFF(NSIZE))
@@ -465,10 +448,6 @@
             //'TEST OUTPUT ARE THE SAME : ',NDST
          CALL EXTCDE ( 15 )
       ENDIF
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 4'
-        FLUSH(740+IAPROC)
-#endif
 
       IF ( WRITE ) THEN
           IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST )                    &
@@ -556,10 +535,6 @@
 !
 ! TIME if required --------------------------------------------------- *
 !
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 5'
-        FLUSH(740+IAPROC)
-#endif
       IF (TYPE.EQ.'FULL') THEN
           RPOS  = 1_8 + LRECL*(2-1_8)
           IF ( WRITE ) THEN
@@ -588,18 +563,7 @@
 ! Spectra ------------------------------------------------------------ *
 !          ( Bail out if write for TYPE.EQ.'WIND' )
 !
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 6'
-        FLUSH(740+IAPROC)
-#endif
       IF ( WRITE ) THEN
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, Matching WRITE statement'
-        FLUSH(740+IAPROC)
-        WRITE(740+IAPROC,*)  'W3IORS, TYPE=', TYPE, ' IOSFLG=', IOSFLG
-        WRITE(740+IAPROC,*)  'W3IORS, NAPROC=', NAPROC, ' NAPRST=', NAPRST
-        FLUSH(740+IAPROC)
-#endif
           IF ( TYPE.EQ.'WIND' .OR. TYPE.EQ.'CALM' ) THEN
               IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST ) THEN
                 CLOSE ( NDSR )
@@ -616,18 +580,10 @@
 
               RETURN
             ELSE IF ( IAPROC.LE.NAPROC .OR. IAPROC.EQ. NAPRST ) THEN
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, Need to match 1'
-        FLUSH(740+IAPROC)
-#endif
 !
 ! Original non-server version writing of spectra
 !
               IF ( .NOT.IOSFLG .OR. (NAPROC.EQ.1.AND.NAPRST.EQ.1) ) THEN
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, Need to match 2'
-        FLUSH(740+IAPROC)
-#endif
                   DO JSEA=1, NSEAL
                     CALL INIT_GET_ISEA(ISEA, JSEA)
                     NREC   = ISEA + 2
@@ -643,18 +599,8 @@
                 ELSE
 #endif
 !
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, Before test for UNST_PDLIB_WRITE_TO_FILE'
-        WRITE(740+IAPROC,*)  'W3IORS, GTPYPE=', GTYPE, ' UNGTYPE=', UNGTYPE
-        WRITE(740+IAPROC,*)  'W3IORS, PDLIB=', LPDLIB
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
                 IF (LPDLIB .and. (GTYPE.eq.UNGTYPE)) THEN
-#endif
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, Directly before call for UNST_PDLIB_WRITE_TO_FILE, NDSR=', NDSR
-        FLUSH(740+IAPROC)
 #endif
 #ifdef W3_TIMINGS
                CALL PRINT_MY_TIME("Before UNST_PDLIB_WRITE_TO_FILE")
@@ -748,10 +694,6 @@
 !
             END IF
         ELSE
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 7'
-        FLUSH(740+IAPROC)
-#endif
 !
 ! Reading spectra
 !
@@ -761,12 +703,6 @@
 #endif
           ELSE
             IF (LPDLIB .and. (GTYPE.eq.UNGTYPE)) THEN
-#ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*)  'Before call to UNST_PDLIB_READ_FROM_FILE'
-        FLUSH(740+IAPROC)
-#endif
-#endif
 #ifdef W3_TIMINGS
                CALL PRINT_MY_TIME("Before UNST_PDLIB_READ_FROM_FILE")
 #endif
@@ -775,16 +711,6 @@
 #endif
 #ifdef W3_TIMINGS
                CALL PRINT_MY_TIME("After UNST_PDLIB_READ_FROM_FILE")
-#endif
-#ifdef W3_PDLIB
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*)  ' After call to UNST_PDLIB_READ_FROM_FILE'
-        WRITE(740+IAPROC,*)  ' min/max(VA)=', minval(VA), maxval(VA)
-        DO JSEA=1,NSEAL
-          WRITE(740+IAPROC,*) ' JSEA=', JSEA, ' sum(VA)=', sum(VA(:,JSEA))
-        END DO
-        FLUSH(740+IAPROC)
-#endif
 #endif
             ELSE
 #ifdef W3_MPI
@@ -867,10 +793,6 @@
       NPRTX2 = 1 + (NX-1)/NSIZE
       NPRTY2 = 1 + (NY-1)/NSIZE
 !
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 8'
-        FLUSH(740+IAPROC)
-#endif
       IF ( WRITE ) THEN
 !
           IF (TYPE.EQ.'FULL') THEN
@@ -1070,9 +992,6 @@
               RPOS = 1_8 + LRECL*(NREC-1_8)
               READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)                &
                       TLEV, TICE, TRHO
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading WLV'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS = 1_8 + LRECL*(NREC-1_8)
@@ -1080,9 +999,6 @@
                       (WLV(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
                                       MIN(NSEA,IPART*NSIZE))
                 END DO
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading ICE'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS = 1_8 + LRECL*(NREC-1_8)
@@ -1111,9 +1027,6 @@
               END DO
 #endif
               ALLOCATE ( MAPTMP(NY,NX) )
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading MAPTMP'
-#endif
               DO IY=1, NY
                 DO IPART=1,NPRTX2
                   NREC  = NREC + 1
@@ -1137,9 +1050,6 @@
 #endif
                 ENDIF 
 !
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading UST'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS  = 1_8 + LRECL*(NREC-1_8)
@@ -1147,9 +1057,6 @@
                       (UST(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
                                       MIN(NSEA,IPART*NSIZE))
                 END DO
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading USTDIR'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS  = 1_8 + LRECL*(NREC-1_8)
@@ -1157,9 +1064,6 @@
                       (USTDIR(ISEA),ISEA=1+(IPART-1)*NSIZE,           &
                                       MIN(NSEA,IPART*NSIZE))
                 END DO
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading ASF'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS  = 1_8 + LRECL*(NREC-1_8)
@@ -1167,9 +1071,6 @@
                       (ASF(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
                                       MIN(NSEA,IPART*NSIZE))
                 END DO
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading FPIS'
-#endif
               DO IPART=1,NPART
                 NREC  = NREC + 1
                 RPOS  = 1_8 + LRECL*(NREC-1_8)
@@ -1178,22 +1079,13 @@
                                       MIN(NSEA,IPART*NSIZE))
                 END DO
             IF (OARST) THEN
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading CUR'
-#endif
               IF ( FLOGOA(1,2) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) CX(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) CY(1:NSEA)
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading ICEF'
-#endif
               IF ( FLOGOA(1,12) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) ICEF(1:NSEA)
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading HS'
-#endif
               IF ( FLOGOA(2,1) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1201,9 +1093,6 @@
                   IF (J .LE. NSEA) HS(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading WLM'
-#endif
               IF ( FLOGOA(2,2) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1211,9 +1100,6 @@
                   IF (J .LE. NSEA) WLM(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading T0M1'
-#endif
               IF ( FLOGOA(2,4) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1221,9 +1107,6 @@
                   IF (J .LE. NSEA) T0M1(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading T01'
-#endif
               IF ( FLOGOA(2,5) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1231,9 +1114,6 @@
                   IF (J .LE. NSEA) T01(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading FP0'
-#endif
               IF ( FLOGOA(2,6) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1241,9 +1121,6 @@
                   IF (J .LE. NSEA) FP0(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading THM'
-#endif
               IF ( FLOGOA(2,7) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1251,9 +1128,6 @@
                   IF (J .LE. NSEA) THM(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading WNMEAN'
-#endif
               IF ( FLOGOA(2,19) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1261,9 +1135,6 @@
                   IF (J .LE. NSEA) WNMEAN(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading CHARN'
-#endif
               IF ( FLOGOA(5,2) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1271,9 +1142,6 @@
                   IF (J .LE. NSEA) CHARN(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TAUWI'
-#endif
               IF ( FLOGOA(5,5) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1285,9 +1153,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TWS'
-#endif
               IF ( FLOGOA(5,11) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1295,9 +1160,6 @@
                   IF (J .LE. NSEA) TWS(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TAUO'
-#endif
               IF ( FLOGOA(6,2) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1309,9 +1171,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading BHD'
-#endif
               IF ( FLOGOA(6,3) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1319,9 +1178,6 @@
                   IF (J .LE. NSEA) BHD(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading PHIOC'
-#endif
               IF ( FLOGOA(6,4) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1329,9 +1185,6 @@
                   IF (J .LE. NSEA) PHIOC(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TUS'
-#endif
               IF ( FLOGOA(6,5) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1343,9 +1196,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading USS'
-#endif
               IF ( FLOGOA(6,6) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1357,9 +1207,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TAUICE'
-#endif
               IF ( FLOGOA(6,10) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1371,9 +1218,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TAUOC'
-#endif
               IF ( FLOGOA(6,13) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1385,9 +1229,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading UB'
-#endif
               IF ( FLOGOA(7,2) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1399,9 +1240,6 @@
                   ENDIF
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading PHIBBL'
-#endif
               IF ( FLOGOA(7,4) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 DO I=1, NSEALM
@@ -1409,9 +1247,6 @@
                   IF (J .LE. NSEA) PHIBBL(I) = TMP(J)
                 ENDDO
               ENDIF
-#ifdef W3_DEBUGINIT
-         WRITE(740+IAPROC,*) 'Before reading TAUBBL'
-#endif
               IF ( FLOGOA(7,5) ) THEN
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP(1:NSEA)
                 READ (NDSR,ERR=802,IOSTAT=IERR) TMP2(1:NSEA)
@@ -1493,11 +1328,6 @@
   ELSE
      CLOSE ( NDSR )
   END IF
-!
-#ifdef W3_DEBUGIO
-        WRITE(740+IAPROC,*)  'W3IORS, step 9'
-        FLUSH(740+IAPROC)
-#endif
 !
       IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
       IF (ALLOCATED(TMP))  DEALLOCATE(TMP)

--- a/model/src/w3parall.F90
+++ b/model/src/w3parall.F90
@@ -338,11 +338,6 @@
       DO ITH=1, NTH
         FDDMAX = MAX ( FDDMAX , ABS(ESIN(ITH)*eDDDX - ECOS(ITH)*eDDDY ) )
       END DO
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'eDDDX=', eDDDX, ' Y=', eDDDY
-      WRITE(740+IAPROC,*) 'FDDMAX=', FDDMAX
-      FLUSH(740+IAPROC)
-#endif
       DO IK=1, NK
         FRK(IK) = FACTH * DSDD(IK) / WN(IK,ISEA)
         !FRK(IK) = FRK(IK) / MAX ( 1. , FRK(IK)*FDDMAX/CTMAX )
@@ -352,17 +347,6 @@
         VCFLT(ISP) = FRG(MAPWN(ISP)) * ECOS(ISP) +                     &
            FRK(MAPWN(ISP)) * ( ESIN(ISP)*eDDDX - ECOS(ISP)*eDDDY )
       END DO
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'pdlib: FACTH=', FACTH
-      WRITE(740+IAPROC,*) 'pdlib: CTHG0=', eCTHG0
-      WRITE(740+IAPROC,*) 'pdlib: FDG=', FDG
-      WRITE(740+IAPROC,*) 'pdlib: FDDMAX=', FDDMAX
-      WRITE(740+IAPROC,*) 'pdlib: sum(FRK)=', sum(FRK)
-      WRITE(740+IAPROC,*) 'pdlib: sum(FRG)=', sum(FRG)
-      WRITE(740+IAPROC,*) 'pdlib: sum(DSDD)=', sum(DSDD)
-      WRITE(740+IAPROC,*) 'ISEA=', ISEA, ' sum(VCTH)=', sum(VCFLT)
-      FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_REFRX
 ! 3.c @C/@x refraction and great-circle propagation
@@ -647,12 +631,6 @@
       DCYY   =  -   eDCYDY
       FKD    =    ( eCX*eDDDX + eCY*eDDDY )
       FACK = DTG
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'DCXX=', DCXX, ' DCXYYX=', DCXYYX
-      WRITE(740+IAPROC,*) 'DCYY=', DCYY, ' FKD=', FKD
-      WRITE(740+IAPROC,*) 'DTG=', DTG
-      FLUSH(740+IAPROC)
-#endif
       DO ITH=1, NTH
         FKC(ITH) = EC2(ITH)*DCXX + ESC(ITH)*DCXYYX + ES2(ITH)*DCYY
       END DO
@@ -672,10 +650,6 @@
           DSDD(IK) = 0.
         END IF
       END DO
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'DSDD(min/max)=', minval(DSDD), maxval(DSDD)
-      FLUSH(740+IAPROC)
-#endif
       DO IK=0, NK+1
         FKD0   = FKD / CG(IK,ISEA) * DSDD(IK)
         VELFAC =  FACK/DB(IK+1) 
@@ -684,20 +658,12 @@
           CFLK(IK+1,ITH) = VELNOFILT/VELFAC
         END DO
       END DO
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'sum(CFLK)=', sum(CFLK)
-      FLUSH(740+IAPROC)
-#endif
       DO IK=1,NK
         DO ITH=1,NTH
           ISP=ITH + (IK-1)*NTH
           CAS(ISP)=DBLE(CFLK(IK,ITH))
         END DO
       END DO
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'sum(abs(CAS))=', sum(abs(CAS))
-      FLUSH(740+IAPROC)
-#endif
 !/
 !/ End of JACOBI_INIT ------------------------------------------------ /
 !/
@@ -788,10 +754,6 @@
       CALL STRACE (IENT, 'PROP_FREQ_SHIFT_M2')
 #endif
 
-#ifdef W3_DEBUGDCXDX
-       WRITE(740+IAPROC,*) 'Now we use DCXDX array in PROP_FREQ_SHIFT_M2'
-#endif
-
       IF (LPDLIB) THEN
         eDCXDX = DCXDX(1,IP)
         eDCXDY = DCXDY(1,IP)
@@ -818,33 +780,9 @@
       DCYY   =  - FACK *   eDCYDY
       FKD    =    FACK * ( eCX*eDDDX + eCY*eDDDY )
 
-#ifdef W3_DEBUGDCXDX
-      sumDiff0=0
-      sumDiff1=0
-      sumDiff2=0
-      sumDiff3=0
-      sumDiff4=0
-      sumDiff5=0
-#endif
       DO ITH=1, NTH
         FKC(ITH) = EC2(ITH)*DCXX + ESC(ITH)*DCXYYX + ES2(ITH)*DCYY
-#ifdef W3_DEBUGDCXDX
-        sumDiff0 = sumDiff0 + MIN(EC2(ITH), ZERO)
-        sumDiff1 = sumDiff1 + MIN(DCXX, ZERO)
-        sumDiff2 = sumDiff2 + MIN(ESC(ITH), ZERO)
-        sumDiff3 = sumDiff3 + MIN(DCXYYX, ZERO)
-        sumDiff4 = sumDiff4 + MIN(ES2(ITH), ZERO)
-        sumDiff5 = sumDiff5 + MIN(DCYY, ZERO)
-#endif
       END DO
-#ifdef W3_DEBUGDCXDX
-    WRITE(740+IAPROC,*) 'sumDiff0=', sumDiff0
-    WRITE(740+IAPROC,*) 'sumDiff1=', sumDiff1
-    WRITE(740+IAPROC,*) 'sumDiff2=', sumDiff2
-    WRITE(740+IAPROC,*) 'sumDiff3=', sumDiff3
-    WRITE(740+IAPROC,*) 'sumDiff4=', sumDiff4
-    WRITE(740+IAPROC,*) 'sumDiff5=', sumDiff5
-#endif
 !
       DEPTH  = MAX ( DMIN , DW(ISEA) )
       DO IK=0, NK+1
@@ -855,40 +793,19 @@
         END IF
       END DO
       ISP = -NTH
-#ifdef W3_DEBUGDCXDX
-      sumDiff=0
-      sumDiff1=0
-      sumDiff2=0
-      sumDiff3=0
-#endif
       DO IK=0, NK+1
         FKD0   = FKD / CG(IK,ISEA) * DSDD(IK)
         DO ITH=1, NTH
           ISP = ISP + 1
           VCWN(ISP) = FKD0 + WN(IK,ISEA)*FKC(ITH)
-#ifdef W3_DEBUGDCXDX
-          sumDiff = sumDiff + MAX(VCWN(ISP),ZERO)
-          sumDiff1 = sumDiff1 + MAX(FKD0,ZERO)
-          sumDiff2 = sumDiff2 + MAX(WN(IK,ISEA),ZERO)
-          sumDiff3 = sumDiff3 + MAX(FKC(ITH),ZERO)
-#endif
         END DO
       END DO
-#ifdef W3_DEBUGDCXDX
-    WRITE(740+IAPROC,*) 'sumDiff=', sumDiff
-    WRITE(740+IAPROC,*) 'sumDiff1=', sumDiff1
-    WRITE(740+IAPROC,*) 'sumDiff2=', sumDiff2
-    WRITE(740+IAPROC,*) 'sumDiff3=', sumDiff3
-#endif
 
       sumDiff=0
       DO ISP=1-NTH,NSPEC
         CWNB_M2(ISP) = DBLE(0.5 * ( VCWN(ISP) + VCWN(ISP+NTH) ))
         sumDiff = sumDiff + MAX(CWNB_M2(ISP), ZERO)
       END DO
-#ifdef W3_DEBUGDCXDX
-    WRITE(740+IAPROC,*) 'sumDiff=', sumDiff
-#endif
       DO IK=1,NK
         DWNI_M2(IK) = DBLE( CG(IK,ISEA) / DSIP(IK) )
       END DO
@@ -1085,12 +1002,6 @@
 !/
 #ifdef W3_S
       CALL STRACE (IENT, 'SET_UP_NSEAL_NSEALM')
-#endif
-!!/PDLIB      WRITE(*,*) 'LPDLIB=', LPDLIB
-!!/PDLIB      WRITE(*,*) 'GTYPE=', GTYPE, ' UNGTYPE=', UNGTYPE
-#ifdef W3_DEBUG
-      WRITE(740+IAPROC,*) 'SET_UP, PDLIB=', LPDLIB
-      FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_SHRD

--- a/model/src/w3psmcmd.F90
+++ b/model/src/w3psmcmd.F90
@@ -3160,9 +3160,6 @@
       CXCY(1:NSEA)= CX(1:NSEA) 
 
 !!   Initialize full grid gradient arrays
-#ifdef W3_DEBUGDCXDX
-      WRITE(740+IAPROC,*) 'Before assigning DCXDX to ZERO'
-#endif
       DCXDX = 0.0
       DCXDY = 0.0
 
@@ -3200,10 +3197,6 @@
       END DO
 #ifdef W3_OMPG
 !$OMP END Parallel DO
-#endif
-
-#ifdef W3_DEBUGDCXDX
-      WRITE(740+IAPROC,*) 'After non-trivial assination to DCXDX array'
 #endif
 
 !!    Assign current CY speed to CXCY and set negative cells.

--- a/model/src/w3sdb1md.F90
+++ b/model/src/w3sdb1md.F90
@@ -228,11 +228,6 @@
 ! 1.a. Maximum wave height
 ! 1.a.1. Simple limit
 !
-#ifdef W3_DEBUGDB1
-      WRITE(740+IAPROC,*) 'FDONLY=', FDONLY
-      WRITE(740+IAPROC,*) 'FSSOURCE=', FSSOURCE
-      FLUSH(740+IAPROC)
-#endif
       IF ( FDONLY ) THEN
           HM     = DBLE(SDBC2) * DBLE(DEPTH)
       ELSE
@@ -315,11 +310,6 @@
         WRITE(*,'(A200)') 'IX, DEPTH, CBJ, BB, QB, SDBC1, SDBC2, FMEAN, FMEAN2, HS'
         WRITE(*,'(I10,20F20.10)') IX, DEPTH, CBJ, BB, QB, SDBC1, SDBC2, FMEAN, FMEAN2, 4*SQRT(ETOT)
       ENDIF
-#endif
-
-#ifdef W3_DEBUGDB1
-      WRITE(740+IAPROC,*) 'CBJ=', CBJ
-      FLUSH(740+IAPROC)
 #endif
 !
 ! ... Test output of arrays

--- a/model/src/w3triamd.F90
+++ b/model/src/w3triamd.F90
@@ -200,10 +200,6 @@ CONTAINS
       INTEGER(KIND=4),ALLOCATABLE        :: IFOUND(:), VERTEX(:), BOUNDTMP(:)
       DOUBLE PRECISION, ALLOCATABLE      :: XYBTMP1(:,:),XYBTMP2(:,:)
       REAL                               :: z
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Beginning of READMSH routine'
-     FLUSH(740+IAPROC)
-#endif
 
       OPEN(NDS,FILE = FNAME,STATUS='old')
       READ (NDS,'(A)') COMSTR
@@ -312,11 +308,6 @@ CONTAINS
 !count points connections to allocate array in W3DIMUG 
 !
       CALL COUNT(TRIGPTMP2)
-#ifdef W3_DEBUGINIT
-     WRITE(*,*) 'Call W3DIMUG from READMSH'
-     WRITE(740+IAPROC,*) 'Call W3DIMUG from READMSH'
-     FLUSH(740+IAPROC)
-#endif
       CALL W3DIMUG ( 1, NTRI, NX, COUNTOT, NNZ, NDSE, NDST ) 
 !
 ! fills arrays
@@ -326,14 +317,6 @@ CONTAINS
         YGRD(1,I) = XYBTMP2(2,I) 
         ZB(I)     = XYBTMP2(3,I)
       END DO
-!
-#ifdef W3_DEBUGSTP
-    WRITE(740,*) 'Writing XYB(3,:)'
-    DO I=1,NX
-      WRITE(740,*) 'I,XYB(3,I)=', I, XYB(3,I)
-    END DO
-    FLUSH(740)
-#endif
 !
       DO I=1, NTRI
         ITMP = TRIGPTMP2(:,I)
@@ -449,10 +432,6 @@ CONTAINS
       LOGICAL                            :: lfile_exists
       CHARACTER                          :: COMSTR*1, SPACE*1 = ' ', CELS*64
       DOUBLE PRECISION, ALLOCATABLE      :: XYBTMP1(:,:)
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'Beginning of READMSH routine'
-     FLUSH(740+IAPROC)
-#endif
 
       INQUIRE(FILE=FNAME, EXIST=lfile_exists)
       IF (.NOT. lfile_exists) RETURN
@@ -2198,17 +2177,9 @@ END SUBROUTINE
       INTEGER :: INEXT(3), IPREV(3)
       INTEGER          :: ZNEXT, IP, I, IE, IPNEXT, IPPREV, COUNT
       integer nb0, nb1, nbM1
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 1'
-      FLUSH(740+IAPROC)
-#endif
       STATUS = -1
       INEXT=(/ 2, 3, 1 /) !IPREV=1+MOD(I+1,3)
       IPREV=(/ 3, 1, 2 /) !INEXT=1+MOD(I,3)
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 2'
-      FLUSH(740+IAPROC)
-#endif
       DO IE=1,NTRI 
 ! If one of the points of the triangle is masked out (land) then do as if triangle does not exist... 
 !        IF ((MASK(TRIGP(1,IE)).GT.0).AND.(MASK(TRIGP(2,IE)).GT.0).AND.(MASK(TRIGP(3,IE)).GT.0)) THEN 
@@ -2271,32 +2242,13 @@ END SUBROUTINE
           EXIT
         END IF
       END DO
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 3'
-      FLUSH(740+IAPROC)
-#endif
 
       STATUS = 1 
       CALL GET_BOUNDARY(NX, NTRI, TRIGP, STATUS, PREVVERT, NEXTVERT)
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 4'
-      FLUSH(740+IAPROC)
-#endif
-!      DO IP= 1, NX
-!        WRITE(12000,*) IP, STATUS(IP)
-!      ENDDO
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 5'
-      FLUSH(740+IAPROC)
-#endif
 
 !#ifdef MPI_PARALL_GRID
 !      CALL exchange_p2di(STATUS)
 !#endif
-#ifdef W3_DEBUGSETIOBP
-      WRITE(740+IAPROC,*) 'Calling SETIOBP, step 6'
-      FLUSH(740+IAPROC)
-#endif
       END SUBROUTINE SET_IOBP
 !/ ------------------------------------------------------------------- /
 
@@ -2820,12 +2772,7 @@ END SUBROUTINE
 !
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Set constants
-!      
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 1'
-      FLUSH(740+IAPROC)
-#endif
-      
+!
 #ifdef W3_S
       CALL STRACE (IENT, 'SETUGIOBP')
 #endif
@@ -2833,18 +2780,10 @@ END SUBROUTINE
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 2.  Searches for boundary points
 ! 
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 2'
-      FLUSH(740+IAPROC)
-#endif
       ITMP = MAPSTA(1,:)
       CALL SET_IOBP(ITMP, IOBP) 
       FNAME = 'meshbnd.msh'
       CALL READMSH_IOBP(23456,FNAME) 
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 3'
-      FLUSH(740+IAPROC)
-#endif
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3. Defines directions pointing into land or sea 
@@ -2858,10 +2797,6 @@ END SUBROUTINE
           IOBP(IP)  = 2 
         ENDIF
       END DO
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 4'
-      FLUSH(740+IAPROC)
-#endif
 
       DO IE = 1,NTRI
         I1   =   TRIGP(1,IE)
@@ -2911,10 +2846,6 @@ END SUBROUTINE
           END DO
         END DO
       END DO
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 5'
-      FLUSH(740+IAPROC)
-#endif
       DO IP = 1, NX 
         IF ( IOBPA(IP) .eq. 1 .OR. IOBP(IP) .eq. 3 .OR. IOBP(IP) .eq. 4) IOBPD(:,IP) = 1
       END DO
@@ -2932,10 +2863,6 @@ END SUBROUTINE
 !        IOBPD(ID,:) = iwild
 !      ENDDO
 !#endif
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 7'
-      FLUSH(740+IAPROC)
-#endif
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3. Updates the reflection direction and sharp / flat shoreline angle
 
@@ -2962,29 +2889,9 @@ END SUBROUTINE
               END IF
             END DO
 #endif
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 8'
-      FLUSH(740+IAPROC)
-#endif
-          
-
-!DO IX=1,NX
-!DO ITH=1,NTH
-!  WRITE(500+IAPROC,*) IX,ITH,IOBP(IX),IOBPA(IX),IOBPD(ITH,IX) !,REFLD(1:2,MAPFS(1,IX))
-!ENDDO 
-!ENDDO
-
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 9'
-      FLUSH(740+IAPROC)
-#endif
 !
 ! Recomputes the angles used in the gradients estimation 
 ! 
-#ifdef W3_DEBUGSETUGIOBP
-      WRITE(740+IAPROC,*) 'Calling SETUGIOBP, step 10'
-      FLUSH(740+IAPROC)
-#endif
 !
       RETURN    
       END SUBROUTINE SET_UG_IOBP

--- a/model/src/w3updtmd.F90
+++ b/model/src/w3updtmd.F90
@@ -1335,10 +1335,6 @@
 ! 1.  Process BBPI0 -------------------------------------------------- *
 ! 1.a First intialization
 
-#ifdef W3_DEBUGIOBC
-     WRITE(740+IAPROC,*) 'Beginning of W3UBPT'
-     FLUSH(740+IAPROC)
-#endif
 
 !
       IF ( BBPI0(1,0) .EQ. -1. ) THEN
@@ -1410,14 +1406,6 @@
         END DO
 #endif
 !
-#ifdef W3_DEBUGIOBC
-     WRITE(740+IAPROC,*) 'sum(abs(ABPI0))=', sum(abs(ABPI0))
-     WRITE(740+IAPROC,*) 'sum(abs(ABPIN))=', sum(abs(ABPIN))
-     WRITE(740+IAPROC,*) 'sum(abs(BBPI0))=', sum(abs(BBPI0))
-     WRITE(740+IAPROC,*) 'sum(abs(BBPIN))=', sum(abs(BBPIN))
-     WRITE(740+IAPROC,*) 'End of W3UBPT'
-     FLUSH(740+IAPROC)
-#endif
       RETURN
 !
 ! Formats
@@ -2036,11 +2024,6 @@
       REAL(KIND=8)     :: d1,h,TIDE_HOUR,HH,pp,s,p,enp,dh,dpp,ds,dp,dnp,tau
       REAL             :: FX(44),UX(44),VX(44)
 #endif
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 1'
-           FLUSH(740+IAPROC)
-#endif
-      
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -2049,10 +2032,6 @@
 #endif
 !
       LOCAL   = IAPROC .LE. NAPROC
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 2'
-           FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9000) KDMAX, RDKMIN
@@ -2061,10 +2040,6 @@
 ! 1.  Preparations --------------------------------------------------- *
 ! 1.a Check NK
 !
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 3'
-           FLUSH(740+IAPROC)
-#endif
       IF ( NK .LT. 2 ) THEN
           IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,1000)
           CALL EXTCDE ( 1 )
@@ -2084,10 +2059,6 @@
 !
       MAPDRY = MOD(MAPST2/2,2)
       MAPST2 = MAPST2 - 2*MAPDRY
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 4'
-           FLUSH(740+IAPROC)
-#endif
 !
 ! 1.d Update water levels and save old
 !
@@ -2111,10 +2082,6 @@
 !  ONLY THE FRACTIONAL PART OF A SOLAR DAY NEED BE RETAINED FOR COMPU-
 !  TING THE LUNAR TIME TAU.
 !
-#endif
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 5'
-           FLUSH(740+IAPROC)
 #endif
       DO ISEA=1, NSEA
         IX     = MAPSF(ISEA,1)
@@ -2173,10 +2140,6 @@
 
       END DO ! NSEA 
 
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 6'
-           FLUSH(740+IAPROC)
-#endif
 !
 ! 2.  Loop over all sea points --------------------------------------- *
 !
@@ -2390,10 +2353,6 @@
           END IF
 !
       END DO ! NSEA 
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 7'
-           FLUSH(740+IAPROC)
-#endif
 !
 ! 3.  Reconstruct new MAPST2 ----------------------------------------- *
 !
@@ -2401,32 +2360,16 @@
 !
 ! 4. Re-generates the boundary data ---------------------------------- *
 !
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 8'
-           FLUSH(740+IAPROC)
-#endif
       IF (GTYPE.EQ.UNGTYPE) THEN 
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 9'
-           FLUSH(740+IAPROC)
-#endif
         !CALL SET_UG_IOBP
 #ifdef W3_PDLIB
          CALL SET_IOBDP_PDLIB
-#endif
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 10'
-           FLUSH(740+IAPROC)
 #endif
 #ifdef W3_REF1
       ELSE 
         CALL W3SETREF
 #endif
       ENDIF 
-#ifdef W3_DEBUGW3ULEV
-           WRITE(740+IAPROC,*) 'Beginning of W3ULEV, step 11'
-           FLUSH(740+IAPROC)
-#endif
 !
       RETURN
 !

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -627,30 +627,11 @@
      CALL UOST_SETGRID(IMOD)
 #endif
 
-#ifdef W3_DEBUGRUN
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'NEGATIVE ACTION 1', IS, JSEA, VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-            CALL EXTCDE(666)
-          ENDIF
-        ENDDO
-      ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 1', SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        CALL EXTCDE(666)
-      ENDIF
-#endif
 
 
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 1", 1)
-#endif
-#ifdef W3_DEBUGIOBP
-         IF (NX .ge. 10210) WRITE(*,*) 'CRIT 1:', MAPSTA(1,10210), IOBP(10210)
 #endif
 #endif
 
@@ -752,9 +733,6 @@
 ! 1.a Ending time versus initial time
 !
       DTTST  = DSEC21 ( TIME , TEND )
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) '1 : DTTST=', DTTST, TIME, TEND
-#endif
       FLZERO = DTTST .EQ. 0.
 #ifdef W3_T
       WRITE (NDST,9010) DTTST, FLZERO
@@ -950,16 +928,8 @@
 !
       FLFRST = .TRUE.
       DO
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'First entry in the TIME LOOP'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("First entry in the TIME LOOP")
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.1'
-        FLUSH(740+IAPROC)
 #endif
 !      DO JSEA = 1, NSEAL
 !        DO IS = 1, NSPEC
@@ -1088,9 +1058,6 @@
           ELSE
             DTTST  = 0.
           ENDIF
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) '2 : DTTST=', DTTST, TEND, TOFRST
-#endif
 !
         IF ( DTTST.GE.0. ) THEN
             TCALC = TEND
@@ -1099,14 +1066,8 @@
           END IF
 !
         DTTST  = DSEC21 ( TIME , TCALC )
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) '3 : DTTST=', DTTST, TEND, TOFRST
-#endif
         NT     = 1 + INT ( DTTST / DTMAX - 0.001 )
         DTGA   = DTTST / REAL(NT)
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'DTTST=', DTTST, ' NT=', NT
-#endif
         IF ( DTTST .EQ. 0. ) THEN
             IT0    = 0
             IF ( .NOT.FLZERO ) ITIME  = ITIME - 1
@@ -1132,23 +1093,6 @@
 !
         DTRES  = 0.
 
-#ifdef W3_DEBUGRUN
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'TEST W3WAVE 3', VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-          ENDIF
-        ENDDO
-      ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 3', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-        WRITE(740+IAPROC,*) 'IT0=', IT0, ' NT=', NT
-        FLUSH(740+IAPROC)
-#endif
 !
         DO IT = IT0, NT
 #ifdef W3_TIMINGS
@@ -1188,12 +1132,6 @@
           IF ( ABS(DTRES) .LT. 0.001 ) DTRES  = 0.
           CALL TICK21 ( TIME , DTG )
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'DTGA=', DTGA, ' DTRES=', DTRES
-      WRITE(740+IAPROC,*) 'DTG 1 : DTG=', DTG
-      FLUSH(740+IAPROC)
-#endif
-!
 #ifdef W3_MEMCHECK
        write(40000+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 1'
        call getMallocInfo(mallinfos)
@@ -1212,21 +1150,6 @@
        call printMallInfo(IAPROC+40000,mallInfos)
 #endif
 
-#ifdef W3_DEBUGRUN
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'TEST W3WAVE 4', VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-          ENDIF
-        ENDDO
-      ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 4', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-#endif
 !
           VGX = 0.
           VGY = 0.
@@ -1256,10 +1179,6 @@
 ! 3.1 Interpolate winds, currents, and momentum.
 !     (Initialize wave fields with winds)
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLCUR=', FLCUR
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_DEBUGDCXDX
        WRITE(740+IAPROC,*) 'Debug DCXDX FLCUR=', FLCUR
 #endif
@@ -1270,32 +1189,16 @@
 #endif
 
           IF ( FLCUR  ) THEN
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.4'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before UCUR", 1)
 #endif
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.4.1'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("W3WAVE, step 6.4.1")
 #endif
 
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.4.2 before W3UCUR'
-        FLUSH(740+IAPROC)
-#endif
             CALL W3UCUR ( FLFRST )
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.4.1 after W3UCUR'
-        FLUSH(740+IAPROC)
-#endif
 
 #ifdef W3_MEMCHECK
        write(40000+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 3b '
@@ -1377,10 +1280,6 @@
          CALL PRINT_MY_TIME("After U10, etc. assignation")
 #endif
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.5'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before call to W3UINI", 1)
@@ -1390,10 +1289,6 @@
          CALL PRINT_MY_TIME("Before call W3UINI")
 #endif
           IF ( FLIWND .AND. LOCAL ) CALL W3UINI ( VA )
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.5.1 DTG=', DTG
-        FLUSH(740+IAPROC)
-#endif
 !
           IF ( FLTAUA ) THEN
             CALL W3UTAU ( FLFRST )
@@ -1417,11 +1312,6 @@
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before boundary update")
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLBPI=', FLBPI
-        WRITE(740+IAPROC,*) 'LOCAL=', LOCAL
-        FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_MEMCHECK
@@ -1495,11 +1385,6 @@
 ! 3.3.1 Update ice coverage (if new ice map).
 !     Need to be run on output nodes too, to update MAPSTx
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLICE=', FLICE
-        WRITE(740+IAPROC,*) 'DTI0=', DTI0
-        FLUSH(740+IAPROC)
-#endif
           IF ( FLICE .AND. DTI0.NE.0. ) THEN
 !
               IF ( TICE(1).GE.0 ) THEN
@@ -1527,15 +1412,6 @@
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After FLICE and DTI0")
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.7 DTG=', DTG
-        FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
-#ifdef W3_DEBUGIOBP
-         IF (NX .ge. 10210) WRITE(*,*) 'Before W3ULEV:', MAPSTA(1,10210), IOBP(10210)
-#endif
 #endif
 
 #ifdef W3_MEMCHECK
@@ -1616,16 +1492,8 @@
 !
 ! 3.4 Transform grid (if new water level).
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLLEV=', FLLEV, ' DTL0=', DTL0
-        FLUSH(740+IAPROC)
-#endif
           IF ( FLLEV .AND. DTL0 .NE.0. ) THEN
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'Before time works'
-        FLUSH(740+IAPROC)
-#endif
               IF ( TLEV(1) .GE. 0 ) THEN
                   IF ( DTL0 .LT. 0. ) THEN
                       IDACT(5:5) = 'B'
@@ -1636,22 +1504,10 @@
                 ELSE
                   IDACT(5:5) = 'I'
                 END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'After time works'
-        FLUSH(740+IAPROC)
-#endif
 !
               IF ( IDACT(5:5).NE.' ' ) THEN
 
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'Before W3ULEV'
-        FLUSH(740+IAPROC)
-#endif
                   CALL W3ULEV ( VA, VA )
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'After W3ULEV'
-        FLUSH(740+IAPROC)
-#endif
 
                   UGDTUPDATE=.TRUE.
                   CFLXYMAX = 0.
@@ -1661,29 +1517,14 @@
                   FLDDIR = FLDDIR .OR.  FLCTH .OR. FSREFRACTION        &
                         .OR. FLCK .OR. FSFREQSHIFT
               END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'After IDACT if test'
-        FLUSH(740+IAPROC)
-#endif
           END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'After FLLEV test'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After FFLEV and DTL0", 1)
 #endif
-#ifdef W3_DEBUGIOBP
-         IF (NX .ge. 10210) WRITE(*,*) ' After W3ULEV:', MAPSTA(1,10210), IOBP(10210)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After FFLEV and DTL0")
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLMAP=', FLMAP
-        FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_MEMCHECK
@@ -1716,16 +1557,7 @@
               FLMAP  = .FALSE.
           END IF
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.1 DTG=', DTG
-        FLUSH(740+IAPROC)
-#endif
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.2 DTG=', DTG
-        WRITE(740+IAPROC,*) 'FLDDIR=', FLDDIR
-        FLUSH(740+IAPROC)
-#endif
           IF ( FLDDIR ) THEN
             IF (GTYPE .EQ. SMCTYPE) THEN
               IX = 1
@@ -1747,10 +1579,6 @@
        call printMallInfo(IAPROC+40000,mallInfos)
 #endif
 
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.3 DTG=', DTG
-        FLUSH(740+IAPROC)
-#endif
 !
 !         Calculate PHASE SPEED GRADIENT.
           DCDX = 0.
@@ -1770,10 +1598,6 @@
           END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.4'
-        FLUSH(740+IAPROC)
-#endif
 !
           FLIWND = .FALSE.
           FLFRST = .FALSE.
@@ -1878,16 +1702,6 @@
         PSIC=SED_PSIC(ISEA)
 #endif
 !
-#ifdef W3_DEBUGRUN
-         DO IS = 1, NSPEC
-           IF (VA(IS, JSEA) .LT. 0.) THEN
-             WRITE(740+IAPROC,*) 'TEST W3WAVE 7', VA(IS,JSEA)
-             CALL FLUSH(740+IAPROC)
-           ENDIF
-         ENDDO
-#endif
-
-!
 #ifdef W3_PDLIB
     IF ((IOBP_LOC(JSEA) .eq. 1 .or. IOBP_LOC(JSEA) .eq. 3) &
        & .and. IOBDP_LOC(JSEA) .eq. 1 .and. IOBPA_LOC(JSEA) .eq. 0) THEN
@@ -1984,18 +1798,9 @@
 !            DTG = 60.
             GOTO 370
           END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.5'
-        WRITE(740+IAPROC,*) 'FLDRY=', FLDRY
-        FLUSH(740+IAPROC)
-#endif
           IF ( FLDRY .OR. IAPROC.GT.NAPROC ) THEN
 #ifdef W3_T
               WRITE (NDST,9023)
-#endif
-#ifdef W3_DEBUGRUN
-              WRITE(740+IAPROC,*) 'Jump to 380'
-              FLUSH(740+IAPROC)
 #endif
               GOTO 380
           END IF
@@ -2005,16 +1810,7 @@
 #ifdef W3_T
            WRITE(NDSE,*) 'Computing CFLs .... ',NSEAL
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'FLOGRD(9,3) = ', FLOGRD(9,3)
-        WRITE(740+IAPROC,*) 'UGDTUPDATE=', UGDTUPDATE
-        FLUSH(740+IAPROC)
-#endif
                 IF ( FLOGRD(9,3).AND. UGDTUPDATE ) THEN
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.6'
-        FLUSH(740+IAPROC)
-#endif
                   IF (FSTOTALIMP .eqv. .FALSE.) THEN
                       NKCFL=NK
 #ifdef W3_T
@@ -2059,10 +1855,6 @@
 !
                     END IF
                 END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.8.7'
-        FLUSH(740+IAPROC)
-#endif
 
 #ifdef W3_MEMCHECK
        write(40000+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 15'
@@ -2070,21 +1862,6 @@
        call printMallInfo(IAPROC+40000,mallInfos)
 #endif
 !
-#ifdef W3_DEBUGRUN
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'TEST W3WAVE 8', VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-          ENDIF
-        ENDDO
-      ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 6 ', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-#endif
 
 !
 #ifdef W3_T
@@ -2126,13 +1903,6 @@
 #endif
 !
           FACTH  = DTG / (DTH*REAL(NTLOC))
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, DTCFLI=', DTCFLI
-        WRITE(740+IAPROC,*) 'W3WAVE, DTG=', DTG
-        WRITE(740+IAPROC,*) 'W3WAVE, DTH=', DTH
-        WRITE(740+IAPROC,*) 'W3WAVE, NTLOC=', NTLOC
-        FLUSH(740+IAPROC)
-#endif
           FACK   = DTG / REAL(NTLOC)
 
           TTEST(1) = TIME(1)
@@ -2150,11 +1920,6 @@
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before intraspectral")
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.10'
-        WRITE(740+IAPROC,*) 'FLCTH=', FLCTH, ' FLCK=', FLCK
-        FLUSH(740+IAPROC)
-#endif
           IF ( FLCTH .OR. FLCK ) THEN
               DO ITLOC=1, ITLOCH
 !
@@ -2163,18 +1928,11 @@
 !$OMP DO SCHEDULE (DYNAMIC,1)
 #endif
 !
-#ifdef W3_DEBUGRUN
-                WRITE(740+IAPROC,*) ' ITLOC=', ITLOC
-                WRITE(740+IAPROC,*) ' 1: Before call to W3KTP1 / W3KTP2 / W3KTP3'
-#endif
                 DO JSEA=1, NSEAL
                   CALL INIT_GET_ISEA(ISEA, JSEA)
                   IX     = MAPSF(ISEA,1)
                   IY     = MAPSF(ISEA,2)
 
-#ifdef W3_DEBUGRUN
-                  IF (JSEA == DEBUG_NODE) WRITE(*,*) 'W3WAVE TEST', SUM(VA(:,JSEA))
-#endif
 
                   IF ( GTYPE .EQ. UNGTYPE ) THEN
                     IF (LPDLIB) THEN
@@ -2266,29 +2024,6 @@
 ! 3.6.3 Longitude-latitude
 !       (time step correction in routine)
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12'
-        WRITE(740+IAPROC,*) 'FSN=', FSN
-        WRITE(740+IAPROC,*) 'FSPSI=', FSPSI
-        WRITE(740+IAPROC,*) 'FSFCT=', FSFCT
-        WRITE(740+IAPROC,*) 'FSNIMP=', FSNIMP
-        WRITE(740+IAPROC,*) 'FLCTH=', FLCTH
-        WRITE(740+IAPROC,*) 'FSREFRACTION=', FSREFRACTION
-        WRITE(740+IAPROC,*) 'FLCK=', FLCK
-        WRITE(740+IAPROC,*) 'FSFREQSHIFT=', FSFREQSHIFT
-        WRITE(740+IAPROC,*) 'FLSOU=', FLSOU
-        WRITE(740+IAPROC,*) 'FSSOURCE=', FSSOURCE
-        WRITE(740+IAPROC,*) 'FSTOTALIMP=', FSTOTALIMP
-        WRITE(740+IAPROC,*) 'FSTOTALEXP=', FSTOTALEXP
-        WRITE(740+IAPROC,*) 'FLCUR=', FLCUR
-        WRITE(740+IAPROC,*) 'PDLIB=', LPDLIB
-        WRITE(740+IAPROC,*) 'GTYPE=', GTYPE
-        WRITE(740+IAPROC,*) 'UNGTYPE=', UNGTYPE
-        WRITE(740+IAPROC,*) 'NAPROC=', NAPROC, 'NTPROC=', NTPROC
-        WRITE(740+IAPROC,*) 'FLCX=', FLCX, ' FLCY=', FLCY
-        FLUSH(740+IAPROC)
-#endif
-!
         IF (GTYPE .EQ. UNGTYPE) THEN
           IF (FLAGLL) THEN
             FACX   =  1./(DERA * RADIUS)
@@ -2301,19 +2036,11 @@
 #ifdef W3_PDLIB
        IF ((FSTOTALIMP .eqv. .FALSE.).and.(FLCX .or. FLCY)) THEN
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.1'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
          DO ISPEC=1,NSPEC
            CALL PDLIB_W3XYPUG ( ISPEC, FACX, FACX, DTG,           &
                                 VGX, VGY, UGDTUPDATE )
          END DO
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.2'
-        FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
        END IF
@@ -2321,11 +2048,6 @@
 !
 #ifdef W3_PDLIB
        IF (FSTOTALIMP .and. (IT .ne. 0)) THEN
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.3A'
-        WRITE(*,*), 'W3WAVE, step 6.12.3A'
-        FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
@@ -2335,36 +2057,17 @@
 #ifdef W3_PDLIB
          CALL PDLIB_W3XYPUG_BLOCK_IMPLICIT(IMOD, FACX, FACX, DTG, VGX, VGY)
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.4A'
-        WRITE(*,*), 'W3WAVE, step 6.12.4A'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
        ELSE IF(FSTOTALEXP .and. (IT .ne. 0)) THEN
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.3B'
-        WRITE(*,*), 'W3WAVE, step 6.12.3B'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
          CALL PDLIB_W3XYPUG_BLOCK_EXPLICIT(IMOD, FACX, FACX, DTG, VGX, VGY)
-#endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.12.4B'
-        WRITE(*,*), 'W3WAVE, step 6.12.4B'
-        FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
        ENDIF
 #endif
         ELSE
           IF (FLCX .or. FLCY) THEN
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.13'
-        FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_MPI
        IF ( NRQSG1 .GT. 0 ) THEN
@@ -2373,10 +2076,6 @@
        END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.14'
-        FLUSH(740+IAPROC)
-#endif
 !
 ! Initialize FIELD variable
              FIELD = 0.
@@ -2564,12 +2263,6 @@
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After spatial advection")
 #endif
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.16'
-        WRITE(740+IAPROC,*) 'NTLOC=', NTLOC
-        WRITE(740+IAPROC,*) 'ITLOCH=', ITLOCH
-        FLUSH(740+IAPROC)
-#endif
 !
 ! 3.6.4 Intra-spectral part 2
 !
@@ -2581,18 +2274,11 @@
 !$OMP DO SCHEDULE (DYNAMIC,1)
 #endif
 !
-#ifdef W3_DEBUGRUN
-                WRITE(740+IAPROC,*) ' ITLOC=', ITLOC
-                WRITE(740+IAPROC,*) ' 2: Before call to W3KTP1 / W3KTP2 / W3KTP3'
-#endif
                 DO JSEA = 1, NSEAL
 
                   CALL INIT_GET_ISEA(ISEA, JSEA)
                   IX     = MAPSF(ISEA,1)
                   IY     = MAPSF(ISEA,2)
-#ifdef W3_DEBUGRUN
-                  IF (JSEA == DEBUG_NODE) WRITE(*,*) 'W3WAVE TEST', SUM(VA(:,JSEA))
-#endif
                   DEPTH  = MAX ( DMIN , DW(ISEA) )
 
                   IF ( GTYPE .EQ. UNGTYPE ) THEN
@@ -2674,11 +2360,6 @@
 #endif
 !
           UGDTUPDATE = .FALSE.
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.17'
-        WRITE(740+IAPROC,*) 'FSSOURCE=', FSSOURCE
-        FLUSH(740+IAPROC)
-#endif
 !
 ! 3.6 End propapgation  = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -2743,9 +2424,6 @@
            PSIC=SED_PSIC(ISEA)
 #endif
 
-#ifdef W3_DEBUGRUN
-          IF (JSEA == DEBUG_NODE) WRITE(*,*) 'W3WAVE TEST', ISEA, JSEA, SUM(VA(:,JSEA))
-#endif
 
                 IF ( MAPSTA(IY,IX) .EQ. 1 .AND. FLAGST(ISEA)) THEN
                      TMP1   = WHITECAP(JSEA,1:4)
@@ -2818,30 +2496,8 @@
                     FCUT  (JSEA) = UNDEF
 !                    VA(:,JSEA)  = 0.
                 END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'RET: min/max/sum(VA)=',minval(VA(:,JSEA)),maxval(VA(:,JSEA)),sum(VA(:,JSEA))
-#endif
               END DO
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'min/max/sum(VAtot)=', minval(VA), maxval(VA), sum(VA)
-        FLUSH(740+IAPROC)
-#endif
 
-#ifdef W3_DEBUGRUN
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'TEST W3WAVE 9', VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-          ENDIF
-        ENDDO
-      ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 7', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-#endif
 
 !
 #ifdef W3_OMPG
@@ -2871,10 +2527,6 @@
 !!/MPI              CALL MPI_BARRIER (MPI_COMM_WCMP,IERR_MPI)
 !
             END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.18'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After source terms", 1)
@@ -2893,33 +2545,12 @@
 #endif
 
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.19'
-        FLUSH(740+IAPROC)
-      DO JSEA = 1, NSEAL
-        DO IS = 1, NSPEC
-          IF (VA(IS, JSEA) .LT. 0.) THEN
-            WRITE(740+IAPROC,*) 'TEST W3WAVE 10', VA(IS,JSEA)
-            CALL FLUSH(740+IAPROC)
-          ENDIF
-        ENDDO
-     ENDDO
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 8', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-#endif
 !
 ! 3.8 Update global time step.
 !     (Branch point FLDRY, IT=0)
 !
   380     CONTINUE
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.20'
-        FLUSH(740+IAPROC)
-#endif
           IF (IT.NE.NT) THEN
               DTTST  = DSEC21 ( TIME , TCALC )
               DTG    = DTTST / REAL(NT-IT)
@@ -2938,10 +2569,6 @@
               FLACT  = .FALSE.
               IDACT  = '         '
           END IF
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.21'
-        FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
@@ -2955,10 +2582,6 @@
 !
         END DO
 
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.1'
-        FLUSH(740+IAPROC)
-#endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("W3WAVE, step 6.21.1")
 #endif
@@ -2981,10 +2604,6 @@
 ! 4.a Check if time is output time
 !     Delay if data assimilation time.
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.2'
-        FLUSH(740+IAPROC)
-#endif
 !
         IF ( TOFRST(1)  .EQ. -1 ) THEN
             DTTST  = 1.
@@ -3005,15 +2624,7 @@
         WRITE (NDST,9040) TOFRST, TDN, DTTST, DTTST1, FLAG_O
 #endif
 !
-#ifdef W3_DEBUGRUN
-        WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.3'
-        FLUSH(740+IAPROC)
-#endif
         IF ( DTTST.LE.0. .AND. DTTST1.NE.0. .AND. FLAG_O ) THEN
-#ifdef W3_DEBUGRUN
-            WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.4'
-            FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
           WRITE (NDST,9041)
@@ -3036,16 +2647,8 @@
           FLPART = .FALSE.
           IF ( FLOUT(1) .AND. FLPFLD )                               &
                FLPART = FLPART .OR. DSEC21(TIME,TONEXT(:,1)).EQ.0.
-#ifdef W3_DEBUGRUN
-            WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.7'
-            FLUSH(740+IAPROC)
-#endif
           IF ( FLOUT(6) )                                            &
                FLPART = FLPART .OR. DSEC21(TIME,TONEXT(:,6)).EQ.0.
-#ifdef W3_DEBUGRUN
-            WRITE(740+IAPROC,*) 'W3WAVE, step 6.21.8'
-            FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
             WRITE (NDST,9042) LOCAL, FLPART, FLOUTG
@@ -3067,17 +2670,8 @@
        IF (.NOT. LPDLIB .or. (GTYPE.ne.UNGTYPE)) THEN
          IF (NRQGO.NE.0 ) THEN
 #endif
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'BEFORE STARTALL NRQGO.NE.0 , step 0', &
-                 NRQGO, IRQGO, GTYPE, UNGTYPE, .NOT. LPDLIB .or. (GTYPE.ne.UNGTYPE)
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
            CALL MPI_STARTALL ( NRQGO, IRQGO , IERR_MPI )
-#endif
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'AFTER STARTALL NRQGO.NE.0, step 0'
-      FLUSH(740+IAPROC)
 #endif
 
 #ifdef W3_MPI
@@ -3094,17 +2688,8 @@
 #ifdef W3_MPI
          IF (NRQGO2.NE.0 ) THEN
 #endif
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'BEFORE STARTALL NRQGO2.NE.0, step 0', &
-              NRQGO2, IRQGO2, GTYPE, UNGTYPE, .NOT. LPDLIB .or. (GTYPE.ne.UNGTYPE)
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
            CALL MPI_STARTALL ( NRQGO2, IRQGO2, IERR_MPI )
-#endif
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'AFTER STARTALL NRQGO2.NE.0, step 0'
-      FLUSH(740+IAPROC)
 #endif
 #ifdef W3_MPI
            FLGMPI(1) = .TRUE.
@@ -3116,10 +2701,6 @@
 #ifdef W3_MPI
          END IF
        ELSE
-#endif
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'BEFORE DO_OUTPUT_EXCHANGES, step 0'
-      FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
        CALL DO_OUTPUT_EXCHANGES(IMOD)
@@ -3136,10 +2717,6 @@
 #endif
 
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 1'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
             IF ( FLOUT(2) .AND. NRQPO.NE.0 ) THEN
                 IF ( DSEC21(TIME,TONEXT(:,2)).EQ.0. ) THEN
@@ -3155,10 +2732,6 @@
               END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 2'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
             IF ( FLOUT(4) .AND. NRQRS.NE.0 ) THEN
                 IF ( DSEC21(TIME,TONEXT(:,4)).EQ.0. ) THEN
@@ -3174,10 +2747,6 @@
               END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 2'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
             IF ( FLOUT(8) .AND. NRQRS.NE.0 ) THEN
                 IF ( DSEC21(TIME,TONEXT(:,8)).EQ.0. ) THEN
@@ -3193,10 +2762,6 @@
               END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 3'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
             IF ( FLOUT(5) .AND. NRQBP.NE.0 ) THEN
                 IF ( DSEC21(TIME,TONEXT(:,5)).EQ.0. ) THEN
@@ -3212,10 +2777,6 @@
               END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 4'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
             IF ( FLOUT(5) .AND. NRQBP2.NE.0 .AND.                &
                  IAPROC.EQ.NAPBPT) THEN
@@ -3231,10 +2792,6 @@
               END IF
 #endif
 !
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'After DO_OUTPUT_EXCHANGES, step 5'
-      FLUSH(740+IAPROC)
-#endif
 #ifdef W3_MPI
            IF ( NRQMAX .NE. 0 ) ALLOCATE                         &
                                  ( STATIO(MPI_STATUS_SIZE,NRQMAX) )
@@ -3249,34 +2806,13 @@
 !
 ! 4.c Reset next output time
 
-#ifdef W3_DEBUGRUN
-      IF (MINVAL(VA) .LT. 0.) THEN
-        WRITE(740+IAPROC,*) 'TEST W3WAVE 12', SUM(VA), MINVAL(VA), MAXVAL(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-      IF (SUM(VA) .NE. SUM(VA)) THEN
-        WRITE(740+IAPROC,*) 'NAN in ACTION 9', IX, IY, SUM(VA)
-        CALL FLUSH(740+IAPROC)
-        STOP
-      ENDIF
-#endif
 !
             TOFRST(1) = -1
             TOFRST(2) =  0
 !
             DO J=1, NOTYPE
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'NOTYPE, J=', J
-      FLUSH(740+IAPROC)
-#endif
 
               IF ( FLOUT(J) ) THEN
-!
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'Matching FLOUT(J)'
-      FLUSH(740+IAPROC)
-#endif
 !
 ! 4.d Perform output
 !
@@ -3428,11 +2964,6 @@
 ! If there is a second stream of restart files then J=8 and FLOUT(8)=.TRUE.
             J=8
             IF ( FLOUT(J) ) THEN
-!
-#ifdef W3_DEBUGRUN
-      WRITE(740+IAPROC,*) 'Matching FLOUT(J)'
-      FLUSH(740+IAPROC)
-#endif
 !
 ! 4.d Perform output
 !

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -609,15 +609,6 @@
       SCREEN   =  333
 #endif
 !
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3WAVE, step 1'
-#endif
-#ifdef W3_DEBUGSRC
-      WRITE(740+IAPROC,*) 'Step 1 : max(UST)=', maxval(UST)
-#endif
-#ifdef W3_DEBUGINIT
-      FLUSH(740+IAPROC)
-#endif
       IF ( IOUTP  .NE. IMOD ) CALL W3SETO ( IMOD, NDSE, NDST )
       IF ( IGRID  .NE. IMOD ) CALL W3SETG ( IMOD, NDSE, NDST )
       IF ( IWDATA .NE. IMOD ) CALL W3SETW ( IMOD, NDSE, NDST )
@@ -629,10 +620,8 @@
 
 
 
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 1", 1)
-#endif
 #endif
 
 !
@@ -652,14 +641,8 @@
         ELSE
           SKIP_O = .FALSE.
         END IF
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3WAVE, step 2'
-      FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 2", 1)
-#endif
 #endif
 !
 ! 0.b Subroutine tracing
@@ -760,14 +743,8 @@
         ELSE
           DTL0   = 0.
         END IF
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3WAVE, step 4'
-      FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 4", 1)
-#endif
 #endif
 !
 ! 1.c Current interval
@@ -807,14 +784,8 @@
               TOFRST = TIME
             END IF
         END IF
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3WAVE, step 5'
-      FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 5", 1)
-#endif
 #endif
 !
 ! 1.e Ice concentration interval
@@ -835,14 +806,8 @@
         ELSE
           DTI0   = 0.
         END IF
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'W3WAVE, step 6'
-      FLUSH(740+IAPROC)
-#endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 6", 1)
-#endif
 #endif
 !
 ! 1.f Momentum interval
@@ -946,10 +911,8 @@
 !      ENDIF
 
 
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "W3WAVEMD, step 6.1", 1)
-#endif
 #endif
 !
 !
@@ -1110,10 +1073,8 @@
      END DO
 #endif
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Beginning time loop", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After assigning VAOLD")
@@ -1170,11 +1131,6 @@
         WRITE (NDST,9021) ITIME, IT, TIME, FLMAP, FLDDIR,          &
                           VGX, VGY, DTG, DTRES
 #endif
-#ifdef W3_DEBUGSRC
-      WRITE(740+IAPROC,*) 'DTG 2 : DTG=', DTG
-      WRITE(740+IAPROC,*) 'max(UST)=', maxval(UST)
-      FLUSH(740+IAPROC)
-#endif
 !
 ! 3.1 Interpolate winds, currents, and momentum.
 !     (Initialize wave fields with winds)
@@ -1189,10 +1145,8 @@
 #endif
 
           IF ( FLCUR  ) THEN
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before UCUR", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("W3WAVE, step 6.4.1")
@@ -1280,10 +1234,8 @@
          CALL PRINT_MY_TIME("After U10, etc. assignation")
 #endif
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before call to W3UINI", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before call W3UINI")
@@ -1305,10 +1257,8 @@
 !
 ! 3.2 Update boundary conditions if boundary flag is true (FLBPI)
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before boundary update", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before boundary update")
@@ -1405,10 +1355,8 @@
                   FLMAP  = .TRUE.
               END IF
           END IF
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After FLICE and DTI0", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After FLICE and DTI0")
@@ -1518,10 +1466,8 @@
                         .OR. FLCK .OR. FSFREQSHIFT
               END IF
           END IF
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After FFLEV and DTL0", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After FFLEV and DTL0")
@@ -1912,10 +1858,8 @@
 !
 ! 3.6.2 Intra-spectral part 1
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before intraspectral part 1", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before intraspectral")
@@ -2012,10 +1956,8 @@
        call printMallInfo(IAPROC+40000,mallInfos)
 #endif
 
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
   CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before spatial advection", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("Before spatial advection")
@@ -2049,10 +1991,8 @@
 #ifdef W3_PDLIB
        IF (FSTOTALIMP .and. (IT .ne. 0)) THEN
 #endif
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
         CALL ALL_VA_INTEGRAL_PRINT(IMOD, "Before Block implicit", 1)
-#endif
 #endif
 #ifdef W3_PDLIB
          CALL PDLIB_W3XYPUG_BLOCK_IMPLICIT(IMOD, FACX, FACX, DTG, VGX, VGY)
@@ -2255,10 +2195,8 @@
 !
         END IF
 
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
         CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After spatial advection", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After spatial advection")
@@ -2350,10 +2288,8 @@
 !
                 END DO
             END IF
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
        CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After intraspectral adv.", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("fter intraspectral adv.")
@@ -2527,10 +2463,8 @@
 !!/MPI              CALL MPI_BARRIER (MPI_COMM_WCMP,IERR_MPI)
 !
             END IF
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
           CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After source terms", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("After source terms")
@@ -2570,10 +2504,8 @@
               IDACT  = '         '
           END IF
 !
-#ifdef W3_PDLIB
 #ifdef W3_DEBUGCOH
             CALL ALL_VA_INTEGRAL_PRINT(IMOD, "end of time loop", 1)
-#endif
 #endif
 #ifdef W3_TIMINGS
          CALL PRINT_MY_TIME("end of time loop")

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1281,23 +1281,10 @@
                     IF (READBC.AND.IDACT(1:1).EQ.' ') IDACT(1:1) = 'X'
                 END IF
                 FLACT  = READBC .OR. FLACT
-#ifdef W3_DEBUGIOBC
-     WRITE(740+IAPROC,*) 'READBC=', READBC
-     FLUSH(740+IAPROC)
-#endif
 
                 IF ( READBC ) THEN
-#ifdef W3_DEBUGIOBC
-       WRITE(740+IAPROC,*) 'Before call to W3IOBC'
-       FLUSH(740+IAPROC)
-#endif
                   CALL W3IOBC ( 'READ', NDS(9), TBPI0, TBPIN,       &
                                 ITEST, IMOD )
-#ifdef W3_DEBUGIOBC
-       WRITE(740+IAPROC,*) 'After call to W3IOBC'
-       WRITE(740+IAPROC,*) 'ITEST=', ITEST
-       FLUSH(740+IAPROC)
-#endif
                   IF ( ITEST .NE. 1 ) CALL W3UBPT
                 ELSE
                   ITEST  = 0

--- a/model/src/w3wdatmd.F90
+++ b/model/src/w3wdatmd.F90
@@ -455,10 +455,6 @@
 #ifdef W3_S
       CALL STRACE (IENT, 'W3DIMW')
 #endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 1'
-    FLUSH(740+IAPROC)
-#endif
 
 !
 ! -------------------------------------------------------------------- /
@@ -469,37 +465,21 @@
         ELSE
           FL_ALL = .TRUE.
         END IF
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 2'
-    FLUSH(740+IAPROC)
-#endif
 !
       IF ( NGRIDS .EQ. -1 ) THEN
           WRITE (NDSE,1001)
           CALL EXTCDE (1)
         END IF
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 3'
-    FLUSH(740+IAPROC)
-#endif
 !
       IF ( IMOD.LT.1 .OR. IMOD.GT.NWDATA ) THEN
           WRITE (NDSE,1002) IMOD, NWDATA
           CALL EXTCDE (2)
         END IF
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 4'
-    FLUSH(740+IAPROC)
-#endif
 !
       IF ( WDATAS(IMOD)%DINIT ) THEN
           WRITE (NDSE,1003)
           CALL EXTCDE (3)
         END IF
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 5'
-    FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_T
       WRITE (NDST,9000) IMOD
@@ -507,99 +487,40 @@
 !
       JGRID  = IGRID
       IF ( JGRID .NE. IMOD ) CALL W3SETG ( IMOD, NDSE, NDST )
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 6'
-    FLUSH(740+IAPROC)
-#endif
 !
 ! -------------------------------------------------------------------- /
 ! 2.  Allocate arrays
 !
       CALL SET_UP_NSEAL_NSEALM(NSEAL_DUMMY, NSEALM)
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 7'
-    FLUSH(740+IAPROC)
-#endif
       NSEATM = NSEALM * NAPROC
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8'
-    FLUSH(740+IAPROC)
-#endif
 !
       IF ( FL_ALL ) THEN
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8'
-    FLUSH(740+IAPROC)
-#endif
           ALLOCATE ( WDATAS(IMOD)%VA(NSPEC,0:NSEALM), STAT=ISTAT ); WDATAS(IMOD)%VA = 0.
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.1'
-    FLUSH(740+IAPROC)
-#endif
           CHECK_ALLOC_STATUS ( ISTAT )
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.2'
-    FLUSH(740+IAPROC)
-#endif
-!!/PDLIB          ALLOCATE ( WDATAS(IMOD)%VAOLD(NSPEC,0:NSEALM) )
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.3'
-    FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
           ALLOCATE ( WDATAS(IMOD)%SHAVETOT(NSEAL), stat=istat )
-#endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.4, stat=', istat
-    FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
         IF (.not. LSLOC) THEN
           ALLOCATE ( WDATAS(IMOD)%VSTOT(NSPEC,NSEAL), stat=istat )
 #endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.5, stat=', istat
-    FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
           ALLOCATE ( WDATAS(IMOD)%VDTOT(NSPEC,NSEAL), stat=istat )
-#endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.6, stat=', istat
-    FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
         ENDIF ! LSLOC 
           ALLOCATE ( WDATAS(IMOD)%VAOLD(NSPEC,NSEAL), stat=istat )
 #endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.7, stat=', istat
-    FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
         IF (.not. LSLOC) THEN
          WDATAS(IMOD)%VSTOT=0
 #endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.8'
-    FLUSH(740+IAPROC)
-#endif
 #ifdef W3_PDLIB
           WDATAS(IMOD)%VDTOT=0
-#endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.9'
-    FLUSH(740+IAPROC)
 #endif
 #ifdef W3_PDLIB
         ENDIF ! LSLOC 
           WDATAS(IMOD)%SHAVETOT=.FALSE.
-#endif
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.10'
-    FLUSH(740+IAPROC)
-    WRITE(740+IAPROC,*) 'NSEAL=', NSEAL, ' NSEALM=', NSEALM
-    FLUSH(740+IAPROC)
 #endif
 !
 ! * Four arrays for NL5 (QL)
@@ -629,15 +550,7 @@
 #endif
 !
           IF ( NSEAL .NE. NSEALM ) THEN
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'Before settings to ZERO'
-    FLUSH(740+IAPROC)
-#endif
             DO ISEA=NSEAL+1,NSEALM
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'ISEA=', ISEA
-    FLUSH(740+IAPROC)
-#endif
               WDATAS(IMOD)%VA(:,ISEA) = 0.
 !
 #ifdef W3_NL5
@@ -648,16 +561,8 @@
 #endif
             END DO
           END IF
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 8.11'
-    FLUSH(740+IAPROC)
-#endif
         END IF
 !
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 9'
-    FLUSH(740+IAPROC)
-#endif
       ! ICE, ICEH, ICEF must be defined from 0:NSEA
       ALLOCATE ( WDATAS(IMOD)%WLV(NSEA),                              &
                  WDATAS(IMOD)%ICE(0:NSEA),                            &
@@ -674,10 +579,6 @@
                  WDATAS(IMOD)%ASF(NSEATM),                            &
                  WDATAS(IMOD)%FPIS(NSEATM), STAT=ISTAT                )
       CHECK_ALLOC_STATUS ( ISTAT )
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 10'
-    FLUSH(740+IAPROC)
-#endif
 
       WDATAS(IMOD)%WLV   (:) = 0.
       WDATAS(IMOD)%ICE   (0:NSEA) = 0.
@@ -694,10 +595,6 @@
       WDATAS(IMOD)%ASF   (:) = 0.
       WDATAS(IMOD)%FPIS  (:) = 0.
       WDATAS(IMOD)%DINIT     = .TRUE.
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 11'
-    FLUSH(740+IAPROC)
-#endif
       CALL W3SETW ( IMOD, NDSE, NDST )
 !
 #ifdef W3_T
@@ -709,10 +606,6 @@
 !
       IF ( JGRID .NE. IMOD ) CALL W3SETG ( JGRID, NDSE, NDST )
 !
-#ifdef W3_DEBUGINIT
-    WRITE(740+IAPROC,*) 'W3DIMW, step 12'
-    FLUSH(740+IAPROC)
-#endif
       RETURN
 !
 ! Formats

--- a/model/src/wminiomd.F90
+++ b/model/src/wminiomd.F90
@@ -640,10 +640,6 @@
 #ifdef W3_S
       CALL STRACE (IENT, 'WMIOBG')
 #endif
-#ifdef W3_DEBUGIOBC
-      WRITE(740+IAPROC,*)  'Begin of W3IOBG'
-      FLUSH(740+IAPROC)
-#endif
 
 
 !
@@ -1136,10 +1132,6 @@
 ! 5.  Successful update
 !
       IF ( PRESENT(DONE) ) DONE = .TRUE.
-#ifdef W3_DEBUGIOBC
-      WRITE(740+IAPROC,*)  'End of W3IOBG'
-      FLUSH(740+IAPROC)
-#endif
 !
       RETURN
 !

--- a/model/src/ww3_ounf.F90
+++ b/model/src/ww3_ounf.F90
@@ -169,9 +169,7 @@
       USE W3IOGOMD, ONLY: W3IOGO, W3READFLGRD, W3FLGRDFLAG
       USE W3INITMD, ONLY: WWVER, SWITCHES
       USE W3ODATMD, ONLY: NAPROC, NOSWLL, PTMETH, PTFCUT
-#ifdef W3_DEBUG
       USE W3ODATMD, only : IAPROC
-#endif
 !/
       USE W3GDATMD
       USE W3WDATMD, ONLY: TIME, WLV, ICE, ICEH, ICEF, BERG,            &
@@ -305,12 +303,6 @@
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3.  Read general data and first fields from file
 !
-#ifdef W3_DEBUG
-      WRITE (NDSO,*) 'Before FLOGRD(2,1)=', FLOGRD(2,1)
-      WRITE (NDSO,*) 'IAPROC=', IAPROC
-      WRITE(740+IAPROC,*) 'Calling W3IOGO from ww3_ounf'
-      FLUSH(740+IAPROC)
-#endif
       CALL W3IOGO ( 'READ', NDSOG, IOTEST )
 !
       WRITE (NDSO,930)

--- a/model/src/ww3_shel.F90
+++ b/model/src/ww3_shel.F90
@@ -473,9 +473,6 @@
    CALL CPL_OASIS_INIT(MPI_COMM)
  ELSE
 #endif
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'Before MPI_INIT, ww3_shel'
-#endif
 #ifdef W3_OMPH
        ! For hybrid MPI-OpenMP specify required thread level. JGLi06Sep2019
        IF( FLHYBR ) THEN
@@ -488,9 +485,6 @@
 #ifdef W3_OMPH
        ENDIF
 #endif
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'After MPI_INIT, ww3_shel'
-#endif
 #ifdef W3_MPI
       MPI_COMM = MPI_COMM_WORLD
 #endif
@@ -501,9 +495,6 @@
 !
 #ifdef W3_MPI
       CALL MPI_COMM_SIZE ( MPI_COMM, NAPROC, IERR_MPI )
-#endif
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*) 'After MPI_COMM_SIZE, NAPROC=', NAPROC
 #endif
 #ifdef W3_MPI
       CALL MPI_COMM_RANK ( MPI_COMM, IAPROC, IERR_MPI )
@@ -525,10 +516,6 @@
 ! 1.  IO set-up
 ! 1.a For shell
 !
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'ww3_shel, step 1'
-      FLUSH(740+IAPROC)
-#endif
       NDSI   = 10
       NDSS   = 90
       NDSO   =  6
@@ -560,10 +547,6 @@
       NDSF(7)  = 17
       NDSF(8)  = 18
       NDSF(9)  = 19
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'ww3_shel, step 2'
-      FLUSH(740+IAPROC)
-#endif
 !
 #ifdef W3_NCO
 !
@@ -665,10 +648,6 @@
       FLLSTI = .FALSE. ! This is associated with J.EQ.4 (ice)
       FLLSTR = .FALSE. ! This is associated with J.EQ.6 (rhoa)
       FLLST_ALL = .FALSE. ! For all
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'ww3_shel, step 3'
-      FLUSH(740+IAPROC)
-#endif
 
 ! If using experimental mud or ice physics, additional lines will
 !  be read in from ww3_shel.inp and applied, so JFIRST is changed from
@@ -698,11 +677,6 @@
       JFIRST=-7
 #endif
 
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'ww3_shel, step 4'
-      WRITE(740+IAPROC,*) 'JFIRST=', JFIRST
-      FLUSH(740+IAPROC)
-#endif
 
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WW3_SHEL SECTION 2a'
@@ -1229,23 +1203,10 @@
 !
       IF (.NOT. FLGNML) THEN
 
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) ' FNMPRE=', TRIM(FNMPRE)
-        FLUSH(740+IAPROC)
-#endif
         OPEN (NDSI,FILE=TRIM(FNMPRE)//'ww3_shel.inp',STATUS='OLD',IOSTAT=IERR)
         REWIND (NDSI)
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) 'Before read 2002, case 1'
-        FLUSH(740+IAPROC)
-#endif
 !AR: I changed the error handling for err=2002, see commit message ...
         READ (NDSI,'(A)') COMSTR
-#ifdef W3_DEBUGINIT
-        WRITE(740+IAPROC,*) ' COMSTR=', COMSTR
-        WRITE(740+IAPROC,*) ' After read 2002, case 1'
-        FLUSH(740+IAPROC)
-#endif
         IF (COMSTR.EQ.' ') COMSTR = '$'
         IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,901) COMSTR
 
@@ -1255,27 +1216,9 @@
         DO J=JFIRST, 9
           CALL NEXTLN ( COMSTR , NDSI , NDSEN )
           IF ( J .LE. 6 ) THEN
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before read 2002, case 2'
-      FLUSH(740+IAPROC)
-#endif
             READ (NDSI,*) FLAGTFC(J), FLH(J)
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) '     J=', J, ' FLAGTFC=', FLAGTFC(J), ' FLH=', FLH(J)
-      WRITE(740+IAPROC,*) ' After read 2002, case 2'
-      FLUSH(740+IAPROC)
-#endif
           ELSE
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before read 2002, case 3'
-      FLUSH(740+IAPROC)
-#endif
             READ (NDSI,*) FLAGTFC(J)
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) '     J=', J, ' FLAGTFC=', FLAGTFC(J)
-      WRITE(740+IAPROC,*) ' After read 2002, case 3'
-      FLUSH(740+IAPROC)
-#endif
           END IF
         END DO
 
@@ -1321,10 +1264,6 @@
        call printMallInfo(IAPROC,mallInfos)
 #endif
 
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'ww3_shel, step 5'
-      FLUSH(740+IAPROC)
-#endif
 !
         INFLAGS1(10) = .FALSE.
 #ifdef W3_MGW
@@ -1367,13 +1306,7 @@
 ! 2.2 Time setup
 
         CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'Before read 2002, case 4'
-#endif
         READ (NDSI,*) TIME0
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), ' After read 2002, case 4'
-#endif
 
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WW3_SHEL SECTION 2c'
@@ -1382,17 +1315,7 @@
 #endif
 
         CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'Before read 2002, case 5'
-#endif
         READ (NDSI,*) TIMEN
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), ' After read 2002, case 5'
-#endif
-
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'ww3_shel, step 6'
-#endif
 !
 #ifdef W3_MEMCHECK
        write(740+IAPROC,*) 'memcheck_____:', 'WW3_SHEL SECTION 2d'
@@ -1402,22 +1325,13 @@
 
 ! 2.3 Domain setup
 
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'ww3_shel, step 7'
-#endif
         CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'Before read 2002, case 6'
-#endif
         READ (NDSI,*) IOSTYP
 #ifdef W3_PDLIB
      IF (IOSTYP .gt. 1) THEN
        WRITE(*,*) 'IOSTYP not supported in domain decomposition mode'
        CALL EXTCDE ( 6666 )
      ENDIF
-#endif
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), ' After read 2002, case 6'
 #endif
         CALL W3IOGR ( 'GRID', NDSF(7) )
         IF ( FLAGLL ) THEN
@@ -1426,9 +1340,6 @@
           FACTOR = 1.E-3
         END IF
 
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'ww3_shel, step 8'
-#endif
 
 ! 2.4 Output dates
 
@@ -1437,17 +1348,8 @@
 #ifdef W3_COU
         NOTYPE = 7
 #endif
-#ifdef W3_DEBUGINIT
-      write(740+IAPROC,*), 'Before NOTYPE loop'
-#endif
         DO J = 1, NOTYPE
-#ifdef W3_DEBUGINIT
-        write(740+IAPROC,*), 'J=', J, '/ NOTYPE=', NOTYPE
-#endif
           CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-        write(740+IAPROC,*), 'Before read 2002, case 7'
-#endif
 !
 ! CHECKPOINT
         IF(J .EQ. 4) THEN
@@ -1528,9 +1430,6 @@
         END IF
 !          WRITE(*,*) 'OFILES(J)= ', OFILES(J),J
 !
-#ifdef W3_DEBUGINIT
-        write(740+IAPROC,*), ' After read 2002, case 7'
-#endif
           ODAT(5*(J-1)+3) = MAX ( 0 , ODAT(5*(J-1)+3) )
 !
 #ifdef W3_MEMCHECK
@@ -1545,9 +1444,6 @@
           IF ( ODAT(5*(J-1)+3) .NE. 0 ) THEN
 
 ! Type 1: fields of mean wave parameters
-#ifdef W3_DEBUGINIT
-            write(740+IAPROC,*), 'Case analysis'
-#endif
             IF ( J .EQ. 1 ) THEN
               CALL W3READFLGRD ( NDSI, NDSO, 9, NDSEN, COMSTR, FLGD,   &
                                  FLGRD, IAPROC, NAPOUT, IERR )
@@ -1583,13 +1479,7 @@
                 NPTS   = 0
                 DO
                   CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-                  write(740+IAPROC,*), 'Before read 2002, case 8'
-#endif
                   READ (NDSI2,*) XX, YY, PN
-#ifdef W3_DEBUGINIT
-                  write(740+IAPROC,*), ' After read 2002, case 8'
-#endif
                   IF ( ILOOP.EQ.1 .AND. IAPROC.EQ.1 ) THEN
                     BACKSPACE (NDSI)
                     READ (NDSI,'(A)') LINE
@@ -1644,13 +1534,7 @@
 ! Type 3: track output
             ELSE IF ( J .EQ. 3 ) THEN
               CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-              write(740+IAPROC,*), 'Before read 2002, case 9'
-#endif
               READ (NDSI,*) TFLAGI
-#ifdef W3_DEBUGINIT
-              write(740+IAPROC,*), ' After read 2002, case 9'
-#endif
 !
               IF ( .NOT. TFLAGI ) NDS(11) = -NDS(11)
               IF ( IAPROC .EQ. NAPOUT ) THEN
@@ -1666,14 +1550,7 @@
             ELSE IF ( J .EQ. 6 ) THEN
 !             IPRT: IX0, IXN, IXS, IY0, IYN, IYS
               CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-              write(740+IAPROC,*), 'Before reading IPRT'
-              write(740+IAPROC,*), 'Before read 2002, case 10'
-#endif
               READ (NDSI,*) IPRT, PRTFRM
-#ifdef W3_DEBUGINIT
-              write(740+IAPROC,*), ' After read 2002, case 10'
-#endif
 !
               IF ( IAPROC .EQ. NAPOUT ) THEN
                 IF ( PRTFRM ) THEN
@@ -1713,13 +1590,7 @@
           ! Start of loop
           DO
             CALL NEXTLN ( COMSTR , NDSI , NDSEN )
-#ifdef W3_DEBUGINIT
-            write(740+IAPROC,*), 'Before read 2002, case 11'
-#endif
             READ (NDSI,*) IDTST
-#ifdef W3_DEBUGINIT
-            write(740+IAPROC,*), ' After read 2002, case 11'
-#endif
 
 
             ! Exit if illegal id
@@ -1745,75 +1616,33 @@
                 NH(J)    = NH(J) + 1
                 IF ( NH(J) .GT. NHMAX ) GOTO 2006
                 IF ( J .LE. 1  ) THEN ! water levels, etc. : get HA
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 12'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 12'
-#endif
                 ELSE IF ( J .EQ. 2 ) THEN ! currents: get HA and HD
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 13'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J), HD(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 13'
-#endif
                 ELSE IF ( J .EQ. 3 ) THEN ! wind: get HA HD and HS
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 14'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J), HD(NH(J),J), HS(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 14'
-#endif
                 ELSE IF ( J .EQ. 4 ) THEN ! ice
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 15'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 15'
-#endif
                 ELSE IF ( J .EQ. 5 ) THEN ! atmospheric momentum
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 16'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J), HD(NH(J),j)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 16'
-#endif
                 ELSE IF ( J .EQ. 6 ) THEN ! air density
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 17'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 16'
-#endif
                 ELSE IF ( J .EQ. 10 ) THEN ! mov: HA and HD
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), 'Before read 2002, case 18'
-#endif
                   READ (NDSI,*) IDTST,           &
                         THO(1,J,NH(J)), THO(2,J,NH(J)),            &
                         HA(NH(J),J), HD(NH(J),J)
-#ifdef W3_DEBUGINIT
-                     write(740+IAPROC,*), ' After read 2002, case 18'
-#endif
                 END IF
               END IF
             END DO
@@ -1888,9 +1717,6 @@
 !
 
         DO J=JFIRST, 6 
-#ifdef W3_DEBUGINIT
-     write(740+IAPROC,*), 'J=',J,'INFLAGS1(J)=',INFLAGS1(J), 'FLAGSC(J)=', FLAGSC(J) 
-#endif
           IF ( INFLAGS1(J) .AND. .NOT. FLAGSC(J)) THEN
             IF ( FLH(J) ) THEN
               IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,954) IDFLDS(J)

--- a/model/src/ww3_strt.F90
+++ b/model/src/ww3_strt.F90
@@ -578,11 +578,6 @@
      FACTOR = 1.
 #endif
             VA(:,JSEA) = FACTOR * E21
-#ifdef W3_DEBUGINIT
-     WRITE(740+IAPROC,*) 'JSEA=', JSEA, '  FACTOR=', FACTOR
-     WRITE(740+IAPROC,*) '   sum(E21)=', sum(E21)
-     WRITE(740+IAPROC,*) '   sum(VA)=', sum(VA(:,JSEA))
-#endif
 !
 
 !
@@ -830,9 +825,6 @@
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 9.  Convert E(sigma) to N(k)
 !
-#ifdef W3_DEBUGINIT
-       WRITE(740+IAPROC,*) 'ITYPE=', ITYPE
-#endif
       IF ( ITYPE.NE.3 .AND. ITYPE.NE.5 ) THEN
           IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,990)
 !
@@ -841,18 +833,12 @@
           HSIG   = 0.
 #endif
 !
-#ifdef W3_DEBUGINIT
-       WRITE(740+IAPROC,*) 'Doing rescaling operation'
-#endif
           DO JSEA=1, NSEAL
 #ifdef W3_DIST
             ISEA   = IAPROC + (JSEA-1)*NAPROC
 #endif
 #ifdef W3_SHRD
             ISEA   = JSEA
-#endif
-#ifdef W3_DEBUGINIT
-       WRITE(740+IAPROC,*) ' rescal ISEA=', ISEA, ' JSEA=', JSEA
 #endif
             DEPTH  = MAX ( DMIN , -ZB(ISEA) )
 #ifdef W3_O6
@@ -907,15 +893,9 @@
 #ifdef W3_O6
           NSX    = 1 + NX/35
           NSY    = 1 + NY/35
-#ifdef W3_DEBUGINIT
-         Print *, 'Before call to PRTBLK'
-#endif
           IF ( IAPROC .EQ. NAPOUT ) CALL PRTBLK                   &
                       (NDSO, NX, NY, NX, HSIG, MAPO, 0, 0.,       &
                        1, NX, NSX, 1, NY, NSY, 'Hs', 'm')
-#ifdef W3_DEBUGINIT
-         Print *, 'After call to PRTBLK'
-#endif
 #endif
 #ifdef W3_MPI
         END IF
@@ -927,20 +907,7 @@
 !10.  Write restart file.
 !
       IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,995)
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before call to W3IORS'
-      WRITE(740+IAPROC,*) 'min/max/sum(VA)=', minval(VA), maxval(VA), sum(VA)
-      FLUSH(740+IAPROC)
-#endif
       CALL W3IORS ( INXOUT, NDSR, SIG(NK) )
-#ifdef W3_DEBUGINIT
-      WRITE(740+IAPROC,*) 'Before call to W3IORS'
-      WRITE(740+IAPROC,*) 'min/max/sum(VA)=', minval(VA), maxval(VA), sum(VA)
-      DO ISEA=1,NSEA
-        WRITE(740+IAPROC,*) 'ISEA=', ISEA, ' sum(VA)=', sum(VA(:,ISEA))
-      END DO
-      FLUSH(740+IAPROC)
-#endif
 !
       GOTO 888
 !


### PR DESCRIPTION
# Pull Request Summary
Elimination of many print statements that are just useless and plainly annoying.
by Mathieu DutSik


## Description
It cleans up the code which makes it clearer


Please also include the following information: 
Reviewed by Jessica Meixner and Tyler Hesser

### Commit Message
Reduction in the number of print statements.



### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [X ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ X] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?  Regression tests were compared between NOAA-EMC and the feature branch
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? yes.  ERDC JIM and Intel
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_): attached
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/9602098/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/9602100/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/9602101/matrixDiff.txt)

