### PR TITLE
Bugfix: inconsistent arrays sizes for NDS/MDS.

### DIFF
--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -456,7 +456,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Parameter list
     !/
-    INTEGER, INTENT(IN)           :: IMOD, MDS(13), MTRACE(2),      &
+    INTEGER, INTENT(IN)           :: IMOD, MDS(15), MTRACE(2),      &
          ODAT(40),NPT, IPRT(6),&
          MPI_COMM
     LOGICAL, INTENT(IN)           :: IsMulti

--- a/model/src/ww3_shel.F90
+++ b/model/src/ww3_shel.F90
@@ -329,7 +329,7 @@ PROGRAM W3SHEL
        NDSEN, IERR, J, I, ILOOP, IPTS, NPTS,     &
        NDTNEW, MPI_COMM = -99,                   &
        FLAGTIDE, COUPL_COMM, IH, N_TOT
-  INTEGER             :: NDSF(-7:9), NDS(13), NTRACE(2), NDT(7:9), &
+  INTEGER             :: NDSF(-7:9), NDS(15), NTRACE(2), NDT(7:9), &
        TIME0(2), TIMEN(2), TTIME(2), TTT(2),     &
        NH(-7:10), THO(2,-7:10,NHMAX), RCLD(7:9), &
        NODATA(7:9), ODAT(40), IPRT(6) = 0,       &
@@ -600,6 +600,9 @@ PROGRAM W3SHEL
   NDS(11) = 22
   NDS(12) = 23
   NDS(13) = 34
+  NDS(14) = 36
+  NDS(15) = 37
+
   !
   NTRACE(1) =  NDS(3)
   NTRACE(2) =  10


### PR DESCRIPTION
# Pull Request Summary
Fixes inconsistent array size bug in w3initmd.

## Description
Fixes bug where new NDS array in W3ODAT has been expanded to size 15 to accommodate new ASCII output unit numbers (see #1089) , but some local arrays in other parts of the code are still of size 13. 

Also, unit numbers for NDS(14) and NDS(15) were not explicitly defined (as far as I can tell).

### Issue(s) addressed
Fixes: #1097 

### Commit Message
Update local unit number arrays (NDS, MDS) to be same size of array defined in w3odatmd (size=15). Also, defined unit numbers for NDS(14) and NDS(15).

### Check list  
- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested? TBC
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

