### PR TITLE
Intel CI update Jan 2024

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -98,7 +98,7 @@ jobs:
     strategy:
       matrix:
         switch: [Ifremer1, NCEP_st2, NCEP_st4, ite_pdlib, NCEP_st4sbs, NCEP_glwu, OASACM, UKMO, MULTI_ESMF]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: checkout-ww3
@@ -119,6 +119,7 @@ jobs:
 
       - name: build-ww3
         run: |
+          sudo mv /usr/local /usr/local_mv
           . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -26,7 +26,7 @@ env:
 
 jobs:
   setup:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
 
@@ -72,8 +72,8 @@ jobs:
           spack compiler find
           sudo apt install cmake
           spack external find
-          spack add intel-oneapi-mpi
           spack config add "packages:all:require:['%intel']"
+          spack config add "packages:mpi:require:'intel-oneapi-mpi'"
           spack concretize
           spack install --dirty -v --fail-fast
           spack clean --all

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -72,8 +72,8 @@ jobs:
           spack compiler find
           sudo apt install cmake
           spack external find
-          spack config add "packages:all:require:['%intel']"
           spack config add "packages:mpi:require:'intel-oneapi-mpi'"
+          spack config add "packages:all:require:['%intel']"
           spack concretize
           spack install --dirty -v --fail-fast
           spack clean --all

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -62,6 +62,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          sudo mv /usr/local /usr/local_mv
           # Install NetCDF, ESMF, g2, etc using Spack
           . /opt/intel/oneapi/setvars.sh
           git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -120,6 +120,7 @@ jobs:
       - name: build-ww3
         run: |
           sudo mv /usr/local /usr/local_mv
+          sudo apt install cmake
           . /opt/intel/oneapi/setvars.sh
           source spack/share/spack/setup-env.sh
           spack env activate ww3-intel


### PR DESCRIPTION
# Pull Request Summary
This PR updates the Intel CI.

## Description
This PR
 - updates to ubuntu-latest;
 - moves /usr/local out of the way to avoid cmake/glibc problems; and
 - ensures that the apt-supplied intel-oneapi-mpi is used.

### Issue(s) addressed
Related to https://github.com/NOAA-EMC/WW3/issues/1156

### Commit Message
`Update Intel CI (relocate /usr/local; ensure intel-oneapi-mpi; use ubuntu-latest)`

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

Intel CI tests run successfully.

