### PR TITLE
apply patch for reported issue #967

### DIFF
--- a/model/src/w3profsmd.F90
+++ b/model/src/w3profsmd.F90
@@ -1266,7 +1266,7 @@ CONTAINS
       DO IBI=1, NBI
         IP    = MAPSF(ISBPI(IBI),1)
         AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-             *IOBPA(IP)*(1-IOBPD(ITH,IP)) / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+             *IOBPA(IP)*IOBPD(ITH,IP) / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
       END DO
     END IF
 


### PR DESCRIPTION
# Pull Request Summary
Pull request generated by invitation of https://github.com/aronroland for revision to address issue reported at https://github.com/NOAA-EMC/WW3/issues/967

## Description
Fix inverted logic, multiplying by (1-IOBPD(ITH,IP)) rather than IOBPD(ITH,IP) in subroutine W3XYPFSNIMP of the file w3profsmd.F90.

### Issue(s) addressed
When running an unstructured mesh using the implicit-n solver and providing with boundary input, the routine W3XYPFSNIMP clears the boundary input.

### Commit Message
Simple logic fix for time interpolation of boundary nodes at the end of W3XYPFSNIMP.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

