### PR TITLE
Fix code stability issue #1173  + Fix build 'remarks'  PR #1201

### DIFF
--- a/model/src/w3arrymd.F90
+++ b/model/src/w3arrymd.F90
@@ -2250,10 +2250,10 @@ CONTAINS
     !
 900 FORMAT (/'  Location : ',A/                               &
          '  Spectrum : ',A,' (Normalized) ',              &
-         '  Maximum value : ',E8.3,1X,A/)
+         '  Maximum value : ',E10.3,1X,A/)
 901 FORMAT (/'  Location : ',A/                               &
-         '  Spectrum : ',A,'  Units : ',E8.3,1X,A,        &
-         '  Maximum value : ',E8.3,1X,A/)
+         '  Spectrum : ',A,'  Units : ',E10.3,1X,A,        &
+         '  Maximum value : ',E10.3,1X,A/)
     !
 910 FORMAT (5X,'  ang.|  frequencies (Hz) '/                  &
          5X,'  deg.|',F6.3,15F8.3)

--- a/model/src/w3bullmd.F90
+++ b/model/src/w3bullmd.F90
@@ -268,8 +268,8 @@ CONTAINS
     !
     CSVBLINE      = BLANK2
     !
+    IPG1 = 0
     IF (IOUT .EQ. 1) THEN
-      IPG1 = 0
       DO IP=1, NPTAB
         HST(IP,1) = -99.9
         TPT(IP,1) = -99.9
@@ -286,10 +286,12 @@ CONTAINS
     !
     HSTOT  = XPART(1,0)
     TP     = XPART(2,0)
-    HSP = XPART(1,1:NPART)
-    TPP = XPART(2,1:NPART)
-    WNP = TPI / XPART(3,1:NPART)
-    DMP = MOD( XPART(4,1:NPART) + 180., 360.)
+    DO IP=1, NPART
+      HSP(IP) = XPART(1,IP)
+      TPP(IP) = XPART(2,IP)
+      WNP(IP) = TPI / XPART(3,IP)
+      DMP(IP) = MOD( XPART(4,IP) + 180., 360.)
+    ENDDO
 
     NZERO = 0
     NZERO = COUNT( HSP <= BHSMIN .AND. HSP /= 0.  )

--- a/model/src/w3gridmd.F90
+++ b/model/src/w3gridmd.F90
@@ -6357,7 +6357,7 @@ CONTAINS
          '        SDSBRF1 = ',F5.2,', SDSBRFDF =',I2,', '/ &
          '        SDSBM0 = ',F5.2, ', SDSBM1 =',F5.2,      &
          ', SDSBM2 =',F5.2,', SDSBM3 =',F5.2,', SDSBM4 =', &
-         F5.2,', '/,                                       &
+         F7.2,', '/,                                       &
          '        SPMSS = ',F5.2, ', SDKOF =',F5.2,        &
          ', SDSMWD =',F5.2,', SDSFACMTF =',F5.1,', '/      &
          '        SDSMWPOW =',F3.1,', SDSNMTF =', F5.2,    &

--- a/model/src/w3tidemd.F90
+++ b/model/src/w3tidemd.F90
@@ -823,11 +823,11 @@ CONTAINS
     !      read in inference information now as it will be used in the lsq matrix
     !
     DO K=1,10
-      READ(KR1,'(4X,A5,E16.10,i5)')TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
+      READ(KR1,'(4X,A5,E17.10,i5)')TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
       !      write(6,1010)TIDE_KONAN(K),TIDE_SIGAN(K),TIDE_NINF(k)
       IF (TIDE_KONAN(K).EQ.KBLANK) EXIT
       do k2=1,TIDE_NINF(k)
-        read(kr1,'(4X,A5,E16.10,2F10.3)') TIDE_KONIN(K,k2),TIDE_SIGIN(K,k2),TIDE_R(K,k2),TIDE_ZETA(K,k2)
+        read(kr1,'(4X,A5,E17.10,2F10.3)') TIDE_KONIN(K,k2),TIDE_SIGIN(K,k2),TIDE_R(K,k2),TIDE_ZETA(K,k2)
       END DO
     END DO
     TIDE_NIN=K-1

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -2423,7 +2423,7 @@ CONTAINS
                 OPEN (NDSDAT,FILE=FNMPRE(:JJ)//FNAME,ERR=800,     &
                      IOSTAT=IERR)
                 IF (FSC.LT.1E-4) THEN
-                  WRITE(FSCS,'(G7.1)') FSC
+                  WRITE(FSCS,'(G8.1)') FSC
                 ELSE
                   WRITE(FSCS,'(F7.4)') FSC
                 END IF


### PR DESCRIPTION
# Pull Request Summary
 This PR fixes issue #1173  reported by NCO during HAFS.v1 implementation regarding ww3_outp debug build failure as well as the addition of PR #1201  to address the fix for build remarks  

## Description

With these changes the debug build will not encounter a failure while running ww3_outp in addition to the elimination of some build remarks for WW3.

Please also include the following information: 
* Add any suggestions for a reviewer: @BijuThomas-NOAA @BinLiu-NOAA 
* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _none_


### Issue(s) addressed

* Please list any issues associated with this PR, including those the PR will fix/close:  
fixes noaa-emc/ww3/issues/<#1173>


### Commit Message

Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
- Fix Bugzilla for hafs.v2, include PR #1201 for build remarks fix


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Four tests were conducted, with and without the fixes, and with Release and Debug build flags. The runs with and without the fixes are reproducible with the Release flag, which is expected. The run with the fix and debug flag fixes the issue with code instability while running ww3_outp. Runs without the fix and with the Debug flag reproduce the error that NCO had reported.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
ww3_ufs1.1 was tested. ww3_outp was executed to reproduce the error and check if the bug fix has been effective.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
parts of Matrix 12 , on Hera with intel compiler


