### PR TITLE
Fix for ww3_ta1 regtest and ww3_from_ftp.sh version echo string

### DIFF
--- a/model/bin/ww3_from_ftp.sh
+++ b/model/bin/ww3_from_ftp.sh
@@ -45,8 +45,8 @@ fi
 
 dir0=$(cd $(dirname $0) > /dev/null && pwd -P)
 ww3dir=$(dirname $(dirname $dir0))
- 
-#Get top level directory of ww3 from user: 
+
+#Get top level directory of ww3 from user:
 echo -e "\n\n This script will download data from the ftp for WAVEWATCH III "
 if [ "$interactive" = "n" ]
 then
@@ -55,19 +55,19 @@ else
 echo -e "Enter the absolute or relative path to the main/top directory, "
 echo -e "this would be '../../' if in the model/bin directory "
 echo -e "or './' if already in the top/main directory:"
-  read ww3dir 
+  read ww3dir
 fi
 
-#Move to top level directory of ww3: 
-cd $ww3dir 
+#Move to top level directory of ww3:
+cd $ww3dir
 
-#Download from ftp and uptar: 
-echo -e "Downloading and untaring file from ftp:" 
+#Download from ftp and uptar:
+echo -e "Downloading and untaring file from ftp:"
 wget --no-check-certificate https://ftp.emc.ncep.noaa.gov/static_files/public/WW3/ww3_from_ftp.${ww3ver}.tar.gz
 tar -xvzf ww3_from_ftp.${ww3ver}.tar.gz
 
 #Move regtest info from data_regtests to regtests:
-echo -e "Moving data from data_regtests to regtests"  
+echo -e "Moving data from data_regtests to regtests"
 cp -r data_regtests/ww3_tp2.18/input/*.nc  regtests/ww3_tp2.18/input/
 cp -r data_regtests/ww3_tp2.15/input/wind.nc  regtests/ww3_tp2.15/input/
 cp -r data_regtests/ww3_tp2.15/input/*.nc  regtests/ww3_tp2.15/input_rho/
@@ -93,7 +93,7 @@ if [ ! -d regtests/ww3_tp2.14/input/oasis3-mct/doc ]
 then
   mkdir regtests/ww3_tp2.14/input/oasis3-mct/doc
 fi
-cp -r data_regtests/ww3_tp2.14/input/oasis3-mct/doc/* regtests/ww3_tp2.14/input/oasis3-mct/doc/ 
+cp -r data_regtests/ww3_tp2.14/input/oasis3-mct/doc/* regtests/ww3_tp2.14/input/oasis3-mct/doc/
 cp -r data_regtests/ww3_tp2.14/input/toy/*.nc.OAS*CM regtests/ww3_tp2.14/input/toy/
 cp -r data_regtests/ww3_tp2.14/input/toy/r-toy.nc.OASACM regtests/ww3_tp2.14/input/toy/r-toy.nc.OASACM2
 cp -r data_regtests/ww3_tp2.14/input/toy/toy_coupled_field.nc.OASACM regtests/ww3_tp2.14/input/toy/toy_coupled_field.nc.OASACM2
@@ -110,7 +110,7 @@ cp -r data_regtests/ww3_ufs1.1/input_unstr/*     regtests/ww3_ufs1.1/input_unstr
 cp -r data_regtests/ww3_ufs1.1/input/*.nc  regtests/ww3_ufs1.2/input/
 cp -r data_regtests/ww3_ufs1.2/input/*     regtests/ww3_ufs1.2/input/
 cp -r data_regtests/ww3_ufs1.3/input/*nc   regtests/ww3_ufs1.3/input/
-#Do you want to clean up (aka delete tar file, delete the data_regtests directory) 
+#Do you want to clean up (aka delete tar file, delete the data_regtests directory)
 echo -e "\n\n Do you want to delete the tar file ww3_from_ftp.${ww3ver}.tar.gz [y|n]: "
 if [ "$interactive" = "n" ]
 then
@@ -120,10 +120,10 @@ else
 fi
 if [ "${keep}" = "N" ] || [ "${keep}" = "n" ]
 then
-  echo -e '\n Deleting tar file ww3_from_ftp.${ww3ver}.tar.gz'
+  echo -e "\n Deleting tar file ww3_from_ftp.${ww3ver}.tar.gz"
   rm ww3_from_ftp.${ww3ver}.tar.gz
 else
-  echo -e ' Not deleting tar file.' 
+  echo -e ' Not deleting tar file.'
 fi
 
 echo -e "\n\n Files were copied from the data_regtests to the regtests folder."
@@ -139,9 +139,9 @@ then
   echo -e '\n Deleting the data_regtests folder'
   rm -rf data_regtests
 else
-  echo -e ' Not deleting the data_regtests folder.' 
+  echo -e ' Not deleting the data_regtests folder.'
 fi
 
-#move back to original directory: 
+#move back to original directory:
 cd $curr_dir
 echo -e "End of ww3_from_ftp.sh"

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -7,7 +7,7 @@
 # --------------------------------------------------------------------------- #
 #    Modification history
 #    27-Jan-2014 : Adapts ww3_ounf section for multigrid            ( version 4.18 )
-#    04-May-2020 : F. Ardhuin added step 3.b2 for CDL input files   ( version 7.12 ) 
+#    04-May-2020 : F. Ardhuin added step 3.b2 for CDL input files   ( version 7.12 )
 #    20-Apr-2021 : A. Abdolali added ww3_grib bulid and execution   ( version 7.12 )
 #    21-May-2021 : C. Bunney add support for ALPS job placement     ( version 7.12 )
 #
@@ -19,8 +19,8 @@
 #    to the grdset file.
 #  - When running through ww3_prep, run_test is not smart enough to process
 #    multiple input files of the same type. For example, for wind it wants
-#    a file ww3_prep_wind.inp and does not know what to do if you have two 
-#    files, ww3_prep_wind_hwna_15m.inp and ww3_prep_wind_gfs_30m.inp. 
+#    a file ww3_prep_wind.inp and does not know what to do if you have two
+#    files, ww3_prep_wind_hwna_15m.inp and ww3_prep_wind_gfs_30m.inp.
 #    It needs to rename wind.ww3 as wind.wind_gfs_30m, for example, but
 #    looks for wind_gfs_30m.ww3 where it should look for wind.ww3. Another
 #    loop is needed to make this work.
@@ -173,8 +173,8 @@ then
   usage
   exit 1
 fi
-#uncomment next line to add S & T switches to every test 
-#testST=1  
+#uncomment next line to add S & T switches to every test
+#testST=1
 if [ ! $exec_p = "none" ]
 then
   exit_p=$exec_p
@@ -332,7 +332,7 @@ then
     then
       rstgl_grids="`awk '/^RSTGL:/' $path_i/$grdset | sed 's/RSTGL\://'`"
       rstgl_gint="true"
-    else 
+    else
       rstgl_grids=""
       rstgl_gint="false"
     fi
@@ -382,7 +382,7 @@ then # Add time counter if -T
 fi
 
 # --------------------------------------------------------------------------- #
-# Build all executables 
+# Build all executables
 # --------------------------------------------------------------------------- #
 
 if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
@@ -398,7 +398,7 @@ then
 fi
 
 cd $path_s
-cd ../ 
+cd ../
 path_cmake="`pwd`"
 
 path_e=$path_w/exe
@@ -408,24 +408,24 @@ ofile=$path_w/build.log
 
 echo "   Building WW3, exes will be in $path_e"
 
-echo "Exe directory is $path_e" > $ofile 
+echo "Exe directory is $path_e" > $ofile
 path_build_root=${path_build_root:-$path_w/build}
 if [ $force_shrd ]
-then 
+then
 
   # build pre- & post-processing programs with SHRD only
   echo "Forcing a SHRD build" >> $ofile
   path_build=${path_build_root}_SHRD
   mkdir -p $path_build
   cd $path_build
-  if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ; 
-  then 
+  if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ;
+  then
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                   sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
                   sed 's/B4B //'     | sed 's/METIS //' | \
                   sed 's/SCOTCH //' > $path_build/switch
-  else 
+  else
     cat $file_c | sed 's/DIST/SHRD/' | sed 's/MPI //'   | \
                   sed 's/OMPG //'    | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
@@ -433,7 +433,7 @@ then
                   sed 's/SCOTCH //' >  $path_build/switch
   fi
 
-  echo "Switch file is $path_build/switch with switches:" >> $ofile 
+  echo "Switch file is $path_build/switch with switches:" >> $ofile
   cat $path_build/switch >> $ofile
   cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1
   rc=$?
@@ -442,32 +442,32 @@ then
     echo "The build log is in $ofile"
     exit
   fi
-  make -j 8 > $ofile 2>&1 
+  make -j 8 > $ofile 2>&1
   rc=$?
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in make."
     echo "The build log is in $ofile"
     exit
   fi
-  make install > $ofile 2>&1 
+  make install > $ofile 2>&1
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in make install."
     echo "The build log is in $ofile"
     exit
   fi
 
-  cp $path_build/install/bin/* $path_e/ 
-  
-  if [ $pomp ] || [ $nproc ] 
-  then 
+  cp $path_build/install/bin/* $path_e/
+
+  if [ $pomp ] || [ $nproc ]
+  then
     echo "non-SHRD build" >> $ofile
-    #build without SHRD 
-    path_build=${path_build_root} 
+    #build without SHRD
+    path_build=${path_build_root}
     mkdir -p $path_build
     cd $path_build
     \cp -f $file_c $path_build/switch
-    echo "Switch file is $path_build/switch with switches:" >> $ofile 
-    cat $path_build/switch >> $ofile  
+    echo "Switch file is $path_build/switch with switches:" >> $ofile
+    cat $path_build/switch >> $ofile
     cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile  2>&1
     rc=$?
     if [[ $rc -ne 0 ]] ; then
@@ -475,13 +475,13 @@ then
       echo "The build log is in $ofile"
       exit
     fi
-    make -j 8 > $ofile 2>&1 
+    make -j 8 > $ofile 2>&1
     if [[ $rc -ne 0 ]] ; then
       echo "Fatal error in make."
       echo "The build log is in $ofile"
       exit
     fi
-    make install > $ofile 2>&1 
+    make install > $ofile 2>&1
     if [[ $rc -ne 0 ]] ; then
       echo "Fatal error in make install."
       echo "The build log is in $ofile"
@@ -492,15 +492,15 @@ then
     cp $path_build/install/bin/ww3_multi $path_e/
     cp $path_build/install/bin/ww3_systrk $path_e/
     cp $path_build/install/bin/ww3_prtide $path_e/
-  fi 
+  fi
 else
   path_build=${path_build_root}
   mkdir -p $path_build
   cd $path_build
-  if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ; 
+  if [[ "$outopt" = "all" ]] || [[ "$outopt" = "grib" ]] ;
   then
-    cat $file_c | sed 's/NOGRB/NCEP2/' > $path_build/switch 
-  else 
+    cat $file_c | sed 's/NOGRB/NCEP2/' > $path_build/switch
+  else
     \cp -f $file_c $path_build/switch
   fi
   echo "Switch file is $path_build/switch with switches:" >> $ofile
@@ -512,13 +512,13 @@ else
     echo "The build log is in $ofile"
     exit
   fi
-  make -j 8 > $ofile 2>&1 
+  make -j 8 > $ofile 2>&1
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in make."
     echo "The build log is in $ofile"
     exit
   fi
-  make install > $ofile 2>&1 
+  make install > $ofile 2>&1
   if [[ $rc -ne 0 ]] ; then
     echo "Fatal error in make install."
     echo "The build log is in $ofile"
@@ -537,7 +537,7 @@ then # Add time counter if -T
   cumult_comp=`echo "$Maketime + $cumult_comp" | bc`
   printf "\n %8.2f sec compile time" $Maketime  >> time_count.txt
 fi
- 
+
 # --------------------------------------------------------------------------- #
 # 3. Execute Test                                                             #
 # --------------------------------------------------------------------------- #
@@ -707,15 +707,15 @@ then
       errmsg "$path_e/$prog not found"
       exit 1
     fi
-  
+
     for g in $model_grids
     do
-  
+
       if [ $multi -eq 2 ]
       then
         gu="_$g"
       fi
-  
+
       # link conf file
       if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
       then
@@ -727,21 +727,21 @@ then
         \ln -s $ifile $prog.inp
         ofile="$path_w/`basename $ifile .inp`${gu}.out"
       fi
-  
+
       echo "   Processing $ifile"
       echo "   Screen output routed to $ofile"
-  
+
       if [ $multi -eq 2 ]
       then
         \rm -f mod_def.ww3
         \ln -s mod_def.$g mod_def.ww3
       fi
-  
+
       if [ $time_count ]
       then # Add time counter if -T
         Tstart=`date +"%s.%2N"`
       fi
-  
+
       if $path_e/$prog > $ofile
       then
         \rm -f $prog.inp
@@ -759,7 +759,7 @@ then
         errmsg "Error occured during $path_e/$prog execution"
         exit 1
       fi
-  
+
       if [ $time_count ]
       then # Add time counter if -T
         Tend=`date +"%s.%2N"`
@@ -767,11 +767,11 @@ then
         cumult_run=`echo "$Maketime + $cumult_run" | bc`
         printf "\n $prog \n %8.2f sec run time \n" $Maketime >> time_count.txt
       fi
-  
+
     done
-  
+
   fi
-  
+
 fi
 
 if [ $exit_p = $prog ]
@@ -795,26 +795,26 @@ then
 
   if [ $? = 0 ]
   then
-  
+
     echo ' '
     echo '+---------------------+'
     echo '| Boundary conditions |'
     echo '+---------------------+'
     echo ' '
-  
+
     if [ ! -f $path_e/$prog ]
     then
       errmsg "$path_e/$prog not found"
       exit 1
     fi
-  
+
     for g in $model_grids
     do
       if [ $multi -eq 2 ]
       then
         gu="_$g"
       fi
-  
+
       # link conf file
       if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
       then
@@ -826,21 +826,21 @@ then
         \ln -s $ifile $prog.inp
         ofile="$path_w/`basename $ifile .inp`${gu}.out"
       fi
-  
+
       echo "   Processing $ifile"
       echo "   Screen output routed to $ofile"
-  
+
       if [ $multi -eq 2 ]
       then
         \rm -f mod_def.ww3
         \ln -s mod_def.$g mod_def.ww3
       fi
-      
+
       if [ $time_count ]
       then # Add time counter if -T
         Tstart=`date +"%s.%2N"`
       fi
-  
+
       if $path_e/$prog > $ofile
       then
         \rm -f $prog.inp
@@ -858,7 +858,7 @@ then
         errmsg "Error occured during $path_e/$prog execution"
         exit 1
       fi
-  
+
       if [ $time_count ]
       then # Add time counter if -T
         Tend=`date +"%s.%2N"`
@@ -866,9 +866,9 @@ then
         cumult_run=`echo "$Maketime + $cumult_run" | bc`
         printf "\n $prog \n %8.2f sec run time \n" $Maketime >> time_count.txt
       fi
-  
+
     done
-  
+
   fi
 
 fi
@@ -891,10 +891,10 @@ then
   else
     ifile="`ls $path_i/$prog.inp 2>/dev/null`"
   fi
-  
+
   if [ $? = 0 ]
   then
-  
+
     echo ' '
     echo '+---------------------+'
     echo '| Boundary conditions |'
@@ -906,14 +906,14 @@ then
       errmsg "$path_e/$prog not found"
       exit 1
     fi
-  
+
     for g in $model_grids
     do
       if [ $multi -eq 2 ]
       then
         gu="_$g"
       fi
-  
+
       # link conf file
       if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
       then
@@ -925,16 +925,16 @@ then
         \ln -s $ifile $prog.inp
         ofile="$path_w/`basename $ifile .inp`${gu}.out"
       fi
-  
+
       echo "   Processing $ifile"
       echo "   Screen output routed to $ofile"
-  
+
       if [ $multi -eq 2 ]
       then
         \rm -f mod_def.ww3
         \ln -s mod_def.$g mod_def.ww3
       fi
-  
+
       if [ $time_count ]
       then # Add time counter if -T
         Tstart=`date +"%s.%2N"`
@@ -957,7 +957,7 @@ then
         errmsg "Error occured during $path_e/$prog execution"
         exit 1
       fi
-  
+
       if [ $time_count ]
       then # Add time counter if -T
         Tend=`date +"%s.%2N"`
@@ -965,9 +965,9 @@ then
         cumult_run=`echo "$Maketime + $cumult_run" | bc`
         printf "\n $prog \n %8.2f sec run time \n" $Maketime >> time_count.txt
       fi
-  
+
     done
-  
+
   fi
 
 fi
@@ -1007,12 +1007,12 @@ then
 
     for g in $input_grids
     do
-  
+
       if [ $multi -eq 2 ]
       then
         gu="_$g"
       fi
-  
+
       for ifile in $inputs
       do
 
@@ -1061,7 +1061,7 @@ then
           errmsg "Error occured during $path_e/$prog execution"
           exit 1
         fi
-  
+
         if [ $time_count ]
         then # Add time counter if -T
           Tend=`date +"%s.%2N"`
@@ -1153,16 +1153,16 @@ then
           otype="`basename $ifile .inp | sed s/^${prog}_// | sed s/^${g}_//`"
           ofile="$path_w/`basename $ifile .inp`.out"
         fi
-  
+
         echo "   Processing $ifile"
         echo "   Screen output routed to $ofile"
-  
+
         if [ $multi -eq 2 ]
         then
           \rm -f mod_def.ww3
           \ln -s mod_def.$g mod_def.ww3
         fi
-  
+
         if [ $time_count ]
         then # Add time counter if -T
           Tstart=`date +"%s.%2N"`
@@ -1236,7 +1236,7 @@ then
       if [ $nproc ]
       then
         if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
-        then 
+        then
           runprog="$runprog -n $nproc"
         else
           runprog="$runprog -np $nproc"
@@ -1274,10 +1274,10 @@ then
           otype="`basename $ifile .inp | sed s/^${prog}_//`"
           ofile="$path_w/`basename $ifile .inp`.out"
         fi
-  
+
         echo "   Processing $ifile"
         echo "   Screen output routed to $ofile"
-  
+
         if [ $multi -eq 2 ]
         then
           \rm -f mod_def.ww3
@@ -1285,7 +1285,7 @@ then
         fi
 
         mv $otype.ww3 $otype.ww3_tide
-  
+
         if [ $time_count ]
         then # Add time counter if -T
           Tstart=`date +"%s.%2N"`
@@ -1333,7 +1333,7 @@ fi
 # 3.f Main program ---------------------------------------------------------- #
 
 if [ -e $path_i/bottomspectrum.inp ]
-then  
+then
   cp $path_i/bottomspectrum.inp .
 fi
 
@@ -1384,7 +1384,7 @@ then
       \ln -s $ifile
     fi
   fi
-  
+
 # config filename - gridset option (eq 2)
   if [ $multi -eq 2 ]
   then
@@ -1392,7 +1392,7 @@ then
   else
     fileconf="${prog}"
   fi
-  
+
 # select inp/nml files
   if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
   then
@@ -1400,17 +1400,17 @@ then
   else
     ifile="`ls $path_i/${fileconf}.inp 2>/dev/null`"
   fi
-  
-  
+
+
   if [ $? = 0 ]
   then
-  
+
     echo ' '
     echo '+--------------------+'
     echo '|    Main program    |'
     echo '+--------------------+'
     echo ' '
-  
+
     if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
     then
       if make -C $path_s/esmf $prgb
@@ -1420,15 +1420,15 @@ then
         exit 1
       fi
     fi
-  
+
     if [ ! -f $path_e/$prgb ]
     then
       errmsg "$path_e/$prgb not found"
       exit 1
     fi
-  
+
     ofile="$path_w/$prog.out"
-  
+
     if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
     then
       \rm -f $prog.nml
@@ -1437,7 +1437,7 @@ then
       \rm -f $prog.inp
       \ln -s $ifile $prog.inp
     fi
-  
+
     if [ $multi -ge 1 ] && [ $coupl = "ESMF" ]
     then
       \rm -f PET*.ESMF_LogFile
@@ -1454,7 +1454,7 @@ then
         echo "pet_count: 1" >> ww3_esmf.rc
       fi
     fi
-  
+
     echo "   Processing $ifile"
     echo "   Screen output copied to $ofile"
 
@@ -1464,7 +1464,7 @@ then
       if [ $nproc ]
       then
         if [ $batchq = "slurm" ] || [ $batchq = "alps" ]
-        then 
+        then
           runprog="$runprog -n $nproc"
         else
           runprog="$runprog -np $nproc"
@@ -1489,12 +1489,12 @@ then
         export OMP_NUM_THREADS=$nproc
       fi
     fi
-  
+
     if [ $time_count ]
     then # Add time counter if -T
       Tstart=`date +"%s.%2N"`
     fi
-  
+
     if [ $multi -eq 0 ] && [ $coupl = "OASIS" ]
     then
       halfnproc=$(($nproc / 2))
@@ -1583,14 +1583,14 @@ then
     echo '+-------------------------+'
     echo ' '
 
-    #if rstgl_gint is set to true copy over restart files (assume its restart001)  
+    #if rstgl_gint is set to true copy over restart files (assume its restart001)
     if [ $rstgl_gint = "true" ]
-    then 
-       for gname in $model_grids      
-       do 
-         cp restart001.$gname restart.$gname 
-       done 
-    fi 
+    then
+       for gname in $model_grids
+       do
+         cp restart001.$gname restart.$gname
+       done
+    fi
 
     if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
     then
@@ -1691,7 +1691,7 @@ do
       echo "$rline"
       echo '+--------------------+'
       echo ' '
-    
+
       if [ ! -f $path_e/$prog ]
       then
         errmsg "$path_e/$prog not found"
@@ -1763,7 +1763,7 @@ do
                 echo "   GRIB output files moved to $g.grb2"
               fi
             fi
-       
+
         else
             errmsg "Error occured during $path_e/$prog execution"
         fi
@@ -1789,7 +1789,7 @@ do
           echo "   Processing $ifile"
           echo "   Screen output routed to $ofile"
 
- 
+
           if [ $multi -eq 2 ]
           then
             \rm -f mod_def.ww3
@@ -1809,7 +1809,7 @@ do
         if [ $prog == 'ww3_ounf' ] && [ ! -z ${path_i}/ounfmeta.inp ]; then
            ln -sf ${path_i}/ounfmeta.inp .
         fi
-    
+
         if $path_e/$prog > $ofile
           then
             \rm -f $prog.inp
@@ -1871,7 +1871,7 @@ do
             printf "\n $prog \n %8.2f sec run time \n" $Maketime >> time_count.txt
           fi
 
-       
+
         done
         fi
 
@@ -1948,7 +1948,7 @@ do
 
         for ifile in $inputs
         do
-    
+
           # link conf file
           if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
           then
@@ -1965,7 +1965,7 @@ do
 
           echo "   Processing $ifile"
           echo "   Screen output routed to $ofile"
-    
+
           if [ $multi -eq 2 ]
           then
             \rm -f mod_def.ww3
@@ -2058,10 +2058,10 @@ do
         errmsg "$path_e/$prog not found"
         exit 1
       fi
-    
+
       for g in $point_grids
       do
-    
+
         if [ $multi -eq 2 ]
         then
           if [ ! -e track_o.$g ]
@@ -2073,7 +2073,7 @@ do
         else
           fileconf="$prog"
         fi
-  
+
 # select inp/nml files
         if [ $nml_input ] && [ ! -z "`ls ${path_i}/${fileconf}.nml 2>/dev/null`" ]
         then
@@ -2101,7 +2101,7 @@ do
           otype="`basename $ifile .inp | sed s/^${prog}_//`"
           ofile="$path_w/`basename $ifile .inp`.out"
         fi
-    
+
         echo "   Processing $ifile"
         echo "   Screen output routed to $ofile"
 
@@ -2133,7 +2133,7 @@ do
             elif [ -e track.nc ]
             then
               mv track.nc track_$g.nc
-            fi        
+            fi
           fi
         else
           errmsg "Error occured during $path_e/$prog execution"
@@ -2265,9 +2265,9 @@ then
     echo '|   Update Restart File   |'
     echo '+-------------------------+'
     echo ' '
-  
+
 # link conf file
-    if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ] 
+    if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
     then
       \rm -f $prog.nml
       \ln -s $ifile $prog.nml
@@ -2277,14 +2277,14 @@ then
       \ln -s $ifile $prog.inp
       ofile="$path_w/`basename $ifile .inp`.out"
     fi
-  
+
     echo "   Processing $ifile"
     echo "   Screen output copied to $ofile"
-    
+
 # Additional Files
      \rm -f anl.grbtxt
-     \ln -s "$path_i/anl.grbtxt" anl.grbtxt
-     
+     [[ -f $path_i/anl.grbtxt ]] && \ln -s "$path_i/anl.grbtxt" anl.grbtxt
+
      mv -f restart001.ww3 restart.ww3
 
      runprog=$runcmd
@@ -2304,7 +2304,7 @@ then
      then # Add time counter if -T
        Tstart=`date +"%s.%2N"`
      fi
-  
+
      if $runprog $path_e/$prog | tee $ofile
      then
        \rm -f $prog.inp
@@ -2320,9 +2320,9 @@ then
       cumult_run=`echo "$Maketime + $cumult_run" | bc`
       printf "\n $prog \n %8.2f sec run time \n" $Maketime >> time_count.txt
     fi
-  
+
   fi
-  
+
 fi
 
 if [ $exit_p = $prog ]
@@ -2338,7 +2338,7 @@ then
 fi
 
 if [ $time_count ]
-then # Export cumultive time if time_count  
+then # Export cumultive time if time_count
   printf "\n\n Total compile time: %8.2f sec" $cumult_comp >> time_count.txt
   printf "\n Total run time    : %8.2f sec" $cumult_run >> time_count.txt
   printf "\n" >> time_count.txt
@@ -2356,4 +2356,3 @@ echo ' '
 # --------------------------------------------------------------------------- #
 # End of script                                                               #
 # --------------------------------------------------------------------------- #
-


### PR DESCRIPTION
# Pull Request Summary
A fix for the `ww3_ta1` result from `matrix.comp`, additionally a fix for `ww3_from_ftp.sh` output.


## Description
Two small fixes:
* A fix for regtest `ww3_ta1` result from `matrix.comp` that `0 files differ`.  This problem occurs when `run_cmake_test` tries to create soft link from a file in the `input/` directory, to the `work/` directory.  However, the file it's trying to link (`anl.grbtxt`) does not exist in the `input` directory, so the `work/` directory then contains a broken link to this file.  When `matrix.comp` is executed, it finds this broken link in the respective `work/` directories and leads to the `0 files differ` result.  The solution is a one-line fix to only link this file if it exist in `input/`.
* A fix for the data download script, `ww3_from_ftp.sh`.  Near the end of this script, text including a shell variable is enclosed in single quotes (`' '`) for an `echo`, which does not evaluate the variable when printed to the screen.  This is fixed by switching to double quotes (`" "`) to allow for shell variable evaluation.
* _Note:  There are a number of whitespace changes because my text editor is set to automatically strip it out. Aside from these, there is only a one-line change in each file for this PR._
  * `run_cmake_test`: https://github.com/MatthewMasarik-NOAA/WW3/blob/dc8368d7c8d10b716f111da8230a046d1b9f996c/regtests/bin/run_cmake_test#L2286 
  * `ww3_from_ftp.sh`: https://github.com/MatthewMasarik-NOAA/WW3/blob/dc8368d7c8d10b716f111da8230a046d1b9f996c/model/bin/ww3_from_ftp.sh#L123

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR?
  * No answers will change.

### Issue(s) addressed
* NA

### Commit Message
Fix '0 files differ' and ww3_from_ftp.sh file version string

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * By running the full matrix of regression tests for: `intel`/`hera`
    *  vs. develop:   to confirm answers are not changing
    *  vs. itself:   to confirm `ww3_ta1` fix.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No. These are changes to scripts (`ww3_from_ftp.sh`, and `run_cmake_test`) outside the F90 source. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  `hera`, `intel`.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Only the known non-b4b, with the regtest `ww3_ta1`, no longer a non-identical. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):


#### vs. develop
```
**********************************************************************                              
********************* non-identical cases ****************************                              
**********************************************************************                              
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)                                  
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)                             
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)                              
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)                              
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)                            
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)                                
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)                          
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)                           
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)                            
mww3_test_03/./work_PR2_UQ_MPI_d2                     (13 files differ)                             
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)                               
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)                             
ww3_ta1/./work_UPD0F_U                     (0 files differ)                                         
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)                                     
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)                                     
ww3_ufs1.3/./work_a                     (3 files differ)                                            
                                                                                                    
**********************************************************************                              
************************ identical cases *****************************                              
**********************************************************************
```
[dev.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11298153/dev.matrixCompSummary.txt)
[dev.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11298152/dev.matrixCompFull.txt)
[dev.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11298151/dev.matrixDiff.txt)
<br>


#### vs. itself
```
**********************************************************************                              
********************* non-identical cases ****************************                              
**********************************************************************                              
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)                                  
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)                             
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)                              
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)                              
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)                             
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)                                 
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (13 files differ)                          
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)                           
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)                            
mww3_test_03/./work_PR2_UQ_MPI_d2                     (14 files differ)                             
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)                               
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)                             
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)                                     
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)                                     
ww3_ufs1.3/./work_a                     (3 files differ)                                            
                                                                                                    
**********************************************************************                              
************************ identical cases *****************************                              
**********************************************************************
```
[fix.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11298163/fix.matrixCompSummary.txt)
[fix.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11298161/fix.matrixCompFull.txt)
[fix.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11298162/fix.matrixDiff.txt)
