### PR TITLE
Resolve division by 0 when meshcap is run with WW3-CICE coupling; Add timers and overwrite capability for mod_def timesteps to meshcap 

### DIFF
--- a/model/src/cmake/src_list.cmake
+++ b/model/src/cmake/src_list.cmake
@@ -66,6 +66,7 @@ set(nuopc_mesh_cap_src
   wav_shel_inp.F90
   wav_comp_nuopc.F90
   wav_import_export.F90
+  wav_wrapper_mod.F90
   )
 
 set(esmf_multi_cap_src

--- a/model/src/w3fld1md.F90
+++ b/model/src/w3fld1md.F90
@@ -1116,7 +1116,11 @@ CONTAINS
     DO K=KA1, KA2-1
       AVG=SUM(INSPC(K,:))/MAX(REAL(NTH),1.)
       DO T=1,NTH
-        INSPC(K,T)=BT(K)*INSPC(K,T)/TPI/(WN2(K)**3.0)/AVG
+        if (avg /= 0.0) then
+          INSPC(K,T)=BT(K)*INSPC(K,T)/TPI/(WN2(K)**3.0)/AVG
+        else
+          inspc(k,t) = 0.0
+        end if
       ENDDO
     ENDDO
     !-----------------------------------------------------------
@@ -1134,7 +1138,11 @@ CONTAINS
       ENDDO
       AVG=SUM(NORMSPC)/MAX(REAL(NTH),1.)
       DO T=1, NTH
-        INSPC(K,T) = SAT * NORMSPC(T)/TPI/(WN2(K)**3.0)/AVG
+        if (avg /= 0.0) then
+          INSPC(K,T) = SAT * NORMSPC(T)/TPI/(WN2(K)**3.0)/AVG
+        else
+          inspc(k,t) = 0.0
+        end if
       ENDDO
     ENDDO
     DO T=1, NTH
@@ -1148,7 +1156,11 @@ CONTAINS
     AVG=SUM(NORMSPC)/MAX(REAL(NTH),1.)!1./4.
     DO K=KA3+1, NKT
       DO T=1, NTH
-        INSPC(K,T)=NORMSPC(T)*(SAT)/TPI/(WN2(K)**3.0)/AVG
+        if (avg /= 0.0) then
+          INSPC(K,T)=NORMSPC(T)*(SAT)/TPI/(WN2(K)**3.0)/AVG
+        else
+          inspc(k,t) = 0.0
+        end if
       ENDDO
     ENDDO
     DEALLOCATE(ANGLE1)

--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -48,6 +48,7 @@ module wav_comp_nuopc
   use w3odatmd              , only : user_netcdf_grdout
   use w3odatmd              , only : time_origin, calendar_name, elapsed_secs
   use wav_shr_mod           , only : casename, multigrid, inst_suffix, inst_index, unstr_mesh
+  use wav_wrapper_mod       , only : ufs_settimer, ufs_logtimer, ufs_file_setlogunit, wtime
 #ifndef W3_CESMCOUPLED
   use wmwavemd              , only : wmwave
   use wmupdtmd              , only : wmupd2
@@ -101,7 +102,8 @@ module wav_comp_nuopc
                                                            !! set using restart_option, restart_n and restart_ymd
   integer :: time0(2)
   integer :: timen(2)
-
+  integer :: nu_timer                                      !< simple timer log, unused except by UFS
+  logical :: runtimelog = .false.                          !< logical flag for writing runtime log files
   character(*), parameter :: modName =  "(wav_comp_nuopc)" !< the name of this module
   character(*), parameter :: u_FILE_u = &                  !< a character string for an ESMF log message
        __FILE__
@@ -238,6 +240,7 @@ contains
     character(len=*), parameter :: subname=trim(modName)//':(InitializeAdvertise) '
     !-------------------------------------------------------------------------------
 
+    call ufs_settimer(wtime)
     rc = ESMF_SUCCESS
     call ESMF_LogWrite(trim(subname)//' called', ESMF_LOGMSG_INFO)
 
@@ -369,6 +372,15 @@ contains
     write(logmsg,'(A,l)') trim(subname)//': Wave wav_coupling_to_cice setting is ',wav_coupling_to_cice
     call ESMF_LogWrite(trim(logmsg), ESMF_LOGMSG_INFO)
 
+    ! Determine Runtime logging
+    call NUOPC_CompAttributeGet(gcomp, name="RunTimeLog", value=cvalue, isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) runtimelog=(trim(cvalue)=="true")
+    write(logmsg,*) runtimelog
+    call ESMF_LogWrite('WW3_cap:RunTimeLog = '//trim(logmsg), ESMF_LOGMSG_INFO)
+    if (runtimelog) then
+      call ufs_file_setLogUnit('./log.ww3.timer',nu_timer,runtimelog)
+    end if
     call advertise_fields(importState, exportState, flds_scalar_name, rc)
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
@@ -475,6 +487,7 @@ contains
     rc = ESMF_SUCCESS
     if (dbug_flag > 5) call ESMF_LogWrite(trim(subname)//' called', ESMF_LOGMSG_INFO)
 
+    call ufs_settimer(wtime)
     !--------------------------------------------------------------------
     ! Set up data structures
     !--------------------------------------------------------------------
@@ -871,6 +884,7 @@ contains
       enddo
     end if
 #endif
+    if (root_task) call ufs_logtimer(nu_timer,time,start_tod,'InitializeRealize time: ',runtimelog,wtime)
 
     if (dbug_flag > 5) call ESMF_LogWrite(trim(subname)//' done', ESMF_LOGMSG_INFO)
 
@@ -1041,6 +1055,8 @@ contains
     if ( root_task ) then
       write(nds(1),'(a,3i4,i10)') 'ymd2date currTime wav_comp_nuopc hh,mm,ss,ymd', hh,mm,ss,ymd
     end if
+    if (root_task) call ufs_logtimer(nu_timer,time,tod,'ModelAdvance time since last step: ',runtimelog,wtime)
+    call ufs_settimer(wtime)
 
     ! use next time; the NUOPC clock is not updated
     ! until the end of the time interval
@@ -1138,6 +1154,8 @@ contains
     if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
     if (dbug_flag > 5) call ESMF_LogWrite(trim(subname)//' done', ESMF_LOGMSG_INFO)
+    if (root_task) call ufs_logtimer(nu_timer,time,tod,'ModelAdvance time: ',runtimelog,wtime)
+    call ufs_settimer(wtime)
 
   end subroutine ModelAdvance
 
@@ -1357,6 +1375,7 @@ contains
     end if
 
     call ESMF_LogWrite(trim(subname)//' done', ESMF_LOGMSG_INFO)
+    if(root_task) call ufs_logtimer(nu_timer,timen,0,'ModelFinalize time: ',runtimelog,wtime)
 
   end subroutine ModelFinalize
 
@@ -1575,6 +1594,7 @@ contains
     ! Initialize ww3 for ufs (called from InitializeRealize)
 
     use w3odatmd     , only : fnmpre
+    use w3gdatmd     , only : dtcfl, dtcfli, dtmax, dtmin
     use w3initmd     , only : w3init
     use wav_shel_inp , only : read_shel_config
     use wav_shel_inp , only : npts, odat, iprt, x, y, pnames, prtfrm
@@ -1591,6 +1611,7 @@ contains
     character(len=CL) :: logmsg
     logical           :: isPresent, isSet
     character(len=CL) :: cvalue
+    integer           :: dt_in(4)
     character(len=*), parameter :: subname = '(wav_comp_nuopc:wavinit_ufs)'
     ! -------------------------------------------------------------------
 
@@ -1638,6 +1659,17 @@ contains
     call w3init ( 1, .false., 'ww3', mds, ntrace, odat, flgrd, flgr2, flgd, flg2, &
          npts, x, y, pnames, iprt, prtfrm, mpi_comm )
 
+    call NUOPC_CompAttributeGet(gcomp, name='dt_in', isPresent=isPresent, isSet=isSet, rc=rc)
+    if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    if (isPresent .and. isSet) then
+      call NUOPC_CompAttributeGet(gcomp, name='dt_in', value=cvalue, rc=rc)
+      if (ChkErr(rc,__LINE__,u_FILE_u)) return
+      read(cvalue,*)dt_in
+      dtmax  = real(dt_in(1),4)
+      dtcfl  = real(dt_in(2),4)
+      dtcfli = real(dt_in(3),4)
+      dtmin  = real(dt_in(4),4)
+    end if
     if (dbug_flag > 5) call ESMF_LogWrite(trim(subname)//' done', ESMF_LOGMSG_INFO)
   end subroutine waveinit_ufs
 

--- a/model/src/wav_wrapper_mod.F90
+++ b/model/src/wav_wrapper_mod.F90
@@ -1,0 +1,146 @@
+!> @file wav_wrapper_mod
+!!
+!> A wrapper module for log functionality in UFS
+!!
+!> @details Contains public logging routines for UFS and
+!! stub routines for CESM
+!!
+!> Denise.Worthen@noaa.gov
+!> @date 01-08-2024
+module wav_wrapper_mod
+
+#ifdef CESMCOUPLED
+  use perf_mod      , only : t_startf, t_stopf, t_barrierf
+  use shr_file_mod  , only : shr_file_getlogunit, shr_file_setlogunit
+  use wav_kind_mod  , only : r8 => shr_kind_r8, r4 => shr_kind_r4, i4 => shr_kind_i4
+  use wav_kind_mod  , only : CL => shr_kind_cl, CS => shr_kind_cs
+
+  implicit none
+
+  real(r8) :: wtime = 0.0
+contains
+  ! Define stub routines that do nothing - they are just here to avoid
+  ! having cppdefs in the main program
+  subroutine ufs_settimer(timevalue)
+    real(r8),    intent(inout) :: timevalue
+  end subroutine ufs_settimer
+  subroutine ufs_logtimer(nunit,times,tod,string,runtimelog,wtime0)
+    integer,          intent(in) :: nunit
+    integer(i4),      intent(in) :: times(2), tod
+    character(len=*), intent(in) :: string
+    logical,          intent(in) :: runtimelog
+    real(r8),         intent(in) :: wtime0
+  end subroutine ufs_logtimer
+  subroutine ufs_file_setLogUnit(filename,nunit,runtimelog)
+    character(len=*),  intent(in)  :: filename
+    logical,           intent(in)  :: runtimelog
+    integer,           intent(out) :: nunit
+  end subroutine ufs_file_setLogUnit
+  subroutine ufs_logfhour(msg,hour)
+    character(len=*),  intent(in)  :: msg
+    real(r8),          intent(in)  :: hour
+  end subroutine ufs_logfhour
+#else
+
+  use wav_kind_mod , only : r8 => shr_kind_r8, r4 => shr_kind_r4, i4 => shr_kind_i4
+  use wav_kind_mod , only : CL => shr_kind_cl, CS => shr_kind_cs
+
+  implicit none
+
+  real(r8) :: wtime = 0.0
+contains
+  subroutine ufs_settimer(timevalue)
+    !> Set a time value
+    !! @param[inout]    timevalue    a MPI time value
+    !!
+    !> Denise.Worthen@noaa.gov
+    !> @date 01-08-2024
+
+    real(r8),    intent(inout) :: timevalue
+    real(r8)                   :: MPI_Wtime
+    timevalue = MPI_Wtime()
+  end subroutine ufs_settimer
+
+  subroutine ufs_logtimer(nunit,times,tod,string,runtimelog,wtime0)
+    !> Log a time interval
+    !! @param[in]    nunit              the log file unit
+    !! @param[in]    times              the ymd,hms time values
+    !! @param[in]    tod                the elapsed seconds in the day
+    !! @param[in]    string             a message string to log
+    !! @param[in]    runtimelog         a logical to control the log function
+    !! @param[in]    wtime0             an initial MPI time
+    !!
+    !> Denise.Worthen@noaa.gov
+    !> @date 01-08-2024
+    integer,          intent(in)    :: nunit
+    integer(i4),      intent(in)    :: times(2),tod
+    character(len=*), intent(in)    :: string
+    logical,          intent(in)    :: runtimelog
+    real(r8),         intent(in)    :: wtime0
+    real(r8)                        :: MPI_Wtime, timevalue
+    if (.not. runtimelog) return
+    if (wtime0 > 0.) then
+      timevalue = MPI_Wtime()-wtime0
+      write(nunit,'(3i8,a,g14.7)')times,tod,' WW3 '//trim(string),timevalue
+    end if
+  end subroutine ufs_logtimer
+
+  subroutine ufs_file_setLogUnit(filename,nunit,runtimelog)
+    !> Create a log unit
+    !! @param[in]    filename           the log filename
+    !! @param[in]    runtimelog         a logical to control the log function
+    !! @param[out]   nunit              the log file unit
+    !!
+    !> Denise.Worthen@noaa.gov
+    !> @date 01-08-2024
+
+    character(len=*),  intent(in)    :: filename
+    logical,           intent(in)    :: runtimelog
+    integer,           intent(out)   :: nunit
+    if (.not. runtimelog) return
+    open (newunit=nunit, file=trim(filename))
+  end subroutine ufs_file_setLogUnit
+
+  subroutine ufs_logfhour(msg,hour)
+    !> Log the completion of model output
+    !! @param[in]    msg                the log message
+    !! @param[in]    hour               the forecast hour
+    !!
+    !> Denise.Worthen@noaa.gov
+    !> @date 01-08-2024
+
+    character(len=*), intent(in) :: msg
+    real(r8),         intent(in) :: hour
+
+    character(len=CS)            :: filename
+    integer(r4)                  :: nunit
+
+    write(filename,'(a,i3.3)')'log.ww3.f',int(hour)
+    open(newunit=nunit,file=trim(filename))
+    write(nunit,'(a)')'completed: ww3'
+    write(nunit,'(a,f10.3)')'forecast hour:',hour
+    write(nunit,'(a)')'valid time: '//trim(msg)
+    close(nunit)
+  end subroutine ufs_logfhour
+
+  ! Define stub routines that do nothing - they are just here to avoid
+  ! having cppdefs in the main program
+  subroutine shr_file_setLogUnit(nunit)
+    integer, intent(in) :: nunit
+  end subroutine shr_file_setLogUnit
+  subroutine shr_file_getLogUnit(nunit)
+    integer, intent(in) :: nunit
+  end subroutine shr_file_getLogUnit
+  subroutine t_startf(string)
+    character(len=*) :: string
+  end subroutine t_startf
+  subroutine t_stopf(string)
+    character(len=*) :: string
+  end subroutine t_stopf
+  subroutine t_barrierf(string, comm)
+    character(len=*) :: string
+    integer:: comm
+  end subroutine t_barrierf
+#endif
+
+end module wav_wrapper_mod

--- a/model/src/wav_wrapper_mod.F90
+++ b/model/src/wav_wrapper_mod.F90
@@ -9,15 +9,14 @@
 !> @date 01-08-2024
 module wav_wrapper_mod
 
-#ifdef CESMCOUPLED
-  use perf_mod      , only : t_startf, t_stopf, t_barrierf
-  use shr_file_mod  , only : shr_file_getlogunit, shr_file_setlogunit
   use wav_kind_mod  , only : r8 => shr_kind_r8, r4 => shr_kind_r4, i4 => shr_kind_i4
   use wav_kind_mod  , only : CL => shr_kind_cl, CS => shr_kind_cs
 
   implicit none
 
   real(r8) :: wtime = 0.0
+
+#ifdef CESMCOUPLED
 contains
   ! Define stub routines that do nothing - they are just here to avoid
   ! having cppdefs in the main program
@@ -41,13 +40,6 @@ contains
     real(r8),          intent(in)  :: hour
   end subroutine ufs_logfhour
 #else
-
-  use wav_kind_mod , only : r8 => shr_kind_r8, r4 => shr_kind_r4, i4 => shr_kind_i4
-  use wav_kind_mod , only : CL => shr_kind_cl, CS => shr_kind_cs
-
-  implicit none
-
-  real(r8) :: wtime = 0.0
 contains
   subroutine ufs_settimer(timevalue)
     !> Set a time value
@@ -122,25 +114,6 @@ contains
     write(nunit,'(a)')'valid time: '//trim(msg)
     close(nunit)
   end subroutine ufs_logfhour
-
-  ! Define stub routines that do nothing - they are just here to avoid
-  ! having cppdefs in the main program
-  subroutine shr_file_setLogUnit(nunit)
-    integer, intent(in) :: nunit
-  end subroutine shr_file_setLogUnit
-  subroutine shr_file_getLogUnit(nunit)
-    integer, intent(in) :: nunit
-  end subroutine shr_file_getLogUnit
-  subroutine t_startf(string)
-    character(len=*) :: string
-  end subroutine t_startf
-  subroutine t_stopf(string)
-    character(len=*) :: string
-  end subroutine t_stopf
-  subroutine t_barrierf(string, comm)
-    character(len=*) :: string
-    integer:: comm
-  end subroutine t_barrierf
 #endif
 
 end module wav_wrapper_mod


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 

Resolve potential division by zero found when coupling WW3 with CICE.
Adds run timers to the meshcap.

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
 - fixes #1159 
 - fixes #1162 
- required by https://github.com/ufs-community/ufs-weather-model/issues/1367

Adds generation of a timer log in the meshcap, which will report, for example, the time spent in ``modelAdvance`` as well as the time spent before starting the next Advance. The capability is added using a wrapper mod (mimicking the CICE wrapper mod) so that no additional ifdefs are required in the cap. The output generated in ``log.ww3.timer`` is

```
20210322   60000   21600 WW3 InitializeRealize time: 0.7798858
20210322   60000   21600 WW3 ModelAdvance time since last step:  4.489980
20210322   61200   22320 WW3 ModelAdvance time:  2.570183
20210322   61200   22320 WW3 ModelAdvance time since last step:  8.023816
20210322   62400   23040 WW3 ModelAdvance time:  1.164186
```

Also adds capability to over-write timesteps from the mod_def file with other values. See associated UWM https://github.com/ufs-community/ufs-weather-model/pull/2086 for description of how this works.
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

prevent division by 0 in appendtail and add timers to meshcap

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Regression tests in UWM were run. Logs are posted in associated UWM PR #2085 https://github.com/ufs-community/ufs-weather-model/pull/2085
