### PR TITLE
CMake: MPI flags always added when OASIS is compiled

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -105,6 +105,8 @@ set(netcdf_programs ww3_ounf ww3_ounp ww3_bounc ww3_trnc ww3_prnc)
 if("OASIS" IN_LIST switches)
   find_package(OASIS REQUIRED)
   target_link_libraries(ww3_lib PUBLIC OASIS::OASIS)
+  find_package(MPI REQUIRED COMPONENTS Fortran)
+  target_link_libraries(ww3_lib PUBLIC MPI::MPI_Fortran)
 endif()
 
 if(NETCDF)


### PR DESCRIPTION
# Pull Request Summary
When compiling with CMake and the OASIS flag is included, MPI is always included in the CMakeLists.txt.

## Description

This PR makes sure that when OASIS is enabled, MPI flags are automatically added, since OASIS always needs it.

* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? no

### Issue(s) addressed
* fixes #1352 

### Commit Message
MPI flags always added when OASIS is compiled 
 
### Testing

* The compilation and execution of ww3_tp2.14 is successful now.
