### PR TITLE
Indicator log file for gridded output in production/GFS.v16

### DIFF
--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -3503,6 +3503,7 @@
 
 !!!MTM
       IF ( WRITE .AND. (OFILES(1).EQ.1) ) THEN
+          ! The NDSOG file unit was closed above so can be reused for NDSOGLOG
           NDSOGLOG = NDSOG
           OPEN (NDSOGLOG,FILE=FNMPRE(:J)//TIMETAG//'.out_grd.'//FILEXT(:I)//'.FINISHED', &
                form ='FORMATTED',ERR=800,IOSTAT=IERR)

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -2516,7 +2516,7 @@
       CHARACTER(LEN=10)       :: VERTST
 
 !!!MTM
-      INTEGER                 :: NDSOGLOG = 12444
+      INTEGER                 :: NDSOGLOG
 !!!MTM
 !/
 !/ ------------------------------------------------------------------- /
@@ -3503,6 +3503,7 @@
 
 !!!MTM
       IF ( WRITE .AND. (OFILES(1).EQ.1) ) THEN
+          NDSOGLOG = NDSOG
           OPEN (NDSOGLOG,FILE=FNMPRE(:J)//TIMETAG//'.out_grd.'//FILEXT(:I)//'.FINISHED', &
                form ='FORMATTED',ERR=800,IOSTAT=IERR)
           WRITE (NDSOGLOG,*) ''

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -2514,6 +2514,10 @@
 !/ARC      REAL                    :: UDARC
       CHARACTER(LEN=30)       :: IDTST, TNAME
       CHARACTER(LEN=10)       :: VERTST
+
+!!!MTM
+      INTEGER                 :: NDSOGLOG = 12444
+!!!MTM
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -3496,6 +3500,17 @@
 !
       IF(OFILES(1) .EQ. 1) CLOSE(NDSOG)
 !
+
+!!!MTM
+      IF ( WRITE .AND. (OFILES(1).EQ.1) ) THEN
+          OPEN (NDSOGLOG,FILE=FNMPRE(:J)//TIMETAG//'.out_grd.'//FILEXT(:I)//'.FINISHED', &
+               form ='FORMATTED',ERR=800,IOSTAT=IERR)
+          WRITE (NDSOGLOG,*) ''
+          CALL FLUSH (NDSOGLOG)
+          CLOSE (NDSOGLOG)
+      ENDIF
+!!!MTM
+
 !/MPI      CALL W3SETA ( IGRD, NDSE, NDST )
 !
       RETURN

--- a/model/ftn/w3iogomd.ftn
+++ b/model/ftn/w3iogomd.ftn
@@ -2514,10 +2514,7 @@
 !/ARC      REAL                    :: UDARC
       CHARACTER(LEN=30)       :: IDTST, TNAME
       CHARACTER(LEN=10)       :: VERTST
-
-!!!MTM
       INTEGER                 :: NDSOGLOG
-!!!MTM
 !/
 !/ ------------------------------------------------------------------- /
 !/
@@ -3500,10 +3497,8 @@
 !
       IF(OFILES(1) .EQ. 1) CLOSE(NDSOG)
 !
-
-!!!MTM
       IF ( WRITE .AND. (OFILES(1).EQ.1) ) THEN
-          ! The NDSOG file unit was closed above so can be reused for NDSOGLOG
+          ! The NDSOG file unit was closed above so can now be reused for NDSOGLOG
           NDSOGLOG = NDSOG
           OPEN (NDSOGLOG,FILE=FNMPRE(:J)//TIMETAG//'.out_grd.'//FILEXT(:I)//'.FINISHED', &
                form ='FORMATTED',ERR=800,IOSTAT=IERR)
@@ -3511,7 +3506,6 @@
           CALL FLUSH (NDSOGLOG)
           CLOSE (NDSOGLOG)
       ENDIF
-!!!MTM
 
 !/MPI      CALL W3SETA ( IGRD, NDSE, NDST )
 !


### PR DESCRIPTION
# Pull Request Summary
Adds the writing of a log file to indicate that a particular gridded output file has finished writing.  

## Description
* Provide a detailed description of what this PR does.
  * This _indicator file_ will be used to signal to the post-processing scripts that a gridded output file is ready to be accessed and read.  This is implemented in a simple way by reusing the Fortran IO unit number for the gridded output once that file has already been closed (thanks to @JessicaMeixner-NOAA for the suggestion!).

* What bug does it fix, or what feature does it add?
  * This fixes an infrequent occurrence in the global-workflow where a gridded output file has an attempted read on it before the file has completed writing. 
* Is a change of answers expected from this PR?
  * No.  This just addresses an issue that has occurred in post-processing.

Please also include the following information: 
* Add any suggestions for a reviewer 
  * @JessicaMeixner-NOAA 
* Mention any labels that should be added:  
  * _bug_.
* Are answer changes expected from this PR?
  * No. 

### Issue(s) addressed
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
  - fixes #1321

### Commit Message
w3iogomd.ftn: Add indicator log file write for gridded output 

### Check list  
- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
  * Testing  during development was done in standalone mode with a modified regtest which is verified by a separate process checking for `out_grd` files and indicator files.
  * Final testing was performed within `global-workflow:dev/gfs.v16` and passed b4b.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
  * N/A. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
  * No.  It is not a requirement for the `production/GFS.v16` branch.
  * Functionality and b4b were confirmed in the global-workflow testing. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
  * No changes expected, though indicator logs will now be present in the run directory.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
  * Not required for `production/GFS.v16`.
