### PR TITLE
Minor update to ncep regtests

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -62,8 +62,6 @@ EOF
   then
     # If no other h, assuming Hera
     batchq='slurm'
-    basemodcomp='intel/2022.1.2'
-    basemodmpi='impi/2022.1.2'
     spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.0/envs/unified-env-noavx512/install/modulefiles/Core'
     modcomp='stack-intel/2021.5.0'
     modmpi='stack-intel-oneapi-mpi/2021.5.1'
@@ -72,8 +70,6 @@ EOF
   elif [ $isorion ]
   then
     batchq='slurm'
-    basemodcomp='intel/2022.1.2'
-    basemodmpi='impi/2022.1.2'
     spackstackpath='/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.5.0/envs/unified-env/install/modulefiles/Core'
     modcomp='stack-intel/2022.0.2'
     modmpi='stack-intel-oneapi-mpi/2021.5.1'
@@ -94,7 +90,7 @@ EOF
 
 # 1.a Computer/ user dependent set up
 
-  echo '#!/bin/sh --login'                                   > matrix.head
+  echo '#!/bin/sh'                                           > matrix.head
   echo ' '                                                  >> matrix.head
   if [ $batchq = "slurm" ] && [ $isorion ]
   then


### PR DESCRIPTION
# Pull Request Summary
Minor updates to the ncep regtests

## Description
The two minor updates here are: 
* removing the two intel loads before the spack intel loads 
* removing the --login from the bash script  which was pointed out as un-necessary by @MatthewMasarik-NOAA 

Please also include the following information: 
* Add any suggestions for a reviewer  @MatthewMasarik-NOAA 
* Mention any labels that should be added:  none 
* Are answer changes expected from this PR? No answer changes 

### Issue(s) addressed
No issue for minor update/follow up on previous PR. 

### Commit Message
Minor update to ncep regtets

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, hera and orion w/intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):


The differences for both hera and orion are the same I have on the previous PR when comparing with itself, these are comparing against the previous PR branch (ie develop). 

Hera: 
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (12 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```


[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13619062/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13619063/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13619064/matrixDiff.txt)


And on Orion, the full logs: 
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13619068/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13619069/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13619070/matrixDiff.txt)

