### PR TITLE
Fix build 'remarks'

### DIFF
--- a/model/src/w3arrymd.F90
+++ b/model/src/w3arrymd.F90
@@ -2250,10 +2250,10 @@ CONTAINS
     !
 900 FORMAT (/'  Location : ',A/                               &
          '  Spectrum : ',A,' (Normalized) ',              &
-         '  Maximum value : ',E8.3,1X,A/)
+         '  Maximum value : ',E10.3,1X,A/)
 901 FORMAT (/'  Location : ',A/                               &
-         '  Spectrum : ',A,'  Units : ',E8.3,1X,A,        &
-         '  Maximum value : ',E8.3,1X,A/)
+         '  Spectrum : ',A,'  Units : ',E10.3,1X,A,        &
+         '  Maximum value : ',E10.3,1X,A/)
     !
 910 FORMAT (5X,'  ang.|  frequencies (Hz) '/                  &
          5X,'  deg.|',F6.3,15F8.3)

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -6439,7 +6439,7 @@ CONTAINS
          '        SDSBRF1 = ',F5.2,', SDSBRFDF =',I2,', '/ &
          '        SDSBM0 = ',F5.2, ', SDSBM1 =',F5.2,      &
          ', SDSBM2 =',F5.2,', SDSBM3 =',F5.2,', SDSBM4 =', &
-         F5.2,', '/,                                       &
+         F7.2,', '/,                                       &
          '        SPMSS = ',F5.2, ', SDKOF =',F5.2,        &
          ', SDSMWD =',F5.2,', SDSFACMTF =',F5.1,', '/      &
          '        SDSMWPOW =',F3.1,', SDSNMTF =', F5.2,    &

--- a/model/src/w3tidemd.F90
+++ b/model/src/w3tidemd.F90
@@ -823,11 +823,11 @@ CONTAINS
     !      read in inference information now as it will be used in the lsq matrix
     !
     DO K=1,10
-      READ(KR1,'(4X,A5,E16.10,i5)')TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
+      READ(KR1,'(4X,A5,E17.10,i5)')TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
       !      write(6,1010)TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
       IF (TIDE_KONAN(K).EQ.KBLANK) EXIT
       do k2=1,TIDE_NINF(k)
-        read(kr1,'(4X,A5,E16.10,2F10.3)') TIDE_KONIN(K,k2),TIDE_SIGIN(K,k2),TIDE_R(K,k2),TIDE_ZETA(K,k2)
+        read(kr1,'(4X,A5,E17.10,2F10.3)') TIDE_KONIN(K,k2),TIDE_SIGIN(K,k2),TIDE_R(K,k2),TIDE_ZETA(K,k2)
       END DO
     END DO
     TIDE_NIN=K-1

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -2433,7 +2433,7 @@ CONTAINS
                 OPEN (NDSDAT,FILE=FNMPRE(:JJ)//FNAME,ERR=800,     &
                      IOSTAT=IERR)
                 IF (FSC.LT.1E-4) THEN
-                  WRITE(FSCS,'(G7.1)') FSC
+                  WRITE(FSCS,'(G8.1)') FSC
                 ELSE
                   WRITE(FSCS,'(F7.4)') FSC
                 END IF


### PR DESCRIPTION
# Pull Request Summary
Resolves  compiler '`remark`'s from building the `develop` branch.

## Description
* Provide a detailed description of what this PR does.
  * Fixes the width descriptors in WW3 source which cause the compiler to output `remark`s.  This involved enforcing the suggested width, `W>=D+7`, by choosing the minimal change, `W=D+7`.  This PR is for the `develop` branch.  After acceptance it will be PR'd to the `dev/ufs-weather-model` branch to resolve the WW3 portion of ufs-community/ufs-weather-model/issues/1984.  The `remark`s fixed for `develop` are shown below.  Note, there is one additional remark to be fixed in the `dev/ufs-weather-model` branch. 
```
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/w3arrymd.F90(2255): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/w3arrymd.F90(2256): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/w3arrymd.F90(2253): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/w3tidemd.F90(826): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/w3tidemd.F90(830): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
/scratch1/NCEPDEV/climate/Matthew.Masarik/projs/UFS/support/ww3-verify-current/model/src/ww3_outf.F90(2436): remark #8291: Recommended relationship between field width 'W' and the number of fractional digits 'D' in this edit descriptor is 'W>=D+7'.
```
* Is a change of answers expected from this PR?
  * The ww3_grid.out log files will differ due to spacing from the updated width descriptors.
  

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR?
  * No, but beware when running matrix.comp that many log files will have differences due to the adjusted width of output fields.

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close.
- fixes #1199 
- related to ufs-community/ufs-weather-model/issues/1984

### Commit Message
Fix compiler build 'remark's

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
* How were these changes tested?
  * Comparison of regtest matrix runs.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * The changes are fixes -- no new test needed. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Yes.  `hera` / `intel`. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * No answer changes, though expect log file differences.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * [matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/14562997/matrixCompSummary.txt)
  * [matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/14562996/matrixCompFull.txt)
  * [matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/14562995/matrixDiff.txt)


#### Verification of fix
  * [develop-build.log.txt](https://github.com/NOAA-EMC/WW3/files/14543092/develop-build.log.txt)
  * [fix-build.log.txt](https://github.com/NOAA-EMC/WW3/files/14543091/fix-build.log.txt)