### PR TITLE
Update hpc-stack hera.intel module path to current UFS

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -60,7 +60,7 @@ EOF
   then
     # If no other h, assuming Hera
     batchq='slurm'
-    hpcstackpath='/scratch2/NCEPDEV/nwprod/hpc-stack/libs/hpc-stack/modulefiles/stack'
+    hpcstackpath='/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
     hpcstackversion='hpc/1.2.0'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -62,6 +62,8 @@ EOF
     batchq='slurm'
     hpcstackpath='/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
     hpcstackversion='hpc/1.2.0'
+    basemodcomp='intel/2022.1.2'
+    basemodmpi='impi/2022.1.2'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'
     metispath='/scratch2/COASTAL/coastal/save/Ali.Abdolali/hpc-stack/parmetis-4.0.3'
@@ -135,6 +137,12 @@ EOF
   echo "  module load $modcmake"                            >> matrix.head
   echo "  module use $hpcstackpath"                         >> matrix.head
   echo "  module load $hpcstackversion"                     >> matrix.head
+  if [ ! -z $basemodcomp ]; then
+    echo "  module load $basemodcomp"                       >> matrix.head
+  fi
+  if [ ! -z $basemodmpi ]; then
+    echo "  module load $basemodmpi"                        >> matrix.head
+  fi
   echo "  module load $modcomp"                             >> matrix.head
   echo "  module load $modmpi"                              >> matrix.head
   echo "  module load $modnetcdf"                           >> matrix.head


### PR DESCRIPTION
# Pull Request Summary
Updates the `modulefile` path for `hera.intel` regtests to the current path specified in `ufs-weather-model`. 

## Description
* The path to hpc-stack on `hera.intel` is updated to the specification found in [ufs-weather-model/modulefiles/ufs_hera.intel.lau](https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_hera.intel.lua).  
* Explicit load of intel/impi modules are needed with this path change.
* No answers are expected to change, the same version (1.2.0) of hpc-stack is loaded.
* Update prior to pr #849. 

Please also include the following information: 
* Are answer changes expected from this PR? 
  * No. 

### Issue(s) addressed
* Works towards pr #849.

### Commit Message
Update hpc-stack hera.intel module path to current UFS

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Regression test matrix was run and compared against develop. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No.  We don't test for compiler/stack -related updates.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  Hera/intel. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Only the known non-b4b changes (and some mod_defs for unstructured) are expected.
```bash
**********************************************************************     
********************* non-identical cases ****************************     
**********************************************************************     
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)         
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)    
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)     
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)      
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)     
mww3_test_03/./work_PR2_UNO_MPI_d2                     (10 files differ)   
mww3_test_03/./work_PR1_MPI_d2                     (13 files differ)       
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ) 
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)  
mww3_test_03/./work_PR3_UNO_MPI_d2                     (18 files differ)   
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)    
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)      
mww3_test_03/./work_PR3_UQ_MPI_d2                     (17 files differ)    
ww3_ta1/./work_UPD0F_U                     (0 files differ)                
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)            
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)            
ww3_tp2.17/./work_ma                     (1 files differ)                  
ww3_tp2.17/./work_a                     (1 files differ)                   
ww3_tp2.17/./work_mc1                     (1 files differ)                 
ww3_tp2.17/./work_mb                     (1 files differ)                  
ww3_tp2.17/./work_mc                     (1 files differ)                  
ww3_tp2.17/./work_ma1                     (1 files differ)                 
ww3_tp2.17/./work_c                     (1 files differ)                   
ww3_tp2.17/./work_b                     (1 files differ)                   
ww3_tp2.6/./work_ST0                     (1 files differ)                  
ww3_tp2.6/./work_ST4                     (1 files differ)                  
ww3_tp2.6/./work_pdlib                     (1 files differ)                
ww3_ts4/./work_ug_MPI                     (1 files differ)                 
ww3_ufs1.3/./work_a                     (3 files differ)                   
                                                                           
**********************************************************************     
************************ identical cases *****************************     
********************************************************************** 
```

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/10229465/matrixCompSummary.txt)
  * [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/10229466/matrixCompFull.txt)
  * [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/10229464/matrixDiff.txt)