### PR TITLE
Add ice time variables to restart file

### DIFF
--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -845,7 +845,7 @@ CONTAINS
           WRITEBUFF(:) = 0.
           WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR) WRITEBUFF
           WRITE (NDSR,POS=RPOS,ERR=803,IOSTAT=IERR)           &
-               TLEV, TICE, TRHO
+               TLEV, TICE, TRHO, TIC1, TIC5
           DO IPART=1,NPART
             NREC  = NREC + 1
             RPOS  = 1_8 + LRECL*(NREC-1_8)
@@ -1026,7 +1026,7 @@ CONTAINS
       IF (TYPE.EQ.'FULL') THEN
         RPOS = 1_8 + LRECL*(NREC-1_8)
         READ (NDSR,POS=RPOS,ERR=802,IOSTAT=IERR)                &
-             TLEV, TICE, TRHO
+             TLEV, TICE, TRHO, TIC1, TIC5
         DO IPART=1,NPART
           NREC  = NREC + 1
           RPOS = 1_8 + LRECL*(NREC-1_8)

--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -69,7 +69,7 @@ MODULE W3IORSMD
   !/
   !/ Private parameter statements (ID strings)
   !/
-  CHARACTER(LEN=10), PARAMETER, PRIVATE :: VERINI = '2021-05-28'
+  CHARACTER(LEN=10), PARAMETER, PRIVATE :: VERINI = '2024-04-26'
   CHARACTER(LEN=26), PARAMETER, PRIVATE ::                        &
        IDSTR = 'WAVEWATCH III RESTART FILE'
   !/


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 

## Description
This is a bug-fix cherry-picked from PR #1211 that was found when testing restart reproduciblity for wave-ice coupling.  Two variables (TIC1, TIC5) are needed to be added to the restarts. 

Note some instructions on how to convert restart files (not necessarily recommended) are being drafted here: https://github.com/NOAA-EMC/WW3/wiki/Converting-Binary-Restarts-from-Older-to-Newer-Versions

### Issue(s) addressed
An issue was never created.  

### Commit Message
Add ice time variables to restart file

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) No, because we do not test restart-reproducibility for all configurations.  This was found in coupling tests. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Matrix, Hera with Intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
There are lots of changes to answers because the restart files change.  It's the expected diff's + lots of restart diffs. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
[matrixCompFull.txt](https://github.com/NOAA-EMC/WW3/files/15200250/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/NOAA-EMC/WW3/files/15200251/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/NOAA-EMC/WW3/files/15200252/matrixDiff.txt)

