### PR TITLE
Move  Intel CI tests from ubuntu-latest to ubuntu-20.04 

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -8,7 +8,7 @@ concurrency:
 
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel6
+  cache_key: intel7
   CC: icc
   FC: ifort
   CXX: icpc
@@ -21,7 +21,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 
 
     steps:
 
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         switch: [Ifremer1, NCEP_st2, NCEP_st4, ite_pdlib, NCEP_st4sbs, NCEP_glwu, OASACM, UKMO, MULTI_ESMF]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 
 
     steps:
       - name: checkout-ww3


### PR DESCRIPTION
# Pull Request Summary
There have been some CI issues with intel.  Moving from unbuntu-latest to ubuntu-20.04 resolves this issue. 

## Description
Updated CI testing from intel from ubuntu-latest to ubuntu-20.04 .  This is a temporary fix and issue #910 will remain open until a solution with ubuntu-latest can be found.    Thank you to @MatthewMasarik-NOAA who's idea it was to try this and @AlexanderRichert-NOAA who tested this and confirmed this worked with other codes.  



### Issue(s) addressed
 Isssue #910 will remain open, this temporarily fixes this. 

### Commit Message
Move  Intel CI tests from ubuntu-latest to ubuntu-20.04  co-author: Matthew Masarik 

### Check list  


- [x ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Through ci 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?). This is just updating the CI, so no impact to other regression tests. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? No. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_): Was not ran, "passsing" is if the ci runs. 

