### PR TITLE
Enable doxygen in cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ project(
 
 get_directory_property(hasParent PARENT_DIRECTORY)
 if(hasParent)
-  # Unset flags that come from Parent (ie UFS or other coupled build) 
+  # Unset flags that come from Parent (ie UFS or other coupled build)
   # for potential (-r8/-r4) conflict
   set(CMAKE_Fortran_FLAGS "")
   set(CMAKE_C_FLAGS "")
@@ -22,8 +22,9 @@ endif()
 
 set(MULTI_ESMF OFF CACHE BOOL "Build ww3_multi_esmf library")
 set(NETCDF ON CACHE BOOL "Build NetCDF programs (requires NetCDF)")
-set(ENDIAN "BIG" CACHE STRING "Endianness of unformatted output files. Valid values are 'BIG', 'LITTLE', 'NATIVE'.") 
+set(ENDIAN "BIG" CACHE STRING "Endianness of unformatted output files. Valid values are 'BIG', 'LITTLE', 'NATIVE'.")
 set(EXCLUDE_FIND "" CACHE STRING "Don't try and search for these libraries (assumd to be handled by the compiler/wrapper)")
+set(ENABLE_DOCS OFF CACHE BOOL "Enable building of doxygen generated documentation")
 
 # make sure all "exclude_find" entries are lower case
 list(TRANSFORM EXCLUDE_FIND TOLOWER)
@@ -58,6 +59,13 @@ if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
 endif()
 
 add_subdirectory(model)
+
+# Turn on doxygen html documentation
+if (ENABLE_DOCS)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/docs/cmake")
+  include(EnableDoxygen)
+  add_subdirectory(docs)
+endif()
 
 # Turn on unit testing.
 #include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ endif()
 
 add_subdirectory(model)
 
-# Turn on doxygen html documentation
+# Turn on doxygen documentation
 if (ENABLE_DOCS)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/docs/cmake")
   include(EnableDoxygen)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -1,0 +1,1 @@
+EnableDoxygen(docs)

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = @bin_basedir@/docs
+OUTPUT_DIRECTORY       = @doc_output@
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @src_basedir@/model/src
+INPUT                  = @src_input@
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docs
+OUTPUT_DIRECTORY       = @bin_basedir@/docs
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -829,7 +829,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = model/src
+INPUT                  = @src_basedir@/model/src
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -2285,7 +2285,7 @@ CLASS_DIAGRAMS         = NO
 # DIA_PATH tag allows you to specify the directory where the dia binary resides.
 # If left empty dia is assumed to be found in the default search path.
 
-DIA_PATH               = 
+DIA_PATH               =
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.

--- a/docs/cmake/EnableDoxygen.cmake
+++ b/docs/cmake/EnableDoxygen.cmake
@@ -15,13 +15,13 @@ function(EnableDoxygen outdir)
         ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile @ONLY)
     set(DOXYGEN_GENERATE_HTML YES)
     set(DOXYGEN_QUIET YES)
-###MTM    set(DOXYGEN_HTML_OUTPUT ${CMAKE_BINARY_DIR}/${outdir}/html)
     add_custom_target(enable_docs
         COMMAND
-        ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile
-###MTM        ALL
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${outdir}
-        COMMENT "Generate Doxygen HTML documentation")
+          ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile
+        WORKING_DIRECTORY
+          ${CMAKE_BINARY_DIR}/${outdir}
+        COMMENT
+          "Generate Doxygen HTML documentation")
     message("-- Doxygen HTML index page: "
         ${CMAKE_BINARY_DIR}/${outdir}/html/index.html)
 endfunction()

--- a/docs/cmake/EnableDoxygen.cmake
+++ b/docs/cmake/EnableDoxygen.cmake
@@ -1,0 +1,27 @@
+# doxygen documentation- Matt Masarik 24-Jul-2024.
+function(EnableDoxygen outdir)
+  find_package(Doxygen)
+    if (NOT DOXYGEN_FOUND)
+      add_custom_target(enable_docs
+          COMMAND false
+          COMMENT "Doxygen not found")
+      return()
+    endif()
+
+    set(src_basedir "${CMAKE_SOURCE_DIR}")
+    set(bin_basedir "${CMAKE_BINARY_DIR}")
+    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${outdir}/html)
+    CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
+        ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile @ONLY)
+    set(DOXYGEN_GENERATE_HTML YES)
+    set(DOXYGEN_QUIET YES)
+###MTM    set(DOXYGEN_HTML_OUTPUT ${CMAKE_BINARY_DIR}/${outdir}/html)
+    add_custom_target(enable_docs
+        COMMAND
+        ${DOXYGEN_EXECUTABLE} ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile
+###MTM        ALL
+        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/${outdir}
+        COMMENT "Generate Doxygen HTML documentation")
+    message("-- Doxygen HTML index page: "
+        ${CMAKE_BINARY_DIR}/${outdir}/html/index.html)
+endfunction()

--- a/docs/cmake/EnableDoxygen.cmake
+++ b/docs/cmake/EnableDoxygen.cmake
@@ -8,8 +8,8 @@ function(EnableDoxygen outdir)
       return()
     endif()
 
-    set(src_basedir "${CMAKE_SOURCE_DIR}")
-    set(bin_basedir "${CMAKE_BINARY_DIR}")
+    set(src_input "${CMAKE_SOURCE_DIR}/model/src")
+    set(doc_output "${CMAKE_BINARY_DIR}/${outdir}")
     file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${outdir}/html)
     CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/docs/Doxyfile.in
         ${CMAKE_BINARY_DIR}/${outdir}/Doxyfile @ONLY)

--- a/docs/cmake/EnableDoxygen.cmake
+++ b/docs/cmake/EnableDoxygen.cmake
@@ -1,6 +1,6 @@
 # Doxygen documentation- Matt Masarik 24-Jul-2024.
 function(EnableDoxygen outdir)
-  find_package(Doxygen)
+  find_package(Doxygen REQUIRED)
     if (NOT DOXYGEN_FOUND)
       add_custom_target(enable_docs
           COMMAND false

--- a/docs/cmake/EnableDoxygen.cmake
+++ b/docs/cmake/EnableDoxygen.cmake
@@ -1,4 +1,4 @@
-# doxygen documentation- Matt Masarik 24-Jul-2024.
+# Doxygen documentation- Matt Masarik 24-Jul-2024.
 function(EnableDoxygen outdir)
   find_package(Doxygen)
     if (NOT DOXYGEN_FOUND)


### PR DESCRIPTION
# Pull Request Summary
Enables doxygen documention within the cmake build system. 

## Description
Doxygen support is added to the build system via:
* A cache variable (`ENABLE_DOCS`) is added to the main `CMakeLists.txt` file, which is currently set to `OFF` by default.
* A `cmake` module is added (`EnableDoxygen`) which takes an output directory as an argument. Default is set as `docs`.
* `EnableDoxygen` adds a target (`enable_docs`) to the build system.  If `doxygen` is not found on the system, the target will fail, otherwise `doxygen` will be run and the output location of `index.html` is displayed during `cmake` config.
* There are only changes to the `cmake` build files to handle `doxygen` documentation, so there are no answer changes expected.

#### Usage
Steps to generate `doxygen` documentation from the WW3 root directory:
```
mkdir build && cd build
cmake -DSWITCH=<path-to-switch> -DENABLE_DOCS=ON -S .. -B .
cmake --build . --target enable_docs                         # make enable_docs
```
View html docs in browser (ex, firefox) for default output location
```
firefox docs/html/index.html
```

* Tested using doxygen v1.8.17.  
* _Note that it's not necessary to build the model to generate the doxygen documentation. Specifying the target `enable_docs` will just run `doxygen` on the source files. However, the dependencies (i.e, Fortran compiler, NetCDF, etc) still need to be available due to checks within the build system._

Please also include the following information: 
* Add any suggestions for a reviewer:
  * @edwardhartnett @AlexanderRichert-NOAA 
* Mention any labels that should be added:
  * _documentation_, _new feature_
* Are answer changes expected from this PR?
  * No. 

### Issue(s) addressed
- fixes #1171
- A follow-on PR will address #25

### Commit Message
Enable doxygen documentation in the cmake build system

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [na] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [na] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * By building the doxygen documentation and verifying output in a browser (ubuntu 20.04, doxygen 1.8.17, mozilla firefox 128.0).  The current default doxygen documentation homepage:
  
<img width="1031" alt="doxygen_ww3_homepage" src="https://github.com/user-attachments/assets/c40e260b-4512-479f-bc92-c097dbc55d7c">

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * No. Documentation is not tested. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * N/A. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * N/A. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * N/A.