### PR TITLE
update logic to ensure you are not accessing uninitialized dates

### DIFF
--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -2409,8 +2409,7 @@ CONTAINS
 #endif
         !
 #ifdef W3_MPI
-        IF ( ( (DSEC21(TIME,TONEXT(:,1)).EQ.0.) .AND. FLOUT(1) ) .OR. &
-             (  (DSEC21(TIME,TONEXT(:,7)).EQ.0.) .AND. FLOUT(7) .AND. SBSED ) ) THEN
+        IF ( (FLOUTG) .OR. (FLOUTG2 .AND. SBSED) ) THEN
           IF (.NOT. LPDLIB) THEN
             IF (NRQGO.NE.0 ) THEN
 #endif


### PR DESCRIPTION
# Pull Request Summary
Fixing a bug that was found in which we were trying to access a date that was uninitialized that caused problems with GNU+mpich (although the bug is there for other compilers as well, it just didn't trigger errors). 

## Description
This changes the logic in an if statement to ensure that we do not use an uninitialized date.   The logic has been updated based on @CarstenHansen suggestion which is cleaner than the bug-fix currently implemented in dev/ufs-waether-model.  An update to dev/ufs-weather-model will  be made to use this cleaner fix when develop is merged into the dev/ufs-weather-model branch. 

Please also include the following information: 
* Add any suggestions for a reviewer  @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? This does not change any answers because when the date is un-initialized the value of the flag was also false. 

### Issue(s) addressed
- closes #1109 

### Commit Message
update logic to ensure you are not accessing uninitialized dates

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [n/a] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [n/a] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?  Matrix regtests 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes - although you need a very specific compiler combo in debug mode to throw the error. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, Hera Intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) No changes are expected in the output. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13216917/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13216919/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13216920/matrixDiff.txt)

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (13 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (20 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
