### PR TITLE
ww3_prnc.F90: IY out-of-range fix

### DIFF
--- a/model/src/ww3_prnc.F90
+++ b/model/src/ww3_prnc.F90
@@ -1059,7 +1059,7 @@ PROGRAM W3PRNC
           ! Manages the simple closure of the grid
           !
           IF (ICLO.EQ.ICLOSE_NONE) THEN
-            IF (IX21(IX,1).LT.1.OR.IX21(IX,1).GT.NXI-1) WRITE(NDSO,1042) IX, IY, X, Y
+            IF (IX21(IX,1).LT.1.OR.IX21(IX,1).GT.NXI-1) WRITE(NDSO,1041) IX, X, Y
             IX21(IX,1) =   MAX ( 1 , MIN(IX21(IX,1),NXI-1) )
             IX22(IX,1) =   IX21(IX,1) + 1
           ELSE
@@ -1067,7 +1067,7 @@ PROGRAM W3PRNC
             IX22(IX,1) =   MOD(IX21(IX,1),NXI)+1
           END IF
           IY21(IX,1) =   1 + INT((Y-Y0I)/SYI)
-          IF (IY21(IX,1).LT.1.OR.IY21(IX,1).GT.NYI-1) WRITE(NDSO,1042) IX, IY, X, Y
+          IF (IY21(IX,1).LT.1.OR.IY21(IX,1).GT.NYI-1) WRITE(NDSO,1041) IX, X, Y
           IY21(IX,1) =   MAX ( 1 , MIN(IY21(IX,1),NYI-1) )
           IY22(IX,1) =   IY21(IX,1) + 1
           !
@@ -2438,6 +2438,9 @@ PROGRAM W3PRNC
        '     2MS2 2MN2 2NK2 MNS2 MSN2 2SM2 3MSN2 '      &
        '     M4 MS4 MN4 M6 2MS6 2MN6'/)
   !
+1041 FORMAT (/' *** WAVEWATCH-III WARNING W3PRNC : '/                &
+       '     GRID POINT ',I6,2F7.2,/                         &
+       ' NOT COVERED BY INPUT GRID.'/)
 1042 FORMAT (/' *** WAVEWATCH-III WARNING W3PRNC : '/                &
        '     GRID POINT ',2I6,2F7.2,/                         &
        ' NOT COVERED BY INPUT GRID.'/)


### PR DESCRIPTION
# Pull Request Summary
Fixes a variable out-of-range bug in `ww3_prnc.F90`.

## Description
What bug does it fix, or what feature does it add?
  * In the program `ww3_prnc`, a diagnostic `WRITE` statement tries to print the grid index, `IY`, which is not in scope at the time.  It is in a code block that apparently only needs `IX`.  To fix this `IY` is removed from the print arguments in two instances, and a new `FORMAT` statement is created and used to match the arguments.
 
Is a change of answers expected from this PR?
  * No.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA  
* Mention any labels that should be added:  
  * _bug_.
* Are answer changes expected from this PR? 
  * No.

### Issue(s) addressed
- fixes #1183 


### Commit Message
ww3_prnc.F90:  fix out-of-scope grid index write statement

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * The matrix was run.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * Bugfix.  No expected changes.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Hera / Intel. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * Only the known non-b4b's. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (18 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```
  * [pr_1185.hera.2024-01-31.matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/14116839/pr_1185.hera.2024-01-31.matrixCompSummary.txt)
  * [pr_1185.hera.2024-01-31.matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/14116840/pr_1185.hera.2024-01-31.matrixCompFull.txt)
  * [pr_1185.hera.2024-01-31.matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/14116836/pr_1185.hera.2024-01-31.matrixDiff.txt)
