### PR TITLE
Initialise VD and VS in w3srcemd

### DIFF
--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -829,6 +829,9 @@ CONTAINS
     FLTEST = .TRUE.
 #endif
     !
+    VD     = 0.   ! VS and VD definitely need initialising.
+    VS     = 0.
+    !
     VDIO   = 0.
     VSIO   = 0.
     DEPTH  = MAX ( DMIN , D_INP )


### PR DESCRIPTION
# Pull Request Summary
Source term variables `VD` and `VS` were not being properly initialised to zero before use in w3srcemd.

## Description
It was noted recently that some of the `ww3_t2.21` regression tests were not bit-for-bit anymore.
After running in debug mode with `-finit-real=snan` compiler flag (to initialise all real variables with signalling NaN values), it was possible to track down a possible culprit in the w3srcemd module.

The `VD` and `VS` variables are not properly intialised prior to them being used.

This is unfortunately not caught by the compiler as a warning as it _looks like_ they are being set in a loop.
Unfortunately, the loops bounds are not always covering the full dimensionality of VS/VD leaving some bins unitialised.

See #1036 and discussion here for details:
https://github.com/NOAA-EMC/WW3/issues/1030#issuecomment-1614844763

### Issue(s) addressed
- fixes #1036 

### Commit Message
Initialise VD and VS in w3srcemd

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **Regtests against self (for self-consistency) and against develop**.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **Yes**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **Cray XC, GNU Fortran**
* Please indicate the expected changes in the regression test output: **Potential for small changes across all regtests due to proper initialisation of the primary source/diagonal term arrays.**
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_): **See results in discussion below**

