### PR TITLE
Update w3srcemd.F90 for considering the contribution of ice scattering of IS1

### DIFF
--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -2127,7 +2127,7 @@ CONTAINS
 
 #ifdef W3_IS1
         ! IS1 doesn't dissipate wave energy, it just redistribute the scattered energy to other directions
-        SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) = SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) + VSIR(IS)*DTMIN
+        SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) = SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) + VSIR(IS)*DTG
 #endif
 
 #ifdef W3_IS2

--- a/model/src/w3srcemd.F90
+++ b/model/src/w3srcemd.F90
@@ -2124,6 +2124,12 @@ CONTAINS
         !
         ! Second part of ice term integration: scattering including re-distribution in directions
         !
+
+#ifdef W3_IS1
+        ! IS1 doesn't dissipate wave energy, it just redistribute the scattered energy to other directions
+        SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) = SPEC(1+(IK-1)*NTH:NTH+(IK-1)*NTH) + VSIR(IS)*DTMIN
+#endif
+
 #ifdef W3_IS2
         IF (IS2PARS(2).GE.0) THEN
           IF (IS2PARS(20).GT.0.5) THEN


### PR DESCRIPTION
I reported a bug [#1386](https://github.com/NOAA-EMC/WW3/issues/1386), the current IS1 is not contributing to action density spectrum. Since scattering doesn’t dissipate wave energy, I believe the correct solution is to redistribute the scattered energy to other directions, similar to IS2.

# Pull Request Summary
<!-- A short overview of the PR --> 

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

### Issue(s) addressed
Addresses #1305
Addresses #1386

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

