### PR TITLE
Add restart NetCDF indicator log and improve log using free unit number

### DIFF
--- a/model/src/w3iopomd.F90
+++ b/model/src/w3iopomd.F90
@@ -2015,7 +2015,7 @@ CONTAINS
       ! Create TIMETAG for file name using YYYYMMDD.HHMMS prefix
       WRITE(TIMETAG,"(i8.8,'.'i6.6)")TIME(1),TIME(2)
       filename = FNMPRE_LOCAL(:LEN_TRIM(FNMPRE_LOCAL))//TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
-      FNAME = TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
+      FNAME = TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))
     ELSE 
       filename = FNMPRE_LOCAL(:LEN_TRIM(FNMPRE_LOCAL))//'out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
     END IF 

--- a/model/src/w3iopomd.F90
+++ b/model/src/w3iopomd.F90
@@ -2015,7 +2015,7 @@ CONTAINS
       ! Create TIMETAG for file name using YYYYMMDD.HHMMS prefix
       WRITE(TIMETAG,"(i8.8,'.'i6.6)")TIME(1),TIME(2)
       filename = FNMPRE_LOCAL(:LEN_TRIM(FNMPRE_LOCAL))//TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
-      FNAME = TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))
+      FNAME = TIMETAG//'.out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
     ELSE 
       filename = FNMPRE_LOCAL(:LEN_TRIM(FNMPRE_LOCAL))//'out_pnt.'//FILEXT(:LEN_TRIM(FILEXT))//'.nc'
     END IF 

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -610,6 +610,7 @@ CONTAINS
     integer            :: memunit
     character(len=16)  :: user_timestring    !YYYY-MM-DD-SSSSS
     character(len=256) :: fname
+    character(len=256) :: log_fname
     !/ ------------------------------------------------------------------- /
     ! 0.  Initializations
     !
@@ -2383,7 +2384,8 @@ CONTAINS
           if (rstwr) then
             call set_user_timestring(tend,user_timestring)
             fname = trim(FNMRST)//trim(user_restfname)//trim(user_timestring)//'.nc'
-            call write_restart(trim(fname), va, mapsta+8*mapst2)
+            log_fname = trim(FNMRST)//'log.'//trim(user_restfname)//trim(user_timestring)//'.nc.txt'
+            call write_restart(trim(fname), va, mapsta+8*mapst2, trim(log_fname))
           end if
         end if
 

--- a/model/src/wav_history_mod.F90
+++ b/model/src/wav_history_mod.F90
@@ -110,7 +110,7 @@ contains
     character(len=16)   :: user_timestring    !YYYY-MM-DD-SSSSS
     ! indicator logfile
     character(len=256)  :: log_fname          ! log file name
-    integer             :: log_unit = 28888   ! unit number for log file
+    integer             :: log_unit           ! unit number for log file
 
     integer :: n, xtid, ytid, xeid, ztid, stid, mtid, ptid, ktid, timid, nmode
     integer :: len_s, len_m, len_p, len_k
@@ -455,7 +455,7 @@ contains
     ! create indicator log file after NetCDF file is written
     if (iaproc == 1) then   ! only root processor writes the log file
       ! open the log file and write the complete message
-      open(unit=log_unit, file=trim(log_fname), form='FORMATTED')
+      open(newunit=log_unit, file=trim(log_fname), form='FORMATTED')
       write(log_unit, *) 'The '//trim(fname)//' file has been successfully written!'
       call flush(log_unit)
       close(log_unit)

--- a/model/src/wav_restart_mod.F90
+++ b/model/src/wav_restart_mod.F90
@@ -67,7 +67,7 @@ contains
     integer              :: dimid(3)
     real   , allocatable :: lva(:,:)
     integer, allocatable :: lmap(:)
-    integer              :: log_unit = 26666
+    integer              :: log_unit
     !-------------------------------------------------------------------------------
 
 #ifdef W3_PDLIB
@@ -216,7 +216,7 @@ contains
     ! create indicator log file after NetCDF file is written
      if (iaproc == 1) then   ! only root processor writes the log file
        ! open the log file and write the complete message
-       open(unit=log_unit, file=trim(log_fname), form='FORMATTED')
+       open(newunit=log_unit, file=trim(log_fname), form='FORMATTED')
        write(log_unit, *) 'The '//trim(fname)//' file has been successfully written!'
        call flush(log_unit)
        close(log_unit)

--- a/model/src/wav_restart_mod.F90
+++ b/model/src/wav_restart_mod.F90
@@ -52,13 +52,14 @@ contains
   !!
   !> author DeniseWorthen@noaa.gov
   !> @date 08-26-2024
-  subroutine write_restart (fname, va, mapsta)
+  subroutine write_restart (fname, va, mapsta, log_fname)
 
     use w3odatmd , only : time_origin, calendar_name, elapsed_secs
 
     real            , intent(in) :: va(1:nspec,0:nsealm)
     integer         , intent(in) :: mapsta(ny,nx)
     character(len=*), intent(in) :: fname
+    character(len=*), intent(in), optional :: log_fname
 
     ! local variables
     integer              :: timid, xtid, ytid
@@ -66,6 +67,7 @@ contains
     integer              :: dimid(3)
     real   , allocatable :: lva(:,:)
     integer, allocatable :: lmap(:)
+    integer              :: log_unit = 26666
     !-------------------------------------------------------------------------------
 
 #ifdef W3_PDLIB
@@ -210,6 +212,15 @@ contains
     call pio_freedecomp(pioid, iodesc2d)
     call pio_freedecomp(pioid, iodesc2dint)
     call pio_closefile(pioid)
+
+    ! create indicator log file after NetCDF file is written
+     if (iaproc == 1) then   ! only root processor writes the log file
+       ! open the log file and write the complete message
+       open(unit=log_unit, file=trim(log_fname), form='FORMATTED')
+       write(log_unit, *) 'The '//trim(fname)//' file has been successfully written!'
+       call flush(log_unit)
+       close(log_unit)
+     end if
 
   end subroutine write_restart
 


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
Add a restart NetCDF indicator log feature and improve the log files by using a free unit number instead of a hardwiring one.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This pull request enhances the dev/ufs-weather-model branch by adding a log file to confirm the completion of NetCDF restart files, improving traceability in the workflow. The feature is implemented through modifications to w3wavemd.F90 and wav_restart_mod.F90. Additionally, to ensure robustness, hardcoded log file unit numbers are replaced with dynamic allocation using 'newunit' in these files. This improvement is also applied to gridded NetCDF indicator logs by updating wav_history_mod.F90, promoting portability and flexibility across the codebase.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addressing issue #1406 and #1400 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Add restart NetCDF indicator log and use free unit number for the log

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch.
Up to date with dev/ufs-weather-model 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Tested with ufs-weather-model rt run
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
No. The changes are for ufs-weather-model
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Ran rt on Hera
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

