### PR TITLE
Add reading of binary restart with PIO for runtype=initial 

### DIFF
--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -985,9 +985,22 @@ CONTAINS
           call extcde (60, msg="required restart file " // trim(fname) // " does not exist")
         end if
       else
-        call read_restart('none')
-        ! mapst2 is module variable defined in read of mod_def; maptst is from 2.b above
-        flcold = .true.
+        if (restart_from_binary) then
+          call set_user_timestring(time,user_timestring)
+          fname = trim(user_restfname)//trim(user_timestring)
+          inquire(file=trim(fname), exist=exists)
+          if (exists) then
+            call w3iors('READ', nds(6), sig(nk), imod, filename=trim(fname))
+          else
+            call read_restart('none')
+            ! mapst2 is module variable defined in read of mod_def; maptst is from 2.b above
+            flcold = .true.
+           end if
+        else
+          call read_restart('none')
+          ! mapst2 is module variable defined in read of mod_def; maptst is from 2.b above
+          flcold = .true.
+        end if
       end if
     else
 #endif

--- a/model/src/w3initmd.F90
+++ b/model/src/w3initmd.F90
@@ -992,10 +992,8 @@ CONTAINS
           if (exists) then
             call w3iors('READ', nds(6), sig(nk), imod, filename=trim(fname))
           else
-            call read_restart('none')
-            ! mapst2 is module variable defined in read of mod_def; maptst is from 2.b above
-            flcold = .true.
-           end if
+            call extcde (60, msg="required restart file " // trim(fname) // " does not exist") 
+          end if
         else
           call read_restart('none')
           ! mapst2 is module variable defined in read of mod_def; maptst is from 2.b above


### PR DESCRIPTION
# Pull Request Summary

Adding capability to read WW3 restart files when using PIO and runtype=initial. 

## Description

For the high resolution (HR) prototypes, we want to be able to read a WW3 binary restart even though the runtype=initial.  These code changes allow for that.   This does not address wanting to use a NetCDF restart with runtype=initial. 

Is a change of answers expected from this PR? No. Unless you are running the coupled model with runtype=initial, this will allow for ICs to now be read. 

Please also include the following information: 
* Add any suggestions for a reviewer: @sbanihash   
* Mention any labels that should be added:  _new feature_
* Are answer changes expected from this PR? No 

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
- fixes https://github.com/NOAA-EMC/WW3/issues/1358

### Commit Message
Add reading of binary restart with PIO for runtype=initial 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) dev/ufs-weather-model  branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
--- UFS weather model PR: https://github.com/ufs-community/ufs-weather-model/pull/2585 
[RegressionTests_hera.log](https://github.com/user-attachments/files/18620168/RegressionTests_hera.log)
--- Global-workflow test output: /scratch1/NCEPDEV/climate/Jessica.Meixner/UpdateFixandHiresIC/c48t05

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) No. This is a ufs-weather-model issue and its also not covered by regresstion tests in ufs-waether-model. We do use this in production runs during the transition from binary-> netcdf restarts. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? No. Will do if requested. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) None. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
--- Will run if requested, currently have not been done. 

