### PR TITLE
[ww3_ounf] Removed reference to PHIOC in PHICE output section.

### DIFF
--- a/model/src/ww3_ounf.F90
+++ b/model/src/ww3_ounf.F90
@@ -1815,9 +1815,6 @@ CONTAINS
             ! Wave to sea ice energy flux
           ELSE IF ( IFI .EQ. 6 .AND. IFJ .EQ. 11 ) THEN
             IF (NCVARTYPEI.EQ.3) NCVARTYPE=4
-            DO ISEA=1, NSEA
-              PHIOC(ISEA)=MIN(3000.,PHIOC(ISEA))
-            END DO
             CALL S2GRID(PHICE(1:NSEA), X1)
             !
             ! Partitioned surface stokes drift


### PR DESCRIPTION
# Pull Request Summary
Removed code referencing `PHIOC` in output section for `PHICE` in `ww3_ounf`.

## Description
Likely a cut-and-paste error...
Should not affect output results.

Only regtests with netCDF gridded output run.

### Issue(s) addressed
Fixes  #1092

### Commit Message
Removed code referencing `PHIOC` in output section for `PHICE` in `ww3_ounf`.

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Regression test
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) N/A
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? CRAY HPC, GNU Fortran
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp 
  - All regtests with gridded netCDF output are bit-for-bit


