### PR TITLE
Add support for IntelLLVM compiler

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -66,6 +66,21 @@ if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
     set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
   endif()
 
+elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(IntelLLVM)$")
+  set(compile_flags -no-fma -g -traceback -i4 -real-size 32 -fp-model precise -assume byterecl -fno-alias)
+  set(compile_flags_release -O3)
+  # SHELL: prefix fixes CMake attempting to de-duplicate the repeated uses of 'all' in -warn, -debug, -check
+  # See https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication
+  set(compile_flags_debug -O0 "SHELL:-debug all" "SHELL:-warn all" "SHELL:-check all" -check noarg_temp_created -fp-stack-check -heap-arrays -traceback -fpe0)
+
+  if(APPLE)
+    # The linker on macOS does not include `common symbols` (usually module variables without a default value) by default
+    # Passing the -c flag includes them and fixes an error with undefined symbols
+    # Only ifort marks these symbols as common, compared to GCC
+    set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
+    set(CMAKE_C_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
+  endif()
+
 elseif(CMAKE_Fortran_COMPILER_ID MATCHES "^(GNU)$")
   set(compile_flags -g -fno-second-underscore -ffree-line-length-none)
   set(compile_flags_release -O3)


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR adds support for Intel LLVM compiler.

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

`model/src/CMakeLists.txt` has been updated to recognize 'IntelLLVM as a valid compiler id and to define compiler flags for Intel LLVM compiler.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Add support for IntelLLVM compiler

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? ufs-weather-model regression test on Hera. See https://github.com/ufs-community/ufs-weather-model/pull/2224. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

