### PR TITLE
update run_cmake_test to catch build errors and exit

### DIFF
--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -437,23 +437,24 @@ then
   cat $path_build/switch >> $ofile
   cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1
   rc=$?
-  if [[ $rc -ne 0 ]] ; then
+  if (( rc != 0 )); then
     echo "Fatal error in cmake."
-    echo "The build log is in $ofile"
-    exit
+    echo "The build log is in ${ofile}"
+    exit ${rc}
   fi
   make -j 8 > $ofile 2>&1
   rc=$?
-  if [[ $rc -ne 0 ]] ; then
+  if (( rc != 0 )); then 
     echo "Fatal error in make."
-    echo "The build log is in $ofile"
-    exit
+    echo "The build log is in ${ofile}"
+    exit ${rc}
   fi
   make install > $ofile 2>&1
-  if [[ $rc -ne 0 ]] ; then
+  rc=$?
+  if (( rc != 0 )); then 
     echo "Fatal error in make install."
     echo "The build log is in $ofile"
-    exit
+    exit ${rc}
   fi
 
   cp $path_build/install/bin/* $path_e/
@@ -470,22 +471,24 @@ then
     cat $path_build/switch >> $ofile
     cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile  2>&1
     rc=$?
-    if [[ $rc -ne 0 ]] ; then
+    if (( rc != 0 )); then
       echo "Fatal error in cmake."
-      echo "The build log is in $ofile"
-      exit
+      echo "The build log is in ${ofile}"
+      exit ${rc}
     fi
     make -j 8 > $ofile 2>&1
-    if [[ $rc -ne 0 ]] ; then
+    rc=$?
+    if (( rc != 0 )); then
       echo "Fatal error in make."
-      echo "The build log is in $ofile"
-      exit
+      echo "The build log is in ${ofile}"
+      exit ${rc}
     fi
     make install > $ofile 2>&1
-    if [[ $rc -ne 0 ]] ; then
+    rc=$?
+    if (( rc != 0 )); then
       echo "Fatal error in make install."
       echo "The build log is in $ofile"
-      exit
+      exit ${rc}
     fi
     path_e=$path_w/exe
     cp $path_build/install/bin/ww3_shel $path_e/
@@ -509,22 +512,24 @@ else
   cat $path_build/switch >> $ofile
   cmake $path_cmake ${CMAKE_OPTIONS} -DSWITCH=$path_build/switch -DCMAKE_INSTALL_PREFIX=install > $ofile 2>&1
   rc=$?
-  if [[ $rc -ne 0 ]] ; then
+  if (( rc != 0 )); then
     echo "Fatal error in cmake."
-    echo "The build log is in $ofile"
-    exit
+    echo "The build log is in ${ofile}"
+    exit ${rc}
   fi
   make -j 8 > $ofile 2>&1
-  if [[ $rc -ne 0 ]] ; then
+  rc=$?
+  if (( rc != 0 )); then 
     echo "Fatal error in make."
-    echo "The build log is in $ofile"
-    exit
+    echo "The build log is in ${ofile}"
+    exit ${rc}
   fi
   make install > $ofile 2>&1
-  if [[ $rc -ne 0 ]] ; then
-    echo "Fatal error in make install."
-    echo "The build log is in $ofile"
-    exit
+  rc=$?
+  if (( rc != 0 )); then  
+    echo "Fatal error in make."
+    echo "The build log is in ${ofile}"
+    exit ${rc}
   fi
 
   cp $path_build/install/bin/* $path_e/


### PR DESCRIPTION
# Pull Request Summary
Update run_cmake_test to better capture build errors 

## Description
Updates run_cmake_test to make sure we catch build errors and exit instead of continuing on. 

Please also include the following information: 
* Add any suggestions for a reviewer  @ukmo-ccbunney @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_,
* Are answer changes expected from this PR? No 

### Issue(s) addressed
No issue, found investigating other issues. 

### Commit Message
update run_cmake_test to catch build errors and exit

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Yes - I made sure it caught build errors in a branch with known errors and I ran full matrix of test 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes, bug fix
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? yes  hera, intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) Only the known non-b4b tests. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)

```
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/14389087/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/14389088/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/14389089/matrixDiff.txt)
