### PR TITLE
fix code stability test failed in ww3_outp #1173

### DIFF
--- a/model/src/w3bullmd.F90
+++ b/model/src/w3bullmd.F90
@@ -268,8 +268,8 @@ CONTAINS
     !
     CSVBLINE      = BLANK2
     !
+    IPG1 = 0
     IF (IOUT .EQ. 1) THEN
-      IPG1 = 0
       DO IP=1, NPTAB
         HST(IP,1) = -99.9
         TPT(IP,1) = -99.9
@@ -286,10 +286,12 @@ CONTAINS
     !
     HSTOT  = XPART(1,0)
     TP     = XPART(2,0)
-    HSP = XPART(1,1:NPART)
-    TPP = XPART(2,1:NPART)
-    WNP = TPI / XPART(3,1:NPART)
-    DMP = MOD( XPART(4,1:NPART) + 180., 360.)
+    DO IP=1, NPART
+      HSP(IP) = XPART(1,IP)
+      TPP(IP) = XPART(2,IP)
+      WNP(IP) = TPI / XPART(3,IP)
+      DMP(IP) = MOD( XPART(4,IP) + 180., 360.)
+    ENDDO
 
     NZERO = 0
     NZERO = COUNT( HSP <= BHSMIN .AND. HSP /= 0.  )


### PR DESCRIPTION
# Pull Request Summary
Fixes a code stability issue in `ww3_outp`.

## Description
* Provide a detailed description of what this PR does.
  * Fixes code stability test failure in `ww3_outp`.  This fix was cherry-picked from @sbanihash's PR to `production/hafs.v2`. 
* What bug does it fix, or what feature does it add?
  * Bug fix for program `ww3_outp`.
* Is a change of answers expected from this PR?
  * No.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Mention any labels that should be added:  
  * _bug_
* Are answer changes expected from this PR? 
  * No.

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #1173 

### Commit Message
Fix code stability issue in ww3_outp

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Running the matrix. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * The change is a bug fix, no new tests needed.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * Hera/intel.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * No changes expected.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

* [matrixCompSummary.txt](https://github.com/user-attachments/files/15996026/matrixCompSummary.txt)
* [matrixDiff.txt](https://github.com/user-attachments/files/15996024/matrixDiff.txt)
* [matrixCompFull.txt](https://github.com/user-attachments/files/15996025/matrixCompFull.txt)