### PR TITLE
Orion module update and typo fixes

### DIFF
--- a/model/src/w3profsmd.F90
+++ b/model/src/w3profsmd.F90
@@ -681,7 +681,7 @@ CONTAINS
         IF (REFPARS(3).LT.0.5.AND.IOBPD(ITH,IP).EQ.0.AND.IOBPA(IP).EQ.0) THEN
           U(IP) = AC(IP) ! restores reflected boundary values
         ENDIF
-#endif^
+#endif
       END DO
       ! update spectrum
       AC = U

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -1424,7 +1424,7 @@ CONTAINS
 #ifdef W3_PDLIB
       IF (B_JGS_LIMITER_FUNC == 2) THEN
         DO IK=1, NK
-          JAC      = CG1(IK)/CLATSL 
+          JAC      = CG1(IK)/CLATSL
           JAC2     = 1./TPI/SIG(IK)
           FRLOCAL  = SIG(IK)*TPIINV
 #ifdef W3_ST6
@@ -1449,7 +1449,7 @@ CONTAINS
 #ifdef W3_ST6
         VS(IS) = VS(IS) + VSWL(IS)
 #endif
-#ifndef W3_PDLIB 
+#ifndef W3_PDLIB
 #ifdef W3_TR1
         VS(IS) = VS(IS) + VSTR(IS)
 #endif
@@ -1491,8 +1491,8 @@ CONTAINS
 #endif
       END DO  ! end of loop on IS
 
-      !VD = 0 
-      !VS = 0 
+      !VD = 0
+      !VS = 0
       !
       DT     = MAX ( 0.5, DT ) ! The hardcoded min. dt is a problem for certain cases e.g. laborotary scale problems.
       !
@@ -1702,7 +1702,8 @@ CONTAINS
         RETURN ! return everything is done for the implicit ...
 
       END IF ! srce_imp_pre
-#endif !W3_PDLIB
+!W3_PDLIB
+#endif
       !
 #ifdef W3_T
       WRITE (NDST,9040) DTRAW, DT, SHAVE
@@ -1736,7 +1737,7 @@ CONTAINS
           eInc1 = VDTR(IS) * DT / MAX ( 1. , (1.-HDT*VDTR(IS)))
           SPEC(IS) = MAX ( 0. , SPEC(IS)+eInc1 )
         END DO
-#endif 
+#endif
 
 #ifdef W3_DEBUGSRC
         IF (IX == DEBUG_NODE) WRITE(44,'(1EN15.4)') SUM(VSIN)
@@ -2257,7 +2258,7 @@ CONTAINS
     IF (IX .eq. DEBUG_NODE) THEN
       WRITE(740+IAPROC,*) '5 : sum(SPEC)=', sum(SPEC)
     END IF
-#endif 
+#endif
 
 #ifdef W3_REF1
     IF (REFLEC(1).GT.0.OR.REFLEC(2).GT.0.OR.(REFLEC(4).GT.0.AND.BERG.GT.0)) THEN

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -74,7 +74,7 @@ EOF
     batchq='slurm'
     basemodcomp='intel/2022.1.2'
     basemodmpi='impi/2022.1.2'
-    hpcstackpath='/work/noaa/epic-ps/hpc-stack/libs/intel/2022.1.2/modulefiles/stack'
+    hpcstackpath='/work/noaa/epic-ps/role-epic-ps/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
     hpcstackversion='hpc/1.2.0'
     modcomp='hpc-intel/2022.1.2'
     modmpi='hpc-impi/2022.1.2'


### PR DESCRIPTION
# Pull Request Summary
Update to `orion` `intel` module path and two typo corrections.

## Description
This PR combines:
  * Update the `module use` path for `orion.intel` regtests to the current path in the ufs-weather-model modulefiles (https://github.com/ufs-community/ufs-weather-model/blob/2cf22273c7eedd6b6b7a0137143a65d675b507cf/modulefiles/ufs_orion.intel.lua#L11).  This fixes the 'hanging' behavior that was recently being observed during regtests on `orion` (see logs below).
  * Two typo corrections submitted by @jcwarner-usgs (issue #1006).
  * _Note: some whitespace has been auto-removed by my text editor_.
* Is a change of answers expected from this PR?
  * No.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Co-author
  * @jcwarner-usgs 
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR? 
  * No.

### Issue(s) addressed
- fixes #1006

### Commit Message
Update to `orion` `intel` module path and two typo corrections.

### Check list  
- [x] Branch is p to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * `intel` regression test matrix run on `orion`, and `hera`.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No changes.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes. `orion.intel`, `hera.intel`.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Only the known non-b4b differences were found.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * Matrix regression tests were run for three cases:
    1. `develop` - tests in `matrix01`, `matrix02`, `matrix03` all hung in regression tests at runtime.  This is the 'hanging' behavior that had been observed recently.  The `cat` of these outfiles are posted here to show they each timed out after 8 hours (for reference `matrix04`--`matrix13` finished in < 3 hours), along with runs for 'fix1' and 'fix2', which did not hang.
    2. 'fix1' - no hanging observed.
    3. 'fix2' - identical test to 'fix1'.  This run was done to be able to confirm the fix for the 'hanging' in more than one run, and to confirm no answer changes between runs (`matrix.comp`).  
     * [orion.dev.matrix01-03.out.txt](https://github.com/NOAA-EMC/WW3/files/11509040/orion.dev.matrix01-03.out.txt)
      * [orion.fix1.matrix01-03.out.txt](https://github.com/NOAA-EMC/WW3/files/11509039/orion.fix1.matrix01-03.out.txt)
      * [orion.fix2.matrix01-03.out.txt](https://github.com/NOAA-EMC/WW3/files/11509038/orion.fix2.matrix01-03.out.txt)
     
  * `orion` `matrix.comp` for 'fix1' vs. 'fix2'.
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (17 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.14/./work_OASACM4                     (1 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

  * [orion.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11509094/orion.matrixCompSummary.txt)
  * [orion.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11509095/orion.matrixCompFull.txt)
  * [orion.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11509092/orion.matrixDiff.txt)



  * _note:  `orion` at times has flakey behavior.  The appearance of `ww3_tp2.14/./work_OASACM4` in the list above is for a text log file, `OUTPUT_TOY.txt`, which contains an extra record.  This is benign and is seen from time to time.  The same regtests done on `hera` confirm this.  In the `matrixCompSummary.txt` below this record is not present._
  
     * `hera` `matrix.comp` for 'develop' vs. 'fix'.
```
**********************************************************************          
********************* non-identical cases ****************************          
**********************************************************************          
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)          
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)           
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)          
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)         
mww3_test_03/./work_PR1_MPI_d2                     (9 files differ)             
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)      
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)       
mww3_test_03/./work_PR3_UNO_MPI_d2                     (13 files differ)        
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)         
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)           
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)        
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)         
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)                 
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)                 
ww3_ufs1.3/./work_a                     (3 files differ)                        
                                                                                
**********************************************************************          
************************ identical cases *****************************          
**********************************************************************
```
  * [hera.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11509217/hera.matrixCompSummary.txt)
   * [hera.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11509218/hera.matrixCompFull.txt)
   * [hera.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11509216/hera.matrixDiff.txt)