### PR TITLE
Uninitialised arrays in W3SDB1

### DIFF
--- a/model/src/w3sdb1md.F90
+++ b/model/src/w3sdb1md.F90
@@ -232,12 +232,12 @@ CONTAINS
     !
     ! 0.  Initialzations ------------------------------------------------- /
     !     Never touch this 4 lines below ... otherwise my exceptionhandling will not work.
+    S = 0.
+    D = 0.
 
     THR = DBLE(1.E-15)
     IF (SUM(A) .LT. THR) RETURN
 
-    S = 0.
-    D = 0.
     IWB = 1
     !
 #ifdef W3_T


### PR DESCRIPTION
# Pull Request Summary
Source arrays `S` and `D` W3SDB1 are potentially left uninitialised if subroutine returns early due to zero energy in spectrum.

## Description
Fix simply moves the initialisation of `S` and `D` to the top of the subroutine above the RETURN statement.

### Issue(s) addressed
Fixes #1106 

### Commit Message
Initialised `S` and `D` arrays in W3SDB1 before potential early return if zero energy.

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- (N/A) If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- (N/A) If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **TBC**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **Yes**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **Cray HPC; GNU Compiler**
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

