### PR TITLE
Fix missing mod_def file for ww3_trck/trnc in multi-grid regression tests

### DIFF
--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -2026,7 +2026,7 @@ done # end of loop on progs
 case $outopt in
   native) out_progs="ww3_trck" ;;
   netcdf) out_progs="ww3_trnc" ;;
-  both)   out_progs="ww3_trck ww3_trnc" ;;
+  both|all) out_progs="ww3_trck ww3_trnc" ;;
   *)      out_progs="" ;;
 esac
 

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -2023,7 +2023,6 @@ do
 done # end of loop on progs
 
 # 3.i Track output ---------------------------------------------------------- #
-
 case $outopt in
   native) out_progs="ww3_trck" ;;
   netcdf) out_progs="ww3_trnc" ;;
@@ -2070,6 +2069,9 @@ do
           then
             continue
           fi
+
+          \ln -s mod_def.$g mod_def.ww3
+
           gu="_$g"
           fileconf="$prog${gu}"
         else
@@ -2124,6 +2126,7 @@ do
           \rm -f $prog.nml
           if [ $multi -eq 2 ]
           then
+            \rm -f mod_def.ww3
             \rm -f track_o.ww3
             if [ $nml_input ] && [ ! -z "`basename ${ifile} | grep -o nml`" ]
             then

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -2023,6 +2023,7 @@ do
 done # end of loop on progs
 
 # 3.i Track output ---------------------------------------------------------- #
+
 case $outopt in
   native) out_progs="ww3_trck" ;;
   netcdf) out_progs="ww3_trnc" ;;

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -2368,7 +2368,7 @@ done # end of loop on progs
 case $outopt in
   native) out_progs="ww3_trck" ;;
   netcdf) out_progs="ww3_trnc" ;;
-  both)   out_progs="ww3_trck ww3_trnc" ;;
+  both|all) out_progs="ww3_trck ww3_trnc" ;;
   *)      out_progs="" ;;
 esac
 

--- a/regtests/bin/run_test
+++ b/regtests/bin/run_test
@@ -2448,6 +2448,9 @@ do
           then
             continue
           fi
+
+          \ln -s mod_def.$g mod_def.ww3
+
           gu="_$g"
           fileconf="$prog${gu}"
         else
@@ -2502,6 +2505,7 @@ do
           \rm -f $prog.nml
           if [ $multi -eq 2 ]
           then
+            \rm -f mod_def.ww3
             \rm -f track_o.ww3
             if [ $nml_input ] && [ ! -z "`echo ${ifile} | grep -o nml`" ]
             then


### PR DESCRIPTION
# Pull Request Summary
Fix missing mod_def.ww3 file in multigrid regression tests for track output.

## Description
When running `ww3_trck` or `ww3_trnc` in a multi-grid regression test, the program fails with a "missing mod_def.ww3 file" error.

This is because the section of code in `run_test` and `run_cmake_test` that runs the `ww3_trnc` and `ww3_trck` programs is not linking in a mod_def file from one of the driver grids.

The missing logic has been added to `run_cmake_test` (and the deprecated  `run_test` for the sake of consistency).

### Issue(s) addressed
Fixes #1090 

### Commit Message
Fix missing mod_def.ww3 file in multigrid regression tests for track output.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

