### PR TITLE
Improve oasis grid writing

### DIFF
--- a/model/src/w3oacpmd.F90
+++ b/model/src/w3oacpmd.F90
@@ -314,8 +314,8 @@ CONTAINS
           CORLAT(I,1,4) = CORLAT(I,1,3)
           ! areas
           AREA(I,1) = 0.25 * IJKCEL(3,I)*DLON * IJKCEL(4,I)*DLAT
-          ! Model grid mask
-          MASK(I,1) = 1
+          ! Model grid mask: 0 - sea  / 1 - open boundary cells (the land is already excluded)
+          MASK(I,1) = 0
         ENDDO
 #endif
         !

--- a/model/src/w3oacpmd.F90
+++ b/model/src/w3oacpmd.F90
@@ -162,13 +162,16 @@ CONTAINS
     !/                  | Last update :          April-2016 |
     !/                  +-----------------------------------+
     !/
-    !/    Jul-2013 : Origination.                    ( version 4.18 )
-    !/    April-2016 : Add comments (J. Pianezze)    ( version 5.07 )
-    !/    Sept-2016 : Correct bug MPI (J. Pianezze)  ( version 5.12 )
+    !/    Jul-2013 : Origination.                     ( version 4.18 )
+    !/    April-2016 : Add comments (J. Pianezze)     ( version 5.07 )
+    !/    Sept-2016 : Correct bug MPI (J. Pianezze)   ( version 5.12 )
+    !/    Jan-2025 : Use scrip format (J.M. Castillo) ( version x.xx )
     !/
     !  1. Purpose :
     !
-    !     Grid data file definition
+    !     Grid data file definition in the scrip format.
+    !     In this format, grid corners are specified in counterclockwise
+    !     order, being the first corner the one at the bottom left.
     !
     !  2. Method :
     !  3. Parameters :
@@ -250,41 +253,30 @@ CONTAINS
         NYS=1
         NYN=NY
         !
-        ! lat/lon
         ALLOCATE ( LON(NNODES,1), LAT(NNODES,1) )
-        I = 0
-        DO IY = NYS, NYN
-          DO IX = NXW, NXE
-            I = I+1
-            LON(I,1)=XGRD(IY,IX)*FACTOR
-            LAT(I,1)=YGRD(IY,IX)*FACTOR
-          END DO
-        END DO
-        !
-        ! areas, corners
         ALLOCATE ( AREA(NNODES,1), CORLON(NNODES,1,4), CORLAT(NNODES,1,4) )
-        I = 0
-        DO IY = NYS, NYN
-          DO IX = NXW, NXE
-            I = I+1
-            CORLON(I,1,1)=LON(I,1)+HPFAC(IY,IX)/2.*FACTOR
-            CORLON(I,1,2)=LON(I,1)-HPFAC(IY,IX)/2.*FACTOR
-            CORLON(I,1,3)=LON(I,1)-HPFAC(IY,IX)/2.*FACTOR
-            CORLON(I,1,4)=LON(I,1)+HPFAC(IY,IX)/2.*FACTOR
-            CORLAT(I,1,1)=LAT(I,1)+HQFAC(IY,IX)/2.*FACTOR
-            CORLAT(I,1,2)=LAT(I,1)+HQFAC(IY,IX)/2.*FACTOR
-            CORLAT(I,1,3)=LAT(I,1)-HQFAC(IY,IX)/2.*FACTOR
-            CORLAT(I,1,4)=LAT(I,1)-HQFAC(IY,IX)/2.*FACTOR
-            AREA(I,1)=HPFAC(IY,IX)*HQFAC(IY,IX)
-          END DO
-        END DO
-        !
-        ! Model grid mask
         ALLOCATE ( MASK(NNODES,1) )
+        !
         I = 0
         DO IY = NYS, NYN
           DO IX = NXW, NXE
             I = I+1
+            ! lat/lon
+            LON(I,1) = XGRD(IY,IX)*FACTOR
+            LAT(I,1) = YGRD(IY,IX)*FACTOR
+            !
+            ! areas, corners
+            CORLON(I,1,1) = LON(I,1)-HPFAC(IY,IX)/2.*FACTOR
+            CORLON(I,1,2) = LON(I,1)+HPFAC(IY,IX)/2.*FACTOR
+            CORLON(I,1,3) = CORLON(I,1,2)
+            CORLON(I,1,4) = CORLON(I,1,1)
+            CORLAT(I,1,1) = LAT(I,1)-HQFAC(IY,IX)/2.*FACTOR
+            CORLAT(I,1,2) = CORLAT(I,1,1)
+            CORLAT(I,1,3) = LAT(I,1)+HQFAC(IY,IX)/2.*FACTOR
+            CORLAT(I,1,4) = CORLAT(I,1,3)
+            AREA(I,1) = HPFAC(IY,IX)*HQFAC(IY,IX)
+            !
+            ! Model grid mask
             ! Get the mask : 0 - sea  / 1 - open boundary cells (the land is already excluded)
             IF ((MAPSTA(IY,IX) .EQ. 1)) THEN
               MASK(I,1) = 0
@@ -317,9 +309,9 @@ CONTAINS
           CORLON(I,1,3) = CORLON(I,1,2)
           CORLON(I,1,4) = CORLON(I,1,1)
           CORLAT(I,1,1) = Y0 + IJKCel(2,I)*DLAT
-          CORLAT(I,1,2)=CORLAT(I,1,1)
+          CORLAT(I,1,2) = CORLAT(I,1,1)
           CORLAT(I,1,3) = Y0 + (IJKCel(2,I) + IJKCel(4,I))*DLAT
-          CORLAT(I,1,4)=CORLAT(I,1,3)
+          CORLAT(I,1,4) = CORLAT(I,1,3)
           ! areas
           AREA(I,1) = 0.25 * IJKCEL(3,I)*DLON * IJKCEL(4,I)*DLAT
           ! Model grid mask


### PR DESCRIPTION
# Pull Request Summary
Rewrite the cpl_oasis_grid subroutine for better performance and to use OASIS and SCRIP standards.

## Description
This is just a change providing a small performance gain in the code (mainly substituting three identical double loops by a single one), using the SCRIP convention to write grid corners, and the oasis convention to declare the grid mask. It should not change answers, but the grid.nc file generated by OASIS will change due to a rearrangement of data in regular grids and the change of mask values for SMC grids.

The reviewer is encouraged to look at the OASIS and SCRIP documentation.
Possible label that could be applied could be _enhancement_.

### Issue(s) addressed
- fixes #1353 

### Commit Message
Rewrite the cpl_oasis_grid subroutine for better performance and to use OASIS and SCRIP standards.

### Check list  

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Regression tests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Yes, they are covered by the tp2.14 tests
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
The change only affect tests tp2.14. The only change in results has to do with the changes in the grid.nc OASIS output file discussed above.
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):