### PR TITLE
Init bugs

### DIFF
--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -1539,9 +1539,9 @@ CONTAINS
                   evS = -evS
                   evD = 2*evD
                 ENDIF
-#endif
                 B_JAC(ISP,JSEA)                   = B_JAC(ISP,JSEA) + SIDT * eVS
                 ASPAR_JAC(ISP,PDLIB_I_DIAG(JSEA)) = ASPAR_JAC(ISP,PDLIB_I_DIAG(JSEA)) - SIDT * eVD
+#endif
 
 #ifdef W3_TR1
                 eVS = VSTR(ISP) * JAC
@@ -1553,9 +1553,9 @@ CONTAINS
                   evS = -evS
                   evD = 2*evD
                 ENDIF
-#endif
                 B_JAC(ISP,JSEA)                   = B_JAC(ISP,JSEA) + SIDT * eVS
                 ASPAR_JAC(ISP,PDLIB_I_DIAG(JSEA)) = ASPAR_JAC(ISP,PDLIB_I_DIAG(JSEA)) - SIDT * eVD
+#endif
               END DO
             END DO
 

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1453,6 +1453,12 @@ CONTAINS
         call print_memcheck(memunit, 'memcheck_____:'//' WW3_WAVE TIME LOOP 13')
         !
 #ifdef W3_PDLIB
+
+        IF (LPDLIB .and. .not. FLSOU .and. .not. FSSOURCE) THEN
+          B_JAC     = 0.
+          ASPAR_JAC = 0.
+        ENDIF
+
         IF (LPDLIB .and. FLSOU .and. FSSOURCE) THEN
 #endif
 

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1490,6 +1490,8 @@ CONTAINS
 
             CALL INIT_GET_ISEA(ISEA, JSEA)
 
+            IF ((IOBP_LOC(IP).eq.1..or.IOBP_LOC(JSEA).eq. 3).and.IOBDP_LOC(IP).eq.1.and.IOBPA_LOC(IP).eq.0) THEN
+
             IX     = MAPSF(ISEA,1)
             IY     = MAPSF(ISEA,2)
             DELA=1.
@@ -1562,6 +1564,7 @@ CONTAINS
             WRITE(740+IAPROC,*) '     SHAVETOT=', SHAVETOT(JSEA)
             FLUSH(740+IAPROC)
 #endif
+          ENDIF 
           END DO ! JSEA
         END IF ! PDLIB
 #endif


### PR DESCRIPTION
# Pull Request Summary
This solves issue #1071 

## Description
See #1071 

Please also include the following information: 
Dear reviewer, as described in #1071 bugs have been found for the case when certain source terms or all source terms are switched off within the implicit UG scheme. The bugs have been solved and tested within the cases provided by ERDC. 
 
* Mention any labels that should be added:
 _bug_

* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: 

Reg-tests may change where the described settings are used. 

### Issue(s) addressed
See #1071 

### Commit Message
Non initialized Arrays for TR0, DB0 or FLSOU = .false. and erroneous boundary handling of the source terms for the Neumann boundary condtion on unstructured grids (implicit scheme) 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Regression tests, will be done within the PR review ... 

