### PR TITLE
Add NETCDFF_CONFIG flag to support NetCDF > 4.9.1

### DIFF
--- a/model/bin/README.md
+++ b/model/bin/README.md
@@ -38,7 +38,7 @@ WW3_PARCOMPN = <how many parallel make tasks to use, default to 4 if not set >
 
 The requirements for NetCDF are: 
 * NetCDF version 4.1.1 or higher (Use "nc-config --version" to check)
-  - if using NetCDF 4.9.2 or higher, `nc-config` no longer looks for and returns values from `nf-config` if enabled (see the [netcdf-c 4.9.2 changelog](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29)).
+  - if using NetCDF 4.9.2 or higher, `nc-config` no longer looks for and returns values from `nf-config` if enabled (see the [netcdf-c 4.9.2 changelog](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md#492---march-14-2023)).
 * NetCDF-4 API enabled (Use "nc-config --has-nc4" to check) 
 * Define `NETCDF_CONFIG` env variable
 * Define `NETCDFF_CONFIG` env variable

--- a/model/bin/README.md
+++ b/model/bin/README.md
@@ -37,15 +37,16 @@ WW3_PARCOMPN = <how many parallel make tasks to use, default to 4 if not set >
 ## To build NetCDF executables you need:
 
 The requirements for NetCDF are: 
-* NetCDF version 4.1.1 or higher (Use "nc-config --version" to check) 
+* NetCDF version 4.1.1 or higher (Use "nc-config --version" to check)
+  - if using NetCDF 4.9.2 or higher, `nc-config` no longer looks for and returns values from `nf-config` if enabled (see the [netcdf-c 4.9.2 changelog](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29)).
 * NetCDF-4 API enabled (Use "nc-config --has-nc4" to check) 
 * Define `NETCDF_CONFIG` env variable
 * Define `NETCDFF_CONFIG` env variable
+  - If using a version of NetCDF < 4.9.2, `NETCDFF_CONFIG` is optional and will be set to the value provided for `NETCDF_CONFIG`.
 
 `NETCDF_CONFIG` = < path to NetCDF-4 nc-config utility >
 `NETCDFF_CONFIG` = < path to NetCDF-4 nf-config utility >
 
->**Note:**  (Camille Teicheira 2023-07-26): as of [netcdf-c 4.9.2](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29) `nc-config` no longer looks for and returns values from `nf-config` if enabled, so we need to be specific and provide both utilities. If using a version of NetCDF < 4.9.2, `NETCDFF_CONFIG` is optional and will be set to the value provided for `NETCDF_CONFIG`.
 
 ## To use the PDLIB switch:
 

--- a/model/bin/README.md
+++ b/model/bin/README.md
@@ -39,9 +39,13 @@ WW3_PARCOMPN = <how many parallel make tasks to use, default to 4 if not set >
 The requirements for NetCDF are: 
 * NetCDF version 4.1.1 or higher (Use "nc-config --version" to check) 
 * NetCDF-4 API enabled (Use "nc-config --has-nc4" to check) 
-* Define NETCDF_CONFIG env variable
+* Define `NETCDF_CONFIG` env variable
+* Define `NETCDFF_CONFIG` env variable
 
-NETCDF_CONFIG = < path to NetCDF-4 nc-config utility >
+`NETCDF_CONFIG` = < path to NetCDF-4 nc-config utility >
+`NETCDFF_CONFIG` = < path to NetCDF-4 nf-config utility >
+
+>**Note:**  (Camille Teicheira 2023-07-26): as of [netcdf-c 4.9.2](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29) `nc-config` no longer looks for and returns values from `nf-config` if enabled, so we need to be specific and provide both utilities. If using a version of NetCDF < 4.9.2, `NETCDFF_CONFIG` is optional and will be set to the value provided for `NETCDF_CONFIG`.
 
 ## To use the PDLIB switch:
 

--- a/model/bin/comp.tmpl
+++ b/model/bin/comp.tmpl
@@ -77,9 +77,15 @@
   fi
 
   # netcdf include dir
+  # NOTE (Camille Teicheira 2023-07-26):
+  # NETCDFF_CONFIG should be the path to `nf-config`
+  # NETDCDF_CONFIG should be the path to `nc-config`
+  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
+  # values from nf-config if enabled, so we need to be specific
+  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ]
   then
-    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDF_CONFIG --fc`"; fi
+    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi
     opt="$opt `$NETCDF_CONFIG --cflags`"
   fi
 

--- a/model/bin/comp.tmpl
+++ b/model/bin/comp.tmpl
@@ -77,12 +77,6 @@
   fi
 
   # netcdf include dir
-  # NOTE (Camille Teicheira 2023-07-26):
-  # NETCDFF_CONFIG should be the path to `nf-config`
-  # NETDCDF_CONFIG should be the path to `nc-config`
-  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
-  # values from nf-config if enabled, so we need to be specific
-  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ]
   then
     if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi

--- a/model/bin/link.tmpl
+++ b/model/bin/link.tmpl
@@ -112,12 +112,6 @@
   fi
 
   # netcdf library dir
-  # NOTE (Camille Teicheira 2023-07-26):
-  # NETCDFF_CONFIG should be the path to `nf-config`
-  # NETDCDF_CONFIG should be the path to `nc-config`
-  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
-  # values from nf-config if enabled, so we need to be specific
-  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ] ; then
     if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi
     libs="$libs `$NETCDFF_CONFIG --flibs` `$NETCDF_CONFIG --libs`"

--- a/model/bin/link.tmpl
+++ b/model/bin/link.tmpl
@@ -112,9 +112,15 @@
   fi
 
   # netcdf library dir
+  # NOTE (Camille Teicheira 2023-07-26):
+  # NETCDFF_CONFIG should be the path to `nf-config`
+  # NETDCDF_CONFIG should be the path to `nc-config`
+  # as of netcdf-c 4.9.2 nc-config no longer looks for and returns
+  # values from nf-config if enabled, so we need to be specific
+  # https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md?plain=1#L29
   if [ "$netcdf_compile" = 'yes' ] ; then
-    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDF_CONFIG --fc`"; fi
-    libs="$libs `$NETCDF_CONFIG --flibs` `$NETCDF_CONFIG --libs`"
+    if [ "$mpi_mod" = 'no' ]; then comp="`$NETCDFF_CONFIG --fc`"; fi
+    libs="$libs `$NETCDFF_CONFIG --flibs` `$NETCDF_CONFIG --libs`"
   fi
 
   # scotch library 

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -330,7 +330,7 @@ EOF
       return 1
     else
       netcdf_compile_message
-      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value"; echo ' '
+      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value: $NETCDF_CONFIG"; echo ' '
       NETCDFF_CONFIG=$NETCDF_CONFIG
     fi
   fi

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -273,8 +273,9 @@ For compiling with NetCDF, the following environment variable
 is required:
 
     NETCDF_CONFIG = <path to NetCDF-4 nc-config utility>
+    NETCDFF_CONFIG = <path to NetCDF-4 nf-config utility>
 
-The nc-config utility (part of the NetCDF-4 install) is used to
+The nc-config and nf-config utilities (part of the NetCDF-4 install) is used to
 determine the appropriate compile and link flags.
 
 For NetCDF routines to compile, WAVEWATCH III requires
@@ -317,6 +318,21 @@ EOF
     netcdf_compile_message
     echo "$mode: NetCDF version $netcdf_version < 4.1.1"; echo ' '
     return 1
+  fi
+
+
+  if [ -z "$NETCDFF_CONFIG" ]
+  then
+    if [ `echo $netcdf_version | tr -d . | tr -d - | tr -d 'A-Z a-z'` -gt 491 ]
+    then
+      netcdf_compile_message
+      echo "$mode: NetCDF version $netcdf_version > 4.9.1 and NETCDFF_CONFIG is not defined. NETCDFF_CONFIG must be defined for NetCDF versions > 4.9.1"; echo ' '
+      return 1
+    else
+      netcdf_compile_message
+      echo "$mode: NETCDFF_CONFIG not defined; using NETCDF_CONFIG value"; echo ' '
+      NETCDFF_CONFIG=$NETCDF_CONFIG
+    fi
   fi
 
   return 0

--- a/model/bin/w3_make
+++ b/model/bin/w3_make
@@ -283,6 +283,9 @@ NetCDF version 4.1.1 or higher. Use "nc-config --version" to check
 the version of the installed NetCDF. It is also required for NetCDF
 to be compiled with the NetCDF-4 API enabled. Use "nc-config --has-nc4"
 to check if the installed NetCDF has the NetCDF-4 API enabled.
+As of netcdf-c 4.9.2 "nc-config" no longer looks for and returns values
+from "nf-config" if enabled, so both paths to both utilities need to be
+explicitly provided.
 
 ***********************************************************************
 
@@ -319,7 +322,6 @@ EOF
     echo "$mode: NetCDF version $netcdf_version < 4.1.1"; echo ' '
     return 1
   fi
-
 
   if [ -z "$NETCDFF_CONFIG" ]
   then

--- a/model/esmf/Makefile
+++ b/model/esmf/Makefile
@@ -13,7 +13,8 @@ SWITCHES := $(shell cat switch)
 
 WWATCH3_ENV := $(WW3_BINDIR)/wwatch3.env
 NETCDF_CONFIG := $(shell which nc-config)
-export WWATCH3_ENV NETCDF_CONFIG
+NETCDFF_CONFIG := $(shell which nf-config)
+export WWATCH3_ENV NETCDF_CONFIG NETCDFF_CONFIG
 
 EXE := $(WW3_EXEDIR)/ww3_multi_esmf
 


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 

Updates executable generation to support NetCDF > 4.9.1

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

As of [`netcdf-c 4.9.2`](https://github.com/Unidata/netcdf-c/blob/main/RELEASE_NOTES.md#492---march-14-2023) the ability to access `nf-config` values via `nc-config` is no longer supported. For example, the commands `nc-config --flibs` or `nc-config --fc` no longer work. See this [outdated documentation for more examples](https://www.unidata.ucar.edu/software/netcdf/workshops/most-recent/utilities/Nc-config.html).

This behavior is currently hardcoded into the generation of the WW3 NetCDF pre- and post-processing executables. This PR adds a new environment variable `NETCDFF_CONFIG` whose value should be the path of `nf-config`. This environment variable will be required for versions of NetCDF-c > 4.9.1. If using a version of NetCDF-c < 4.9.1, `NETCDFF_CONFIG` is optional and it's value will be set to the provided value for `NETCDF_CONFIG`, and thus this change is backwards compatible.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
No specific issues, although may help with https://github.com/NOAA-EMC/WW3/issues/392.

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

Add NETCDFF_CONFIG flag to support NetCDF > 4.9.1

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

I would appreciate some guidance on how to test these changes -- I have tested this locally extensively by building and running WW3 (specifically by compiling the netcdf executables with `./model/bin/w3_automake ww3_ounf ww3_prnc ww3_ounp` as well as `ww3_multi` with the same command), but I am new to the WW3 test frameworks and am unclear which (if any) of the tests in this repo would appropriate to run.