### PR TITLE
utilize ungridded dimensions for the partitioned stokes drift between WW3 and MOM6

### DIFF
--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -593,7 +593,11 @@ contains
     integer          , intent(out) :: rc
 
     ! Local variables
+#ifdef W3_CESMCOUPLED
     real(R8)          :: fillvalue = 1.0e30_R8                 ! special missing value
+#else
+    real(R8)          :: fillvalue = zero                      ! special missing value
+#endif
     type(ESMF_State)  :: exportState
     integer           :: n, jsea, isea, ix, iy, ib
 
@@ -944,7 +948,6 @@ contains
     real(ESMF_KIND_R8), pointer :: chkn(:)  ! 1D Charnock export field pointer
 
     ! local variables
-    real   , parameter :: zero  = 0.0
     integer            :: isea, jsea, ix, iy
     real               :: emean, fmean, fmean1, wnmean, amax, ustar, ustdr
     real               :: tauwx, tauwy, cd, z0, fmeanws, dlwmean

--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -138,17 +138,11 @@ contains
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_ustokes')
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes')
       !call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_hstokes')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_x', ungridded_lbound=1, ungridded_ubound=3)
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_y', ungridded_lbound=1, ungridded_ubound=3)
     else
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_z0')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_ustokes1')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_ustokes2')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_ustokes3')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes1')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes2')
-      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes3')
     end if
+    call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_x', ungridded_lbound=1, ungridded_ubound=3)
+    call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_y', ungridded_lbound=1, ungridded_ubound=3)
 
     ! AA TODO: In the above fldlist_add calls, we are passing hardcoded ungridded_ubound values (3) because, USSPF(2)
     ! is not initialized yet. It is set during w3init which gets called at a later phase (realize). A permanent solution
@@ -608,8 +602,6 @@ contains
     real(r8), pointer :: wbcuru(:)
     real(r8), pointer :: wbcurv(:)
     real(r8), pointer :: wbcurp(:)
-    !real(r8), pointer :: uscurr(:)
-    !real(r8), pointer :: vscurr(:)
     real(r8), pointer :: sxxn(:)
     real(r8), pointer :: sxyn(:)
     real(r8), pointer :: syyn(:)
@@ -622,14 +614,8 @@ contains
     real(r8), pointer :: wave_elevation_spectrum(:,:)
 
     ! Partitioned stokes drift
-    real(r8), pointer :: sw_pstokes_x(:,:) ! cesm
-    real(r8), pointer :: sw_pstokes_y(:,:) ! cesm
-    real(r8), pointer :: sw_ustokes1(:)    ! ufs
-    real(r8), pointer :: sw_vstokes1(:)    ! ufs
-    real(r8), pointer :: sw_ustokes2(:)    ! ufs
-    real(r8), pointer :: sw_vstokes2(:)    ! ufs
-    real(r8), pointer :: sw_ustokes3(:)    ! ufs
-    real(r8), pointer :: sw_vstokes3(:)    ! ufs
+    real(r8), pointer :: sw_pstokes_x(:,:)
+    real(r8), pointer :: sw_pstokes_y(:,:)
     character(len=*), parameter :: subname='(wav_import_export:export_fields)'
     !---------------------------------------------------------------------------
 
@@ -666,7 +652,6 @@ contains
       enddo
     end if
 #endif
-
     ! surface stokes drift
     if (state_fldchk(exportState, 'Sw_ustokes')) then
       call state_getfldptr(exportState, 'Sw_ustokes', sw_ustokes, rc=rc)
@@ -710,19 +695,6 @@ contains
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call CalcRoughl(z0rlen)
     endif
-
-    !TODO: what is difference between uscurr/vscurr and sw_ustokes,sw_vstokes?
-    ! uscurr has standard name eastward_stokes_drift_current
-    ! vscurr has standard name northward_stokes_drift_current
-    ! in fd_nems.yaml but this seems to be calculated a (:,:) value
-    !if ( state_fldchk(exportState, 'uscurr') .and. &
-    !     state_fldchk(exportState, 'vscurr')) then
-    !   call state_getfldptr(exportState, 'uscurr', uscurr, rc=rc)
-    !   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    !   call state_getfldptr(exportState, 'vscurr', vscurr, rc=rc)
-    !   if (ChkErr(rc,__LINE__,u_FILE_u)) return
-    !   call CalcStokes3D( va, uscurr, vscurr )
-    !endif
 
     if ( state_fldchk(exportState, 'wbcuru') .and. &
          state_fldchk(exportState, 'wbcurv') .and. &
@@ -774,42 +746,6 @@ contains
         end do
       end if
     endif
-
-    if ( state_fldchk(exportState, 'Sw_ustokes1') .and. &
-         state_fldchk(exportState, 'Sw_ustokes2') .and. &
-         state_fldchk(exportState, 'Sw_ustokes3') .and. &
-         state_fldchk(exportState, 'Sw_vstokes1') .and. &
-         state_fldchk(exportState, 'Sw_vstokes2') .and. &
-         state_fldchk(exportState, 'Sw_vstokes3') ) then
-
-      call state_getfldptr(exportState, 'Sw_ustokes1', sw_ustokes1, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'Sw_ustokes2', sw_ustokes2, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'Sw_ustokes3', sw_ustokes3, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'Sw_vstokes1', sw_vstokes1, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'Sw_vstokes2', sw_vstokes2, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'Sw_vstokes3', sw_vstokes3, rc=rc)
-      if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      sw_ustokes1(:)= zero
-      sw_vstokes1(:)= zero
-      sw_ustokes2(:)= zero
-      sw_vstokes2(:)= zero
-      sw_ustokes3(:)= zero
-      sw_vstokes3(:)= zero
-      call CALC_U3STOKES(va, 2)
-      do jsea = 1,nseal
-        sw_ustokes1(jsea)=ussp(jsea,1)
-        sw_vstokes1(jsea)=ussp(jsea,nk+1)
-        sw_ustokes2(jsea)=ussp(jsea,2)
-        sw_vstokes2(jsea)=ussp(jsea,nk+2)
-        sw_ustokes3(jsea)=ussp(jsea,3)
-        sw_vstokes3(jsea)=ussp(jsea,nk+3)
-      end do
-    end if
 
     if (dbug_flag > 5) then
       call state_diagnose(exportState, 'at export ', rc=rc)


### PR DESCRIPTION
# Pull Request Summary

Enables field exchanges for partitioned stokes drift using ungridded dimensions with the WW3 mesh cap 

## Description


Removes the 6 fields associated with partitioned stokes drift export within the dev/ufs-weather-model mesh cap in favor of 2 fields with 3 ungridded dimesions each.

### Issue(s) addressed

UWM Issue [#1526](https://github.com/ufs-community/ufs-weather-model/issues/1526)

### Commit Message

Enables field exchanges for partitioned stokes drift using ungridded dimensions with the WW3 mesh cap 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

See UWM PR [#1527](https://github.com/ufs-community/ufs-weather-model/pull/1527) for testing details. 

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

