### PR TITLE
Update NCEP regtests for Orion:  Rocky9 OS

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -60,7 +60,7 @@ EOF
   modbacio='bacio/2.4.1'
   modg2='g2/3.4.5'
   modw3emc='w3emc/2.10.0'
-  modesmf='esmf/8.5.0'
+  modesmf='esmf/8.6.0'
   modscotch='scotch/7.0.4'
 
 # Set batchq queue, choose modules and other custom variables to fit system and
@@ -94,10 +94,10 @@ EOF
     if [ $compiler = "intel" ]
     then
       batchq='slurm'
-      spackstackpath='/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core'
-      modcomp='stack-intel/2022.0.2'
-      modmpi='stack-intel-oneapi-mpi/2021.5.1'
-      metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/orion/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
+      spackstackpath='module use  /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core'
+      modcomp='stack-intel/2021.9.0'
+      modmpi='stack-intel-oneapi-mpi/2021.9.0'
+      metispath=''
       modcmake='cmake/3.23.1'
     else
       echo "Compiler $compiler not supported on orion"

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -94,7 +94,7 @@ EOF
     if [ $compiler = "intel" ]
     then
       batchq='slurm'
-      spackstackpath='module use  /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core'
+      spackstackpath='/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core'
       modcomp='stack-intel/2021.9.0'
       modmpi='stack-intel-oneapi-mpi/2021.9.0'
       metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/orion/intel/spack-stack/1.6.0/parmetis-4.0.3/install'

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -97,7 +97,7 @@ EOF
       spackstackpath='module use  /work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core'
       modcomp='stack-intel/2021.9.0'
       modmpi='stack-intel-oneapi-mpi/2021.9.0'
-      metispath=''
+      metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/orion/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
     else
       echo "Compiler $compiler not supported on orion"

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -22,11 +22,11 @@ usage ()
 {
   cat 2>&1 << EOF
 
-  Usage: $myname model_dir compiler 
+  Usage: $myname model_dir compiler
   Required:
     model_dir : path to model dir of WW3 source
-  Optional: 
-    compiler : intel (default) or gnu 
+  Optional:
+    compiler : intel (default) or gnu
 EOF
 }
 
@@ -36,16 +36,16 @@ EOF
     main_dir="$1" ; shift
     if [ ! $# = 0 ]
     then
-      compiler="$1"; shift 
-    else 
+      compiler="$1"; shift
+    else
       compiler='intel'
-    fi 
+    fi
   else
     usage
     exit 1
   fi
- 
-  
+
+
 
 # Convert main_dir to absolute path
   main_dir="`cd $main_dir 1>/dev/null 2>&1 && pwd`"
@@ -66,29 +66,29 @@ EOF
 # Set batchq queue, choose modules and other custom variables to fit system and
 # to define headers etc (default to original version if empty)
   ishera=`hostname | grep hfe`
-  isorion=`hostname | grep Orion`
+  isorion=`hostname | grep orion`
   ishercules=`hostname | grep hercules`
   if [ $ishera ]
   then
     batchq='slurm'
     if [ $compiler = "intel" ]
-    then 
+    then
       spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core'
       modcomp='stack-intel/2021.5.0'
       modmpi='stack-intel-oneapi-mpi/2021.5.1'
       metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hera/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
     elif [ $compiler = "gnu" ]
-    then 
+    then
       spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core'
       modcomp='stack-gcc/9.2.0'
       modmpi='stack-openmpi/4.1.5'
       metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hera/gnu/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
-    else 
-      echo "Compiler $compiler not supported on hera" 
-      exit 1 
-    fi 
+    else
+      echo "Compiler $compiler not supported on hera"
+      exit 1
+    fi
   elif [ $isorion ]
   then
     if [ $compiler = "intel" ]
@@ -100,11 +100,11 @@ EOF
       metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/orion/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
     else
-      echo "Compiler $compiler not supported on orion" 
+      echo "Compiler $compiler not supported on orion"
       exit 1
-    fi  
-  elif [ $ishercules ] 
-  then 
+    fi
+  elif [ $ishercules ]
+  then
     batchq='slurm'
     if [ $compiler = "intel" ]
     then
@@ -114,7 +114,7 @@ EOF
       metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/hercules/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
     elif [ $compiler = "gnu" ]
-    then 
+    then
       spackstackpath='/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core'
       spackstackpath2='/work/noaa/epic/role-epic/spack-stack/hercules/modulefiles'
       modcomp='stack-gcc/12.2.0'
@@ -122,7 +122,7 @@ EOF
       metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/hercules/gnu/spack-stack/1.6.0/parmetis-4.0.3/install'
       modcmake='cmake/3.23.1'
     else
-      echo "Compiler $compiler not supported on hercules" 
+      echo "Compiler $compiler not supported on hercules"
       exit 1
     fi
   else
@@ -195,7 +195,7 @@ EOF
   echo "  module use $spackstackpath"                       >> matrix.head
   if [ ! -z $spackstackpath2 ]; then
     echo "  module use $spackstackpath2"                    >> matrix.head
-  fi 
+  fi
   echo "  module load $modcomp"                             >> matrix.head
   echo "  module load $modmpi"                              >> matrix.head
   echo "  module load $modcmake"                            >> matrix.head


### PR DESCRIPTION
# Pull Request Summary
Makes the necessary updates to the NCEP regtests for Orion to account for OS upgrade to Rocky9.  This also includes a related bug fix.

## Description
Contains the following:
  * Update to module environment for Rocky9 OS (based on current UFS/modulefiles:  [ufs_common.lua](https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_common.lua), [ufs_orion.intel.lua](https://github.com/ufs-community/ufs-weather-model/blob/develop/modulefiles/ufs_orion.intel.lua)).
  * New Parmetis built with updated modules (Note:  the path remains the same, but a new build is in place).
  * Bug fix associated with a null assignment to variable `batchq` in `matrix_cmake_ncep`.
  * Text editor auto cleanup of trailing whitespace.

Please also include the following information: 
* Add any suggestions for a reviewer
  * @JessicaMeixner-NOAA   
* Mention any labels that should be added:  
  * _bug_,  _enhancement_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: 
  * No change to answers (out_grd, out_pnt), though two tests have files that differ described in the Testing section.


### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #1262 

### Commit Message
Updates to NCEP regtests for Orion Rocky9 OS

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 


### Testing
* How were these changes tested?
  * Two sets of matrix regression tests:  develop vs. pr, and pr vs. pr. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No.  Regtests are not needed for HPC center software changes.
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  *  Orion / intel.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * develop vs. PR 
     * `ww3_tp2.1` - netcdf output.  An issue will be created to track these differences.
     * `ww3_ufs1.1/unstr` - only due to added switch, `BIN2NC`, in netcdf output.
  * PR vs. PR
    * Only known non-b4b's. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

**develop vs. PR branch**
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (19 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (26 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (20 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.1/./work_PR1                     (1 files differ)
ww3_tp2.1/./work_PR1_MPI                     (1 files differ)
ww3_tp2.1/./work_PR3_UNO                     (1 files differ)
ww3_tp2.1/./work_PR2_UQ                     (1 files differ)
ww3_tp2.1/./work_PR3_UQ                     (1 files differ)
ww3_tp2.1/./work_PR3_UQ_MPI                     (1 files differ)
ww3_tp2.1/./work_PR3_UNO_MPI                     (1 files differ)
ww3_tp2.1/./work_PR2_UNO                     (1 files differ)
ww3_tp2.1/./work_PR2_UQ_MPI                     (1 files differ)
ww3_tp2.1/./work_PR2_UNO_MPI                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.1/./work_unstr_c                     (1 files differ)
ww3_ufs1.1/./work_unstr_b                     (1 files differ)
ww3_ufs1.1/./work_unstr_a                     (1 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
``` 

* [dev.matrixCompSummary.txt](https://github.com/user-attachments/files/16147732/dev.matrixCompSummary.txt)
* [dev.matrixCompFull.txt](https://github.com/user-attachments/files/16147730/dev.matrixCompFull.txt)
* [dev.matrixDiff.txt](https://github.com/user-attachments/files/16147728/dev.matrixDiff.txt)


**PR vs. PR**
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
 
**********************************************************************
************************ identical cases *****************************
**********************************************************************
```

* [pr.matrixCompSummary.txt](https://github.com/user-attachments/files/16147784/pr.matrixCompSummary.txt)
* [pr.matrixCompFull.txt](https://github.com/user-attachments/files/16147782/pr.matrixCompFull.txt)
* [pr.matrixDiff.txt](https://github.com/user-attachments/files/16147783/pr.matrixDiff.txt)

