### PR TITLE
initialize USSP_WN for mod_def

### DIFF
--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -2962,6 +2962,7 @@ CONTAINS
       CALL EXTCDE( 31)
     ENDIF
 
+    USSP_WN = 0.0 ! initialize to 0s
     DO J=1,USSPF(2)
       USSP_WN(j) = STK_WN(J)
     ENDDO


### PR DESCRIPTION
# Pull Request Summary
Initialize USSP_WN for mod_def 

## Description
If a compiler assigns random numbers instead of zeros you will notice that mod_defs are different because of USSP_WN.  While the uninitialized variables are never used, this insures the array is initialized to zero and clean things up for compilers that assign random numbers. 

Please also include the following information: 
* Add any suggestions for a reviewer: @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? Since these variables are never used if you use a compiler that initializes the values to zero by default you will not notice any answer changes.  If your compiler initalizes things to random values, you will see differences in mod_defs, but no other answer changes. 

### Issue(s) addressed
Closes https://github.com/NOAA-EMC/WW3/issues/1160 

### Commit Message
initialize USSP_WN for mod_def

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix of regtests  on hera with intel.  Note other smaller tests were done on hercules + gnu on a branch which is what exposed this issue.   We do not see answer changes on hera+intel
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) To see the impact a particular machine/compiler combo is needed. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? intel on hera  
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
Depends on compiler, but for hera+intel, only non-b4b.  If you have a compiler that initializes to random numbers, mod_defs will be different. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/13903974/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/13903975/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/13903976/matrixDiff.txt)


```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
