### PR TITLE
IC4M10: New Wave Attenuation Scheme

### DIFF
--- a/model/src/w3sic4md.F90
+++ b/model/src/w3sic4md.F90
@@ -89,6 +89,7 @@ MODULE W3SIC4MD
   !        *** Rogers et al. tech. rep. 2021 (RYW2021)
   !        *** Yu et al. CRST 2022
   !        *** Yu JMSE 2022
+  !        *** Meylan et al. Ocean Modeling 2021
   !
   !  6. Switches :
   !
@@ -138,6 +139,7 @@ CONTAINS
     !/    11-Jan-2024 : Method 8 added (Meylan et al. 2018)   (E. Rogers)
     !/    11-Jan-2024 : Method 9 added (Rogers et al., 2021)
     !/                                      denoted "RYW2021" (E. Rogers)
+    !/    14-Aug-2024 : Method 10 added (Meylan et al. 2021)  (E. Thomas)
     !/
     !/        FIXME   : Move field input to W3SRCE and provide
     !/     (S.Zieger)   input parameter to W3SIC1 to make the subroutine
@@ -307,6 +309,8 @@ CONTAINS
     !        suggested default is marked with "(*SD*)", for consistency
     !          with SWAN (v41.31AB or later)
     !
+    !     10) Meylan et al. 2021 (Ocean Modeling): ocean-wave attenuation 
+    !         due to scattering by sea ice floes. 
     !     ------------------------------------------------------------------
     !
     !     For all methods, the user can specify namelist

--- a/model/src/w3sic4md.F90
+++ b/model/src/w3sic4md.F90
@@ -450,6 +450,8 @@ CONTAINS
     REAL, ALLOCATABLE       :: FREQ(:) ! wave frequency
     REAL, ALLOCATABLE       :: MARG1(:), MARG2(:) ! Arguments for M2
     REAL, ALLOCATABLE       :: KARG1(:), KARG2(:), KARG3(:) !Arguments for M3
+    REAL                    :: x1,x2,x3,x1sqr,x2sqr,x3sqr   !Arguments for M10
+    REAL                    :: perfour,amhb,bmhb            !Arguments for M10
     LOGICAL                 :: NML_INPUT ! if using namelist input for M2
 
     !/
@@ -699,6 +701,43 @@ CONTAINS
       DO IK=1,NK
         WN_I(IK)  = Chf*(hice**mpow)*(FREQ(IK)**npow)
       END DO
+    
+    CASE (10)
+      ! Cubic fit to Meylan, Horvat & Bitz 2021
+      ! ICECOEF1 is thickness
+      ! ICECOEF5 is floe size
+      ! TPI/SIG is period
+      x3=min(ICECOEF1,3.5)        ! limit thickness to 3.5 m
+      x3=max(x3,0.1)        ! limit thickness >0.1 m since I make fit below
+      x2=min(ICECOEF5*0.5,100.0)  ! convert dia to radius, limit to 100m
+      x2=max(2.5,x2)
+      x2sqr=x2*x2
+      x3sqr=x3*x3
+      amhb = 2.12e-3
+      bmhb = 4.59e-2
+
+      DO IK=1, NK
+        x1=TPI/SIG(IK)   ! period
+        x1sqr=x1*x1
+        KARG1(ik)=-0.26982 + 1.5043*x3 - 0.70112*x3sqr + 0.011037*x2 +  &
+                  (-0.0073178)*x2*x3 + 0.00036604*x2*x3sqr + &
+                  (-0.00045789)*x2sqr + 1.8034e-05*x2sqr*x3 + &
+                  (-0.7246)*x1 + 0.12068*x1*x3 + &
+                  (-0.0051311)*x1*x3sqr + 0.0059241*x1*x2 + &
+                  0.00010771*x1*x2*x3 - 1.0171e-05*x1*x2sqr + &
+                  0.0035412*x1sqr - 0.0031893*x1sqr*x3 + &
+                  (-0.00010791)*x1sqr*x2 + &
+                  0.00031073*x1**3 + 1.5996e-06*x2**3 + 0.090994*x3**3
+        KARG1(IK)=min(KARG1(IK),0.0)
+        ALPHA(IK) = 10.0**KARG1(IK)  
+        perfour=x1sqr*x1sqr
+        if ((x1.gt.5.0) .and. (x1.lt.20.0)) then
+          ALPHA(IK) = ALPHA(IK) + amhb/x1sqr+bmhb/perfour
+        else if (x1.gt.20.0) then
+          ALPHA(IK) = amhb/x1sqr+bmhb/perfour
+        endif
+          WN_I(IK) = ALPHA(IK) * 0.5
+        end do
 
     CASE DEFAULT
       WN_I = ICECOEF1 !Default to IC1: Uniform in k


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
A new wave attenuation scheme (IC4 method 10) based on Meylan Horvat Bitz Bennetts Ocean Modelling 2021

## Description
This PR adds a new wave attenuation scheme for IC4. It is based on Meylan Horvat Bitz and Bennetts, Ocean Modelling, 2021. It calculated wave damping based on scattering due to sea ice floes. It requires the use of the IS0 switch (no additional scattering term) and sea ice floe size diameter as input from ICECOEF5. 

Suggestions for a reviewers: 
Labels that should be added:   _new feature_


### Commit Message
IC4M10: New wave damping scheme in sea ice based on Meylan Horvat Bitz and Bennetts, Ocean Modelling, 2021. Co-Authors include: Erin Thomas, Cecilia Bitz, David Bailey, Nick Szapiro. 


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
These changes have been tested in fully coupled climate model simulations (E3SM and CESM) which have fully coupled wave (WW3) and sea ice components (the later of which contain sea ice floe size distribution).

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

