### PR TITLE
HAFSv1: remove overwriting of time0/N for inp file 

### DIFF
--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -1579,7 +1579,7 @@ contains
     fnmpre = './'
 
     call ESMF_LogWrite(trim(subname)//' call read_shel_config', ESMF_LOGMSG_INFO)
-    call read_shel_config(mpi_comm, mds, time0_overwrite=time0, timen_overwrite=timen)
+    call read_shel_config(mpi_comm, mds) ! time0_overwrite=time0, timen_overwrite=timen)
 
     call ESMF_LogWrite(trim(subname)//' call w3init', ESMF_LOGMSG_INFO)
     call w3init ( 1, .false., 'ww3', mds, ntrace, odat, flgrd, flgr2, flgd, flg2, &


### PR DESCRIPTION
# Pull Request Summary
Removes the overwritting of the time0/N for the inp file so that restart start and end strides will be based on values chosen in the ww3_shel.inp file instead of start and end times.  

## Description

This is for the HAFSv1 production branch.  It was requested to not write restarts every 6 hours which takes up extra disk space and possibly could effect computational time as well.  In the mesh cap, the restart start and end times were over-written with start and end times which bypassed the desired restart start and end times.  



### Issue(s) addressed
- fixes #963 

### Commit Message
<!--
HAFSv1: remove overwriting of time0/N for inp file
-->

### Check list  

n/a

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Within HAFS system by @BinLiu-NOAA : The forecast run dir is here on Cactus:
/lfs/h2/emc/ptmp/bin.liu/hafsv1_20230327_hfsa_dev_ww3/2021082712/09L/forecast
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) N/A
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? N/A
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) N/A
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_): N/A

