### PR TITLE
matrix minor bugfixes

### DIFF
--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -491,7 +491,9 @@ then
     cp $path_build/install/bin/ww3_shel $path_e/
     cp $path_build/install/bin/ww3_multi $path_e/
     cp $path_build/install/bin/ww3_systrk $path_e/
-    cp $path_build/install/bin/ww3_prtide $path_e/
+    if [ -e $path_build/install/bin/ww3_prtide ]; then
+      cp $path_build/install/bin/ww3_prtide $path_e/
+    fi
   fi
 else
   path_build=${path_build_root}
@@ -1127,9 +1129,9 @@ then
 
         if [ $nml_input ] && [ ! -z "`ls ${path_i}/${prog}*.nml 2>/dev/null`" ]
           then
-          inputs_tmp=`( ls ${path_i}/${prog}${gu}*nml)`
+          inputs_tmp="`ls ${path_i}/${prog}${gu}*nml 2>/dev/null`"
          else
-          inputs_tmp=`( ls ${path_i}/${prog}${gu}*inp)`
+          inputs_tmp="`ls ${path_i}/${prog}${gu}*inp 2>/dev/null`"
         fi
 
         if [ ! -z "$inputs_tmp" ];then

--- a/regtests/ww3_tp2.12/info
+++ b/regtests/ww3_tp2.12/info
@@ -29,7 +29,7 @@
 #   * ww3_grid.inp (dummy grid input file, with assoc .bot, .mask, .obst)   #
 #   * partition.ww3 (raw fields of partition data, 4 time steps)            #
 #   * ww3_systrk.inp (instruction file)                                     #
-#   * ww3_systrk will ABORT if endianess is incompatible with binary file!  #
+#   * ww3_systrk will stop if endianess is incompatible with binary file!  #
 #                                                                           #
 # Sample run_test commands :                                                #
 #   (Note: mpirun commands differ by local system)                          #


### PR DESCRIPTION
# Pull Request Summary
minor bugfixes for matrix grepping on keywords

## Description
- correct error message when not finding ww3_prtide because this exe is only produced if switch TIDE is present
- redirect error output when listing ww3_prnc files for multi implementation
- change ABORT by stop to avoid misleading when detecting crashes based on keywords
- fixes #837 
- fixes #838 

### Commit Message
minor bugfixes for matrix grepping on keywords

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [X] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [X] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

