### PR TITLE
Increase valid_max for f in ounp

### DIFF
--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -3356,7 +3356,7 @@ CONTAINS
       IRET=NF90_PUT_ATT(NCID,VARID(12),'scale_factor',1.)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'add_offset',0.)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_min',0.)
-      IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_max',1.E20)
+      IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_max',1000.)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'_FillValue',NF90_FILL_FLOAT)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'content','TXY')
       IRET=NF90_PUT_ATT(NCID,VARID(12),'associates','time station frequency')

--- a/model/src/ww3_ounp.F90
+++ b/model/src/ww3_ounp.F90
@@ -3356,7 +3356,7 @@ CONTAINS
       IRET=NF90_PUT_ATT(NCID,VARID(12),'scale_factor',1.)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'add_offset',0.)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_min',0.)
-      IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_max',100.)
+      IRET=NF90_PUT_ATT(NCID,VARID(12),'valid_max',1.E20)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'_FillValue',NF90_FILL_FLOAT)
       IRET=NF90_PUT_ATT(NCID,VARID(12),'content','TXY')
       IRET=NF90_PUT_ATT(NCID,VARID(12),'associates','time station frequency')


### PR DESCRIPTION
# Pull Request Summary

The valid_max attribute for the f variable (1D spectra energy) in ww3_ounp is set to 100. It can exceed that value. 

## Description

Set the `valid_max` attribute of the `f` variable to 1e20. Otherwise, large energy gets masked out (it occured with hurricane Fiona 2022). 

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? Only for NetCDF output (ounp) with `POINT%TYPE = 1; SPECTRA%OUTPUT = 2`.  

### Issue(s) addressed

- fixes #988


### Commit Message
Increase valid_max for f in ounp #988

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- N/A If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- N/A If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regression tests and high energy wave case (https://hpfx.collab.science.gc.ca/~bpo001/WW3/issue_988/)
* Are the changes covered by regression tests? No. No ounp output with ITYPE=1 and OTYPE=2. Output could be activated in some test.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, ECCC HPC, intel. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) Differences as expected I think
* Please 
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/11547651/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/11547652/matrixDiff.txt)
provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/11547650/matrixCompFull.txt)
