### PR TITLE
w3fld1md.F90: fix for "crit2"

### DIFF
--- a/model/src/w3fld1md.F90
+++ b/model/src/w3fld1md.F90
@@ -550,9 +550,13 @@ CONTAINS
           TAUDIR=atan2(TAUY, TAUX)
           ! Note: add another criterion (stress direction) for iteration.
           CRIT1=(ABS(USTAR-USTRB)*100.0)/((USTAR+USTRB)*0.5) .GT. 0.1
-          CRIT2=(ABS(TAUDIR-TAUDIRB)*100.0/(TAUDIR+TAUDIRB)*0.5) .GT. 0.1
+          IF ((TAUDIR+TAUDIRB).NE.0.) THEN
+              CRIT2=(ABS(TAUDIR-TAUDIRB)*100.0/(TAUDIR+TAUDIRB)*0.5) .GT. 0.1
+          ELSE
+              CRIT2=.TRUE.
+          ENDIF
           IF (CRIT1 .OR. CRIT2) THEN
-            !            IF ((ABS(USTAR-USTRB)*100.0)/((USTAR+USTRB)*0.5) .GT. 0.1) THEN
+            !    IF ((ABS(USTAR-USTRB)*100.0)/((USTAR+USTRB)*0.5) .GT. 0.1) THEN
             USTRB=USTAR
             TAUDIRB=TAUDIR
             CTR=CTR+1


### PR DESCRIPTION
# Pull Request Summary
Fixes floating point exception in `w3fld1md.F90` when performing a `Debug` run using additional compiler flags.

## Description
Provide a detailed description of what this PR does.
* Fixes a divide-by-zero floating point error.
What bug does it fix, or what feature does it add?
* Bug fix for stability parameter (`CRIT2`) in `w3fld1md.F90`
Is a change of answers expected from this PR?
* No.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA  
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR?
  * No. 

### Issue(s) addressed
- fixes #1169 

### Commit Message
w3fld1md.F90:  fix divide by zero in CRIT2 parameter

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * Running the matrix. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * Yes. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Hera / Intel. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Only the expected known non-b4b's. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * [hera.2024-01-31.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/14114658/hera.2024-01-31.matrixCompSummary.txt)
  * [hera.2024-01-31.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/14114659/hera.2024-01-31.matrixCompFull.txt)
  * [hera.2024-01-31.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/14114656/hera.2024-01-31.matrixDiff.txt)

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```
