### PR TITLE
Fix for inconsistent time in air density input

### DIFF
--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -837,9 +837,9 @@
 ! 1.g Air density time
 !
       IF ( FLRHOA ) THEN
-          DTTST1 = DSEC21 ( TU0 , TUN )
-          DTTST2 = DSEC21 ( TU0 , TIME )
-          DTTST3 = DSEC21 ( TEND , TUN )
+          DTTST1 = DSEC21 ( TR0 , TRN )
+          DTTST2 = DSEC21 ( TR0 , TIME )
+          DTTST3 = DSEC21 ( TEND , TRN )
 #ifdef W3_T
           WRITE (NDST,9018) DTTST1, DTTST2, DTTST3
 #endif


### PR DESCRIPTION
# Pull Request Summary
Fix inconsistent time check in air density input

## Description
f driving data is read from file, the consistency of the times in the file is checked in the W3WAVE subroutine. This is done to make sure that the driving data contains valid data for the time of the run. In the case of air density, the times read from the momentum driving data file are used, which is wrong and can cause false errors. To fix the problem, the variables TR0 and TRN have to be used instead of TU0 and TUN when testing the air density file, which should be evident by reading the code with care.

No change in answers in expected, although configurations using as driving data air density but not momentum will now not fail if set correctly.

Labels that should be added: _bug_


### Issue(s) addressed
- fixes #811 
- fixes noaa-emc/ww3/issues/811

### Commit Message
Fix for inconsistent time check in air density input

### Check list  

- [YES ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ YES] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ N/A] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ N/A] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Regtests, and the amm15-smc configuration at the Met Office driven by air density.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Not covered, and not vital to have it added. Usually, when driving the model with air density the user would like to drive it with momentum too, so the configuration that is failing will not typically be used.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes, on the CrayXC40 at the Met Office using the GNU compiler.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
No changes expected
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
See comment below.

