### PR TITLE
STAB3: fix cmake build for ST4 or ST3

### DIFF
--- a/model/src/cmake/check_switches.cmake
+++ b/model/src/cmake/check_switches.cmake
@@ -52,7 +52,7 @@ function(check_switches switches switch_files)
                 message(FATAL_ERROR "Switch '${valid_opt}' requires '${required_switch}' to be set")
               endif()
             elseif(json_type STREQUAL "ARRAY")
-              string(JSON n_requires_any LENGTH ${vategory} valid-options ${j_options} requries ${i_requires})
+              string(JSON n_requires_any LENGTH ${category} valid-options ${j_options} requires ${i_requires})
               math(EXPR n_requires_any "${n_requires_any} - 1")
 
               # Loop over array and check that one of the switches is present
@@ -70,7 +70,7 @@ function(check_switches switches switch_files)
               if(NOT found)
                 message(FATAL_ERROR "Switch ${valid_opt} requires one of ${possible_values} to be set")
               endif()
-              
+
             endif()
           endforeach()
         endif()
@@ -98,7 +98,7 @@ function(check_switches switches switch_files)
     elseif(num_switches STREQUAL "upto2" AND n_switches_in_category GREATER 2)
       message(FATAL_ERROR "Too many ${category_name} switches found (max 2)")
     endif()
-    
+
   endforeach()
 
   set(${switch_files} ${files} PARENT_SCOPE)

--- a/model/src/cmake/switches.json
+++ b/model/src/cmake/switches.json
@@ -264,7 +264,7 @@
             },
             {
                 "name": "STAB3",
-                "requires": ["ST3", "ST4"]
+                "requires_any": ["ST3", "ST4"]
             }
         ]
     },
@@ -756,16 +756,16 @@
        	    }
         ]
     },
-    {   
-        "name": "ddlib", 
+    {
+        "name": "ddlib",
         "num_switches": "upto1",
         "description": "domain decomposition library",
         "valid-options": [
-            {   
+            {
                 "name": "METIS",
                 "requires": ["PDLIB"]
-            },  
-            {   
+            },
+            {
                 "name": "SCOTCH",
                 "requires": ["PDLIB"]
             }


### PR DESCRIPTION
# Pull Request Summary
Fixes a bug in the `cmake` build regarding the switch `STAB3`.

## Description
Provide a detailed description of what this PR does.
 * Currently selecting the `STAB3` with either `ST4` or `ST3` as intended cannot satisfy the condition in the build that _both_ `ST4` and `ST3` be selected.  This makes it so that `STAB3` and cannot be used with the `cmake` build as is.  This fix resolves the issue and now `STAB3` can be built with either `ST3` or `ST4`.

What bug does it fix, or what feature does it add?
* There were 2 parts to address.  In `switches.json`, the attribute needed to be modified.  Also, a command in `check_switches.cmake` had two typos in the logic block that addresses switches with an `"ARRAY"` of dependent switches.  This likely went unnoticed because we do not have any regtests using `STAB3`, and it is the _only_ switch that has an array of possible dependent switches.  So, the actual changes are just 1 line in each file.  Some whitespace got auto-removed by my editor, so some of that is in there, too.

Is a change of answers expected from this PR?
*  No.  Tests confirmed using both `STAB3/ST3` and `STAB3/ST4` work as expected.  Full matrix shows that none of the answers change, as expected.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Mention any labels that should be added: 
  *  _bug_
* Are answer changes expected from this PR? 
  * No.

### Issue(s) addressed
- fixes #1082 

### Commit Message
STAB3:  fix cmake build for ST4 or ST3

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Individual tests of `STAB3` with `ST4` and `ST3`.

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No, bugfix only.

* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  hera, intel

* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * No changes.

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

* [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/12740881/matrixCompSummary.txt)
* [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/12740883/matrixCompFull.txt)
* [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/12740886/matrixDiff.txt)

