### PR TITLE
initialize IOBDP for unstructured grid before writing to mod_def

### DIFF
--- a/model/src/w3iogrmd.F90
+++ b/model/src/w3iogrmd.F90
@@ -746,9 +746,10 @@ CONTAINS
              B_JGS_NORM_THR,                                  &
              B_JGS_NLEVEL,                                    &
              B_JGS_SOURCE_NONLINEAR
-        !Init COUNTCON to zero, it needs to be set somewhere or
+        !Init COUNTCON and IOBDP to zero, it needs to be set somewhere or
         !removed
         COUNTCON=0
+        IOBDP=0  
         WRITE (NDSM)                                          &
              X0, Y0, SX, SY, DXYMAX, XGRD, YGRD, TRIGP, TRIA, &
              LEN, IEN, ANGLE0, ANGLE, SI, MAXX, MAXY,         &


### PR DESCRIPTION
# Pull Request Summary
Initialize variable to get reproducible mod_def files for unstructured grids. 

## Description
This PR initializes IOBDP=0 before writing this variable in the mod_def for unstructured grids.   Another option would have been to not write this file in the mod_def, but that's a much more disruptive change, so for now this variable is just initialized to zero before writing.  This does not change answers in model runs. Just allows for the mod_def files to be reproducible. 

Please also include the following information: 
* Add any suggestions for a reviewer @aronroland @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? The mod_def for unstructured grids have differences (these are currently in the known b4b, but after this PR there should be no diffs in mod_defs from run-to-run moving forward). 

### Issue(s) addressed
- fixes #700 

### Commit Message

initialize IOBDP for unstructured grid before writing to mod_def


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Ran the regression tests twice from this branch on hera w/intel 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? yes - hera w/intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.): 

Note the following have differences in the unstructured grid mod_def files (which were a known bug before, but will not have differences moving forward): 


```
ww3_tp2.17/./work_ma                     (1 files differ)
ww3_tp2.17/./work_a                     (1 files differ)
ww3_tp2.17/./work_mc1                     (1 files differ)
ww3_tp2.17/./work_mb                     (1 files differ)
ww3_tp2.17/./work_mc                     (1 files differ)
ww3_tp2.17/./work_ma1                     (1 files differ)
ww3_tp2.17/./work_c                     (1 files differ)
ww3_tp2.17/./work_b                     (1 files differ)
ww3_tp2.19/./work_1B_a                     (1 files differ)
ww3_tp2.19/./work_1A_a                     (1 files differ)
ww3_tp2.19/./work_1C_a                     (1 files differ)
ww3_tp2.6/./work_ST0                     (1 files differ)
ww3_tp2.6/./work_ST4                     (1 files differ)
ww3_tp2.6/./work_pdlib                     (1 files differ)
ww3_ts4/./work_ug_MPI                     (1 files differ)
```


* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (12 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
ww3_ta1/./work_UPD0F_U                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.17/./work_ma                     (1 files differ)
ww3_tp2.17/./work_a                     (1 files differ)
ww3_tp2.17/./work_mc1                     (1 files differ)
ww3_tp2.17/./work_mb                     (1 files differ)
ww3_tp2.17/./work_mc                     (1 files differ)
ww3_tp2.17/./work_ma1                     (1 files differ)
ww3_tp2.17/./work_c                     (1 files differ)
ww3_tp2.17/./work_b                     (1 files differ)
ww3_tp2.19/./work_1B_a                     (1 files differ)
ww3_tp2.19/./work_1A_a                     (1 files differ)
ww3_tp2.19/./work_1C_a                     (1 files differ)
ww3_tp2.6/./work_ST0                     (1 files differ)
ww3_tp2.6/./work_ST4                     (1 files differ)
ww3_tp2.6/./work_pdlib                     (1 files differ)
ww3_ts4/./work_ug_MPI                     (1 files differ)
ww3_ufs1.3/./work_a                     (2 files differ)
```


[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11250368/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11250369/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11250370/matrixDiff.txt)


Note comparing this branch to itself, we then get the following more limited differences: 

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (11 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
ww3_ta1/./work_UPD0F_U                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```


[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11250371/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11250372/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11250373/matrixDiff.txt)

