### PR TITLE
Initialize SATINDICES to 1

### DIFF
--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -2095,7 +2095,7 @@ CONTAINS
          MPARS(IMOD)%SRCPS%CUMULW(MSPEC,MSPEC),        &
          STAT=ISTAT                                   )
     CHECK_ALLOC_STATUS ( ISTAT )
-    MPARS(IMOD)%SRCPS%SATINDICES(:,:)=0.
+    MPARS(IMOD)%SRCPS%SATINDICES(:,:)=1.
     MPARS(IMOD)%SRCPS%SATWEIGHTS(:,:)=0.
     MPARS(IMOD)%SRCPS%CUMULW(:,:)=0.
 #endif


### PR DESCRIPTION
# Pull Request Summary
Initialize SATINDICES to 1 to avoide debug failure. 

## Description
While trying to debug an issue on dev/ufs-weather-model, it was noted that SATINDICES is intialized to 0, however in other parts of the code it's set to 1 as an initial value so setting it to 1 after allocation. 

### Issue(s) addressed
- https://github.com/NOAA-EMC/WW3/issues/1356

### Commit Message
Initialize SATINDICES to 1

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? in matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) ?
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? hera, intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
No changes expected. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (2 files differ)
```

[matrixCompFull.txt](https://github.com/user-attachments/files/18741009/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/18741010/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/18741011/matrixDiff.txt)

