### PR TITLE
Fix nuopc cap for radiation stress components

### DIFF
--- a/model/src/w3iorsmd.F90
+++ b/model/src/w3iorsmd.F90
@@ -1376,6 +1376,7 @@ CONTAINS
         TICE(1) = -1
         TICE(2) =  0
         TRHO(1) = -1
+        TRHO(2) =  0
         TIC1(1) = -1
         TIC1(2) =  0
         TIC5(1) = -1

--- a/model/src/wav_grdout.F90
+++ b/model/src/wav_grdout.F90
@@ -223,8 +223,8 @@ contains
 
     !  6   Wave-ocean layer
     gridoutdefs(6,1:25) = [ &
-         varatts( "SXY  ", "SXX       ", "Radiation stresses xx                           ", "N m-1     ", "  ", .false.) , &
-         varatts( "SXY  ", "SYY       ", "Radiation stresses yy                           ", "N m-1     ", "  ", .false.) , &
+         varatts( "SXX  ", "SXX       ", "Radiation stresses xx                           ", "N m-1     ", "  ", .false.) , &
+         varatts( "SYY  ", "SYY       ", "Radiation stresses yy                           ", "N m-1     ", "  ", .false.) , &
          varatts( "SXY  ", "SXY       ", "Radiation stresses xy                           ", "N m-1     ", "  ", .false.) , &
          varatts( "TWO  ", "TAUOX     ", "Wave to ocean momentum flux x                   ", "m2 s-2    ", "  ", .false.) , &
          varatts( "TWO  ", "TAUOY     ", "Wave to ocean momentum flux y                   ", "m2 s-2    ", "  ", .false.) , &

--- a/model/src/wav_import_export.F90
+++ b/model/src/wav_import_export.F90
@@ -145,6 +145,9 @@ contains
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_vstokes')
     else
       call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_z0')
+      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_wavsuu')
+      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_wavsuv')
+      call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_wavsvv')
     end if
     call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_x', ungridded_lbound=1, ungridded_ubound=3)
     call fldlist_add(fldsFrWav_num, fldsFrWav, 'Sw_pstokes_y', ungridded_lbound=1, ungridded_ubound=3)
@@ -753,14 +756,14 @@ contains
       call CalcBotcur( va, wbcuru, wbcurv, wbcurp)
     end if
 
-    if ( state_fldchk(exportState, 'wavsuu') .and. &
-         state_fldchk(exportState, 'wavsuv') .and. &
-         state_fldchk(exportState, 'wavsvv')) then
-      call state_getfldptr(exportState, 'sxxn', sxxn, rc=rc)
+    if ( state_fldchk(exportState, 'Sw_wavsuu') .and. &
+         state_fldchk(exportState, 'Sw_wavsuv') .and. &
+         state_fldchk(exportState, 'Sw_wavsvv')) then
+      call state_getfldptr(exportState, 'Sw_wavsuu', sxxn, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'sxyn', sxyn, rc=rc)
+      call state_getfldptr(exportState, 'Sw_wavsuv', sxyn, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
-      call state_getfldptr(exportState, 'syyn', syyn, rc=rc)
+      call state_getfldptr(exportState, 'Sw_wavsvv', syyn, rc=rc)
       if (ChkErr(rc,__LINE__,u_FILE_u)) return
       call CalcRadstr2D( va, sxxn, sxyn, syyn)
     end if


### PR DESCRIPTION
# Pull Request Summary
This PR aims to fix NUOPC cap (mesh cap) to enable coupling with ocean component via radiation stress components.

## Description
Fixes NUOPC cap to correctly provide radiation stress components in export state.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

### Commit Message
N/A

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
The DATM+SCHSIM+WW3 configuration is tested and passing in UFS Coastal side
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Yes, we have a DATM+SCHSIM+WW3 RT under ufs-weather-model fork
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Coupled `cpld_control_p8` is running without any issue on Hercules with Intel compiler.
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
No answer change
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

