### PR TITLE
Fixed invalid deallocation in WW3_PRNC

### DIFF
--- a/model/src/ww3_prnc.F90
+++ b/model/src/ww3_prnc.F90
@@ -299,7 +299,8 @@ PROGRAM W3PRNC
   REAL, ALLOCATABLE       :: XC(:,:), YC(:,:), AC(:,:),           &
        DATA(:,:), XTEMP(:,:)
   !
-  REAL, POINTER           :: ALA(:,:), ALO(:,:)
+  REAL, ALLOCATABLE, TARGET :: ALA(:,:), ALO(:,:)
+  REAL, POINTER           :: PTR_ALA(:,:), PTR_ALO(:,:)
   !
   DOUBLE PRECISION        :: REFJULDAY, CURJULDAY, STARTJULDAY, STPJULDAY
   !
@@ -385,6 +386,7 @@ PROGRAM W3PRNC
 #endif
   !
   !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
   ! 1.a  Set number of models
   !
   CALL W3NMOD ( 1, 6, 6 )
@@ -1007,7 +1009,9 @@ PROGRAM W3PRNC
       !
       ! ... create grid search utility
       !
-      GSI = W3GSUC( .TRUE., FLAGLL, ICLO, ALO, ALA )
+      PTR_ALA => ALA
+      PTR_ALO => ALO
+      GSI = W3GSUC( .TRUE., FLAGLL, ICLO, PTR_ALO, PTR_ALA )
       !
       ! ... construct Interpolation data
       !
@@ -1210,9 +1214,9 @@ PROGRAM W3PRNC
         !
         ! ... read lat-lon data
         !
-        IF ( ASSOCIATED(ALA) ) THEN
+        IF ( ALLOCATED(ALA) ) THEN
           DEALLOCATE ( ALA, ALO )
-          NULLIFY ( ALA, ALO )
+          NULLIFY ( PTR_ALA, PTR_ALO )
         END IF
         ALLOCATE ( ALA(NXJ(J),NYJ(J)), ALO(NXJ(J),NYJ(J)) )
         CALL INA2R (ALA, NXJ(J), NYJ(J), 1, NXJ(J), 1, NYJ(J),&
@@ -2221,7 +2225,7 @@ PROGRAM W3PRNC
   END DO ! NTI
   !
   DEALLOCATE(XC,YC,AC,XTEMP)
-  IF (ASSOCIATED(ALA)) DEALLOCATE(ALA,ALO)
+  IF (ALLOCATED(ALA)) DEALLOCATE(ALA,ALO)
   !
   !     End loop over input fields
   !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/model/src/ww3_prnc.F90
+++ b/model/src/ww3_prnc.F90
@@ -386,7 +386,6 @@ PROGRAM W3PRNC
 #endif
   !
   !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-
   ! 1.a  Set number of models
   !
   CALL W3NMOD ( 1, 6, 6 )


### PR DESCRIPTION
# Pull Request Summary
Bug fix for deallocation of invalid memory (arrays `ALA` and `ALO`) in ww3_prnc.

## Description
This issue was picked up when running ww3_prnc with runtime error checks enabled.

Fix changes variable types to ALLOCATABLE and adds new pointer variables for passing parameters to grid search routine W3GSUC.

### Issue(s) addressed
- fixes #1015 

### Commit Message
Bugfix deallocation of invalid memory in ww3_prnc

### Check list  
- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **Regtests running ww3_prnc**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **Yes**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **Yes**
* Please indicate the expected changes in the regression test output: **None**
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

..TBC..