### PR TITLE
Updates for HAFSv1 production branch 

### DIFF
--- a/.github/workflows/gnu.yml
+++ b/.github/workflows/gnu.yml
@@ -1,5 +1,5 @@
 name: GNU Linux Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  cache_key: gnu5
+  cache_key: gnu8
   CC: gcc-10
   FC: gfortran-10
   CXX: g++-10
@@ -19,7 +19,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-ww3
@@ -37,19 +37,20 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_gnu.yaml') }}
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
           # Install NetCDF, ESMF, g2, etc using Spack
+          sudo apt install cmake
           git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
-          spack env create ww3-gnu ww3/model/ci/spack.yaml
+          spack env create ww3-gnu ww3/model/ci/spack_gnu.yaml
           spack env activate ww3-gnu
           spack compiler find
-          spack external find
+          spack external find cmake
           spack add mpich@3.4.2
           spack concretize
           spack install --dirty -v
@@ -72,7 +73,7 @@ jobs:
     strategy:
       matrix:
         switch: [Ifremer1, NCEP_st2, NCEP_st4, ite_pdlib, NCEP_st4sbs, NCEP_glwu, OASACM, UKMO, MULTI_ESMF, NUOPC_MESH]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-ww3
@@ -88,7 +89,7 @@ jobs:
             spack
             ~/.spack
             work_oasis3-mct
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_gnu.yaml') }}
 
       - name: build-ww3
         run: |

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -1,20 +1,14 @@
 name: Intel Linux Build
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
-# without having to do it in manually every step
-defaults:
-  run:
-    shell: bash -leo pipefail {0}
-
 # Set I_MPI_CC/F90 so Intel MPI wrapper uses icc/ifort instead of gcc/gfortran
 env:
-  cache_key: intel6
+  cache_key: intel7
   CC: icc
   FC: ifort
   CXX: icpc
@@ -22,12 +16,12 @@ env:
   I_MPI_F90: ifort
 
 # Split into a dependency build step, and a WW3 build step which
-# builds multiple switches in a matrix. The setup is run once and
+# builds multiple switches in a matrix. The setup is run once and 
 # the environment is cached so each build of WW3 can share the dependencies.
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 
 
     steps:
 
@@ -48,7 +42,7 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_intel.yaml') }}
 
       - name: install-intel-compilers
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -57,27 +51,31 @@ jobs:
           sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo apt-get update
-          sudo apt-get install intel-oneapi-dev-utilities intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
+          sudo apt-get install intel-oneapi-mpi-devel intel-oneapi-openmp intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
 
       # Build WW3 spack environment
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
           # Install NetCDF, ESMF, g2, etc using Spack
+          . /opt/intel/oneapi/setvars.sh
+          sudo mv /usr/local /usrlocal_renamed
+          sudo apt install cmake
           git clone -c feature.manyFiles=true https://github.com/spack/spack.git
           source spack/share/spack/setup-env.sh
-          spack env create ww3-intel ww3/model/ci/spack.yaml
+          ln -s $(realpath $(which gcc)) spack/lib/spack/env/intel/gcc # spack/make bug in ESMF
+          spack env create ww3-intel ww3/model/ci/spack_intel.yaml
           spack env activate ww3-intel
           spack compiler find
-          spack external find
+          spack external find cmake
           spack add intel-oneapi-mpi
           spack concretize
-          spack install --dirty -v
+          spack install --dirty -v --fail-fast
 
       - name: build-oasis
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel
           export WWATCH3_DIR=${GITHUB_WORKSPACE}/ww3/model
@@ -93,17 +91,13 @@ jobs:
     strategy:
       matrix:
         switch: [Ifremer1, NCEP_st2, NCEP_st4, ite_pdlib, NCEP_st4sbs, NCEP_glwu, OASACM, UKMO, MULTI_ESMF, NUOPC_MESH]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 
 
     steps:
       - name: checkout-ww3
         uses: actions/checkout@v2
         with:
             path: ww3
-
-      - name: install-intel
-        run: |
-          echo "source /opt/intel/oneapi/setvars.sh" >> ~/.bash_profile
 
       - name: cache-env
         id: cache-env
@@ -114,10 +108,11 @@ jobs:
             ~/.spack
             work_oasis3-mct
             /opt/intel
-          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack.yaml') }}
+          key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('ww3/model/ci/spack_intel.yaml') }}
 
       - name: build-ww3
         run: |
+          . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel
           cd ww3

--- a/model/ci/spack_gnu.yaml
+++ b/model/ci/spack_gnu.yaml
@@ -1,7 +1,8 @@
 spack:
   packages:
     all:
-      compiler: [intel, gcc]
+      compiler:
+      - gcc@10.0:10
   specs:
   - metis@5.1.0~shared
   - parmetis@4.0.3~shared
@@ -13,4 +14,5 @@ spack:
   - w3emc@2.9.2
   - esmf@8.1.1~pio~pnetcdf~xerces
   view: true
-  concretization: together
+  concretizer:
+    unify: when_possible

--- a/model/ci/spack_intel.yaml
+++ b/model/ci/spack_intel.yaml
@@ -1,0 +1,20 @@
+spack:
+  packages:
+    all:
+      compiler: [intel]
+      providers:
+        mpi: [intel-oneapi-mpi]
+  specs:
+  - metis@5.1.0~shared
+  - parmetis@4.0.3~shared
+  - netcdf-c@4.7.4~dap
+  - netcdf-fortran@4.5.3
+  - jasper@2.0.32
+  - g2@3.4.5
+  - bacio@2.4.1
+  - w3emc@2.9.2
+  - esmf@8.1.1~pio~pnetcdf~xerces
+  - intel-oneapi-mpi %intel
+  view: true
+  concretizer:
+    unify: when_possible

--- a/model/src/cmake/src_list.cmake
+++ b/model/src/cmake/src_list.cmake
@@ -19,6 +19,7 @@ set(ftn_src
   w3iogrmd.F90
   w3iopomd.F90
   w3iorsmd.F90
+  w3iorsmdold.F90
   w3iosfmd.F90
   w3iotrmd.F90
   w3macros.h

--- a/model/src/w3iorsmdold.F90
+++ b/model/src/w3iorsmdold.F90
@@ -1,0 +1,829 @@
+#include "w3macros.h"
+!/ ------------------------------------------------------------------- /
+      MODULE  W3IORSMDOLD
+!/
+!/                  +-----------------------------------+
+!/                  | WAVEWATCH III           NOAA/NCEP |
+!/                  |           H. L. Tolman            |
+!/                  |                      FORTRAN 2003 |
+!/                  | Last update :         03-Aug-2020 |
+!/                  +-----------------------------------+
+!/
+!/    See subroutine for update log.
+!/
+!  1. Purpose :
+!
+!     Read/write restart files.
+!
+!  2. Variables and types :
+!
+!      Name      Type  Scope    Description
+!     ----------------------------------------------------------------
+!      VERINI    C*10  Private  Restart file version number.
+!      IDSTR     C*26  Private  Restart file UD string.
+!     ----------------------------------------------------------------
+!
+!  3. Subroutines and functions :
+!
+!      Name      Type  Scope    Description
+!     ----------------------------------------------------------------
+!      W3IORS    Subr. Public   Read/write restart files.
+!     ----------------------------------------------------------------
+!
+!  4. Subroutines and functions used :
+!
+!      Name      Type  Module   Description
+!     ----------------------------------------------------------------
+!      W3SETO, W3SETG, W3SETW, W3DIMW
+!                Subr. W3xDATMD Manage data structures.
+!      STRACE    Subr. W3SERVMD Subroutine tracing.            (!/S)
+!      EXTCDE    Subr. W3SERVMD Abort program with exit code.
+!      MPI_STARTALL, MPI_WAITALL                              (!/MPI)
+!                Subr.          MPI persistent communication routines
+!     ----------------------------------------------------------------
+!
+!  5. Remarks :
+!
+!  6. Switches :
+!
+!     See also routine.
+!
+!  7. Source code :
+!
+!/ ------------------------------------------------------------------- /
+      PUBLIC
+!/
+!/ Private parameter statements (ID strings)
+!/
+      CHARACTER(LEN=10), PARAMETER, PRIVATE :: VERINI = 'III  5.10 '
+      CHARACTER(LEN=26), PARAMETER, PRIVATE ::                        &
+                               IDSTR = 'WAVEWATCH III RESTART FILE'
+!/
+      CONTAINS
+!/ ------------------------------------------------------------------- /
+!JDM      SUBROUTINE W3IORSOLD ( INXOUT, NDSR, DUMFPI, IMOD, FLRSTRT )
+      SUBROUTINE W3IORSOLD ( INXOUT, NDSR, DUMFPI, RSTYPE, IMOD )
+
+!/
+!/                  +-----------------------------------+
+!/                  | WAVEWATCH III           NOAA/NCEP |
+!/                  |           H. L. Tolman            |
+!/                  |                        FORTRAN 90 |
+!/                  | Last update :         05-Jun-2018 |
+!/                  +-----------------------------------+
+!/
+!/    12-Jan-1999 : Final FORTRAN 77                    ( version 1.18 )
+!/    27-Dec-1999 : Upgrade to FORTRAN 90               ( version 2.00 )
+!/    30-Apr-2002 : Add ice for transparencies.         ( version 2.20 )
+!/    13-Nov-2002 : Add stress as vector.               ( version 3.00 )
+!/    19-Aug-2003 : Output server options added.        ( version 3.04 )
+!/    09-Dec-2004 : Multiple grid version.              ( version 3.06 )
+!/    24-Jun-2005 : Adding MAPST2.                      ( version 3.07 )
+!/    27-Jun-2006 : Adding file name preamble.          ( version 3.09 )
+!/    05-Jul-2006 : Consolidate stress arrays.          ( version 3.09 )
+!/    08-May-2007 : Starting from calm as an option.    ( version 3.11 )
+!/    17-May-2007 : Adding NTPROC/NAPROC separation.    ( version 3.11 )
+!/    22-Jun-2007 : Dedicated output processes.         ( version 3.11 )
+!/    15-Apr-2008 : Clean up for distribution.          ( version 3.14 )
+!/    21-Apr-2008 : Remove PGI bug internal files.      ( version 3.14 )
+!/    29-May-2009 : Preparing distribution version.     ( version 3.14 )
+!/    30-Oct-2009 : Output file name with 3 digit id.   ( version 3.14 )
+!/                  (W. E. Rogers, NRL)
+!/    14-Nov-2013 : Remove cold start init. UST(DIR).   ( version 4.13 )
+!/    31-May-2016 : Optimize restart file size for un-  ( version 5.10 )
+!/                  structured grid and restart read.
+!/                  (M. Ward, NCI, S. Zieger, BOM)
+!/    10-Mar-2017 : File access mode changed to 'STREAM'( version 6.02 )
+!/                  (S. Zieger, BOM)
+!/    09-Aug-2017 : Bug fix for MPI restart read issue  ( version 6.02 )
+!/                  (T. Campbell, NRL)
+!/    05-Jun-2018 : Add PDLIB/TIMINGS/DEBUGIO           ( version 6.04 )
+!/                  DEBUGINIT/MPI
+!/    19-Dec-2019 : Optional second stream of           ( version 7.00 )
+!/                  restart files
+!/                  (Roberto Padilla-Hernandez & J.H. Alves)
+!/    03-Aug-2020 : Updates so that it can be used to generate HWRF IC 
+!/         This routine was created by taking the production/GFSv16
+!/    18-Sep-2020 : Updates for compiling, needed to hardcode variables 
+!/         and change the interface to match the older style
+!/         Also make sure that NSEAL is not used, as it is 0 use NSEA
+!branch and processing it with the following switches: 
+!F90 NCO NOGRB SHRD SCRIP SCRIPNC WRST NC4 PR3 UQ FLX0 SEED ST4 STAB0
+!NL1 BT1 DB1 MLIM TR0 BS0 XX0 RWND WNX1 WNT1 CRX1 CRT1 O0 O1 O2 O3 O4 O5
+!O6 O7 O14 O15 IC0 IS0 REF0 
+!/
+!/    Copyright 2009-2013 National Weather Service (NWS),
+!/       National Oceanic and Atmospheric Administration.  All rights
+!/       reserved.  WAVEWATCH III is a trademark of the NWS.
+!/       No unauthorized use without permission.
+!/
+!  1. Purpose :
+!
+!     Reads/writes restart files.
+!
+!  2. Method :
+!
+!     The file is opened within the routine, the name is pre-defined
+!     and the unit number is given in the parameter list. The restart
+!     file is written using UNFORMATTED write statements. The routine
+!     generates new names when called more than once. File names are :
+!
+!                                 restart000.FILEXT
+!                                 restart001.FILEXT
+!                                 restart002.FILEXT etc.
+!
+!     Optionally, a second stream of restart files is generated given
+!     a secondary stride definad by an additional start/end time line
+!     triggered by an optional argument added to the end of the stan-
+!     dard restart request line (a sixth argument flag set to T). File
+!     names include a time-tag prefix:
+!
+!                                 YYYYMMDD.HHMMSS.restart.FILEXT
+!
+!     The file to be read thus always is unnumbered, whereas all
+!     written files are automatically numbered.
+!
+!  3. Parameters :
+!
+!     Parameter list
+!     ----------------------------------------------------------------
+!       INXOUT  C*(*)  I   Test string for read/write, valid are:
+!                          'READ' Reading of a restart file.
+!                          'HOT'  Writing a full restart from the model.
+!                          'COLD' Writing a cold start file.
+!                          'WIND' Initialize fields using first wind
+!                                 field.
+!                          'CALM' Starting from calm conditions.
+!       NDSR    Int.  I/O  File unit number.
+!       DUMFPI  Real   I   Dummy values for FPIS for cold start.
+!       RSTYPE  Int.   O   Type of input field,
+!                           0 : cold start,
+!                           1 : cold start with fetch-limited spectra,
+!                           2 : full restart,
+!                           3 : for writing file.
+!                           4 : starting from calm.
+!       IMOD    Int.   I   Optional grid number, defaults to 1.
+!       FLRSTRT LOGIC  I    OTIONAL TRUE: A second request for restart files
+!     ----------------------------------------------------------------
+!
+!  4. Subroutines used :
+!
+!     See module documentation.
+!
+!  5. Called by :
+!
+!      Name      Type  Module   Description
+!     ----------------------------------------------------------------
+!      W3INIT    Subr. W3INITMD Wave model initialization routine.
+!      W3WAVE    Subr. W3WAVEMD Actual wave model routine.
+!      WW3_STRT  Prog.   N/A    Initial conditions program.
+!     ----------------------------------------------------------------
+!
+!  6. Error messages :
+!
+!       Tests on INXOUT, file status and on array dimensions.
+!
+!  7. Remarks :
+!
+!     - MAPSTA is dumped as it contains information on inactive points.
+!       Note that the original MAPSTA is dumped in the model def. file
+!       for use in the initial conditions (and output) programs.
+!     - Note that MAPSTA and MAPST2 data is combinded in the file.
+!     - The depth is recalculated in a write to avoid floating point
+!       errors in W3STRT.
+!     - Fields and field info read by all, written by las processor
+!       only.
+!     - The MPP version of the model will perform a gather here to
+!       maximize hiding of communication with IO.
+!
+!  8. Structure :
+!
+!     +---------------------------------------------------------------+
+!     | initialisations                                               |
+!     | test INXOUT                                                   |
+!     | open file                                                     |
+!     +---------------------------------------------------------------|
+!     |                             WRITE ?                           |
+!     | Y                                                           N |
+!     |-------------------------------|-------------------------------|
+!     | Write identifiers and         | Write identifiers and         |
+!     |   dimensions.                 |   dimensions.                 |
+!     |                               | Check ident. and dimensions.  |
+!     +-------------------------------+-------------------------------|
+!     |                       Full restart ?                          |
+!     | Y                                                           N |
+!     |-------------------------------|-------------------------------|
+!     | read/write/test time          |                               |
+!     +-------------------------------+-------------------------------|
+!     |                             WRITE ?                           |
+!     | Y                                                           N |
+!     |-------------------------------|-------------------------------|
+!     |          TYPE = 'WIND' ?      |          TYPE = 'WIND' ?      |
+!     | Y                           N | Y                           N |
+!     |---------------|---------------|---------------|---------------|
+!     | close file    | write spectra | gen. fetch-l. | read spectra  |
+!     | RETURN        |               |   spectra.    |               |
+!     |---------------+---------------+---------------+---------------|
+!     |                             WRITE ?                           |
+!     | Y                                                           N |
+!     |-------------------------------|-------------------------------|
+!     |          TYPE = 'FULL' ?      |          TYPE = 'FULL' ?      |
+!     | Y                           N | Y                           N |
+!     |---------------|---------------|---------------|---------------|
+!     | write level & | ( prep. level | read level &  | initalize l.& |
+!     |   (ice) map & |   for test    |   (ice) map.& |   times       |
+!     |   times       |   output )    |   times       | ( no ice )    |
+!     +---------------+---------------+---------------+-------------- +
+!
+!  9. Switches :
+!
+!     !/SEED  Linear input / seeding option.
+!     !/LNx
+!
+!     !/SHRD  Switch for shared / distributed memory architecture.
+!     !/DIST  Id.
+!     !/MPI   Id.
+!
+!     !/S     Enable subroutine tracing.
+!     !/T     Enable test output
+!
+! 10. Source code :
+!
+!/ ------------------------------------------------------------------- /
+      USE W3GDATMD, ONLY: W3SETG, W3SETREF !JDM, RSTYPE
+      USE W3ODATMD, ONLY: W3SETO
+!/
+      USE W3GDATMD, ONLY: NX, NY, NSEA, NSPEC, MAPSTA, MAPST2, &
+                          GNAME, FILEXT, GTYPE, UNGTYPE
+!JDM      USE W3TRIAMD, ONLY: SETUGIOBP
+      USE W3WDATMD
+      USE W3IDATMD, ONLY: WXN, WYN, W3SETI
+!JDM      USE W3IDATMD, ONLY: WXNwrst, WYNwrst
+      USE W3ODATMD, ONLY: NDSE, NDST, IAPROC, NAPROC, NAPERR, NAPRST, &
+                          IFILE => IFILE4, FNMPRE, NTPROC, IOSTYP
+!/
+      USE W3SERVMD, ONLY: EXTCDE
+      USE CONSTANTS,ONLY: file_endian
+!JDM      USE CONSTANTS, only: LPDLIB
+!JDM      USE W3PARALL, ONLY: INIT_GET_ISEA, INIT_GET_JSEA_ISPROC
+      USE W3GDATMD, ONLY: NK, NTH
+!!!!!/PDLIB    USE PDLIB_FIELD_VEC!, only : UNST_PDLIB_READ_FROM_FILE, UNST_PDLIB_WRITE_TO_FILE
+!
+      IMPLICIT NONE
+!
+!/
+!/ ------------------------------------------------------------------- /
+!/ Parameter list
+!/
+      INTEGER                       :: NDSR
+!      INTEGER, INTENT(IN)           :: NDSR
+      INTEGER, INTENT(IN), OPTIONAL :: IMOD
+      REAL, INTENT(INOUT)           :: DUMFPI
+      CHARACTER, INTENT(IN)         :: INXOUT*(*)
+      INTEGER, INTENT(OUT)          :: RSTYPE !JDM add back to argument list
+      LOGICAL  :: FLRSTRT=.FALSE. !JDM set to false
+!/
+!/ ------------------------------------------------------------------- /
+!/ Local parameters
+!/
+      INTEGER, PARAMETER      :: LRB = 4
+!
+      INTEGER                 :: IGRD, I, J, LRECL, NSIZE, IERR,      &
+                                 NSEAT, MSPEC, TTIME(2), ISEA, JSEA,  &
+                                 NREC, NPART, IPART, IX, IY, IXL, IP, &
+                                 NPRTX2, NPRTY2, IYL
+      INTEGER, ALLOCATABLE    :: MAPTMP(:,:)
+      INTEGER(KIND=8)         :: RPOS
+      REAL(KIND=LRB), ALLOCATABLE :: WRITEBUFF(:)
+ 
+      LOGICAL                 :: WRITE, IOSFLG
+      CHARACTER(LEN=4)        :: TYPE
+      CHARACTER(LEN=10)       :: VERTST
+!      CHARACTER(LEN=21)       :: FNAME
+      CHARACTER(LEN=100)       :: FNAME
+      CHARACTER(LEN=26)       :: IDTST
+      CHARACTER(LEN=30)       :: TNAME
+      CHARACTER(LEN=15)       :: TIMETAG
+!   Parameters added for backwards porting 
+       REAL, ALLOCATABLE      :: WXNwrst(:,:),WYNwrst(:,:)
+     LOGICAL                  :: LPDLIB = .FALSE.
+!/
+!/ ------------------------------------------------------------------- /
+!/
+!
+! Constant NDSR for using mpiifort in ZEUS ... paralell runs crashing
+!  because compiler doesn't accept reciclyng of UNIT for FORMATTED or
+!  UNFORMATTED files in OPEN
+!
+!     NDSR = 525
+ 
+      IOSFLG = IOSTYP .GT. 0
+!
+! test parameter list input ------------------------------------------ *
+!
+      IF ( PRESENT(IMOD) ) THEN
+          IGRD   = IMOD
+        ELSE
+          IGRD   = 1
+        END IF
+!
+      CALL W3SETO ( IGRD, NDSE, NDST )
+      CALL W3SETG ( IGRD, NDSE, NDST )
+      CALL W3SETW ( IGRD, NDSE, NDST )
+      CALL W3SETI ( IGRD, NDSE, NDST )
+!
+      IF (INXOUT.NE.'READ' .AND. INXOUT.NE.'HOT'  .AND.               &
+          INXOUT.NE.'COLD' .AND. INXOUT.NE.'WIND' .AND.               &
+          INXOUT.NE.'CALM' ) THEN
+          IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,900) INXOUT
+          CALL EXTCDE ( 1 )
+        END IF
+!
+      WRITE = INXOUT .NE. 'READ'
+      IF ( INXOUT .EQ. 'HOT' ) THEN
+          TYPE   = 'FULL'
+        ELSE
+          TYPE   = INXOUT
+        END IF
+!
+! initializations ---------------------------------------------------- *
+!
+      IF ( .NOT.DINIT ) THEN
+          IF ( IAPROC .LE. NAPROC ) THEN
+              CALL W3DIMW ( IMOD, NDSE, NDST )
+            ELSE
+              CALL W3DIMW ( IMOD, NDSE, NDST, .FALSE. )
+            END IF
+        END IF
+!
+      IF ( IAPROC .LE. NAPROC ) VA(:,0) = 0.
+! JDM Added for backwards porting 
+      ALLOCATE(WXNwrst(NX,NY),WYNwrst(NX,NY))
+
+!
+      LRECL  = MAX ( LRB*NSPEC ,                                      &
+                     LRB*(6+(25/LRB)+(9/LRB)+(29/LRB)+(3/LRB)) )
+      NSIZE  = LRECL / LRB
+!     --- Allocate buffer array with zeros (used to
+!         fill bytes up to size LRECL). ---
+      ALLOCATE(WRITEBUFF(NSIZE))
+      WRITEBUFF(:) = 0.
+!
+! open file ---------------------------------------------------------- *
+!
+      I      = LEN_TRIM(FILEXT)
+      J      = LEN_TRIM(FNMPRE)
+!
+!CHECKPOINT
+      !IF ( PRESENT(FLRSTRT) .AND. FLRSTRT) THEN
+      IF ( FLRSTRT) THEN
+          WRITE(TIMETAG,"(i8.8,'.'i6.6)")TIME(1),TIME(2)
+!         FNAME=TIMETAG//'.restart.'//FILEXT(:I)
+          FNAME='restart_wave/'//TIMETAG//'.restart.'//FILEXT(:I)
+      ELSE
+         IF ( IFILE.EQ.0 ) THEN
+            FNAME  = 'restart.'//FILEXT(:I)
+         ELSE
+            FNAME  = 'restartNNN.'//FILEXT(:I)
+            IF ( WRITE .AND. IAPROC.EQ.NAPRST )                         &
+               WRITE (FNAME(8:10),'(I3.3)') IFILE
+        END IF
+      END IF
+ 
+      IFILE  = IFILE + 1
+!
+ 
+      IF(NDST.EQ.NDSR)THEN
+         IF ( IAPROC .EQ. NAPERR )                                    &
+            WRITE(NDSE,'(A,I8)')'UNIT NUMBERS OF RESTART FILE AND '&
+            //'TEST OUTPUT ARE THE SAME : ',NDST
+         CALL EXTCDE ( 15 )
+      ENDIF
+ 
+      IF ( WRITE ) THEN
+          IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST )                    &
+          print*,"FNAME-- ",FNMPRE(:J)//trim(FNAME)
+          OPEN (NDSR,FILE=FNMPRE(:J)//trim(FNAME),FORM='UNFORMATTED', convert=file_endian,       &
+                ACCESS='STREAM',ERR=800,IOSTAT=IERR)
+        ELSE
+          OPEN (NDSR,FILE=FNMPRE(:J)//trim(FNAME),FORM='UNFORMATTED', convert=file_endian,      &
+                ACCESS='STREAM',ERR=800,IOSTAT=IERR,                  &
+                STATUS='OLD',ACTION='READ')
+        END IF
+!
+! test info ---------------------------------------------------------- *
+!
+      IF ( WRITE ) THEN
+!
+          IF ( IAPROC .EQ. NAPRST ) THEN
+!           Because data has mixed data types we do not know how many
+!           bytes remain to fill up to LRECL. ---
+!           --- Make the entire record zero ---
+            WRITEBUFF(:) = 0.
+            WRITE (NDSR,POS=1) WRITEBUFF
+!           --- Replace zeros with data ---
+            WRITE (NDSR,POS=1) IDSTR, VERINI, GNAME, TYPE, NSEA, NSPEC
+          END IF
+          RSTYPE = 3
+!
+        ELSE
+          READ (NDSR,POS=1,ERR=802,IOSTAT=IERR)                       &
+            IDTST, VERTST, TNAME, TYPE, NSEAT, MSPEC
+!
+          IF ( IDTST .NE. IDSTR ) THEN
+              IF ( IAPROC .EQ. NAPERR )                               &
+                  WRITE (NDSE,901) IDTST, IDSTR
+              CALL EXTCDE ( 10 )
+            END IF
+          IF ( VERTST .NE. VERINI ) THEN
+              IF ( IAPROC .EQ. NAPERR )                               &
+                  WRITE (NDSE,902) VERTST, VERINI
+              CALL EXTCDE ( 11 )
+            END IF
+          IF ( TNAME .NE. GNAME ) THEN
+              IF ( IAPROC .EQ. NAPERR )                               &
+                  WRITE (NDSE,903) TNAME, GNAME
+            END IF
+          IF (TYPE.NE.'FULL' .AND. TYPE.NE.'COLD' .AND.               &
+              TYPE.NE.'WIND' .AND. TYPE.NE.'CALM' ) THEN
+              IF ( IAPROC .EQ. NAPERR )                               &
+                  WRITE (NDSE,904) TYPE
+              CALL EXTCDE ( 12 )
+            END IF
+          IF (NSEAT.NE.NSEA .OR. NSPEC.NE.MSPEC) THEN
+              IF ( IAPROC .EQ. NAPERR )                               &
+                  WRITE (NDSE,905) MSPEC, NSEAT, NSPEC, NSEA
+              CALL EXTCDE ( 13 )
+            END IF
+          IF (TYPE.EQ.'FULL') THEN
+              RSTYPE = 2
+            ELSE IF (TYPE.EQ.'WIND') THEN
+              RSTYPE = 1
+            ELSE IF (TYPE.EQ.'CALM') THEN
+              RSTYPE = 4
+            ELSE
+              RSTYPE = 0
+            END IF
+!
+        END IF
+!
+  100 CONTINUE
+!
+! TIME if required --------------------------------------------------- *
+!
+      IF (TYPE.EQ.'FULL') THEN
+          RPOS  = 1_8 + LRECL*(2-1_8)
+          IF ( WRITE ) THEN
+              IF ( IAPROC .EQ. NAPRST ) THEN
+                WRITEBUFF(:) = 0.
+                WRITE (NDSR,POS=RPOS) WRITEBUFF
+                WRITE (NDSR,POS=RPOS) TIME
+              END IF
+            ELSE
+              READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR) TTIME
+              IF (TIME(1).NE.TTIME(1) .OR. TIME(2).NE.TTIME(2)) THEN
+                  IF ( IAPROC .EQ. NAPERR )                           &
+                      WRITE (NDSE,906) TTIME, TIME
+                  CALL EXTCDE ( 20 )
+                END IF
+            END IF
+!
+        END IF
+!
+! Spectra ------------------------------------------------------------ *
+!          ( Bail out if write for TYPE.EQ.'WIND' )
+!
+      IF ( WRITE ) THEN
+          IF ( TYPE.EQ.'WIND' .OR. TYPE.EQ.'CALM' ) THEN
+              IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST ) THEN
+                CLOSE ( NDSR )
+              END IF
+              RETURN
+            ELSE IF ( IAPROC.LE.NAPROC .OR. IAPROC.EQ. NAPRST ) THEN
+!
+! Original non-server version writing of spectra
+!
+              IF ( .NOT.IOSFLG .OR. (NAPROC.EQ.1.AND.NAPRST.EQ.1) ) THEN
+                  DO JSEA=1, NSEA
+                    ISEA  = JSEA    !JDM CALL INIT_GET_ISEA(ISEA, JSEA)
+                    NREC   = ISEA + 2
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITEBUFF(:) = 0.
+                    WRITEBUFF(1:NSPEC) = VA(1:NSPEC,JSEA)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    END DO
+!
+! I/O server version writing of spectra ( !/MPI )
+!
+ 
+!
+                END IF
+!
+            END IF
+        ELSE
+!
+! Reading spectra
+!
+          IF ( TYPE.EQ.'WIND' .OR. TYPE.EQ.'CALM' ) THEN
+          ELSE
+            IF (LPDLIB .and. (GTYPE.eq.UNGTYPE)) THEN
+            ELSE
+              VA = 0.
+              DO JSEA=1, NSEA
+                ISEA  = JSEA    !JDM CALL INIT_GET_ISEA(ISEA, JSEA)
+                NREC   = ISEA + 2
+                RPOS   = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                         (VA(I,JSEA),I=1,NSPEC)
+                ENDDO
+            END IF
+          END IF
+        END IF
+ 
+!AR: Must be checked better ... will do that when cleaning debugging switches!
+        VA = MAX(0.,VA)
+!
+! Water level etc. if required --------------------------------------- *
+!     ( For cold start write test output and cold start initialize
+!       water levels. Note that MAPSTA overwrites the one read from the
+!       model definition file, so that it need not be initialized. )
+!
+      NREC   = NSEA + 3
+      NPART  = 1 + (NSEA-1)/NSIZE
+      NPRTX2 = 1 + (NX-1)/NSIZE
+      NPRTY2 = 1 + (NY-1)/NSIZE
+!
+      IF ( WRITE ) THEN
+!
+          IF (TYPE.EQ.'FULL') THEN
+!
+              IF ( IAPROC .EQ. NAPRST ) THEN
+!
+                  RPOS  = 1_8 + LRECL*(NREC-1_8)
+                  WRITEBUFF(:) = 0.
+                  WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                  WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)           &
+                          TLEV, TICE
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (WLV(ISEA),ISEA=1+(IPART-1)*NSIZE,          &
+                                          MIN(NSEA,IPART*NSIZE))
+                    END DO
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (ICE(ISEA),ISEA=1+(IPART-1)*NSIZE,          &
+                                          MIN(NSEA,IPART*NSIZE))
+                  END DO
+                  DO IX=1, NX
+                    DO IPART=1,NPRTY2
+                      NREC  = NREC + 1
+                      RPOS  = 1_8 + LRECL*(NREC-1_8)
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)       &
+                          (WXN(IX,IYL),IYL=1+(IPART-1)*NSIZE,         &
+                                         MIN(NY,IPART*NSIZE))
+                    END DO
+                  END DO
+                  DO IX=1, NX
+                    DO IPART=1,NPRTY2
+                      NREC  = NREC + 1
+                      RPOS  = 1_8 + LRECL*(NREC-1_8)
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)       &
+                          (WYN(IX,IYL),IYL=1+(IPART-1)*NSIZE,         &
+                                         MIN(NY,IPART*NSIZE))
+                    END DO
+                  END DO
+                  ALLOCATE ( MAPTMP(NY,NX) )
+                  MAPTMP = MAPSTA + 8*MAPST2
+                  DO IY=1, NY
+                    DO IPART=1,NPRTX2
+                      NREC  = NREC + 1
+                      RPOS  = 1_8 + LRECL*(NREC-1_8)
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)       &
+                             WRITEBUFF
+                      WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)       &
+                            (MAPTMP(IY,IXL),IXL=1+(IPART-1)*NSIZE,    &
+                                                MIN(NX,IPART*NSIZE))
+                      END DO
+                    END DO
+                  DEALLOCATE ( MAPTMP )
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (UST(ISEA),ISEA=1+(IPART-1)*NSIZE,          &
+                                          MIN(NSEA,IPART*NSIZE))
+                    END DO
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (USTDIR(ISEA),ISEA=1+(IPART-1)*NSIZE,       &
+                                          MIN(NSEA,IPART*NSIZE))
+                    END DO
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (ASF(ISEA),ISEA=1+(IPART-1)*NSIZE,          &
+                                          MIN(NSEA,IPART*NSIZE))
+                    END DO
+                  DO IPART=1,NPART
+                    NREC  = NREC + 1
+                    RPOS  = 1_8 + LRECL*(NREC-1_8)
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
+                    WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)         &
+                          (FPIS(ISEA),ISEA=1+(IPART-1)*NSIZE,         &
+                                          MIN(NSEA,IPART*NSIZE))
+                    END DO
+                END IF
+            END IF
+        ELSE
+          IF (TYPE.EQ.'FULL') THEN
+              RPOS = 1_8 + LRECL*(NREC-1_8)
+              READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)                &
+                      TLEV, TICE
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (WLV(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
+                                      MIN(NSEA,IPART*NSIZE))
+                END DO
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (ICE(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
+                                      MIN(NSEA,IPART*NSIZE))
+              END DO
+              DO IX=1, NX
+               DO IPART=1,NPRTY2
+                NREC  = NREC + 1
+                RPOS = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (WXNwrst(IX,IYL),IYL=1+(IPART-1)*NSIZE,         &
+                                      MIN(NY,IPART*NSIZE))
+               END DO
+              END DO
+              DO IX=1, NX
+               DO IPART=1,NPRTY2
+                NREC  = NREC + 1
+                RPOS = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (WYNwrst(IX,IYL),IYL=1+(IPART-1)*NSIZE,         &
+                                      MIN(NY,IPART*NSIZE))
+               END DO
+              END DO
+              ALLOCATE ( MAPTMP(NY,NX) )
+              DO IY=1, NY
+                DO IPART=1,NPRTX2
+                  NREC  = NREC + 1
+                  RPOS  = 1_8 + LRECL*(NREC-1_8)
+                  READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)            &
+                        (MAPTMP(IY,IXL),IXL=1+(IPART-1)*NSIZE,        &
+                                            MIN(NX,IPART*NSIZE))
+                  END DO
+                END DO
+              MAPSTA = MOD(MAPTMP+2,8) - 2
+              MAPST2 = (MAPTMP-MAPSTA) / 8
+              DEALLOCATE ( MAPTMP )
+!
+! Updates reflections maps:
+!
+              IF (GTYPE.EQ.UNGTYPE) THEN
+                !CALL SETUGIOBP   !JDM compiler errors
+                ENDIF
+!
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS  = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (UST(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
+                                      MIN(NSEA,IPART*NSIZE))
+                END DO
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS  = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (USTDIR(ISEA),ISEA=1+(IPART-1)*NSIZE,           &
+                                      MIN(NSEA,IPART*NSIZE))
+                END DO
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS  = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (ASF(ISEA),ISEA=1+(IPART-1)*NSIZE,              &
+                                      MIN(NSEA,IPART*NSIZE))
+                END DO
+              DO IPART=1,NPART
+                NREC  = NREC + 1
+                RPOS  = 1_8 + LRECL*(NREC-1_8)
+                READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)              &
+                      (FPIS(ISEA),ISEA=1+(IPART-1)*NSIZE,             &
+                                      MIN(NSEA,IPART*NSIZE))
+                END DO
+            ELSE
+              TLEV(1) = -1
+              TLEV(2) =  0
+              TICE(1) = -1
+              TICE(2) =  0
+              TIC1(1) = -1
+              TIC1(2) =  0
+              TIC5(1) = -1
+              TIC5(2) =  0
+              WXNwrst =  0.
+              WYNwrst =  0.
+              WLV     =  0.
+              ICE     =  0.
+              ASF     =  1.
+              FPIS    =  DUMFPI
+            END IF
+        END IF
+!
+! Close file --------------------------------------------------------- *
+!
+      IF ( .NOT.IOSFLG .OR. IAPROC.EQ.NAPRST ) THEN
+        CLOSE ( NDSR )
+      END IF
+!
+      IF (ALLOCATED(WXNwrst)) DEALLOCATE(WXNwrst)
+      IF (ALLOCATED(WYNwrst)) DEALLOCATE(WYNwrst)
+
+      IF (ALLOCATED(WRITEBUFF)) DEALLOCATE(WRITEBUFF)
+!
+      RETURN
+!
+! Escape locations read errors :
+!
+  800 CONTINUE
+      TYPE   = 'CALM'
+      RSTYPE = 4
+      IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,990) TYPE, IERR
+      GOTO 100
+!
+  801 CONTINUE
+      IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,991)
+      CALL EXTCDE ( 30 )
+!
+  802 CONTINUE
+      IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,992) IERR
+      CALL EXTCDE ( 31 )
+!
+  803 CONTINUE
+      IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,993) IERR, RPOS
+      CALL EXTCDE ( 31 )
+!
+! Formats
+!
+  900 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     ILLEGAL INXOUT VALUE: ',A/)
+  901 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     ILLEGAL IDSTR, READ : ',A/                       &
+               '                   CHECK : ',A/)
+  902 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     ILLEGAL VERINI, READ : ',A/                      &
+               '                    CHECK : ',A/)
+  903 FORMAT (/' *** WAVEWATCH III WARNING IN W3IORS :'/              &
+               '     ILLEGAL GNAME, READ : ',A/                       &
+               '                   CHECK : ',A/)
+  904 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     ILLEGAL TYPE : ',A/)
+  905 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     CONFLICTING NSPEC, NSEA GRID : ',2I8/            &
+               '                         EXPECTED : ',2I8/)
+  906 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS :'/                &
+               '     CONFLICTING TIMES: FILE : ',I10.8,I8.6/          &
+               '                       MODEL : ',I10.8,I8.6/)
+!
+  990 FORMAT (/' *** WAVEWATCH III WARNING IN W3IORS : '/             &
+               '     NO READABLE RESTART FILE, ',                     &
+                    'INITIALIZE WITH ''',A,''' INSTEAD'/              &
+               '     IOSTAT =',I5/)
+  991 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS : '/               &
+               '     PREMATURE END OF FILE'/)
+  992 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS : '/               &
+               '     ERROR IN READING FROM FILE'/                     &
+               '     IOSTAT =',I5/)
+  993 FORMAT (/' *** WAVEWATCH III ERROR IN W3IORS : '/               &
+               '     ERROR IN WRITING TO FILE'/                       &
+               '     IOSTAT =',I5,', POS =',I11 /)
+!
+!/
+!/ End of W3IORSOLD ----------------------------------------------------- /
+!/
+      END SUBROUTINE W3IORSOLD
+!/
+!/ End of module W3IORSMDOLD -------------------------------------------- /
+!/
+      END MODULE W3IORSMDOLD

--- a/model/src/ww3_bound.F90
+++ b/model/src/ww3_bound.F90
@@ -559,6 +559,10 @@ PROGRAM W3BOUND
             !
             READ(200+IP,'(A1,A10,A1,2F7.2,F10.1,F7.2,F6.1,F7.2,F6.1)') &
                  space,buoyname,space,LATS(IP),LONS(IP),depth,U10,Udir,Curr,Currdir
+            !JDM: NEED TO ADD LONGERTERM FIX HERE!!!! This is a fix
+            !because the lon from the spec points is (0-360) while grid
+            !uses -180:180  
+            IF ((XGRD(1,1)<0.0).AND.(LONS(IP)>179.0)) LONS(IP)=LONS(IP)-360.0 
 #ifdef W3_RTD
             IF (ISRTD) THEN
               ! Rotated coordinates are scaled in range 0 - 360

--- a/model/src/ww3_gint.F90
+++ b/model/src/ww3_gint.F90
@@ -126,6 +126,9 @@ PROGRAM W3GRID_INTERP
   USE W3ARRYMD, ONLY : PRTBLK
   USE W3GSRUMD
   USE W3TRIAMD
+  USE W3WDATMD, ONLY: VA
+  USE W3IORSMD, ONLY: W3IORS
+  USE W3IORSMDOLD, ONLY: W3IORSOLD
   !/
   IMPLICIT NONE
   !/
@@ -168,6 +171,14 @@ PROGRAM W3GRID_INTERP
   REAL, ALLOCATABLE       :: INT_MAP(:,:)
   LOGICAL                 :: L360=.FALSE., LPLC, INGRD, BRNCHCL, BRNCHCR, INGRID
   CHARACTER               :: COMSTR*1, IDTIME*23, FNAMEWHT*32
+  REAL                    :: XXX !< Dummy Value for w3iors call
+  LOGICAL                 :: OUTorREST !< True interpolate out_grd or False restart
+  INTEGER                 :: INTYPE 
+  INTEGER, ALLOCATABLE    :: MAPSTA_NG(:,:),MAPST2_NG(:,:) 
+  INTEGER, ALLOCATABLE    :: NOINT(:),NOINT2(:),MAPSTATMP(:,:) 
+  INTEGER                 :: iNOINT,iNOINT2,JSEA,iloops 
+  CHARACTER(LEN=8)        :: WORDS(5)
+  CHARACTER(LEN=80)       :: LINEIN
   !
   !---------------------------------------------------------------------------
   ! 1. Initialization
@@ -203,10 +214,26 @@ PROGRAM W3GRID_INTERP
   IF ( COMSTR .EQ. ' ' ) COMSTR = '$'
   WRITE (NDSO,901) COMSTR
   !
-  ! 3.b Read starting time, time step and number of outputs
+  ! 3.b.1 Read starting time, time step and number of outputs
   !
   CALL NEXTLN ( COMSTR, NDSI, NDSE )
-  READ (NDSI,*,END=2001,ERR=2002) TOUT, DTREQ, NOUT
+
+  WORDS(1:5)=''
+  READ (NDSI,'(A)') LINEIN
+  READ(LINEIN,*,iostat=ierr) WORDS
+
+  READ(WORDS( 1 ), * ) TOUT(1)
+  READ(WORDS( 2 ), * ) TOUT(2)
+  READ(WORDS( 3 ), * ) DTREQ
+  READ(WORDS( 4 ), * ) NOUT
+
+  ! Set flag OUTorREST for out_grd (True) or restart.* (FALSE)
+  IF (WORDS(5) .EQ. 'F') THEN 
+    OUTorREST = .false.
+  ELSE 
+    OUTorREST = .true. 
+  ENDIF
+
   DTREQ  = MAX ( 0. , DTREQ )
   IF ( DTREQ.EQ.0 ) NOUT = 1
   NOUT   = MAX ( 1 , NOUT )
@@ -248,22 +275,24 @@ PROGRAM W3GRID_INTERP
            'TESTED WITH TRIPOLE GRIDS. STOPPING NOW.'
       CALL EXTCDE ( 1 )
     END IF
-
     IF ( IG .NE. NG .AND. NOSWLL_MIN .GE. OUTPTS(IG)%NOSWLL ) THEN
       NOSWLL_MIN = OUTPTS(IG)%NOSWLL
     END IF
-    !
+    IF ( IG .EQ. NG) THEN 
+      ALLOCATE(MAPSTA_NG(NY,NX),MAPST2_NG(NY,NX)) 
+      MAPSTA_NG=MAPSTA
+      MAPST2_NG=MAPST2
+    END IF 
   END DO
-  !
   IF ( NOSWLL_MIN .NE. OUTPTS(NG)%NOSWLL ) THEN
     WRITE (NDSO,907) NOSWLL_MIN, OUTPTS(NG)%NOSWLL
     NOSWLL_MIN = MIN (NOSWLL_MIN,OUTPTS(NG)%NOSWLL)
   END IF
-
   CALL NEXTLN ( COMSTR, NDSI, NDSE )
   READ (NDSI,'(I1)',END=2001,ERR=2002) INTMETHOD
   WRITE (NDSO,917) INTMETHOD
-
+  CLOSE(NDSI)
+ 
   !
   ! 3.e Allocate memory for integration map and initialize with grid status map
   !
@@ -286,6 +315,7 @@ PROGRAM W3GRID_INTERP
   !
   CALL W3SETG( NG, 6, 6)
   WRITE (NDSO,908) NSEA
+  NSEAL=NSEA ! Set for reading restarts 
   !
   ALLOCATE ( GR_INTS(NSEA) )
   !
@@ -293,6 +323,9 @@ PROGRAM W3GRID_INTERP
     IF ( MINVAL ( XGRD ) .LT. 0 .OR.                                     &
          MAXVAL ( XGRD ) .GT. 180.0 ) L360 = .TRUE.
   END IF
+          
+  ALLOCATE ( NOINT(NSEA) )           
+  iNOINT=0
   !
   ! 4.b Check if weight files exist or create it
   !
@@ -724,6 +757,8 @@ PROGRAM W3GRID_INTERP
 #ifdef W3_T
         WRITE (NDSO,909)IX, IY
 #endif
+        iNOINT=iNOINT+1 
+        NOINT(iNOINT)=ISEA 
         MAPINT = 1
         MAPST2(IY,IX) = MAPST2(IY,IX) + MAPINT*16
         MAPSTA(IY,IX) = -ABS ( MAPSTA(IY,IX) )
@@ -766,95 +801,138 @@ PROGRAM W3GRID_INTERP
   ! 5.a Set-up dimensions for target grid outputs and allocate file pointers
   !
   CALL W3SETA(NG, 6, 6)
-  CALL W3DIMA(NG, 6, 6, .TRUE. )
-  CALL W3DIMW(NG, 6, 6, .TRUE. )
+  CALL W3DIMA(NG, 6, 6, .TRUE.)
+  IF (OUTorREST) THEN 
+    CALL W3DIMW(NG, 6, 6, .TRUE.)
+  ELSE 
+    CALL W3DIMW(NG, 6, 6)
+  END IF 
   ALLOCATE(FIDOUT(NG))
   DO IG = 1,NG
     FIDOUT(IG) = 30 + (IG-1)*10
   END DO
-  !
-  ! 5.b Initialize and read the first set of fields for base grids
-  !
-  DO IG = 1,NG-1
-    CALL W3SETO( IG, 6, 6)
-    CALL W3IOGO('READ',FIDOUT(IG),IOTST,IG)
-    IF ( IOTST .NE. 0 ) THEN
-      GO TO 2111
-    ENDIF
-  END DO
-  !
-  ! 5.c Setup the output flag options for the target grid
-  !
-  WRITE (NDSO,910)
-  DO I = 1, NOGRP
-    OUTPTS(NG)%OUT1%FLOGRD(I,:) = OUTPTS(1)%OUT1%FLOGRD(I,:)
-    WRITE (NDSO,911) I
-    IF (I.LT.9) THEN
-      WRITE (NDSO, 912) (OUTPTS(NG)%OUT1%FLOGRD(I,J),J=1,NGRPP)
-    ELSE
-      WRITE (NDSO, 913)
-    END IF
-  END DO
-  WRITE (NDSO, 915)
-  !
-  !     Print output flags in human readable from. Mark
-  !     groups that do not make sense to interpolate to
-  !     target grid (e.g. Groups 9, 10).
-  !
-  DO I=1, NOGRP
-    DO J=1, NGRPP
-      IF ( OUTPTS(NG)%OUT1%FLOGRD(I,J) ) THEN
-        IF ( I .EQ. 4 .AND. J .EQ. 8 ) THEN
-          WRITE (NDSO, 916) I,IDOUT(I,J), '*** NOT IMPLEMENTED ***'
-          OUTPTS(NG)%OUT1%FLOGRD(I,J) = .FALSE.
-        ELSE IF ( I .LE. 8 ) THEN
-          WRITE (NDSO, 916) I,IDOUT(I,J), ' '
-        ELSE
-          WRITE (NDSO, 916) I,IDOUT(I,J), '*** NOT IMPLEMENTED ***'
-          OUTPTS(NG)%OUT1%FLOGRD(I,J) = .FALSE.
-        END IF
+  !---- If out_grd --------------
+  IF (OUTorREST) THEN !OUTorREST=.TRUE.=out_grd FALSE=restart
+    !
+    ! 5.b Initialize and read the first set of fields for base grids
+    !
+    DO IG = 1,NG-1
+      CALL W3SETO( IG, 6, 6)
+      CALL W3IOGO('READ',FIDOUT(IG),IOTST,IG)
+      IF ( IOTST .NE. 0 ) THEN
+        GO TO 2111
+       ENDIF
+    END DO
+    !
+    ! 5.c Setup the output flag options for the target grid
+    !
+    WRITE (NDSO,910)
+    DO I = 1, NOGRP
+      OUTPTS(NG)%OUT1%FLOGRD(I,:) = OUTPTS(1)%OUT1%FLOGRD(I,:)
+      WRITE (NDSO,911) I
+      IF (I.LT.9) THEN
+        WRITE (NDSO, 912) (OUTPTS(NG)%OUT1%FLOGRD(I,J),J=1,NGRPP)
+      ELSE
+        WRITE (NDSO, 913)
       END IF
     END DO
-  END DO
-  WRITE (NDSO, 915)
-  !
-  ! 5.d Carry out interpolation in an infinite loop till appropriate
-  !     time steps are interpolated
-  !
-  IOUT = 0
-  !
-  DO
-    DTEST = DSEC21 ( WDATAS(1)%TIME, TOUT )
-    IF ( DTEST .GT. 0. ) THEN
-      DO IG = 1,NG-1
-        CALL W3IOGO('READ',FIDOUT(IG),IOTST,IG)
-        IF ( IOTST .NE. 0 ) THEN
-          GO TO 2111
-        ENDIF
+    WRITE (NDSO, 915)
+    !
+    !     Print output flags in human readable from. Mark
+    !     groups that do not make sense to interpolate to
+    !     target grid (e.g. Groups 9, 10).
+    !
+    DO I=1, NOGRP
+      DO J=1, NGRPP
+        IF ( OUTPTS(NG)%OUT1%FLOGRD(I,J) ) THEN
+          IF ( I .EQ. 4 .AND. J .EQ. 8 ) THEN
+            WRITE (NDSO, 916) I,IDOUT(I,J), '*** NOT IMPLEMENTED ***'
+            OUTPTS(NG)%OUT1%FLOGRD(I,J) = .FALSE.
+          ELSE IF ( I .LE. 8 ) THEN
+            WRITE (NDSO, 916) I,IDOUT(I,J), ' '
+          ELSE
+            WRITE (NDSO, 916) I,IDOUT(I,J), '*** NOT IMPLEMENTED ***'
+            OUTPTS(NG)%OUT1%FLOGRD(I,J) = .FALSE.
+          END IF
+        END IF
       END DO
-      CYCLE
-    ENDIF
-    IF ( DTEST .LT. 0. ) THEN
+    END DO
+    WRITE (NDSO, 915)
+    !
+    ! 5.d Carry out interpolation in an infinite loop till appropriate
+    !     time steps are interpolated
+    !
+    IOUT = 0
+    !
+    DO
+      DTEST = DSEC21 ( WDATAS(1)%TIME, TOUT )
+      IF ( DTEST .GT. 0. ) THEN
+        DO IG = 1,NG-1
+          CALL W3IOGO('READ',FIDOUT(IG),IOTST,IG)
+          IF ( IOTST .NE. 0 ) THEN
+            GO TO 2111
+          ENDIF
+        END DO
+        CYCLE
+      ENDIF
+      IF ( DTEST .LT. 0. ) THEN
+        CALL TICK21 ( TOUT , DTREQ )
+        CYCLE
+      END IF
+      !
+      IOUT = IOUT + 1
+      CALL STME21 ( TOUT, IDTIME)
+      WRITE (NDSO,914) IDTIME
+      !
+      WDATAS(NG)%TIME = WDATAS(1)%TIME
+      CALL W3SETO(NG, 6, 6)
+      CALL W3SETG(NG, 6, 6)
+      CALL W3SETA(NG, 6, 6)
+      CALL W3SETW(NG, 6, 6)
+      !
+      CALL W3EXGI ( NG-1, NSEA, NOSWLL_MIN, INTMETHOD, OUTorREST,MAPSTA_NG,MAPST2_NG )
+      !
       CALL TICK21 ( TOUT , DTREQ )
-      CYCLE
-    END IF
-    !
-    IOUT = IOUT + 1
-    CALL STME21 ( TOUT, IDTIME)
-    WRITE (NDSO,914) IDTIME
-    !
-    WDATAS(NG)%TIME = WDATAS(1)%TIME
-    CALL W3SETO(NG, 6, 6)
+      IF ( IOUT .GE. NOUT ) EXIT
+    END DO
+    GOTO 2222
+  ! --- if Restart file --------
+  ELSE !OUTorREST=.FALSE. 
+   !
+   ! 5.b Initialize and read the first set of restarts for base grids
+   !
+    DO IG = 1,NG-1
+      WDATAS(IG)%TIME = TOUT
+      CALL W3SETG(IG, 6, 6)
+      CALL W3SETW(IG, 6, 6)
+      CALL W3SETA(IG, 6, 6)
+      CALL W3SETO(IG, 6, 6)
+#ifdef W3_WRST
+      CALL W3DIMI(IG, 6, 6)
+#endif
+      NSEAL=NSEA ! Set for reading restarts 
+
+      !To use an older model version restart file (add a w3iorsold)
+      CALL W3IORSOLD ( 'READ', 56, XXX, INTYPE, IG )
+      !CALL W3IORS ( 'READ', 56, XXX, IG )
+    END DO
+
+    ! 5.d Carry out interpolation
+    WDATAS(NG)%TIME = TOUT
     CALL W3SETG(NG, 6, 6)
-    CALL W3SETA(NG, 6, 6)
     CALL W3SETW(NG, 6, 6)
-    !
-    CALL W3EXGI ( NG-1, NSEA, NOSWLL_MIN, INTMETHOD )
-    !
-    CALL TICK21 ( TOUT , DTREQ )
-    IF ( IOUT .GE. NOUT ) EXIT
-  END DO
-  GOTO 2222
+    CALL W3SETA(NG, 6, 6)
+    CALL W3SETO(NG, 6, 6)
+#ifdef W3_WRST
+    INPUTS(NG)%INFLAGS1(3)=.TRUE.
+    CALL W3DIMI(NG, 6, 6)
+#endif
+
+    CALL W3EXGI ( NG-1, NSEA, NOSWLL_MIN, INTMETHOD, OUTorREST,MAPSTA_NG,MAPST2_NG )
+
+    GOTO 2222
+
+  END IF !OUTorREST
   !
   !---------------------------------------------------------------------------
   ! Escape locations read errors :
@@ -862,15 +940,12 @@ PROGRAM W3GRID_INTERP
 2000 CONTINUE
   WRITE (NDSE,1000) IERR
   CALL EXTCDE ( 1 )
-  !
 2001 CONTINUE
   WRITE(NDSE,1001)
   CALL EXTCDE ( 2 )
-  !
 2002 CONTINUE
   WRITE(NDSE,1002) IERR
   CALL EXTCDE ( 3 )
-  !
 2111 CONTINUE
   WRITE(NDSO,950)
 2222 CONTINUE
@@ -941,7 +1016,8 @@ CONTAINS
   !> @param[in] INTMETHOD
   !> @author A. Chawla @date 22-Mar-2021
   !
-  SUBROUTINE W3EXGI ( NGRD, NSEA, NOSWLL_MIN, INTMETHOD )
+  SUBROUTINE W3EXGI ( NGRD, NSEA, NOSWLL_MIN, INTMETHOD, OUTorRESTflag, &
+                      MAPSTA_NG,MAPST2_NG )
     !/                  +-----------------------------------+
     !/                  | WAVEWATCH-III           NOAA/NCEP |
     !/                  |             A. Chawla             |
@@ -991,7 +1067,8 @@ CONTAINS
     USE W3WDATMD
     USE W3ODATMD, ONLY: NOGE
     USE W3IOGOMD, ONLY: W3IOGO
-    USE W3GDATMD, ONLY: E3DF, NK
+    USE W3GDATMD, ONLY: E3DF, NK, NSPEC
+    USE W3IORSMD, ONLY: W3IORS
     !/ -------------------------------------------------------------------------/
     !/ Parameter List
     !/
@@ -1068,6 +1145,13 @@ CONTAINS
     !/
     LOGICAL       :: ACTIVE
     LOGICAL       :: USEGRID(NGRD)
+    !
+    !variables for restart 
+    LOGICAL                 :: OUTorRESTflag
+    REAL                    :: VAAUX(NSPEC), SUMRES(NSPEC)
+    INTEGER                 :: INTYPE 
+    REAL                    :: XXX
+    INTEGER                 :: MAPSTA_NG(NY,NX),MAPST2_NG(NY,NX)
     !/
     !
     !-------------------------------------------------------------------
@@ -1207,6 +1291,11 @@ CONTAINS
     MSCD     = UNDEF
     QP       = UNDEF
     !
+    ! Restart variables
+    IF (.NOT.(OUTorRESTflag)) THEN
+      VA       = UNDEF
+    ENDIF 
+    !
     !-------------------------------------------------------------------
     ! 2.  Loop through output points
     !
@@ -1263,10 +1352,12 @@ CONTAINS
             IF ( LMAPLND .EQ. 1 ) NMAPLND = NMAPLND + 1
             IF ( LMAPMSK .EQ. 1 ) NMAPMSK = NMAPMSK + 1
           END DO
-          NMAPICE = NMAPICE*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
-          NMAPDRY = NMAPDRY*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
-          NMAPLND = NMAPLND*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
-          NMAPMSK = NMAPMSK*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
+          IF (GR_INTS(ISEA)%IND_WTS(IG)%NP>0) THEN 
+            NMAPICE = NMAPICE*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
+            NMAPDRY = NMAPDRY*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
+            NMAPLND = NMAPLND*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
+            NMAPMSK = NMAPMSK*100/GR_INTS(ISEA)%IND_WTS(IG)%NP
+          ENDIF
           IF ( NMAPICE .GT. 50 ) MAPICET = 1
           IF ( NMAPDRY .GT. 50 ) MAPDRYT = 1
           IF ( NMAPLND .GT. 50 ) MAPLNDT = 1
@@ -1457,6 +1548,16 @@ CONTAINS
             MSCDAUX2    = UNDEF
             QPAUX       = UNDEF
             SUMWT8      = 0
+            ! 
+            ! Restart variables 
+            ! 
+            IF (.NOT.(OUTorRESTflag)) THEN 
+              !If restarts, set all FLOGRD 
+              !to false to avoid unneeded computations 
+              FLOGRD=.FALSE.
+              VAAUX       = UNDEF 
+              SUMRES      = 0
+            ENDIF 
             !
             ! Loop through the points per grid to obtain interpolated values
             !
@@ -2443,6 +2544,21 @@ CONTAINS
                 END IF
               END IF
               !
+              ! Restart variables
+              !
+              IF ( (.NOT.OUTorRESTflag) .AND. ACTIVE ) THEN
+                DO IK = 1,NSPEC
+                  IF ( WDATAS(IGRID)%VA(IK,GSEA) .NE. UNDEF ) THEN
+                    SUMRES(IK) = SUMRES(IK) + WT
+                    IF ( VAAUX(IK) .EQ. UNDEF ) THEN
+                      VAAUX(IK) = WDATAS(IGRID)%VA(IK,GSEA)*WT
+                    ELSE
+                      VAAUX(IK) = VAAUX(IK) +WDATAS(IGRID)%VA(IK,GSEA)*WT
+                    END IF
+                  END IF
+                END DO
+              END IF
+              !
               ! End of loop through the points per grid to obtain interpolated values
             END DO   !/ IPTS = 1, ...
             !
@@ -3300,6 +3416,21 @@ CONTAINS
               QP(ISEA) = QP(ISEA) + QPAUX / REAL( SUMWT8(5)*SUMGRD )
             END IF
             !
+            ! Restart varaibles  
+            ! 
+            IF (.NOT.OUTorRESTflag) THEN
+              DO IK = 1,NSPEC
+                IF ( VAAUX(IK) .NE. UNDEF ) THEN
+                  VAAUX(IK) = VAAUX(IK) / SUMRES(IK)
+                  IF ( VA(IK,ISEA) .EQ. UNDEF )  THEN
+                    VA(IK,ISEA) = VAAUX(IK) / REAL( SUMGRD )
+                  ELSE
+                    VA(IK,ISEA) = VA(IK,ISEA) + VAAUX(IK) / REAL( SUMGRD )
+                  END IF
+                END IF
+              END DO
+            ENDIF 
+            !
           END IF !/ ( USEGRID(IG) )
           !
           ! End of Second loop
@@ -3341,11 +3472,104 @@ CONTAINS
       !
       !/ End of main loop through output points
     END DO   !/ ISEA = 1, NSEA
+
+    ! Check to make sure VA is positive for restart file 
+    ! and do nearest neighbor for points w/out interpolation
+    !
+    IF (.NOT.(OUTorRESTflag)) THEN
+      ALLOCATE( MAPSTATMP(0:(NY+1),0:(NX+1)))
+      ALLOCATE( NOINT2(iNOINT) )
+      MAPSTATMP=0
+      MAPSTATMP(1:NY,1:NX)=MAPSTA          
+
+      iloops=0
+      DO WHILE ( iloops < 6 .AND. iNOINT > 0 ) 
+        iNOINT2=0
+        DO JSEA=1,iNOINT 
+
+          ISEA=NOINT(JSEA) 
+          !look in the box surrounding the point for a 
+          !neighboring point 
+          IX = MAPSF(ISEA,1)
+          IY = MAPSF(ISEA,2)
+
+          IF     ( MAPSTATMP(IY+1,IX)   .EQ. 1 ) THEN 
+            VA(:,ISEA)=VA(:,MAPFS(IY+1,IX))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY,IX+1)   .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY+1,IX)) 
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY-1,IX)   .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY-1,IX))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY,IX-1)   .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY,IX-1))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY+1,IX+1) .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY+1,IX+1))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY-1,IX+1) .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY+1,IX-1))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY-1,IX-1) .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY-1,IX-1))
+            MAPSTATMP(IY,IX)=1
+          ELSEIF ( MAPSTATMP(IY+1,IX-1) .EQ. 1 ) THEN
+            VA(:,ISEA)=VA(:,MAPFS(IY+1,IX-1))
+            MAPSTATMP(IY,IX)=1
+          ELSE 
+            !The immediate box surrounding the point 
+            !has no active sea point
+            iNOINT2=iNOINT2+1
+            NOINT2(iNOINT2)=ISEA
+          ENDIF
+        END DO 
+        iNOINT=iNOINT2
+        NOINT(1:iNOINT2)=NOINT2(1:iNOINT2)
+        iloops=iloops+1 
+      END DO
+
+      DEALLOCATE (NOINT,NOINT2,MAPSTATMP)  
+
+      DO ISEA = 1, NSEA
+        DO IK = 1,NSPEC
+          IF ( VA(IK,ISEA) < 0. ) THEN 
+            VA(IK,ISEA) = 0.
+          END IF
+        END DO
+      END DO
+ 
+      MAPST2=MAPST2_NG
+      MAPSTA=MAPSTA_NG
+
+    END IF !IF (.NOT.(OUTorRESTflag))
+
     !
     !------------------------------------------------------------------------------
     ! 3. Write out interpolated data to target output file
-    !
-    CALL W3IOGO('WRITE',FIDOUT(NG),IOTST,NG)
+    ! 
+    IF (OUTorRESTflag) THEN 
+      CALL W3IOGO('WRITE',FIDOUT(NG),IOTST,NG)
+    ELSE
+      ! A potential future improvement could be to also interpolate other fields 
+      ! in addition to VA for the restart interpolation.  For now these are 
+      ! set to zero.
+      TICE(1)=-1
+      TICE(2)=0
+      TLEV(1)=-1
+      TLEV(2)=0
+      WLV=0.
+      ICE=0.
+      UST=0.
+      USTDIR=0.
+      ASF=0.
+      FPIS=0. 
+#ifdef W3_WRST
+      WXN=0.
+      WYN=0.
+#endif 
+      CALL W3IORS ( 'HOT', 55, XXX, NG) 
+    END IF 
     !
     RETURN
     !


### PR DESCRIPTION
# Pull Request Summary
These are updates needed for HAFSv1 which include: 
* ability to regrid restart files from GFSv16 with ww3_gint 
* fix in ww3_bound needed for BC issue with -180 to 180 v 0 to 360 
* fixes for ci 

## Description
These updates were pulled from an old HWRF branch and have been updated to be used in HAFS.  The updates for ww3_gint will be brought to the develop branch, but the ability to read the GFSv16 restarts in a production branch only update.   The updates for fixing ci were cherry-picked from the develop branch.  The boundary condition fix is needed to properly read in the boundary conditions -- a longer term fix should be investigated to see if this is just a HAFS/HWRF issue or effects others as well.  


### Commit Message
* Do not squash merge as there are 3 separate commits for the 3 items listed above. 


### Check list  

N/A for a  production branch 
 
### Testing

* How were these changes tested? In the HAFS workflow. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) The gint updates will be added to a PR to develop w/a regression test next week. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? No, production workflow is the target here. 