### PR TITLE
Fix compiler remarks for ST6 and GMD

### DIFF
--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -6330,14 +6330,14 @@ CONTAINS
 2923 FORMAT ( '             ',2F8.3,F6.1,2E12.4)
 2922 FORMAT ( '  &SNL3 NQDEF =',I3,', MSC =',F6.2,',  NSC =',   &
          F6.2,',  KDFD =',F6.2,',  KDFS =',F6.2,' /')
-3923 FORMAT ( '  &ANL3 QPARMS = ',2(F5.3,', '),F5.1,', ',E10.4, &
-         ', ',E10.4,' /')
-4923 FORMAT ( '  &ANL3 QPARMS = ',2(F5.3,', '),F5.1,', ',E10.4, &
-         ', ',E10.4,' ,')
-5923 FORMAT ( '                 ',2(F5.3,', '),F5.1,', ',E10.4, &
-         ', ',E10.4,' ,')
-6923 FORMAT ( '                 ',2(F5.3,', '),F5.1,', ',E10.4, &
-         ', ',E10.4,' /')
+3923 FORMAT ( '  &ANL3 QPARMS = ',2(F5.3,', '),F5.1,', ',E11.4, &
+         ', ',E11.4,' /')
+4923 FORMAT ( '  &ANL3 QPARMS = ',2(F5.3,', '),F5.1,', ',E11.4, &
+         ', ',E11.4,' ,')
+5923 FORMAT ( '                 ',2(F5.3,', '),F5.1,', ',E11.4, &
+         ', ',E11.4,' ,')
+6923 FORMAT ( '                 ',2(F5.3,', '),F5.1,', ',E11.4, &
+         ', ',E11.4,' /')
 #endif
     !
 #ifdef W3_NL4
@@ -6453,18 +6453,18 @@ CONTAINS
 925 FORMAT ( '  normalise by threshold spectral density    :  ',A/&
          '  normalise by spectral density              :  ',A/&
          '  coefficient and exponent  for                 '/  &
-         '   inherent breaking term a1, L as in (21)   : ',E9.3,I3/ &
-         '   cumulative breaking term a2, M as in (22) : ',E9.3,I3/ &
+         '   inherent breaking term a1, L as in (21)   : ',E10.3,I3/ &
+         '   cumulative breaking term a2, M as in (22) : ',E10.3,I3/ &
          ' ')
-2924 FORMAT ( '  &SDS6 SDSET = ',L,', SDSA1 = ',E9.3,              &
-         ', SDSA2 = ',E9.3,', SDSP1 = ',I2,', SDSP1 = ',      &
+2924 FORMAT ( '  &SDS6 SDSET = ',L,', SDSA1 = ',E10.3,              &
+         ', SDSA2 = ',E10.3,', SDSP1 = ',I2,', SDSP1 = ',      &
          I2,' /'                                              )
 
 937 FORMAT (/'  Swell dissipation ',A/                            &
          ' --------------------------------------------------')
 940 FORMAT ( '  subroutine W3SWL6 activated           : ',A/      &
-         '   coefficient b1 ',A,                ' : ',E9.3/   )
-2937 FORMAT ( '  &SWL6 SWLB1 = ',E9.3,', CSTB1 = ',L,' /')
+         '   coefficient b1 ',A,                ' : ',E10.3/   )
+2937 FORMAT ( '  &SWL6 SWLB1 = ',E10.3,', CSTB1 = ',L,' /')
 #endif
     !
 #ifdef W3_BT0
@@ -6549,7 +6549,7 @@ CONTAINS
 946 FORMAT  ('  Isotropic (linear function of ice concentration)'/&
          '        slope                      : ',E10.3/ &
          '        offset                     : ',E10.3)
-2946 FORMAT ( '  &SIS1 ISC1 =',E9.3,', ISC2 =',E9.3)
+2946 FORMAT ( '  &SIS1 ISC1 =',E10.3,', ISC2 =',E10.3)
 #endif
 #ifdef W3_IS2
 947 FORMAT  (/'  Ice scattering ',A,/ &


### PR DESCRIPTION
# Pull Request Summary
This fixes a few formatting outputs for ST6 and GMD.  

## Description
This addresses the remaining compiler remarks which were in ST6 and GMD tests.  This is just formatting write outputs so the differences are in the ww3_grid.out files.  

We should now be able to grep all build.log  files for regression tests and ensure that no new remarks come into the code.  

Please also include the following information: 
* Add any suggestions for a reviewer @MatthewMasarik-NOAA 
* Mention any labels that should be added:  _bug_ 
* Are answer changes expected from this PR? There are differences in ww3_grid.out for ST6 and GMD tests. 

### Issue(s) addressed
Fixes #1203 

### Commit Message
Fix compiler remarks for ST6 and GMD

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix  -- build.log was grep'd for remark we now have no compiler remarks for intel. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes, if you look at build.log 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes, Hera, intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)  There are expected changes in ST6 and GMD regtests in ww3_grid.out due to change in formatting. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):


```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_05/./work_ST6_PR2_UQ_OMP                     (5 files differ)
mww3_test_05/./work_ST6_PR2_UNO_MPI                     (5 files differ)
mww3_test_05/./work_ST6_PR2_UNO_OMP                     (5 files differ)
mww3_test_05/./work_ST6_PR2_UQ_MPI_OMPH                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UQ_MPI_OMPH                     (5 files differ)
mww3_test_05/./work_ST6_PR1_MPI                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UQ_MPI                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UNO_OMP                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UQ_OMP                     (5 files differ)
mww3_test_05/./work_ST6_PR2_UQ_MPI                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UNO_MPI_OMPH                     (5 files differ)
mww3_test_05/./work_ST6_PR2_UNO_MPI_OMPH                     (5 files differ)
mww3_test_05/./work_ST6_PR1_MPI_OMPH                     (5 files differ)
mww3_test_05/./work_ST6_PR1_OMP                     (5 files differ)
mww3_test_05/./work_ST6_PR3_UNO_MPI                     (5 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.15/./work_ST6FLX5                     (1 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ts1/./work_ST4_GMD                     (1 files differ)
ww3_ts1/./work_ST6                     (1 files differ)
ww3_ts1/./work_NL5                     (1 files differ)
ww3_ts2/./work_ST6_PR3_UQ                     (1 files differ)
ww3_ts2/./work_ST6_PR2_UNO                     (1 files differ)
ww3_ts2/./work_ST6_PR2_UQ                     (1 files differ)
ww3_ts2/./work_ST6_PR1                     (1 files differ)
ww3_ts2/./work_ST6_PR3_UNO                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UQ_OMP                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UNO_MPI                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UNO_OMP                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UQ_MPI_OMPH                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UQ_MPI_OMPH                     (1 files differ)
ww3_ts3/./work_ST6_PR1_MPI                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UQ_MPI                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UNO_OMP                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UQ_OMP                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UQ_MPI                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UNO_MPI_OMPH                     (1 files differ)
ww3_ts3/./work_ST6_PR2_UNO_MPI_OMPH                     (1 files differ)
ww3_ts3/./work_ST6_PR1_MPI_OMPH                     (1 files differ)
ww3_ts3/./work_ST6_PR1_OMP                     (1 files differ)
ww3_ts3/./work_ST6_PR3_UNO_MPI                     (1 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```

[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/14636464/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/14636465/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/14636466/matrixDiff.txt)

