### PR TITLE
def/ufs: Bug fix to avoid accessing uninitialized date 

### DIFF
--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -524,6 +524,7 @@ CONTAINS
     REAL                    :: ICEDAVE
     !
     LOGICAL                 :: SBSED
+    LOGICAL                 :: CPLWRTFLG
 #ifdef W3_SEC1
     INTEGER                 :: ISEC1
 #endif
@@ -2432,8 +2433,14 @@ CONTAINS
             do_startall = .true.
           end IF
         else
+          CPLWRTFLG=.FALSE.
+          IF ( FLOUT(7) .AND. SBSED ) THEN
+            IF (DSEC21(TIME,TONEXT(:,7)).EQ.0.) THEN
+              CPLWRTFLG=.TRUE.
+            END IF
+          END IF
           IF ( ( (DSEC21(TIME,TONEXT(:,1)).EQ.0.) .AND. FLOUT(1) ) .OR. &
-               ( (DSEC21(TIME,TONEXT(:,7)).EQ.0.) .AND. FLOUT(7) .AND. SBSED ) ) THEN
+               ( CPLWRTFLG=.FALSE. ) THEN
             do_startall = .true.
           end IF
         end if

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -2440,7 +2440,7 @@ CONTAINS
             END IF
           END IF
           IF ( ( (DSEC21(TIME,TONEXT(:,1)).EQ.0.) .AND. FLOUT(1) ) .OR. &
-               ( CPLWRTFLG ) THEN
+               ( CPLWRTFLG ) ) THEN
             do_startall = .true.
           end IF
         end if

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -2440,7 +2440,7 @@ CONTAINS
             END IF
           END IF
           IF ( ( (DSEC21(TIME,TONEXT(:,1)).EQ.0.) .AND. FLOUT(1) ) .OR. &
-               ( CPLWRTFLG=.FALSE. ) THEN
+               ( CPLWRTFLG ) THEN
             do_startall = .true.
           end IF
         end if


### PR DESCRIPTION
# Pull Request Summary
This PR addresses a bug that was discovered on hercules with gnu debug compilers, where an uninitialized date was being used. 

## Description

This changes logic in w3wave to avoid calling a function with an uninitialized date.  This bug has existed for quite a while but only was exposed on a particular platform with debug in gnu which gave a small-ish random value.  Intel tends to initialize to 0 and extremely large random numbers did not cause issues because flout(7) was also false and we didn't seem to try to access a variable with month 52 that way.  

Please also include the following information: 
* Add any suggestions for a reviewer @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_ 
* Are answer changes expected from this PR? No changes are expected.  


### Issue(s) addressed

This partially address issues https://github.com/NOAA-EMC/WW3/issues/1109 (also needs PR to develop to be closed) and partially addresses https://github.com/ufs-community/ufs-weather-model/issues/1963 

### Commit Message
def/ufs: Bug fix to avoid accessing uninitialized date 

### Check list  


- [x] Branch is up to date with the authoritative repository (NOAA-EMC) dev/ufs-waether-model branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? On hera in ufs-weather-model a baseline was created, WW3 was updated with a bug fix and the baselines were matched.  Testing on hercules resulted in other errors and will be fully tested in ufs-waether-model regression test/commit process. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  yes-ish, exposed only in debug mode on one platform 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? No - ufs-weather-model tests were run instead, a PR to develop branch will have matrix regression tests
* Please indicate the expected changes in the regression test output, -- this should not change answers. 
