### PR TITLE
NCEP regtest module updates:  uses spack-stack/1.5.0, includes scotch/7.0.4

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -41,16 +41,18 @@ EOF
 # Convert main_dir to absolute path
   main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
 
-# Module Versions from HPC-Stack that are common for all platforms
-  modnetcdf='netcdf/4.7.4'
-  modjasper='jasper/2.0.25'
-  modzlib='zlib/1.2.11'
+# Module Versions from spack-stack that are common for all platforms
+  modnetcdfc='netcdf-c/4.9.2'
+  modnetcdff='netcdf-fortran/4.6.0'
+  modjasper='jasper/2.0.32'
+  modzlib='zlib/1.2.13'
   modpng='libpng/1.6.37'
-  modhdf5='hdf5/1.10.6'
+  modhdf5='hdf5/1.14.0'
   modbacio='bacio/2.4.1'
   modg2='g2/3.4.5'
-  modw3emc='w3emc/2.9.2'
-  modesmf='esmf/8.3.0b09'
+  modw3emc='w3emc/2.10.0'
+  modesmf='esmf/8.4.2'
+  modscotch='scotch/7.0.4'
 
 # Set batchq queue, choose modules and other custom variables to fit system and
 # to define headers etc (default to original version if empty)
@@ -62,25 +64,21 @@ EOF
     batchq='slurm'
     basemodcomp='intel/2022.1.2'
     basemodmpi='impi/2022.1.2'
-    hpcstackpath='/scratch1/NCEPDEV/nems/role.epic/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
-    hpcstackversion='hpc/1.2.0'
-    modcomp='hpc-intel/2022.1.2'
-    modmpi='hpc-impi/2022.1.2'
-    scotchpath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
-    metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
-    modcmake='cmake/3.20.1'
+    spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core'
+    modcomp='stack-intel/2021.5.0'
+    modmpi='stack-intel-oneapi-mpi/2021.5.1'
+    metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/spack-stack/1.5.0/parmetis-4.0.3/install'
+    modcmake='cmake/3.23.1'
   elif [ $isorion ]
   then
     batchq='slurm'
     basemodcomp='intel/2022.1.2'
     basemodmpi='impi/2022.1.2'
-    hpcstackpath='/work/noaa/epic-ps/role-epic-ps/hpc-stack/libs/intel-2022.1.2/modulefiles/stack'
-    hpcstackversion='hpc/1.2.0'
-    modcomp='hpc-intel/2022.1.2'
-    modmpi='hpc-impi/2022.1.2'
-    scotchpath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/scotch-v7.0.3/install'
-    metispath='/work2/noaa/marine/mmasarik/waves/opt/hpc-stack/parmetis-4.0.3/install'
-    modcmake='cmake/3.22.1'
+    spackstackpath='/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core'
+    modcomp='stack-intel/2022.0.2'
+    modmpi='stack-intel-oneapi-mpi/2021.5.1'
+    metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/spack-stack/1.5.0/parmetis-4.0.3/install'
+    modcmake='cmake/3.23.1'
   else
     batchq=
   fi
@@ -139,29 +137,28 @@ EOF
 
 # Netcdf, Parmetis and SCOTCH modules & variables
   echo "  module purge"                                     >> matrix.head
-  echo "  module load $modcmake"                            >> matrix.head
   if [ ! -z $basemodcomp ]; then
     echo "  module load $basemodcomp"                       >> matrix.head
   fi
   if [ ! -z $basemodmpi ]; then
     echo "  module load $basemodmpi"                        >> matrix.head
   fi
-  echo "  module use  $hpcstackpath"                        >> matrix.head
-  echo "  module load $hpcstackversion"                     >> matrix.head
+  echo "  module use  $spackstackpath"                      >> matrix.head
   echo "  module load $modcomp"                             >> matrix.head
   echo "  module load $modmpi"                              >> matrix.head
+  echo "  module load $modcmake"                            >> matrix.head
   echo "  module load $modpng"                              >> matrix.head
   echo "  module load $modzlib"                             >> matrix.head
   echo "  module load $modjasper"                           >> matrix.head
   echo "  module load $modhdf5"                             >> matrix.head
-  echo "  module load $modnetcdf"                           >> matrix.head
+  echo "  module load $modnetcdfc"                          >> matrix.head
+  echo "  module load $modnetcdff"                          >> matrix.head
   echo "  module load $modbacio"                            >> matrix.head
   echo "  module load $modg2"                               >> matrix.head
   echo "  module load $modw3emc"                            >> matrix.head
   echo "  module load $modesmf"                             >> matrix.head
-
+  echo "  module load $modscotch"                           >> matrix.head
   echo "  export METIS_PATH=${metispath}"                   >> matrix.head
-  echo "  export SCOTCH_PATH=${scotchpath}"                 >> matrix.head
   echo "  export path_build_root=$(dirname $main_dir)/regtests/buildmatrix" >> matrix.head
   echo '  [[ -d ${path_build_root} ]] && rm -rf ${path_build_root}'         >> matrix.head
   echo ' '


### PR DESCRIPTION
# Pull Request Summary
Updates the module environment used for NCEP's regtests on RDHPCS machines to use the `spack-stack/1.5.0` stack which includes `scotch/7.0.4`.

## Description
* Key points about this update:
  * Switches to `spack` -based `spack-stack` module stack.  Previously the `hpc-stack` module stack has been used.
  * A module version of `scotch` is used.  Previously the `export`-ed `SCOTCH_PATH` parameter pointed to a local installation.
  * The RDHPCS machines this update applies to are `hera` and `orion`.  
* Mention any labels that should be added: 
  *  _enhancement_
* Are answer changes expected from this PR? 
  * Yes. 
* Please describe the changes and the reason why in addition to which of the following labels would apply: 
  *  Some answers changes are expected and due only to the change in the **module environment**.
  *  _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
  - fixes #1121 

### Commit Message
NCEP regtest module updates:  uses spack-stack/1.5.0, includes scotch/7.0.4

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  *  Answers cannot be expected to reproduce between differing modules stack environments, so the PR branch was run against itself on both `hera` and `orion`.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * NA (we cannot/do not test for module environment changes).
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * `hera/intel`, `orion/intel`. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Changes are expected from previous stack.  The PR branch runs against itself have no unexpected changes. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):


**orion**
Note:  The `(0 files differ)` all checkout as soft links from `input/` that have gone bad.  It is completely benign.  Once these are removed only the known non-b4b are left.

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_02/./work_PR3_UQ_MPI_b_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_d                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_d                     (0 files differ)
mww3_test_02/./work_PR2_UNO_MPI_a                     (0 files differ)
mww3_test_02/./work_PR2_UQ_a                     (0 files differ)
mww3_test_02/./work_PR2_UNO_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_b                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_a                     (0 files differ)
mww3_test_02/./work_PR1_a                     (0 files differ)
mww3_test_02/./work_PR1_MPI_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_c_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_d_c                     (0 files differ)
mww3_test_02/./work_PR2_UNO_d                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_c_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_c_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_d_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_b_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_a_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_a                     (0 files differ)
mww3_test_02/./work_PR3_UNO_b_c                     (0 files differ)
mww3_test_02/./work_PR2_UNO_b                     (0 files differ)
mww3_test_02/./work_PR2_UQ_MPI_a                     (0 files differ)
mww3_test_02/./work_PR2_UQ_MPI_c                     (0 files differ)
mww3_test_02/./work_PR2_UQ_b                     (0 files differ)
mww3_test_02/./work_PR2_UNO_MPI_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_a_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_d                     (0 files differ)
mww3_test_02/./work_PR1_MPI_a                     (0 files differ)
mww3_test_02/./work_PR3_UQ_b                     (0 files differ)
mww3_test_02/./work_PR1_MPI_d                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_b_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_MPI_b                     (0 files differ)
mww3_test_02/./work_PR1_c                     (0 files differ)
mww3_test_02/./work_PR3_UQ_d_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_d                     (0 files differ)
mww3_test_02/./work_PR2_UQ_MPI_b                     (0 files differ)
mww3_test_02/./work_PR2_UNO_MPI_d                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_a                     (0 files differ)
mww3_test_02/./work_PR2_UQ_c                     (0 files differ)
mww3_test_02/./work_PR1_b                     (0 files differ)
mww3_test_02/./work_PR2_UNO_a                     (0 files differ)
mww3_test_02/./work_PR3_UNO_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_b                     (0 files differ)
mww3_test_02/./work_PR2_UNO_MPI_b                     (0 files differ)
mww3_test_02/./work_PR3_UQ_a                     (0 files differ)
mww3_test_02/./work_PR2_UQ_MPI_d                     (0 files differ)
mww3_test_02/./work_PR2_UQ_d                     (0 files differ)
mww3_test_02/./work_PR1_d                     (0 files differ)
mww3_test_02/./work_PR3_UNO_a_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_MPI_a_c                     (0 files differ)
mww3_test_02/./work_PR1_MPI_b                     (0 files differ)
mww3_test_02/./work_PR3_UNO_c_c                     (0 files differ)
mww3_test_02/./work_PR3_UNO_d_c                     (0 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (18 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_ta1/./work_UPD5_U                     (0 files differ)
ww3_ta1/./work_UPD6_U                     (0 files differ)
ww3_ta1/./work_UPD0F_O                     (0 files differ)
ww3_ta1/./work_UPD5_O                     (0 files differ)
ww3_ta1/./work_UPD2_O                     (0 files differ)
ww3_ta1/./work_UPD6_O                     (0 files differ)
ww3_ta1/./work_UPD5_U_cap                     (0 files differ)
ww3_ta1/./work_UPD6_U_cap                     (0 files differ)
ww3_ta1/./work_UPD3_O                     (0 files differ)
ww3_ta1/./work_UPD3_U                     (0 files differ)
ww3_ta1/./work_UPD2_U                     (0 files differ)
ww3_ta1/./work_UPD2_U_cap                     (0 files differ)
ww3_ta1/./work_UPD3_U_cap                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

[orion.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13602285/orion.matrixCompSummary.txt)
[orion.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13602284/orion.matrixDiff.txt)
[orion.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13602286/orion.matrixCompFull.txt)


**hera**
Here only known non-b4bs present.

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

[hera.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13602302/hera.matrixCompSummary.txt)
[hera.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13602301/hera.matrixDiff.txt)
[hera.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13602303/hera.matrixCompFull.txt)


