### PR TITLE
Initial drying of cells for SMC grid

### DIFF
--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -678,6 +678,7 @@ MODULE W3GRIDMD
 #endif
   !
 #ifdef W3_SMC
+  REAL                    :: DVSMC
   REAL                    :: TRNMX, TRNMY
   INTEGER, ALLOCATABLE    :: NLvCelsk(:),  NLvUFcsk(:),  NLvVFcsk(:)
   INTEGER, ALLOCATABLE    :: IJKCelin(:,:),IJKUFcin(:,:),IJKVFcin(:,:)
@@ -3944,6 +3945,12 @@ CONTAINS
     IF (IDFM.EQ.2) WRITE (NDSO,973) TRIM(RFORM)
     IF (FROM.EQ.'NAME' .AND. NDSG.NE.NDSI) &
          WRITE (NDSO,974) TRIM(FNAME)
+
+#ifdef W3_SMC
+    !Li  Save the depth conversion factor for SMC grid use.  JGLi03Nov2023
+    DVSMC = VSC
+#endif
+
     !
     ! 7.e Read bottom depths
     !
@@ -5065,14 +5072,17 @@ CONTAINS
           CALL EXTCDE(65)
         END IF
 
-        !Li  Minimum DMIN depth is used as well for SMC.
-        ZB(ISEA)= - MAX( DMIN, FLOAT( IJKDep(ISEA) ) )
-        MAPFS(IY:IY+JS-1,IX:IX+IK-1)  = ISEA
-        MAPSTA(IY:IY+JS-1,IX:IX+IK-1)  = 1
-        MAPST2(IY:IY+JS-1,IX:IX+IK-1)  = 0
-        MAPSF(ISEA,1)  = IX
-        MAPSF(ISEA,2)  = IY
-        MAPSF(ISEA,3)  = IY + (IX    -1)*NY
+        !Li Allow land cell to be defined by ZLIM value and only reset
+        !Li MAPST* land values for sea points.   JGLi03Nov2023
+        ZB(ISEA) = DVSMC * FLOAT( IJKCel(5, ISEA) )
+        IF( ZB(ISEA) .LT. ZLIM ) THEN
+          MAPSTA(IY:IY+JS-1,IX:IX+IK-1) = 1
+          MAPST2(IY:IY+JS-1,IX:IX+IK-1) = 0
+        ENDIF
+        MAPFS(IY:IY+JS-1,IX:IX+IK-1) = ISEA
+        MAPSF(ISEA,1) = IX
+        MAPSF(ISEA,2) = IY
+        MAPSF(ISEA,3) = IY + (IX-1) * NY
 
         !Li   New variable CLATS to hold cosine latitude at cell centre.
         !Li   Also added CLATIS and CTHG0S for version 4.08.

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -5074,7 +5074,7 @@ CONTAINS
 
         !Li Allow land cell to be defined by ZLIM value and only reset
         !Li MAPST* land values for sea points.   JGLi03Nov2023
-        ZB(ISEA) = DVSMC * FLOAT( IJKCel(5, ISEA) )
+        ZB(ISEA) = DVSMC * FLOAT(IJKDep(ISEA))
         IF( ZB(ISEA) .LT. ZLIM ) THEN
           MAPSTA(IY:IY+JS-1,IX:IX+IK-1) = 1
           MAPST2(IY:IY+JS-1,IX:IX+IK-1) = 0


### PR DESCRIPTION
# Pull Request Summary
Adds functionality to correctly set cells as "dry" when reading in the SMC depth data via `ww3_grid`

## Description
When the SMC grid bottom depths are read in via `ww3_grid`, the minimum water depth is always set to `DMIN` and cells are never initially set to "dry"

This update provides similar functionality to the regular grid where depths below the `ZLIM` cut-off depth have the status set to "dry". This only affects the initial status of the cells when the depths are read in via `ww3_grid`.

Furthermore. the depths are no longer set to a minimum of `DMIN` in `ww3_grid` - this calculation is performed elsewhere in the code, as per the regular grid. This does result in a change in the `mod_def.ww3`  files for the SMC grid regression tests as the raw bottom depths are stored whereas previously any depth < `DMIN` would have a value of `DMIN` stored.

The `dpt` output field in `ww3.201109.nc` of regtest `ww3_tp2.14/OASACM6` is similarly affected by this change.

### Issue(s) addressed
N/A

### Commit Message
Provide initial drying of cells with depth < ZLIM for SMC grid.

### Check list  

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? **Regression tests**
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) **Yes**
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? **Yes; Cray XC; GNU Fortran**
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)

Ignoring the usual non-b4b regtest, differences in the regtests are shown below.
All differences are expected and are a result of the change in minimum depth stored in the mod_def.ww3 files.

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_09/./work_MPI                     (3 files differ)  
mww3_test_09/./work_MPI_ASCII                     (6 files differ)
ww3_tp2.10/./work_MPI                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (1 files differ)
ww3_tp2.14/./work_OASACM6                     (3 files differ)
ww3_tp2.16/./work_MPI                     (1 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (1 files differ)
```
