### PR TITLE
Typo bugfix for W3_IC2 pre-processor directive

### DIFF
--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -757,7 +757,7 @@ CONTAINS
     REAL :: DTRAW
 #endif
 
-#if defined(W3_IC1) || W3_IC2 || defined(W3_IC3) || defined(W3_IC4) || defined(W3_IC5)
+#if defined(W3_IC1) || defined(W3_IC2) || defined(W3_IC3) || defined(W3_IC4) || defined(W3_IC5)
     REAL :: VSIC(NSPEC), VDIC(NSPEC)
 #endif
 


### PR DESCRIPTION
# Pull Request Summary
Small typo correction to pre-processor statement in w3srcemd.F90 for W3_IC2 switch.

## Description
Pre-processor directive line was missing `defined` statement for W3_IC2:

https://github.com/NOAA-EMC/WW3/blob/4d8c3156f0f4d76adde6d2dfdf1104941721bd24/model/src/w3srcemd.F90#L760

should be :
```c
#if defined(W3_IC1) || defined(W3_IC2) || defined(W3_IC3) || defined(W3_IC4) || defined(W3_IC5)
````

No change to answers expected (compilation would have failed if `W3_IC2` was used).


### Commit Message
Correct typo in w3srcemd.F90 pre-processor directive.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regtests (although it was not picked up in the original regtests).
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Possibly not!
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

