### PR TITLE
fix type conversions found w/ GNU+debug on Hera

### DIFF
--- a/model/src/w3sdb1md.F90
+++ b/model/src/w3sdb1md.F90
@@ -187,7 +187,7 @@ CONTAINS
     USE W3ODATMD, ONLY: NDST
     USE W3GDATMD, ONLY: SIG
     USE W3ODATMD, only : IAPROC
-    USE W3PARALL, only : THR 
+    USE W3PARALL, only : THR
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -219,8 +219,8 @@ CONTAINS
     INTEGER, SAVE           :: IENT = 0
 #endif
     REAL*8                    :: HM, BB, ARG, Q0, QB, B, CBJ, HRMS, EB(NK)
-    REAL*8                    :: AUX, CBJ2, RATIO, S0, S1, BR1, BR2, FAK
-    REAL                      :: ETOT, FMEAN2
+    REAL*8                    :: FAK
+    REAL*8                    :: ETOT, FMEAN2
 #ifdef W3_T0
     REAL                    :: DOUT(NK,NTH)
 #endif
@@ -323,7 +323,7 @@ CONTAINS
       ELSE
         CBJ = 0.d0
       ENDIF
-      D = - CBJ
+      D = real(- CBJ, 4)
       S = D * A
     ELSE IF (IWB == 2) THEN
       IF (ETOT .GT. THR) THEN
@@ -333,7 +333,7 @@ CONTAINS
       ELSE
         CBJ  = 0.
       ENDIF
-      D = - CBJ
+      D = real(- CBJ, 4)
       S = D * A
     ENDIF
 


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR -->

Resolves issue which caused GNU+debug failure for UWM test on Hera. See https://github.com/ufs-community/ufs-weather-model/issues/2263 for details


## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information:
* Add any suggestions for a reviewer
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_
-->

After enabling GNU+debug on Hera, the test using WW3 failed with the following error
```
57: Program received signal SIGFPE: Floating-point exception - erroneous arithmetic operation.
57:
57: Backtrace for this error:
57: #0  0x146e594bc5af in ???
57: #1  0x18b6060 in __w3sdb1md_MOD_w3sdb1
57:     at /scratch1/NCEPDEV/nems/Denise.Worthen/WORK/ufs_gnu/WW3/model/src/w3sdb1md.F90:262
```

The compile logs for this test indicated the following conversion message ``Possible change of value in conversion from REAL(8) to REAL(4)`` in w3sdb1md.F90. This PR resolves the conversion error and enables the debug test on Hera to complete. It also resolves two additional conversion warnings w/rt CBJ as well as remove some unused variables in the relevant SR.

The full RT for UWM was run with this change and all tests were B4B. **NOTE** that the relevant test is not currently enabled because of long-standing issues w/ compiling and running with GNU on Hera. 

It is preferable that this PR be merged so that a clean commit can be made for enabling the GNU+debug test on Hera.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

- required by https://github.com/ufs-community/ufs-weather-model/pull/2694

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here.
-->

Define ETOT and FMEAN2 in double precision and use single precision CBJ in w3sdb1md to resolve type conversion warnings for GNU 13.3. Remove unused variables local to subroutine w3sdb1

### Check list

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch.
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop).
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist.
- [ ] If a new feature was added, a regression test for testing the new feature is added.

### Testing

* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
