### PR TITLE
Fix various CI failures for intel/ubuntu-latest

### DIFF
--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -1,5 +1,5 @@
 name: GNU Linux Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-ww3
@@ -37,19 +37,20 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_gnu.yaml') }}
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
           # Install NetCDF, ESMF, g2, etc using Spack
+          sudo apt install cmake
           git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
-          spack env create ww3-gnu ww3/model/ci/spack.yaml
+          spack env create ww3-gnu ww3/model/ci/spack_gnu.yaml
           spack env activate ww3-gnu
           spack compiler find
-          spack external find
+          spack external find cmake
           spack add mpich@3.4.2
           spack concretize
           spack install --dirty -v
@@ -72,7 +73,7 @@ jobs:
     strategy:
       matrix:
         switch: [Ifremer1, NCEP_st2, NCEP_st4, ite_pdlib, NCEP_st4sbs, NCEP_glwu, OASACM, UKMO, MULTI_ESMF]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-ww3
@@ -88,7 +89,7 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_gnu.yaml') }}
 
       - name: build-ww3
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,16 +1,10 @@
 name: Intel Linux Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-
-# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
-# without having to do it in manually every step
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
@@ -22,7 +16,7 @@ env:
   I_MPI_F90: ifort
 
 # Split into a dependency build step, and a WW3 build step which
-# builds multiple switches in a matrix. The setup is run once and
+# builds multiple switches in a matrix. The setup is run once and 
 # the environment is cached so each build of WW3 can share the dependencies.
 
 jobs:
@@ -48,7 +42,7 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_intel.yaml') }}
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -57,27 +51,31 @@ jobs:
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update
-          sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+          sudo apt-get install intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
           # Install NetCDF, ESMF, g2, etc using Spack
+          . /opt/intel/oneapi/setvars.sh
+          sudo mv /usr/local /usrlocal_renamed
+          sudo apt install cmake
           git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
-          spack env create ww3-intel ww3/model/ci/spack.yaml
+          ln -s $(realpath $(which gcc)) spack/lib/spack/env/intel/gcc # spack/make bug in ESMF
+          spack env create ww3-intel ww3/model/ci/spack_intel.yaml
           spack env activate ww3-intel
           spack compiler find
-          spack external find
+          spack external find cmake
           spack add intel-oneapi-mpi
           spack concretize
-          spack install --dirty -v
+          spack install --dirty -v --fail-fast
 
       - name: build-oasis
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel
           export WWATCH3_DIR=${GITHUB_WORKSPACE}/ww3/model
@@ -101,10 +99,6 @@ jobs:
         with:
             path: ww3
 
-      - name: install-intel
-        run: |
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
-
       - name: cache-env
         id: cache-env
         uses: actions/cache@v2
@@ -114,10 +108,11 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_intel.yaml') }}
 
       - name: build-ww3
         run: |
+          . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel
           cd ww3

--- a/model/ci/spack_gnu.yaml
+++ b/model/ci/spack_gnu.yaml
@@ -1,7 +1,8 @@
 spack:
   packages:
     all:
-      compiler: [intel, gcc]
+      compiler:
+      - gcc@10.0:10
   specs:
   - metis@5.1.0~shared
   - parmetis@4.0.3~shared
@@ -13,4 +14,5 @@ spack:
   - w3emc@2.9.2
   - esmf@8.1.1~pio~pnetcdf~xerces
   view: true
-  concretization: together
+  concretizer:
+    unify: true

--- a/model/ci/spack_intel.yaml
+++ b/model/ci/spack_intel.yaml
@@ -1,0 +1,20 @@
+spack:
+  packages:
+    all:
+      compiler: [intel]
+      providers:
+        mpi: [intel-oneapi-mpi]
+  specs:
+  - metis@5.1.0~shared
+  - parmetis@4.0.3~shared
+  - netcdf-c@4.7.4~dap
+  - netcdf-fortran@4.5.3
+  - jasper@2.0.32
+  - g2@3.4.5
+  - bacio@2.4.1
+  - w3emc@2.9.2
+  - esmf@8.1.1~pio~pnetcdf~xerces
+  - intel-oneapi-mpi %intel
+  view: true
+  concretizer:
+    unify: true


### PR DESCRIPTION
# Pull Request Summary
Update workflow and spack configurations to correct several CI issues.

## Description
- Allow manual workflow runs
- Revert use of .bash_profile (avoids problem of preinstalled .bash_profile contents); sourcing /opt/intel/oneapi/setvars.sh instead
- Create spack_intel.yaml (ensures compiler/MPI combination)
- Rename /usr/local so cmake won't pick up on bad library versions (resolves HDF5 failures due to incorrent libc usage)
- Use cmake from apt to speed up CI
- Add --fail-fast to spack installation to facilitate debugging and save time.
- Add workaround for ESMF build failure (due to makefile bug which points to wrong gcc)

### Commit Message
Fix various CI failures for intel/ubuntu-latest

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
Tested in GitHub Actions.
