### PR TITLE
[ww3_multi] Fix unassigned numbers for ASCII output

### DIFF
--- a/model/src/wminitmd.F90
+++ b/model/src/wminitmd.F90
@@ -743,7 +743,7 @@ CONTAINS
     !
     ! 2.c Set up I/O for individual models (initial)
     !
-    ALLOCATE ( MDS(13,NRGRD), NTRACE(2,NRGRD), ODAT(40,0:NRGRD),    &
+    ALLOCATE ( MDS(15,NRGRD), NTRACE(2,NRGRD), ODAT(40,0:NRGRD),    &
          FLGRD(NOGRP,NGRPP,NRGRD), OT2(0:NRGRD), FLGD(NOGRP,NRGRD), &
          MDSF(-NRINP:NRGRD,JFIRST:9), IPRT(6,NRGRD), LPRT(NRGRD),   &
          FLGR2(NOGRP,NGRPP,NRGRD),FLG2D(NOGRP,NGRPP), FLG1D(NOGRP), &
@@ -2303,8 +2303,20 @@ CONTAINS
           SELECT CASE (J)
           CASE (1)
             MDS(7,I) = NDSFND
+#ifdef W3_ASCII
+            CALL WMUGET ( MDSE, MDST, NDSFND, 'OUT' )
+            CALL WMUSET ( MDSE, MDST, NDSFND, .TRUE.,            &
+                 DESC='ASCII output file' )
+            MDS(14,I) = NDSFND  ! ASCII
+#endif
           CASE (2)
             MDS(8,I) = NDSFND
+#ifdef W3_ASCII
+            CALL WMUGET ( MDSE, MDST, NDSFND, 'OUT' )
+            CALL WMUSET ( MDSE, MDST, NDSFND, .TRUE.,            &
+                 DESC='ASCII output file' )
+            MDS(15,I) = NDSFND  ! ASCII
+#endif
           CASE (3)
             MDS(12,I) = NDSFND
             CALL WMUGET ( MDSE, MDST, NDSFND, 'INP' )
@@ -2422,6 +2434,28 @@ CONTAINS
         END IF
       END IF
       !
+#ifdef W3_ASCII
+      IF ( MDS(14,I) .NE. -1 ) THEN ! Grid output (ASCII)
+        IF ( IAPROC .EQ. NAPFLD ) THEN
+          TNAME  = TRIM(FNMPRE)//'out_grd.' // FILEXT(:II) // '.txt'
+          CALL WMUSET ( MDSE,MDST, MDS(14,I), .TRUE., NAME=TNAME )
+        ELSE
+          CALL WMUSET ( MDSE,MDST, MDS(14,I), .FALSE. )
+          MDS(14,I) = -1
+        END IF
+      END IF
+      !
+      IF ( MDS(15,I) .NE. -1 ) THEN ! Point output (ASCII)
+        IF ( IAPROC .EQ. NAPPNT ) THEN
+          TNAME  = TRIM(FNMPRE)//'out_pnt.' // FILEXT(:II) // '.txt'
+          CALL WMUSET ( MDSE,MDST, MDS(15,I), .TRUE., NAME=TNAME )
+        ELSE
+          CALL WMUSET ( MDSE,MDST, MDS(15,I), .FALSE. )
+          MDS(15,I) = -1
+        END IF
+      END IF
+#endif
+!
 #ifdef W3_T
       WRITE (MDST,9081) I, TIME
 #endif
@@ -3389,7 +3423,7 @@ CONTAINS
     !
 #ifdef W3_T
 9020 FORMAT ( ' TEST WMINIT : UNIT NUMBERS FOR GRIDS (',A,')'/    &
-         15X,'GRID MDS(1-13)',43X,'NTRACE')
+         15X,'GRID MDS(1-15)',43X,'NTRACE')
 9021 FORMAT (14X,16I4)
 9022 FORMAT ( ' TEST WMINIT : UNIT NUMBERS FOR INTPUT FILES'/     &
          15X,'GRID MDSF(JFIRST-9)')
@@ -4108,7 +4142,7 @@ CONTAINS
     !
     ! 2.c Set up I/O for individual models (initial)
     !
-    ALLOCATE ( MDS(13,NRGRD), NTRACE(2,NRGRD), ODAT(40,0:NRGRD),    &
+    ALLOCATE ( MDS(15,NRGRD), NTRACE(2,NRGRD), ODAT(40,0:NRGRD),    &
          FLGRD(NOGRP,NGRPP,NRGRD), OT2(0:NRGRD), FLGD(NOGRP,NRGRD), &
          MDSF(-NRINP:NRGRD,JFIRST:9), IPRT(6,NRGRD), LPRT(NRGRD),   &
          FLGR2(NOGRP,NGRPP,NRGRD),FLG2D(NOGRP,NGRPP), FLG1D(NOGRP), &
@@ -5400,8 +5434,20 @@ CONTAINS
           SELECT CASE (J)
           CASE (1)
             MDS(7,I) = NDSFND
+#ifdef W3_ASCII
+            CALL WMUGET ( MDSE, MDST, NDSFND, 'OUT' )
+            CALL WMUSET ( MDSE, MDST, NDSFND, .TRUE.,            &
+                 DESC='ASCII output file' )
+            MDS(14,I) = NDSFND  ! ASCII
+#endif
           CASE (2)
             MDS(8,I) = NDSFND
+#ifdef W3_ASCII
+            CALL WMUGET ( MDSE, MDST, NDSFND, 'OUT' )
+            CALL WMUSET ( MDSE, MDST, NDSFND, .TRUE.,            &
+                 DESC='ASCII output file' )
+            MDS(15,I) = NDSFND  ! ASCII
+#endif
           CASE (3)
             MDS(12,I) = NDSFND
             CALL WMUGET ( MDSE, MDST, NDSFND, 'INP' )
@@ -5519,6 +5565,28 @@ CONTAINS
         END IF
       END IF
       !
+#ifdef W3_ASCII
+      IF ( MDS(14,I) .NE. -1 ) THEN ! Grid output (ASCII)
+        IF ( IAPROC .EQ. NAPFLD ) THEN
+          TNAME  = TRIM(FNMPRE)//'out_grd.' // FILEXT(:II) // '.txt'
+          CALL WMUSET ( MDSE,MDST, MDS(14,I), .TRUE., NAME=TNAME )
+        ELSE
+          CALL WMUSET ( MDSE,MDST, MDS(14,I), .FALSE. )
+          MDS(14,I) = -1
+        END IF
+      END IF
+      !
+      IF ( MDS(15,I) .NE. -1 ) THEN ! Point output (ASCII)
+        IF ( IAPROC .EQ. NAPPNT ) THEN
+          TNAME  = TRIM(FNMPRE)//'out_pnt.' // FILEXT(:II) // '.txt'
+          CALL WMUSET ( MDSE,MDST, MDS(15,I), .TRUE., NAME=TNAME )
+        ELSE
+          CALL WMUSET ( MDSE,MDST, MDS(15,I), .FALSE. )
+          MDS(15,I) = -1
+        END IF
+      END IF
+#endif
+!
 #ifdef W3_T
       WRITE (MDST,9081) I, TIME
 #endif
@@ -6493,7 +6561,7 @@ CONTAINS
     !
 #ifdef W3_T
 9020 FORMAT ( ' TEST WMINITNML : UNIT NUMBERS FOR GRIDS (',A,')'/  &
-         15X,'GRID MDS(1-13)',43X,'NTRACE')
+         15X,'GRID MDS(1-15)',43X,'NTRACE')
 9021 FORMAT (14X,16I4)
 9022 FORMAT ( ' TEST WMINITNML : UNIT NUMBERS FOR INTPUT FILES'/   &
          15X,'GRID MDSF(JFIRST-9)')


### PR DESCRIPTION

# Pull Request Summary
When running ww3_multi with ASCII output (`W3_ASCII` switch), the unit numbers for gridded and point ASCII output are not set and default to -1.

This is causing the model to crash (at least with the GNU compiler) as the unit number is invalid.

## Description
This issue only affects when running in multi grid mode.
Unit numbers are assigned to each grid/output file combination dynamically in WMINITMD.
The logic for assigning unit numbers to the new ASCII gridded/point outputs was missing.
Also, the `MDS` array in the same module was incorrectly sized as 13, rather than 15 elements.

### Issue(s) addressed
Fixes #1116 

### Commit Message
Bugfix: Assign unit numbers to ASCII gridded/point output in multi-grid mode.

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **mww3_test_09 regresssion test.**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Cray HPC; GNU Fortran.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

