### PR TITLE
Remove fp1 and thp1

### DIFF
--- a/model/src/gx_outf.F90
+++ b/model/src/gx_outf.F90
@@ -131,7 +131,7 @@
                           UST, USTDIR, RHOAIR
       USE W3ADATMD, ONLY: CFLXYMAX, CFLTHMAX, AS, CX, CY, UA, UD, WN,  &
                           DW, HS, WLM, T01, T0M1, T02, THM, THS, FP0,  &
-                          THP0, FP1, THP1, ABA, ABD, UBA, UBD, FCUT,   &
+                          THP0, ABA, ABD, UBA, UBD, FCUT,              &
                           SXX, SYY, SXY, PHS, PTP, PLP, PDIR, PSI, PWS,&
                           PTM1, PT1, PT2, PEP, TAUA, TAUADIR,          &
                           PTHP0, PQP, PSW, PPE, PGW, QP,               &

--- a/model/src/pdlib_field_vec.F90
+++ b/model/src/pdlib_field_vec.F90
@@ -814,7 +814,7 @@ MODULE PDLIB_FIELD_VEC
       USE W3WDATMD, ONLY: VA, UST, USTDIR, ASF, FPIS
       USE W3ADATMD, ONLY: MPI_COMM_WAVE, WW3_FIELD_VEC
       USE W3ADATMD, ONLY: HS, WLM, T02
-      USE W3ADATMD, ONLY: T0M1, THM, THS, FP0, THP0, FP1, THP1,  &
+      USE W3ADATMD, ONLY: T0M1, THM, THS, FP0, THP0,             &
                           DTDYN, FCUT, SPPNT, ABA, ABD, UBA, UBD,&
                           SXX, SYY, SXY, USERO, PHS, PTP, PLP,   &
                           PDIR, PSI, PWS, PWST, PNR, PHIAW,      &

--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -174,11 +174,6 @@
 !      CFLTHMAX  R.A.  Public   Max. CFL number for refraction.
 !      CFLKMAX   R.A.  Public   Max. CFL number for wavenumber shift.
 !
-!    Old parameters not yet in new structure ...
-!
-!      FP1       R.A.  Public   Wind sea peak frequency. (parked in 2)
-!      THP1      R.A.  Public   Wind sea peak direction. (parked in 2)
-!
 !    Orphans, commented out here, now automatic arrays in W3WAVE, ....
 !
 !      DRAT      R.A.  Public   Density ration air/water. Was
@@ -381,13 +376,13 @@
 !
         REAL, POINTER         :: HS(:),  WLM(:),  T02(:), T0M1(:),   &
                                  T01 (:),  FP0(:),  THM(:),          &
-                                 THS(:),  THP0(:),  FP1(:), THP1(:), &
+                                 THS(:),  THP0(:),                   &
                                  HSIG(:), STMAXE(:), STMAXD(:),      &
                                  HMAXE(:), HCMAXE(:), HMAXD(:),      &
                                  HCMAXD(:), QP(:), WBT(:), WNMEAN(:)
         REAL, POINTER         :: XHS(:), XWLM(:), XT02(:), XT0M1(:),  &
                                  XT01 (:), XFP0(:), XTHM(:),          &
-                                 XTHS(:), XTHP0(:), XFP1(:), XTHP1(:),&
+                                 XTHS(:), XTHP0(:),                   &
                                  XHSIG(:), XSTMAXE(:), XSTMAXD(:),    &
                                  XHMAXE(:), XHCMAXE(:), XHMAXD(:),    &
                                  XHCMAXD(:), XQP(:), XWBT(:),         &
@@ -562,7 +557,7 @@
 !
       REAL, POINTER           :: HS(:), WLM(:),  T02(:), T0M1(:),     &
                                  T01 (:), FP0(:), THM(:), THS(:),     &
-                                 THP0(:), FP1(:), THP1(:), HSIG(:),   &
+                                 THP0(:), HSIG(:),                    &
                                  STMAXE(:), STMAXD(:), HMAXE(:),      &
                                  HCMAXE(:), HMAXD(:), HCMAXD(:),      &
                                  QP(:), WBT(:), WNMEAN(:)
@@ -1016,8 +1011,7 @@
                  WADATS(IMOD)%T02  (NSEALM), WADATS(IMOD)%T0M1(NSEALM), &
                  WADATS(IMOD)%T01  (NSEALM), WADATS(IMOD)%FP0 (NSEALM), &
                  WADATS(IMOD)%THM  (NSEALM), WADATS(IMOD)%THS (NSEALM), &
-                 WADATS(IMOD)%THP0 (NSEALM), WADATS(IMOD)%FP1 (NSEALM), &
-                 WADATS(IMOD)%THP1 (NSEALM), WADATS(IMOD)%HSIG(NSEALM), &
+                 WADATS(IMOD)%THP0 (NSEALM), WADATS(IMOD)%HSIG(NSEALM), &
                  WADATS(IMOD)%STMAXE (NSEALM),                          &
                  WADATS(IMOD)%STMAXD(NSEALM),                           &
                  WADATS(IMOD)%HMAXE(NSEALM), WADATS(IMOD)%HMAXD(NSEALM),&
@@ -1037,8 +1031,6 @@
       WADATS(IMOD)%THM    = UNDEF
       WADATS(IMOD)%THS    = UNDEF
       WADATS(IMOD)%THP0   = UNDEF
-      WADATS(IMOD)%FP1    = UNDEF
-      WADATS(IMOD)%THP1   = UNDEF
       WADATS(IMOD)%HSIG   = UNDEF
       WADATS(IMOD)%STMAXE = UNDEF
       WADATS(IMOD)%STMAXD = UNDEF
@@ -1747,22 +1739,6 @@
           CHECK_ALLOC_STATUS ( ISTAT )
         END IF
 !
-!     IF ( OUTFLAGS( 2,xx) ) THEN
-!         ALLOCATE ( WADATS(IMOD)%XFP1(NXXX), STAT=ISTAT )
-!         CHECK_ALLOC_STATUS ( ISTAT )
-!       ELSE
-!         ALLOCATE ( WADATS(IMOD)%XFP1(1), STAT=ISTAT )
-!         CHECK_ALLOC_STATUS ( ISTAT )
-!       END IF
-!
-!     IF ( OUTFLAGS( 2,xx) ) THEN
-!         ALLOCATE ( WADATS(IMOD)%XTHP1(NXXX), STAT=ISTAT )
-!         CHECK_ALLOC_STATUS ( ISTAT )
-!       ELSE
-!         ALLOCATE ( WADATS(IMOD)%XTHP1(1), STAT=ISTAT )
-!         CHECK_ALLOC_STATUS ( ISTAT )
-!       END IF
-!
       WADATS(IMOD)%XHS    = UNDEF
       WADATS(IMOD)%XWLM   = UNDEF
       WADATS(IMOD)%XT02   = UNDEF
@@ -1781,8 +1757,6 @@
       WADATS(IMOD)%XHCMAXD= UNDEF
       WADATS(IMOD)%XWBT   = UNDEF
       WADATS(IMOD)%XWNMEAN= UNDEF
-!     WADATS(IMOD)%XFP1   = UNDEF
-!     WADATS(IMOD)%XTHP1  = UNDEF
 !
       IF ( OUTFLAGS( 3, 1) ) THEN
           ALLOCATE ( WADATS(IMOD)%XEF(NXXX,E3DF(2,1):E3DF(3,1)), STAT=ISTAT )
@@ -2842,8 +2816,6 @@
           THM    => WADATS(IMOD)%THM
           THS    => WADATS(IMOD)%THS
           THP0   => WADATS(IMOD)%THP0
-          FP1    => WADATS(IMOD)%FP1
-          THP1   => WADATS(IMOD)%THP1
           HSIG   => WADATS(IMOD)%HSIG
           STMAXE => WADATS(IMOD)%STMAXE
           STMAXD => WADATS(IMOD)%STMAXD
@@ -3190,8 +3162,6 @@
           QP     => WADATS(IMOD)%XQP
           WBT    => WADATS(IMOD)%XWBT
           WNMEAN => WADATS(IMOD)%XWNMEAN
-!         FP1    => WADATS(IMOD)%XFP1
-!         THP1   => WADATS(IMOD)%XTHP1
 !
           EF     => WADATS(IMOD)%XEF
           TH1M   => WADATS(IMOD)%XTH1M

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -2327,7 +2327,7 @@
 
 
 #ifdef W3_MPI
-      USE W3ADATMD, ONLY: T0M1, THM, THS, FP0, THP0, FP1, THP1,   &
+      USE W3ADATMD, ONLY: T0M1, THM, THS, FP0, THP0,             &
                           DTDYN, FCUT, SPPNT, ABA, ABD, UBA, UBD,&
                           SXX, SYY, SXY, USERO, PHS, PTP, PLP,   &
                           PDIR, PSI, PWS, PWST, PNR, PHIAW, PHIOC,&

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1683,12 +1683,7 @@
 !  Compute spectral parameters wrt the mean wave direction
 !  (no tail contribution - Prognostic)
       DO JSEA=1, NSEAL
-#ifdef W3_DIST
-        ISEA   = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-        ISEA   = JSEA
-#endif
+        CALL INIT_GET_ISEA(ISEA, JSEA)
         IX     = MAPSF(ISEA,1)
         IY     = MAPSF(ISEA,2)
         IF ( MAPSTA(IY,IX) .GT. 0 ) THEN
@@ -1709,16 +1704,10 @@
         DO ITH=1, NTH
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
           DO JSEA=1, NSEAL
-#ifdef W3_DIST
-        ISEA      = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-        ISEA      = JSEA
-#endif
             ABX2M(JSEA) = ABX2M(JSEA) + A(ITH,IK,JSEA)*                &
               (ECOS(ITH)*COS(THMP(JSEA))+ESIN(ITH)*SIN(THMP(JSEA)))**2
             ABY2M(JSEA) = ABY2M(JSEA) + A(ITH,IK,JSEA)*                &
@@ -1743,12 +1732,7 @@
 #endif
 !
         DO JSEA=1, NSEAL
-#ifdef W3_DIST
-          ISEA         = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-          ISEA         = JSEA
-#endif
+          CALL INIT_GET_ISEA(ISEA, JSEA)
           FACTOR       = DDEN(IK) / CG(IK,ISEA)
           MSSXM(JSEA)  = MSSXM(JSEA) + ABX2M(JSEA)*FACTOR*             &
             WN(IK,ISEA)**2
@@ -1769,18 +1753,10 @@
         END DO
 
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA,IX,IY,STEX,STEY,STED,ITL,IK)
+!$OMP PARALLEL DO PRIVATE(JSEA,STEX,STEY,STED,ITL,IK)
 #endif
 !
         DO JSEA=1, NSEAL
-#ifdef W3_DIST
-        ISEA      = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-        ISEA      = JSEA
-#endif
-        IX     = MAPSF(ISEA,1)
-        IY     = MAPSF(ISEA,2)
 !
 !  Mean wave period (no tail contribution - Prognostic)
         IF ( ET02(JSEA) .GT. 1.E-7 ) THEN
@@ -2160,11 +2136,10 @@
       DO ITH=1, NTH
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
         DO JSEA=1, NSEAL
-          CALL INIT_GET_ISEA(ISEA, JSEA)
           IF (IKP0(JSEA).NE.0) THEN
               ETX(JSEA) = ETX(JSEA) + A(ITH,IKP0(JSEA),JSEA)*ECOS(ITH)
               ETY(JSEA) = ETY(JSEA) + A(ITH,IKP0(JSEA),JSEA)*ESIN(ITH)
@@ -2178,11 +2153,10 @@
         END DO
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
       DO JSEA=1, NSEAL
-        CALL INIT_GET_ISEA(ISEA, JSEA)
         IF ( ABS(ETX(JSEA))+ABS(ETY(JSEA)) .GT. 1.E-7 .AND.           &
              FP0(JSEA).NE.UNDEF )                                     &
             THP0(JSEA) = ATAN2(ETY(JSEA),ETX(JSEA))
@@ -3810,6 +3784,7 @@
       USE W3ADATMD,  ONLY: CG, WN, DW
       USE W3ADATMD,  ONLY: USSX, USSY,  US3D, USSP
       USE W3ODATMD, ONLY: IAPROC, NAPROC
+      USE W3PARALL, ONLY: INIT_GET_ISEA
 #ifdef W3_S
       USE W3SERVMD, ONLY: STRACE
 #endif
@@ -3881,16 +3856,10 @@
          DO ITH=1, NTH
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
             DO JSEA=1, NSEAL
-#ifdef W3_DIST
-                ISEA         = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-                ISEA         = JSEA
-#endif
                ABX(JSEA)  = ABX(JSEA) + A(ITH,IK,JSEA)*ECOS(ITH)
                ABY(JSEA)  = ABY(JSEA) + A(ITH,IK,JSEA)*ESIN(ITH)
             END DO
@@ -3909,12 +3878,7 @@
 #endif
 !
          DO JSEA=1, NSEAL
-#ifdef W3_DIST
-              ISEA         = IAPROC + (JSEA-1)*NAPROC
-#endif
-#ifdef W3_SHRD
-              ISEA         = JSEA
-#endif
+            CALL INIT_GET_ISEA(ISEA, JSEA)
             FACTOR       = DDEN(IK) / CG(IK,ISEA)
 !
 ! Deep water limits

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -1283,7 +1283,7 @@
       USE W3ADATMD, ONLY: CG, WN, DW
       USE W3ADATMD, ONLY: HS, WLM, T02, T0M1, T01, FP0,               &
                           THM, THS, THP0
-      USE W3ADATMD, ONLY: FP1, THP1, ABA, ABD, UBA, UBD, FCUT, SXX,   &
+      USE W3ADATMD, ONLY: ABA, ABD, UBA, UBD, FCUT, SXX,              &
                           SYY, SXY, PHS, PTP, PLP, PDIR, PSI, PWS,    &
                           PWST, PNR, USERO, TUSX, TUSY, PRMS, TPMS,   &
                           USSX, USSY, MSSX, MSSY, MSSD, MSCX, MSCY,   &
@@ -1314,14 +1314,14 @@
 !/ Local parameters
 !/
       INTEGER                 :: IK, ITH, JSEA, ISEA, IX, IY,         &
-                                 IKP0(NSEAL), IKP1(NSEAL), NKH(NSEAL),&
+                                 IKP0(NSEAL), NKH(NSEAL),             &
                                  ILOW, ICEN, IHGH, I, J, LKMS, HKMS,  &
                                  ITL
 #ifdef W3_S
       INTEGER, SAVE           :: IENT = 0
 #endif
       REAL                    :: FXPMC, FACTOR, FACTOR2, EBAND, FKD,  &
-                                 FP1STR, FP1TST, FPISTR, AABS, UABS,  &
+                                 AABS, UABS,                          &
                                  XL, XH, XL2, XH2, EL, EH, DENOM, KD, &
                                  M1, M2, MA, MB, MC, STEX, STEY, STED
       REAL                    :: ET(NSEAL), EWN(NSEAL), ETR(NSEAL),   &
@@ -1461,9 +1461,6 @@
       HMAXD = UNDEF
       QP    = UNDEF
       WBT    = UNDEF
-!
-      FP1    = UNDEF
-      THP1   = UNDEF
 !
 ! 2.  Integral over discrete part of spectrum ------------------------ *
 !
@@ -2072,54 +2069,14 @@
 ! 4.a Initialize
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA,FPISTR,FP1STR,FP1TST)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
       DO JSEA=1, NSEAL
-        CALL INIT_GET_ISEA(ISEA, JSEA)
         EC  (JSEA) = EBD(NK,JSEA)
         FP0 (JSEA) = UNDEF
         IKP0(JSEA) = 0
         THP0(JSEA) = UNDEF
-#ifdef W3_ST0
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = NK
-#endif
-#ifdef W3_ST1
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = 0
-#endif
-#ifdef W3_ST2
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = NK
-        FPISTR     = MAX ( 0.003 , FPIS(ISEA) * UST(ISEA) / GRAV )
-        FP1STR     = 3.6E-4 + 0.92*FPISTR - 6.3E-10/FPISTR**3
-        FP1TST     = MAX ( 0.003 , FP1STR * UST(ISEA) / GRAV )
-        IF ( FP1TST.LE.SIG(NK) .AND. FP1TST.GT.SIG(1) ) THEN
-            FP1 (JSEA) = TPIINV * FP1TST
-            IKP1(JSEA) = MAX ( 1 , NINT(FACTI2+FACTI1*LOG(FP1TST)) )
-          END IF
-#endif
-#ifdef W3_ST3
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = 0
-#endif
-#ifdef W3_ST4
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = 0
-#endif
-#ifdef W3_ST6
-        FP1 (JSEA) = UNDEF
-        IKP1(JSEA) = NK
-        FPISTR     = MAX ( 0.003 , FPIS(ISEA) * UST(ISEA) / GRAV )
-        FP1STR     = 3.6E-4 + 0.92*FPISTR - 6.3E-10/FPISTR**3
-        FP1TST     = FP1STR / UST(ISEA) * GRAV
-        IF ( FP1TST.LE.SIG(NK) .AND. FP1TST.GT.SIG(1) ) THEN
-            FP1 (JSEA) = TPIINV * FP1TST
-            IKP1(JSEA) = MAX ( 1 , NINT(FACTI2+FACTI1*LOG(FP1TST)) )
-          END IF
-#endif
-        THP1(JSEA) = UNDEF
         END DO
 !
 #ifdef W3_OMPG
@@ -2131,39 +2088,14 @@
       DO IK=NK-1, 2, -1
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
         DO JSEA=1, NSEAL
-          CALL INIT_GET_ISEA(ISEA, JSEA)
           IF ( EC(JSEA) .LT. EBD(IK,JSEA) ) THEN
               EC  (JSEA) = EBD(IK,JSEA)
               IKP0(JSEA) = IK
             END IF
-#ifdef W3_ST1
-          IF ( IKP1(JSEA).EQ.0                             &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK,JSEA)      &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK+1,JSEA)    &
-                 .AND. SIG(IK).GT.FXPMC/UST(ISEA)          &
-                 .AND. SIG(IK).LT.0.75*SIG(NK) )           &
-              IKP1(JSEA) = IK
-#endif
-#ifdef W3_ST3
-          IF ( IKP1(JSEA).EQ.0                             &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK,JSEA)      &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK+1,JSEA)    &
-                 .AND. SIG(IK).GT.FXPMC/MAX(1.E-4,UST(ISEA)) &
-                 .AND. SIG(IK).LT.0.75*SIG(NK) )           &
-              IKP1(JSEA) = IK
-#endif
-#ifdef W3_ST4
-          IF ( IKP1(JSEA).EQ.0                             &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK,JSEA)      &
-                 .AND. EBD(IK-1,JSEA).LT.EBD(IK+1,JSEA)    &
-                 .AND. SIG(IK).GT.FXPMC/MAX(1.E-4,UST(ISEA)) &
-                 .AND. SIG(IK).LT.0.75*SIG(NK) )           &
-              IKP1(JSEA) = IK
-#endif
           END DO
 !
 #ifdef W3_OMPG
@@ -2173,21 +2105,11 @@
         END DO
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
+!$OMP PARALLEL DO PRIVATE(JSEA)
 #endif
 !
       DO JSEA=1, NSEAL
-        CALL INIT_GET_ISEA(ISEA, JSEA)
         IF ( IKP0(JSEA) .NE. 0 ) FP0(JSEA) = SIG(IKP0(JSEA)) * TPIINV
-#ifdef W3_ST1
-        IF ( IKP1(JSEA) .NE. 0 ) FP1(JSEA) = SIG(IKP1(JSEA)) * TPIINV
-#endif
-#ifdef W3_ST3
-        IF ( IKP1(JSEA) .NE. 0 ) FP1(JSEA) = SIG(IKP1(JSEA)) * TPIINV
-#endif
-#ifdef W3_ST4
-        IF ( IKP1(JSEA) .NE. 0 ) FP1(JSEA) = SIG(IKP1(JSEA)) * TPIINV
-#endif
         END DO
 !
 #ifdef W3_OMPG
@@ -2202,11 +2124,10 @@
       XH2    = XH**2
 !
 #ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA,ILOW,ICEN,IHGH,EL,EH,DENOM)
+!$OMP PARALLEL DO PRIVATE(JSEA,ILOW,ICEN,IHGH,EL,EH,DENOM)
 #endif
 !
       DO JSEA=1, NSEAL
-        CALL INIT_GET_ISEA(ISEA, JSEA)
         ILOW   = MAX (  1 , IKP0(JSEA)-1 )
         ICEN   = MAX (  1 , IKP0(JSEA)   )
         IHGH   = MIN ( NK , IKP0(JSEA)+1 )
@@ -2215,36 +2136,6 @@
         DENOM  = XL*EH - XH*EL
         FP0(JSEA) = FP0 (JSEA) * ( 1. + 0.5 * ( XL2*EH - XH2*EL )     &
                        / SIGN ( MAX(ABS(DENOM),1.E-15) , DENOM ) )
-#ifdef W3_ST1
-        ILOW   = MAX (  1 , IKP1(JSEA)-1 )
-        ICEN   = MAX (  1 , IKP1(JSEA)   )
-        IHGH   = MIN ( NK , IKP1(JSEA)+1 )
-        EL     = EBD(ILOW,JSEA) - EBD(ICEN,JSEA)
-        EH     = EBD(IHGH,JSEA) - EBD(ICEN,JSEA)
-        DENOM  = XL*EH - XH*EL
-        FP1(JSEA) = FP1(JSEA) * ( 1. + 0.5 * (XL2*EH - XH2*EL )  &
-                       / SIGN ( MAX(ABS(DENOM),1.E-15) , DENOM ) )
-#endif
-#ifdef W3_ST3
-        ILOW   = MAX (  1 , IKP1(JSEA)-1 )
-        ICEN   = MAX (  1 , IKP1(JSEA)   )
-        IHGH   = MIN ( NK , IKP1(JSEA)+1 )
-        EL     = EBD(ILOW,JSEA) - EBD(ICEN,JSEA)
-        EH     = EBD(IHGH,JSEA) - EBD(ICEN,JSEA)
-        DENOM  = XL*EH - XH*EL
-        FP1(JSEA) = FP1(JSEA) * ( 1. + 0.5 * (XL2*EH - XH2*EL )  &
-                       / SIGN ( MAX(ABS(DENOM),1.E-15) , DENOM ) )
-#endif
-#ifdef W3_ST4
-        ILOW   = MAX (  1 , IKP1(JSEA)-1 )
-        ICEN   = MAX (  1 , IKP1(JSEA)   )
-        IHGH   = MIN ( NK , IKP1(JSEA)+1 )
-        EL     = EBD(ILOW,JSEA) - EBD(ICEN,JSEA)
-        EH     = EBD(IHGH,JSEA) - EBD(ICEN,JSEA)
-        DENOM  = XL*EH - XH*EL
-        FP1(JSEA) = FP1(JSEA) * ( 1. + 0.5 * (XL2*EH - XH2*EL )  &
-                       / SIGN ( MAX(ABS(DENOM),1.E-15) , DENOM ) )
-#endif
         END DO
 !
 #ifdef W3_OMPG
@@ -2297,32 +2188,11 @@
             THP0(JSEA) = ATAN2(ETY(JSEA),ETX(JSEA))
         ETX(JSEA) = 0.
         ETY(JSEA) = 0.
-        IKP1(JSEA) = MAX ( 1 , IKP1(JSEA) )
         END DO
 !
 #ifdef W3_OMPG
 !$OMP END PARALLEL DO
 #endif
-!
-      DO ITH=1, NTH
-!
-#ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(JSEA,ISEA)
-#endif
-!
-        DO JSEA=1, NSEAL
-          CALL INIT_GET_ISEA(ISEA, JSEA)
-          IF ( FP1(JSEA).NE.UNDEF) THEN
-              ETX(JSEA) = ETX(JSEA) + A(ITH,IKP1(JSEA),JSEA)*ECOS(ITH)
-              ETY(JSEA) = ETY(JSEA) + A(ITH,IKP1(JSEA),JSEA)*ESIN(ITH)
-            END IF
-          END DO
-!
-#ifdef W3_OMPG
-!$OMP END PARALLEL DO
-#endif
-!
-        END DO
 !
 #ifdef W3_OMPG
 !$OMP PARALLEL DO PRIVATE(JSEA,ISEA,IX,IY)
@@ -2335,23 +2205,7 @@
         IF ( MAPSTA(IY,IX) .LE. 0 ) THEN
             FP0 (JSEA) = UNDEF
             THP0(JSEA) = UNDEF
-            FP1 (JSEA) = UNDEF
           END IF
-        END DO
-!
-#ifdef W3_OMPG
-!$OMP END PARALLEL DO
-#endif
-!
-#ifdef W3_OMPG
-!$OMP PARALLEL DO PRIVATE(ISEA,JSEA)
-#endif
-!
-      DO JSEA=1, NSEAL
-        CALL INIT_GET_ISEA(ISEA, JSEA)
-        IF ( ABS(ETX(JSEA))+ABS(ETY(JSEA)) .GT. 1.E-7 .AND.           &
-             FP1(JSEA) .NE. UNDEF )                                   &
-            THP1(JSEA) = ATAN2(ETY(JSEA),ETX(JSEA))
         END DO
 !
 #ifdef W3_OMPG
@@ -2373,14 +2227,10 @@
           ELSE IF ( FP0(JSEA) .EQ. UNDEF ) THEN
             WRITE (NDST,9053) ISEA, IX, IY, HS(JSEA), WLM(JSEA),   &
                    T0M1(JSEA), RADE*THM(JSEA), THS(JSEA)
-          ELSE IF ( FP1(JSEA) .EQ. UNDEF ) THEN
+          ELSE
             WRITE (NDST,9054) ISEA, IX, IY, HS(JSEA), WLM(JSEA),   &
                    T0M1(JSEA), RADE*THM(JSEA), THS(JSEA), FP0(JSEA),&
                    THP0(JSEA)
-          ELSE
-            WRITE (NDST,9055) ISEA, IX, IY, HS(JSEA), WLM(JSEA),   &
-                   T0M1(JSEA), RADE*THM(JSEA), THS(JSEA), FP0(JSEA),&
-                   THP0(JSEA), FP1(JSEA), THP1(JSEA)
           END IF
         END DO
 #endif
@@ -2510,12 +2360,11 @@
 !
 #ifdef W3_T
  9050 FORMAT (' TEST W3OUTG : ISEA, IX, IY, HS, L, Tm, THm, THs',     &
-              ', FP0, THP0, FP1, THP1')
+              ', FP0, THP0')
  9051 FORMAT (2X,I8,2I8)
  9052 FORMAT (2X,I8,2I8,F6.2)
  9053 FORMAT (2X,I8,2I8,F6.2,F7.1,F6.2,2F6.1)
  9054 FORMAT (2X,I8,2I8,F6.2,F7.1,F6.2,2F6.1,F6.3,F6.0)
- 9055 FORMAT (2X,I8,2I8,F6.2,F7.1,F6.2,2F6.1,2(F6.3,F6.0))
 #endif
 
 !/
@@ -2658,8 +2507,7 @@
                           TAUA, TAUADIR
       USE W3ADATMD, ONLY: HS, WLM, T02, T0M1, T01, FP0, THM, THS, THP0,&
                           WBT, WNMEAN
-      USE W3ADATMD, ONLY: FP1, THP1, DTDYN, &
-                          FCUT, ABA, ABD, UBA, UBD, SXX, SYY, SXY,     &
+      USE W3ADATMD, ONLY: DTDYN, FCUT, ABA, ABD, UBA, UBD, SXX, SYY, SXY,&
                           PHS, PTP, PLP, PDIR, PSI, PWS, PWST, PNR,    &
                           PTHP0, PQP, PPE, PGW, PSW, PTM1, PT1, PT2,  &
                           PEP, USERO, TAUOX, TAUOY, TAUWIX, TAUWIY,    &

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -123,7 +123,7 @@
       USE W3WDATMD, ONLY: TIME, WLV, ICE, ICEH, ICEF, BERG, UST,      &
                           USTDIR, RHOAIR
       USE W3ADATMD, ONLY: DW, UA, UD, AS, CX, CY, HS, WLM, T0M1, THM, &
-                          THS, FP0, THP0, FP1, THP1, DTDYN, FCUT,     &
+                          THS, FP0, THP0, DTDYN, FCUT,                &
                           ABA, ABD, UBA, UBD, SXX, SYY, SXY, USERO,   &
                           PHS, PTP, PLP, PDIR, PSI, PWS, PWST, PNR,   &
                           PTM1, PT1, PT2, PEP, TAUOCX, TAUOCY,        &


### PR DESCRIPTION
# Pull Request Summary
 Removes FP1 and THP1 from the code as these variables are not used.

## Description
Removes FP1 and THP1 from the code as these variables are not used. Does not affect the local calculation of FP1 in w3src2md.

Tidy up the use of INIT_GET_ISEA in w3iogomd (remove unused ones and replace manual definitions).

Please also include the following information: 
* Add any suggestions for a reviewer : @JessicaMeixner-NOAA 
* Mention any labels that should be added: 
* Are answer changes expected from this PR? No

### Issue(s) addressed
  
- fixes #803

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

Remove FP1 and THP1 variables (unused). Cleanup INIT_GET_ISEA in w3iogomd.

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- N/A If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- N/A If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regression tests
* Are the changes covered by regression tests? N/A
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, rhel-8/icelake-64, Intel oneapi 2022.1.2
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)  No changes because of PR. Expected changes plus local problem with running OMP tests in ww3_ts3; multi crash in ww3_tp2.21/work_ma; matrix.comp sees an extra file on one side in tp2.14 oasis cases but I cannot find it.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/9646620/matrixCompSummary.txt)
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/9646622/matrixCompFull.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/9646621/matrixDiff.txt)