### PR TITLE
Doxygen documentation:  marked source files added, 5th subset

### DIFF
--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -1,5 +1,28 @@
+!> @file 
+!> @brief Define data structures to set up wave model auxiliary data
+!>  for several models simultaneously.
+!> 
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Define data structures to set up wave model auxiliary data
+!>  for several models simultaneously.
+!> 
+!> @details The number of grids is taken from W3GDATMD, and needs to be
+!>  set first with W3DIMG.
+!>
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3ADATMD
 #ifdef W3_MEMCHECK
         USE MallocInfo_m
@@ -665,6 +688,17 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Set up the number of grids to be used.
+!>
+!> @details Use data stored in NGRIDS in W3GDATMD.
+!>
+!> @param[in] NDSE Error output unit number.
+!> @param[in] NDST Test output unit number.
+!>
+!> @author H. L. Tolman
+!> @date   10-Dec-2014
+!>        
       SUBROUTINE W3NAUX ( NDSE, NDST )
 !/
 !/                  +-----------------------------------+
@@ -797,6 +831,20 @@
 !/
       END SUBROUTINE W3NAUX
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Initialize an individual data grid at the proper dimensions.
+!>
+!> @details Allocate directly into the structure array. Note that
+!>  this cannot be done through the pointer alias!
+!>
+!> @param[in] IMOD   Model number to point to.
+!> @param[in] NDSE   Error output unit number.
+!> @param[in] NDST   Test output unit number.
+!> @param[in] D_ONLY Flag for initializing data arrays only.
+!>
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>      
       SUBROUTINE W3DIMA  ( IMOD, NDSE, NDST, D_ONLY )
 !/
 !/                  +-----------------------------------+
@@ -1523,6 +1571,17 @@
 !/
       END SUBROUTINE W3DIMA
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Version of W3DIMX for extended ouput arrays only.
+!>
+!> @param[in] IMOD     Model number to point to.
+!> @param[in] NDSE     Error output unit number.
+!> @param[in] NDST     Test output unit number.
+!> @param[in] OUTFLAGS 
+!>
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>      
       SUBROUTINE W3XDMA  ( IMOD, NDSE, NDST, OUTFLAGS )
 !/
 !/                  +-----------------------------------+
@@ -2395,6 +2454,21 @@
 !/
       END SUBROUTINE W3XDMA
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Initialize an individual data grid at the proper dimensions (DIA).
+!>
+!> @details Allocate directly into the structure array. Note that
+!>  this cannot be done through the pointer alias!
+!>
+!> @param[in] IMOD Model number to point to.
+!> @param[in] NDSE Error output unit number.
+!> @param[in] NDST Test output unit number.
+!> @param[in] NSP  Array dimensions.
+!> @param[in] NSPX Array dimensions.
+!>
+!> @author H. L. Tolman
+!> @date   10-Dec-2014
+!>      
       SUBROUTINE W3DMNL  ( IMOD, NDSE, NDST, NSP, NSPX )
 !/
 !/                  +-----------------------------------+
@@ -2603,6 +2677,19 @@
 !/
       END SUBROUTINE W3DMNL
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Select one of the WAVEWATCH III grids / models.
+!>
+!> @details Point pointers to the proper variables in the proper element
+!>  of the GRIDS array.
+!>
+!> @param[in] IMOD Model number to point to.
+!> @param[in] NDSE Error output unit number.
+!> @param[in] NDST Test output unit number.
+!>
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>      
       SUBROUTINE W3SETA ( IMOD, NDSE, NDST )
 !/
 !/                  +-----------------------------------+
@@ -3069,6 +3156,16 @@
 !/
       END SUBROUTINE W3SETA
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Reduced version of W3SETA to point to expended output arrays.
+!>
+!> @param[in] IMOD Model number to point to.
+!> @param[in] NDSE Error output unit number.
+!> @param[in] NDST Test output unit number.      
+!>
+!> @author H. L. Tolman
+!> @date   22-Mar-2021
+!>      
       SUBROUTINE W3XETA ( IMOD, NDSE, NDST )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3agcmmd.F90
+++ b/model/src/w3agcmmd.F90
@@ -1,5 +1,25 @@
+!> @file 
+!> @brief Contains module used for coupling applications between atmospheric model
+!>  and WW3 with OASIS3-MCT.
+!> 
+!> @author J. Pianezze
+!> @date   Mar-2021
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Module used for coupling applications between atmospheric model
+!>  and WW3 with OASIS3-MCT.
+!> 
+!> @author J. Pianezze
+!> @date   Mar-2021
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3AGCMMD
 !/
 !/                  +-----------------------------------+
@@ -59,6 +79,13 @@
 !
       CONTAINS
 !/ ------------------------------------------------------------------- /
+
+!>
+!> @brief Send coupling fields to atmospheric model.
+!>
+!> @author J. Pianezze
+!> @date   Apr-2016
+!>
       SUBROUTINE SND_FIELDS_TO_ATMOS()
 !/
 !/                  +-----------------------------------+
@@ -192,6 +219,19 @@
 !
 !/ ------------------------------------------------------------------- /
       END SUBROUTINE SND_FIELDS_TO_ATMOS
+
+!>
+!> @brief Receive coupling fields from atmospheric model.
+!>
+!> @param[in]    ID_LCOMM MPI communicator.
+!> @param[in]    IDFLD    Name of the exchange fields.
+!> @param[inout] FXN      First exchange field.
+!> @param[inout] FYN      Second exchange field.
+!> @param[inout] FAN      Third exchange field.
+!>
+!> @author J. Pianezze
+!> @date   Mar-2021
+!>      
 !/ ------------------------------------------------------------------- /
       SUBROUTINE RCV_FIELDS_FROM_ATMOS(ID_LCOMM, IDFLD, FXN, FYN, FAN)
 !/

--- a/model/src/w3bullmd.F90
+++ b/model/src/w3bullmd.F90
@@ -1,5 +1,25 @@
+!> @file 
+!> @brief Contains module W3BULLMD.
+!> 
+!> @author J. H. Alves
+!> @author H. L. Tolman
+!> @date   26-Dec-2012
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Module W3BULLMD.
+!> 
+!> @author J. H. Alves
+!> @author H. L. Tolman
+!> @date   26-Dec-2012
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3BULLMD
 !/
 !/                  +-----------------------------------+
@@ -42,6 +62,30 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Read a WAVEWATCH-III version 1.17 point output data file and
+!>     produces a table of mean parameters for all individual wave
+!>     systems.
+!>         
+!> @details Partitioning is made using the built-in module w3partmd. 
+!>     Partitions are ranked and organized into coherent sequences that
+!>     are then written as tables to output files. Input options for generating
+!>     tables are defined in ww3_outp.inp. This module sorts the table
+!>     data, output to file is controlled by WW3_OUTP.
+!>
+!> @param[in]    NPART 
+!> @param[in]    XPART 
+!> @param[in]    DIMXP 
+!> @param[in]    UABS  
+!> @param[in]    UD    
+!> @param        IPNT  
+!> @param[in]    IOUT  
+!> @param[inout] TIMEV 
+!>
+!> @author J. H. Alves
+!> @author H. L. Tolman
+!> @date   11-Mar-2013
+!>        
       SUBROUTINE W3BULL                                                &
           ( NPART, XPART, DIMXP, UABS, UD, IPNT, IOUT, TIMEV ) 
 !/

--- a/model/src/w3cspcmd.F90
+++ b/model/src/w3cspcmd.F90
@@ -1,5 +1,23 @@
+!> @file 
+!> @brief Convert spectra to new discrete spectral grid.
+!> 
+!> @author H. L. Tolman
+!> @date   01-Nov-2012
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Convert spectra to new discrete spectral grid.
+!> 
+!> @author H. L. Tolman
+!> @date   01-Nov-2012
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3CSPCMD
 !/
 !/                  +-----------------------------------+
@@ -97,6 +115,31 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Convert a set of spectra to a new spectral grid.
+!>
+!> @details Conservative distribution of input energies over new grid.
+!>
+!> @param[in]  SP1  Input spectra.
+!> @param[in]  NFR1 Input number of frequencies.
+!> @param[in]  NTH1 Input number of directions.
+!> @param[in]  XF1  Input frequency increment factor.
+!> @param[in]  FR1  First input frequency.
+!> @param[in]  TH1  First input direction.
+!> @param[out] SP2  Output spectra.
+!> @param[in]  NFR2 Output number of frequencies.
+!> @param[in]  NTH2 Output number of directions.
+!> @param[in]  XF2  Output frequency increment factor.
+!> @param[in]  FR2  First output frequency.
+!> @param[in]  TH2  First output direction.
+!> @param[in]  NSP  Number of spectra.
+!> @param[in]  NDST Unit number for test output.
+!> @param[in]  NDSE Unit number for error output.
+!> @param[in]  FTL  Factor for tail description = XF2**N.
+!>
+!> @author H. L. Tolman
+!> @date   01-Nov-2012
+!>        
       SUBROUTINE W3CSPC ( SP1, NFR1, NTH1, XF1, FR1, TH1,             &
                           SP2, NFR2, NTH2, XF2, FR2, TH2,             &
                           NSP, NDST, NDSE, FTL )

--- a/model/src/w3flx1md.F90
+++ b/model/src/w3flx1md.F90
@@ -1,5 +1,23 @@
+!> @file 
+!> @brief Flux/stress computations according to Wu (1980).
+!> 
+!> @author H. L. Tolman
+!> @date   29-May-2009
+!> 
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Flux/stress computations according to Wu (1980).
+!> 
+!> @author H. L. Tolman
+!> @date   29-May-2009
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3FLX1MD
 !/
 !/                  +-----------------------------------+
@@ -53,6 +71,20 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief FLux/stress computations according to Wu (1980).
+!>
+!> @param[inout] ZWND Wind height.
+!> @param[inout] U10  Wind speed.
+!> @param[inout] U10D Wind direction.
+!> @param[inout] UST  Friction velocity.
+!> @param[inout] USTD Direction of friction velocity.
+!> @param[inout] Z0   Z0 in profile law.
+!> @param[inout] CD   Drag coefficient.
+!>
+!> @author H. L. Tolman
+!> @date   03-Jul-2006
+!>        
       SUBROUTINE W3FLX1 ( ZWND, U10, U10D, UST, USTD, Z0, CD )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3flx2md.F90
+++ b/model/src/w3flx2md.F90
@@ -1,5 +1,23 @@
+!> @file 
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!> 
+!> @author H. L. Tolman
+!> @date   20-Apr-2010
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!> 
+!> @author H. L. Tolman
+!> @date   20-Apr-2020
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3FLX2MD
 !/
 !/                  +-----------------------------------+
@@ -53,6 +71,22 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!>
+!> @param[in]    ZWIND Height of wind.
+!> @param[in]    DEPTH Depth.
+!> @param[in]    FP    Peak frequency.
+!> @param[in]    U     Wind speed.
+!> @param[in]    UDIR  Wind direction.
+!> @param[inout] UST   Friction velocity.
+!> @param[out]   USTD  Direction of friction velocity.
+!> @param[out]   Z0    Z0 in profile law.
+!> @param[out]   CD    Drag coefficient.
+!>
+!> @author H. L. Tolman
+!> @date   10-Jan-2014
+!>        
       SUBROUTINE W3FLX2 ( ZWIND, DEPTH, FP, U, UDIR, UST, USTD, Z0, CD )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3flx3md.F90
+++ b/model/src/w3flx3md.F90
@@ -1,5 +1,25 @@
+!> @file 
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!> 
+!> @author H. L. Tolman
+!> @date   20-Apr-2010
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!> 
+!> @details Cap on flux added compared to W3FLX2.
+!>
+!> @author H. L. Tolman
+!> @date   20-Apr-2010
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3FLX3MD
 !/
 !/                  +-----------------------------------+
@@ -54,6 +74,24 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief FLux/stress computations according Tolman and Chalikov (1996).
+!>
+!> @details Cap on flux added compared to W3FLX2.
+!>
+!> @param[in]    ZWIND Height of wind.
+!> @param[in]    DEPTH Depth.
+!> @param[in]    FP    Peak frequency.
+!> @param[in]    U     Wind speed.
+!> @param[in]    UDIR  Wind direction.
+!> @param[inout] UST   Friction velocity.
+!> @param[out]   USTD  Direction of friction velocity.
+!> @param[out]   Z0    Z0 in profile law.
+!> @param[out]   CD    Drag coefficient.
+!>
+!> @author H. L. Tolman
+!> @date   10-Jan-2014
+!>        
       SUBROUTINE W3FLX3 ( ZWIND, DEPTH, FP, U, UDIR, UST, USTD, Z0, CD )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3flx4md.F90
+++ b/model/src/w3flx4md.F90
@@ -1,5 +1,29 @@
+!> @file 
+!> @brief Flux/stress computations according to Hwang (2011).
+!> 
+!> @author H. L. Tolman
+!> @author S. Zieger
+!> @author Q. Liu
+!> @date   24-Nov-2017
+!>
+
 #include "w3macros.h"
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Flux/stress computations according to Hwang ( 2011).
+!> 
+!> @details Hwang 2011: J Atmos Ocean Tech 28(3)  436-443.
+!>
+!> @author H. L. Tolman
+!> @author S. Zieger
+!> @author Q. Liu
+!> @date   24-Nov-2017
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3FLX4MD
 !/
 !/                  +-----------------------------------+
@@ -59,6 +83,25 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Flux/stress computations according to Hwang (JTECH, 2011).
+!>
+!> @verbatim   
+!>     CD    = 1E-4 ( -0.016 U10**2 + 0.967U10 + 8.058)
+!>     USTAR = U10 * SQRT( U10 )     
+!> @endverbatim        
+!>
+!> @param[in]  ZWND Wind height.
+!> @param[in]  U10  Wind speed.
+!> @param[in]  U10D Wind direction.
+!> @param[out] UST  Friction velocity.
+!> @param[out] USTD Direction of friction velocity.
+!> @param[out] Z0   Z0 in profile law.
+!> @param[out] CD   Drag coefficient.
+!>
+!> @author H. L. Tolman
+!> @date   03-Jul-2006
+!>        
       SUBROUTINE W3FLX4 ( ZWND, U10, U10D, UST, USTD, Z0, CD )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3flx5md.F90
+++ b/model/src/w3flx5md.F90
@@ -1,5 +1,30 @@
+!> @file 
+!> @brief Unified process to obtain friction velocity and drag when stresses
+!>  are an input (from atmospheric model).
+!> 
+!> @author N.G. Valiente
+!> @author J. Edward
+!> @author A. Saulter
+!> @date   01-Jul-2021
+!>
+
 #include "w3macros.h"
+
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Unified process to obtain friction velocity and drag when stresses
+!>  are an input (from atmospheric model).
+!> 
+!> @author N.G. Valiente
+!> @author J. Edward
+!> @author A. Saulter
+!> @date   01-Jul-2021
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
       MODULE W3FLX5MD
 !/
 !/                  +-----------------------------------+
@@ -61,6 +86,35 @@
 !/
       CONTAINS
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Unified process to obtain friction velocity and drag when 
+!>  stresses are an input (from atmospheric model).
+!>
+!> @verbatim
+!>     UST       = SQRT(TAUA / RHOAIR)
+!>     USTD      = TAUADIR
+!>     CD        = (UST/U10)**2
+!>     SQRTCDM1  = MIN(U10/UST,100.0)
+!>     Z0        = ZWND*EXP(-KAPPA*SQRTCDM1)        
+!> @endverbatim        
+!>
+!> @param[in]  ZWND    Wind height.
+!> @param[in]  U10     Wind speed.
+!> @param[in]  U10D    Wind direction.
+!> @param[in]  TAUA    Atmosphere total stress.
+!> @param[in]  TAUADIR Atmosphere total stress directions.
+!> @param[in]  RHOAIR  Air density.
+!> @param[out] UST     Friction velocity.
+!> @param[out] USTD    Direction of friction velocity.
+!> @param[out] Z0      Z0 in profile law.
+!> @param[out] CD      Drag coefficient.
+!> @param[out] CHARN   Charnock coefficient.
+!>
+!> @author N.G. Valiente
+!> @author J. Edward
+!> @author A. Saulter
+!> @date   01-Jul-2021
+!>        
       SUBROUTINE W3FLX5 ( ZWND, U10, U10D, TAUA, TAUADIR, RHOAIR, UST, USTD, Z0, CD, CHARN )
 !/
 !/                  +-----------------------------------+

--- a/model/src/w3sbs1md.F90
+++ b/model/src/w3sbs1md.F90
@@ -1,4 +1,23 @@
+!> @file 
+!> @brief Computes scattering term.
+!> 
+!> @author F. Ardhuin
+!> @date   14-Nov-2010
+!> 
+
 #include "w3macros.h"
+!>
+!> @brief This module computes a scattering term 
+!>  based on the theory by Ardhuin and Magne (JFM 2007).
+!> 
+!> @author F. Ardhuin
+!> @date   14-Nov-2010
+!>
+!> @copyright Copyright 2009-2022 National Weather Service (NWS),
+!>       National Oceanic and Atmospheric Administration.  All rights
+!>       reserved.  WAVEWATCH III is a trademark of the NWS.
+!>       No unauthorized use without permission.
+!>
 !/ ------------------------------------------------------------------- /
       MODULE W3SBS1MD
 !/
@@ -70,6 +89,27 @@
 !/
       CONTAINS
 !
+!>
+!> @brief Bottom scattering source term.
+!>        
+!> @details Without current, goes through a diagonalization of the matrix 
+!>  problem  S(f,:) = M(f,:,:)**E(f,:).
+!>  With current, integrates the source term along the resonant locus.
+        
+!> @param[in] A         Action density spectrum (1-D)
+!> @param[in] CG        Group velocities
+!> @param[in] WN        Wavenumbers
+!> @param[in] DEPTH     Mean water depth
+!> @param[in] CX1       Current components at ISEA
+!> @param[in] CY1       Current components at ISEA
+!> @param[out] TAUSCX   Change of wave momentum due to scattering
+!> @param[out] TAUSCY   Change of wave momentum due to scattering
+!> @param[out] S        Source term (1-D version)
+!> @param[out] D        Diagonal term of derivative (1-D version)
+!>
+!> @author F. Ardhuin
+!> @date   23-Jun-2006
+!>        
       SUBROUTINE W3SBS1(A, CG, WN, DEPTH, CX1, CY1,      &
                                               TAUSCX, TAUSCY, S, D)
 !/
@@ -422,6 +462,15 @@
 !/
       END SUBROUTINE W3SBS1
 !/ ------------------------------------------------------------------- /
+!>
+!> @brief Initialization for bottom scattering source term routine.
+!>
+!> @param[in] inistep
+!>
+!> @author F. Ardhuin
+!> @date   23-Jun-2006
+!>
+      
       SUBROUTINE INSBS1( inistep )
 !/
 !/                  +-----------------------------------+


### PR DESCRIPTION
# Pull Request Summary
Fifth subset of `doxygen` marked source files.

## Description
Provide a detailed description of what this PR does.
* Ten .F90 source files have been marked-up with `doxygen` tags:
  * `w3agcmmd.F90`
  * `w3bullmd.F90`
  * `w3cspcmd.F90`
  * `w3flx1md.F90`
  * `w3flx2md.F90`
  * `w3flx3md.F90`
  * `w3flx4md.F90`
  * `w3flx5md.F90`
  * `w3sbs1md.F90`
  * `w3adatmd.F90`

What bug does it fix, or what feature does it add?
* This PR adds `doxygen` documentation.

Is a change of answers expected from this PR?
* No.  Only documentation is added.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA . 
 
* Mention any labels that should be added:  
  * _documentation_.
 
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply.
  * No.  No active code was edited.  Only documentation was added by means of `doxygen` marked comments.

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- Addresses #586, though does not close.  The issue will be closed when all files in checklist have been marked off.  


### Commit Message
Doxygen documentation:  marked source files added, 5th subset

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * The full matrix of regtests run against current develop.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * The changes are not covered by regression tests as we do not test for documentation.

* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  Hera / Intel.

* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * The only expected changes are the known non-identical tests.

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```bash
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
ww3_ta1/./work_UPD0F_U                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.17/./work_a                     (1 files differ)
ww3_tp2.17/./work_c                     (1 files differ)
ww3_tp2.17/./work_b                     (1 files differ)
ww3_tp2.6/./work_ST0                     (1 files differ)
ww3_tp2.6/./work_ST4                     (1 files differ)
ww3_tp2.6/./work_pdlib                     (1 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

* [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/9685836/matrixCompSummary.txt)
* [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/9685845/matrixCompFull.txt)
* [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/9685847/matrixDiff.txt)
