### PR TITLE
Add option to use shared scotch libs

### DIFF
--- a/cmake/FindSCOTCH.cmake
+++ b/cmake/FindSCOTCH.cmake
@@ -1,33 +1,28 @@
-sage(STATUS "Searching for PTSCOTCHparmetis library ...")
-find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+message(STATUS "Searching for PTSCOTCHparmetis library ...")
+find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3.a  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotchparmetis_inc parmetis.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCH library ...")
-find_library(scotch_lib NAMES libscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotch_lib NAMES libscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotch_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCH library ...")
-find_library(ptscotch_lib NAMES libptscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotch_lib NAMES libptscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotch_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCHerr library ...")
-find_library(scotcherr_lib NAMES libscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotcherr_lib NAMES libscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotcherr_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCHerr library ...")
-find_library(ptscotcherr_lib NAMES libptscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotcherr_lib NAMES libptscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotcherr_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 add_library(PTSCOTCHparmetis::PTSCOTCHparmetis STATIC IMPORTED)
-add_library(PTSCOTCHparmetis::PTSCOTCHparmetis SHARED IMPORTED)
 add_library(SCOTCH::SCOTCH STATIC IMPORTED)
-add_library(SCOTCH::SCOTCH SHARED IMPORTED)
 add_library(PTSCOTCH::PTSCOTCH STATIC IMPORTED)
-add_library(PTSCOTCH::PTSCOTCH SHARED IMPORTED)
 add_library(SCOTCHerr::SCOTCHerr STATIC IMPORTED)
-add_library(SCOTCHerr::SCOTCHerr SHARED IMPORTED)
 add_library(PTSCOTCHerr::PTSCOTCHerr STATIC IMPORTED)
-add_library(PTSCOTCHerr::PTSCOTCHerr SHARED IMPORTED)
 
 set_target_properties(SCOTCH::SCOTCH PROPERTIES
   IMPORTED_LOCATION "${scotch_lib}"

--- a/cmake/FindSCOTCH.cmake
+++ b/cmake/FindSCOTCH.cmake
@@ -1,28 +1,37 @@
 message(STATUS "Searching for PTSCOTCHparmetis library ...")
-find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3.a  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotchparmetis_inc parmetis.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCH library ...")
-find_library(scotch_lib NAMES libscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotch_lib NAMES libscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotch_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCH library ...")
-find_library(ptscotch_lib NAMES libptscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotch_lib NAMES libptscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotch_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCHerr library ...")
-find_library(scotcherr_lib NAMES libscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotcherr_lib NAMES libscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotcherr_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCHerr library ...")
-find_library(ptscotcherr_lib NAMES libptscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotcherr_lib NAMES libptscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotcherr_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
-add_library(PTSCOTCHparmetis::PTSCOTCHparmetis STATIC IMPORTED)
-add_library(SCOTCH::SCOTCH STATIC IMPORTED)
-add_library(PTSCOTCH::PTSCOTCH STATIC IMPORTED)
-add_library(SCOTCHerr::SCOTCHerr STATIC IMPORTED)
-add_library(PTSCOTCHerr::PTSCOTCHerr STATIC IMPORTED)
+if(USE_SHARED_SCOTCH)
+  add_library(PTSCOTCHparmetis::PTSCOTCHparmetis SHARED IMPORTED)
+  add_library(SCOTCH::SCOTCH SHARED IMPORTED)
+  add_library(PTSCOTCH::PTSCOTCH SHARED IMPORTED)
+  add_library(SCOTCHerr::SCOTCHerr SHARED IMPORTED)
+  add_library(PTSCOTCHerr::PTSCOTCHerr SHARED IMPORTED)
+else()
+  add_library(PTSCOTCHparmetis::PTSCOTCHparmetis STATIC IMPORTED)
+  add_library(SCOTCH::SCOTCH STATIC IMPORTED)
+  add_library(PTSCOTCH::PTSCOTCH STATIC IMPORTED)
+  add_library(SCOTCHerr::SCOTCHerr STATIC IMPORTED)
+  add_library(PTSCOTCHerr::PTSCOTCHerr STATIC IMPORTED)
+endif()
+
 
 set_target_properties(SCOTCH::SCOTCH PROPERTIES
   IMPORTED_LOCATION "${scotch_lib}"

--- a/cmake/FindSCOTCH.cmake
+++ b/cmake/FindSCOTCH.cmake
@@ -1,21 +1,27 @@
+if(USE_SHARED_SCOTCH)
+  set(LIB_EXT so)
+else()
+  set(LIB_EXT a)
+endif()
+
 message(STATUS "Searching for PTSCOTCHparmetis library ...")
-find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3.${LIB_EXT}  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotchparmetis_inc parmetis.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCH library ...")
-find_library(scotch_lib NAMES libscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotch_lib NAMES libscotch.${LIB_EXT} HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotch_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCH library ...")
-find_library(ptscotch_lib NAMES libptscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotch_lib NAMES libptscotch.${LIB_EXT} HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotch_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCHerr library ...")
-find_library(scotcherr_lib NAMES libscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotcherr_lib NAMES libscotcherr.${LIB_EXT} HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotcherr_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCHerr library ...")
-find_library(ptscotcherr_lib NAMES libptscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotcherr_lib NAMES libptscotcherr.${LIB_EXT} HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotcherr_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 if(USE_SHARED_SCOTCH)
@@ -24,14 +30,17 @@ if(USE_SHARED_SCOTCH)
   add_library(PTSCOTCH::PTSCOTCH SHARED IMPORTED)
   add_library(SCOTCHerr::SCOTCHerr SHARED IMPORTED)
   add_library(PTSCOTCHerr::PTSCOTCHerr SHARED IMPORTED)
+  set(LIBRARY_TYPE "Shared")
 else()
   add_library(PTSCOTCHparmetis::PTSCOTCHparmetis STATIC IMPORTED)
   add_library(SCOTCH::SCOTCH STATIC IMPORTED)
   add_library(PTSCOTCH::PTSCOTCH STATIC IMPORTED)
   add_library(SCOTCHerr::SCOTCHerr STATIC IMPORTED)
   add_library(PTSCOTCHerr::PTSCOTCHerr STATIC IMPORTED)
+  set(LIBRARY_TYPE "Static")
 endif()
 
+message(STATUS "Using ${LIBRARY_TYPE} SCOTCH libraries.")
 
 set_target_properties(SCOTCH::SCOTCH PROPERTIES
   IMPORTED_LOCATION "${scotch_lib}"

--- a/cmake/FindSCOTCH.cmake
+++ b/cmake/FindSCOTCH.cmake
@@ -1,28 +1,33 @@
-message(STATUS "Searching for PTSCOTCHparmetis library ...")
-find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3.a  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+sage(STATUS "Searching for PTSCOTCHparmetis library ...")
+find_library(ptscotchparmetis_lib NAMES libptscotchparmetisv3  HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotchparmetis_inc parmetis.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCH library ...")
-find_library(scotch_lib NAMES libscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotch_lib NAMES libscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotch_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCH library ...")
-find_library(ptscotch_lib NAMES libptscotch.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotch_lib NAMES libptscotch HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotch_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for SCOTCHerr library ...")
-find_library(scotcherr_lib NAMES libscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(scotcherr_lib NAMES libscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(scotcherr_inc scotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 message(STATUS "Searching for PTSCOTCHerr library ...")
-find_library(ptscotcherr_lib NAMES libptscotcherr.a HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
+find_library(ptscotcherr_lib NAMES libptscotcherr HINTS ENV SCOTCH_PATH PATH_SUFFIXES lib)
 find_path(ptscotcherr_inc ptscotch.h HINTS ENV SCOTCH_PATH PATH_SUFFIXES include)
 
 add_library(PTSCOTCHparmetis::PTSCOTCHparmetis STATIC IMPORTED)
+add_library(PTSCOTCHparmetis::PTSCOTCHparmetis SHARED IMPORTED)
 add_library(SCOTCH::SCOTCH STATIC IMPORTED)
+add_library(SCOTCH::SCOTCH SHARED IMPORTED)
 add_library(PTSCOTCH::PTSCOTCH STATIC IMPORTED)
+add_library(PTSCOTCH::PTSCOTCH SHARED IMPORTED)
 add_library(SCOTCHerr::SCOTCHerr STATIC IMPORTED)
+add_library(SCOTCHerr::SCOTCHerr SHARED IMPORTED)
 add_library(PTSCOTCHerr::PTSCOTCHerr STATIC IMPORTED)
+add_library(PTSCOTCHerr::PTSCOTCHerr SHARED IMPORTED)
 
 set_target_properties(SCOTCH::SCOTCH PROPERTIES
   IMPORTED_LOCATION "${scotch_lib}"

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -126,18 +126,23 @@ if(NetCDF_Fortran_FOUND)
   list(APPEND programs ${netcdf_programs})
 endif()
 
-if(MULTI_ESMF)
+if(UFS_CAP)
   # Don't search for ESMF if target already exists (when build WW3 as UFS submodule)
   if (NOT TARGET esmf)
     find_package(ESMF MODULE REQUIRED)
   endif()
+
+  if(UFS_CAP STREQUAL "MULTI_ESMF")
+    set(cap_src ${esmf_multi_cap_src})
+  elseif(UFS_CAP STREQUAL "NUOPC_MESH")
+    set(cap_src ${nuopc_mesh_cap_src})
+  endif()
   
-  target_sources(ww3_lib PRIVATE wmesmfmd.F90)
+  target_sources(ww3_lib PRIVATE ${cap_src})
   target_link_libraries(ww3_lib PUBLIC esmf)
-  set_target_properties(ww3_lib PROPERTIES OUTPUT_NAME "ww3_multi_esmf")
   # Don't build executables when building WW3 ESMF library
   set(programs "")
-endif() 
+endif()
 
 set_property(SOURCE w3initmd.F90
   APPEND
@@ -158,6 +163,7 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
+  set(USE_SHARED_SCOTCH OFF)
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
-  set(USE_SHARED_SCOTCH OFF)
+  set(USE_SHARED_SCOTCH ON)
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -126,23 +126,18 @@ if(NetCDF_Fortran_FOUND)
   list(APPEND programs ${netcdf_programs})
 endif()
 
-if(UFS_CAP)
+if(MULTI_ESMF)
   # Don't search for ESMF if target already exists (when build WW3 as UFS submodule)
   if (NOT TARGET esmf)
     find_package(ESMF MODULE REQUIRED)
   endif()
-
-  if(UFS_CAP STREQUAL "MULTI_ESMF")
-    set(cap_src ${esmf_multi_cap_src})
-  elseif(UFS_CAP STREQUAL "NUOPC_MESH")
-    set(cap_src ${nuopc_mesh_cap_src})
-  endif()
   
-  target_sources(ww3_lib PRIVATE ${cap_src})
+  target_sources(ww3_lib PRIVATE wmesmfmd.F90)
   target_link_libraries(ww3_lib PUBLIC esmf)
+  set_target_properties(ww3_lib PROPERTIES OUTPUT_NAME "ww3_multi_esmf")
   # Don't build executables when building WW3 ESMF library
   set(programs "")
-endif()
+endif() 
 
 set_property(SOURCE w3initmd.F90
   APPEND
@@ -163,7 +158,6 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
-  set(USE_SHARED_SCOTCH OFF)
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -158,6 +158,7 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
+  set(USE_SHARED_SCOTCH OFF)
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
-  set(USE_SHARED_SCOTCH ON)
+  set(USE_SHARED_SCOTCH OFF)
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -158,7 +158,7 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
-  set(USE_SHARED_SCOTCH OFF)
+  set(USE_SHARED_SCOTCH OFF CACHE BOOL "Use shared SCOTCH")
   find_package(SCOTCH REQUIRED)
   target_sources(ww3_lib PRIVATE ${pdlib_src})
   target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)


### PR DESCRIPTION
# Pull Request Summary
Enable the (optional) use of shared scotch libraries.

## Description
Some changes to cmake/FindSCOTCH.cmake and model/src/CMakeLists.txt are added here so that shared scotch libraries can be used when appropriate/wanted. Future spack-stack installations will most likely install only the shared libraries, so the capability will become necessary. Static library options need to be retain for operational machines where shared libraries are not supported.


Please also include the following information: 
Potential reviewers: @MatthewMasarik-NOAA @JessicaMeixner-NOAA 
*  _enhancement_
* Not sure if it will change results

### Issue(s) addressed
Fixes #1021 

### Commit Message
Enable the (optional) use of shared scotch libraries.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
using the PDLIB RT cmake settings from the UFS-WM (i.e. `cmake  -DAPP=S2SW -DCCPP_SUITES=FV3_GFS_v17_coupled_p8 -DPDLIB=ON ..`)
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
I am only sure of how they would be covered in the UFS-WM S2SW/S2SWA configurations where PDLIB is turned on.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
No
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

