### PR TITLE
Fix indentation in w3wave and w3iogomd

### DIFF
--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1492,79 +1492,79 @@ CONTAINS
 
             IF ((IOBP_LOC(JSEA).eq.1..or.IOBP_LOC(JSEA).eq. 3).and.IOBDP_LOC(JSEA).eq.1.and.IOBPA_LOC(JSEA).eq.0) THEN
 
-            IX     = MAPSF(ISEA,1)
-            IY     = MAPSF(ISEA,2)
-            DELA=1.
-            DELX=1.
-            DELY=1.
+              IX     = MAPSF(ISEA,1)
+              IY     = MAPSF(ISEA,2)
+              DELA=1.
+              DELX=1.
+              DELY=1.
 
 #ifdef W3_REF1
-            IF (GTYPE.EQ.RLGTYPE) THEN
-              DELX=SX*CLATS(ISEA)/FACX
-              DELY=SY/FACX
-              DELA=DELX*DELY
-            END IF
-            IF (GTYPE.EQ.CLGTYPE) THEN
-              ! Maybe what follows works also for RLGTYPE ... to be verified
-              DELX=HPFAC(IY,IX)/ FACX
-              DELY=HQFAC(IY,IX)/ FACX
-              DELA=DELX*DELY
-            END IF
-            REFLEC=REFLC(:,ISEA)
-            REFLEC(4)=BERG(ISEA)*REFLEC(4)
-            REFLED=REFLD(:,ISEA)
+              IF (GTYPE.EQ.RLGTYPE) THEN
+                DELX=SX*CLATS(ISEA)/FACX
+                DELY=SY/FACX
+                DELA=DELX*DELY
+              END IF
+              IF (GTYPE.EQ.CLGTYPE) THEN
+                ! Maybe what follows works also for RLGTYPE ... to be verified
+                DELX=HPFAC(IY,IX)/ FACX
+                DELY=HQFAC(IY,IX)/ FACX
+                DELA=DELX*DELY
+              END IF
+              REFLEC=REFLC(:,ISEA)
+              REFLEC(4)=BERG(ISEA)*REFLEC(4)
+              REFLED=REFLD(:,ISEA)
 #endif
 
 #ifdef W3_BT4
-            D50=SED_D50(ISEA)
-            PSIC=SED_PSIC(ISEA)
+              D50=SED_D50(ISEA)
+              PSIC=SED_PSIC(ISEA)
 #endif
-            !
+              !
 #ifdef W3_DEBUGSRC
-            IF (IX .eq. DEBUG_NODE) THEN
-              WRITE(740+IAPROC,*) 'NODE_SRCE_IMP_PRE : IX=', IX, ' JSEA=', JSEA
-            END IF
-            WRITE(740+IAPROC,*) 'IT/IX/IY/IMOD=', IT, IX, IY, IMOD
-            WRITE(740+IAPROC,*) 'ISEA/JSEA=', ISEA, JSEA
-            WRITE(740+IAPROC,*) 'Before sum(VA)=', sum(VA(:,JSEA))
-            FLUSH(740+IAPROC)
+              IF (IX .eq. DEBUG_NODE) THEN
+                WRITE(740+IAPROC,*) 'NODE_SRCE_IMP_PRE : IX=', IX, ' JSEA=', JSEA
+              END IF
+              WRITE(740+IAPROC,*) 'IT/IX/IY/IMOD=', IT, IX, IY, IMOD
+              WRITE(740+IAPROC,*) 'ISEA/JSEA=', ISEA, JSEA
+              WRITE(740+IAPROC,*) 'Before sum(VA)=', sum(VA(:,JSEA))
+              FLUSH(740+IAPROC)
 #endif
-            CALL W3SRCE(srce_imp_pre, IT, ISEA, JSEA, IX, IY, IMOD, &
-                 VAold(:,JSEA), VA(:,JSEA),                         &
-                 VSioDummy, VDioDummy, SHAVETOT(JSEA),              &
-                 ALPHA(1:NK,JSEA), WN(1:NK,ISEA),                   &
-                 CG(1:NK,ISEA), CLATS(ISEA), DW(ISEA), U10(ISEA),   &
-                 U10D(ISEA),                                        &
+              CALL W3SRCE(srce_imp_pre, IT, ISEA, JSEA, IX, IY, IMOD, &
+                   VAold(:,JSEA), VA(:,JSEA),                         &
+                   VSioDummy, VDioDummy, SHAVETOT(JSEA),              &
+                   ALPHA(1:NK,JSEA), WN(1:NK,ISEA),                   &
+                   CG(1:NK,ISEA), CLATS(ISEA), DW(ISEA), U10(ISEA),   &
+                   U10D(ISEA),                                        &
 #ifdef W3_FLX5
-                 TAUA(ISEA), TAUADIR(ISEA),                         &
+                   TAUA(ISEA), TAUADIR(ISEA),                         &
 #endif
-                 AS(ISEA), UST(ISEA),                               &
-                 USTDIR(ISEA), CX(ISEA), CY(ISEA),                  &
-                 ICE(ISEA), ICEH(ISEA), ICEF(ISEA),                 &
-                 ICEDMAX(ISEA),                                     &
-                 REFLEC, REFLED, DELX, DELY, DELA,                  &
-                 TRNX(IY,IX), TRNY(IY,IX), BERG(ISEA),              &
-                 FPIS(ISEA), DTDYN(JSEA),                           &
-                 FCUT(JSEA), DTGpre, TAUWX(JSEA), TAUWY(JSEA),      &
-                 TAUOX(JSEA), TAUOY(JSEA), TAUWIX(JSEA),            &
-                 TAUWIY(JSEA), TAUWNX(JSEA),                        &
-                 TAUWNY(JSEA),  PHIAW(JSEA), CHARN(JSEA),           &
-                 TWS(JSEA), PHIOC(JSEA), TMP1, D50, PSIC, TMP2,     &
-                 PHIBBL(JSEA), TMP3, TMP4, PHICE(JSEA),             &
-                 TAUOCX(JSEA), TAUOCY(JSEA), WNMEAN(JSEA),          &
-                 RHOAIR(ISEA), ASF(ISEA))
-            IF (.not. LSLOC) THEN
-              VSTOT(:,JSEA) = VSioDummy
-              VDTOT(:,JSEA) = VDioDummy
-            ENDIF
+                   AS(ISEA), UST(ISEA),                               &
+                   USTDIR(ISEA), CX(ISEA), CY(ISEA),                  &
+                   ICE(ISEA), ICEH(ISEA), ICEF(ISEA),                 &
+                   ICEDMAX(ISEA),                                     &
+                   REFLEC, REFLED, DELX, DELY, DELA,                  &
+                   TRNX(IY,IX), TRNY(IY,IX), BERG(ISEA),              &
+                   FPIS(ISEA), DTDYN(JSEA),                           &
+                   FCUT(JSEA), DTGpre, TAUWX(JSEA), TAUWY(JSEA),      &
+                   TAUOX(JSEA), TAUOY(JSEA), TAUWIX(JSEA),            &
+                   TAUWIY(JSEA), TAUWNX(JSEA),                        &
+                   TAUWNY(JSEA),  PHIAW(JSEA), CHARN(JSEA),           &
+                   TWS(JSEA), PHIOC(JSEA), TMP1, D50, PSIC, TMP2,     &
+                   PHIBBL(JSEA), TMP3, TMP4, PHICE(JSEA),             &
+                   TAUOCX(JSEA), TAUOCY(JSEA), WNMEAN(JSEA),          &
+                   RHOAIR(ISEA), ASF(ISEA))
+              IF (.not. LSLOC) THEN
+                VSTOT(:,JSEA) = VSioDummy
+                VDTOT(:,JSEA) = VDioDummy
+              ENDIF
 #ifdef W3_DEBUGSRC
-            WRITE(740+IAPROC,*) 'After sum(VA)=', sum(VA(:,JSEA))
-            WRITE(740+IAPROC,*) '   sum(VSTOT)=', sum(VSTOT(:,JSEA))
-            WRITE(740+IAPROC,*) '   sum(VDTOT)=', sum(VDTOT(:,JSEA))
-            WRITE(740+IAPROC,*) '     SHAVETOT=', SHAVETOT(JSEA)
-            FLUSH(740+IAPROC)
+              WRITE(740+IAPROC,*) 'After sum(VA)=', sum(VA(:,JSEA))
+              WRITE(740+IAPROC,*) '   sum(VSTOT)=', sum(VSTOT(:,JSEA))
+              WRITE(740+IAPROC,*) '   sum(VDTOT)=', sum(VDTOT(:,JSEA))
+              WRITE(740+IAPROC,*) '     SHAVETOT=', SHAVETOT(JSEA)
+              FLUSH(740+IAPROC)
 #endif
-          ENDIF 
+            ENDIF 
           END DO ! JSEA
         END IF ! PDLIB
 #endif


### PR DESCRIPTION
# Pull Request Summary
Fix white-space indentation in w3wave and w3iogo
## Description
Review of https://github.com/NOAA-EMC/WW3/pull/1337 discovered incorrect indentation in w3wave. This fixes that. 

### Issue(s) addressed
Issue was not created. 

### Commit Message
Fix indentation in w3wave and w3iogo 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

Tests are now running (not originally run after only the w3wave updates)

* How were these changes tested? matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? yes hera, intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
No changes. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```


[matrixCompFull.txt](https://github.com/user-attachments/files/18336615/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/18336616/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/18336617/matrixDiff.txt)

