### PR TITLE
Changed order of statements in CMakeLists.txt to avoid linker error

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -152,11 +152,6 @@ if("OMPG" IN_LIST switches)
   target_link_libraries(ww3_lib PUBLIC OpenMP::OpenMP_Fortran)
 endif()
 
-if("MPI" IN_LIST switches)
-  find_package(MPI REQUIRED COMPONENTS Fortran)
-  target_link_libraries(ww3_lib PUBLIC MPI::MPI_Fortran)
-endif()
-
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
@@ -170,6 +165,11 @@ elseif("METIS"  IN_LIST switches)
   else()
     message(FATAL_ERROR "PDLIB requires METIS or SCOTCH library for domain decomposition")
  endif()
+endif()
+
+if("MPI" IN_LIST switches)
+  find_package(MPI REQUIRED COMPONENTS Fortran)
+  target_link_libraries(ww3_lib PUBLIC MPI::MPI_Fortran)
 endif()
 
 if("SCRIP" IN_LIST switches)


### PR DESCRIPTION
# Pull Request Summary

Avoided 'DSO missing from command line' error during the linking step through changing the order of compilation flags.

## Description

When running tp2.19 with the command

`./bin/run_cmake_test -s MPI -s PDLIB -w work_1A_a -f -g a -p mpirun -n 4 -o netcdf -i input_Case1A ../model ww3_tp2.19`

I obtained an error `DSO missing from command line` during the linking step. As explained [here](https://stackoverflow.com/questions/19901934/libpthread-so-0-error-adding-symbols-dso-missing-from-command-line) (second answer) this can be a consequence of the wrong order when linking libraries. I was able to resolve it only by changing the order of two statements in the CMakeLists.txt

It might depend on the gcc/gfortran version, I am using 4:13.2.0.

* Mention any labels that should be added:  _bug_
* Are answer changes expected from this PR? no

### Issue(s) addressed

### Commit Message

Changed order of statements in CMakeLists.txt
 
Avoided 'DSO missing from command line' error during the linking step through changing the order of compilation flags
 
### Testing

* The compilation and execution of ww3_tp2.19 is successful now.
