### PR TITLE
Modify Met Office regtest matrix to run regtests on the new EX machine

### DIFF
--- a/regtests/bin/matrix_cmake_ukmo_cray
+++ b/regtests/bin/matrix_cmake_ukmo_cray
@@ -66,7 +66,7 @@ EOF
   echo '#PBS -l ncpus=16'                                   >> matrix.head
   echo '#PBS -l mem=16GB'                                   >> matrix.head
   echo '#PBS -q shared'                                     >> matrix.head
-  echo '#PBS -l walltime=04:00:00'                          >> matrix.head
+  echo '#PBS -l walltime=03:00:00'                          >> matrix.head
   echo '#PBS -N ww3_regtest'                                >> matrix.head
   echo '#PBS -j oe'                                         >> matrix.head
   echo '#PBS -o matrix.out'                                 >> matrix.head
@@ -78,35 +78,27 @@ EOF
 if [[ $cmplr == "ukmo_cray" ]] || [[ $cmplr == "ukmo_cray_debug" ]]; then
   # Load targetted versions of Cray Development Tools (bug in Fortran StreamIO
   # for older versions) and netCDF/HDF5 modules:
-    echo "module load  cdt/18.12"                         >> matrix.head
-    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
-    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
-    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS"  >> matrix.head
+    echo "module switch PrgEnv-cray PrgEnv-cray/8.4.0"    >> matrix.head
+    echo "module load cpe/23.05"                          >> matrix.head
+    echo "module switch cce cce/15.0.0"                   >> matrix.head
+    echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
+    echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/ParMETIS_CCE"  >> matrix.head
 
 elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     # ParMETIS library not currently working with Cray compiler.
     # Use GNU compiler for programs that use PDLIB.
-    echo "module switch PrgEnv-cray PrgEnv-gnu/5.2.82"    >> matrix.head
-    echo "module load cray-netcdf"                        >> matrix.head
-    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS_GNU" >> matrix.head
-
-elif [[ $cmplr == ukmo_cray_intel* ]]; then
-    echo "module switch PrgEnv-cray PrgEnv-intel"         >> matrix.head
-    echo "module swap intel/15.0.0.090 intel/18.0.5.274"  >> matrix.head
-    echo "module load cdt/18.12"                          >> matrix.head
-    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
-    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
+    echo "module switch PrgEnv-cray PrgEnv-gnu/8.4.0"     >> matrix.head
+    echo "module load cpe/23.05"                          >> matrix.head
+    echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
+    echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
+    echo "export METIS_PATH=data/users/juan.m.castillo/REGTESTS/ParMETIS_GNU" >> matrix.head
 
 else
     echo "Unknown compiler for UKMO regression tests: $cmplr"
     exit 1
 fi
 
-# Need newer cmake version on the XC
-  echo "module load cmake/3.21.3"                         >> matrix.head
-
-# SNP Launcher 7.7.4 allows -np switch:
-  echo "module load cray-snplauncher/7.7.4"               >> matrix.head
   echo "export NETCDF_CONFIG=\$(which nc-config)"         >> matrix.head
 
 # On the Cray XC, we need to stop CMake from searching for

--- a/regtests/bin/matrix_cmake_ukmo_cray
+++ b/regtests/bin/matrix_cmake_ukmo_cray
@@ -83,7 +83,8 @@ if [[ $cmplr == "ukmo_cray" ]] || [[ $cmplr == "ukmo_cray_debug" ]]; then
     echo "module switch cce cce/15.0.0"                   >> matrix.head
     echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
     echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
-    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/ParMETIS_CCE"  >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/parmetis-4.0.3_cce"  >> matrix.head
+    echo "export SCOTCH_PATH=/data/users/juan.m.castillo/REGTESTS/scotch_cce" >> matrix.head
 
 elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     # ParMETIS library not currently working with Cray compiler.
@@ -92,7 +93,8 @@ elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     echo "module load cpe/23.05"                          >> matrix.head
     echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
     echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
-    echo "export METIS_PATH=data/users/juan.m.castillo/REGTESTS/ParMETIS_GNU" >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/parmetis-4.0.3_gnu" >> matrix.head
+    echo "export SCOTCH_PATH=/data/users/juan.m.castillo/REGTESTS/scotch_gnu" >> matrix.head
 
 else
     echo "Unknown compiler for UKMO regression tests: $cmplr"
@@ -101,7 +103,11 @@ fi
 
   echo "export NETCDF_CONFIG=\$(which nc-config)"         >> matrix.head
 
-# On the Cray XC, we need to stop CMake from searching for
+# For CMAKE
+  echo "export CC=cc"                                     >> matrix.head
+  echo "export FTN=ftn"                                   >> matrix.head
+
+# On the EX, we need to stop CMake from searching for
 # the NetCDF libraries - they are provided by the ftn wrapper.
   echo "export CMAKE_OPTIONS=-DEXCLUDE_FIND=\"netcdf\"" >> matrix.head
 

--- a/regtests/bin/matrix_ukmo_cray
+++ b/regtests/bin/matrix_ukmo_cray
@@ -68,7 +68,8 @@ if [[ $cmplr == "ukmo_cray" ]] || [[ $cmplr == "ukmo_cray_debug" ]]; then
     echo "module switch cce cce/15.0.0"                   >> matrix.head
     echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
     echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
-    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/ParMETIS_CCE"  >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/parmetis-4.0.3_cce"  >> matrix.head
+    echo "export SCOTCH_PATH=/data/users/juan.m.castillo/REGTESTS/scotch_cce" >> matrix.head
 
 elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     # ParMETIS library not currently working with Cray compiler.
@@ -77,14 +78,19 @@ elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     echo "module load cpe/23.05"                          >> matrix.head
     echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
     echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
-    echo "export METIS_PATH=data/users/juan.m.castillo/REGTESTS/ParMETIS_GNU" >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/parmetis-4.0.3_gnu"  >> matrix.head
+    echo "export SCOTCH_PATH=/data/users/juan.m.castillo/REGTESTS/scotch_gnu" >> matrix.head
 
 else
     echo "Unknown compiler for UKMO regression tests: $cmplr"
     exit 1
 fi
 
-  echo "  export NETCDF_CONFIG=\$(which nc-config)"         >> matrix.head
+  echo "  export NETCDF_CONFIG=\$(which nc-config)"       >> matrix.head
+
+# For CMAKE
+  echo "export CC=cc"                                     >> matrix.head
+  echo "export FTN=ftn"                                   >> matrix.head
 
 # Compiler option. Set cmplOption to
 # y if using for the first time or using a different compiler

--- a/regtests/bin/matrix_ukmo_cray
+++ b/regtests/bin/matrix_ukmo_cray
@@ -51,7 +51,7 @@
   echo '#PBS -l ncpus=16'                                   >> matrix.head
   echo '#PBS -l mem=16GB'                                   >> matrix.head
   echo '#PBS -q shared'                                     >> matrix.head
-  echo '#PBS -l walltime=04:00:00'                          >> matrix.head
+  echo '#PBS -l walltime=03:00:00'                          >> matrix.head
   echo '#PBS -N ww3_regtest'                                >> matrix.head
   echo '#PBS -j oe'                                         >> matrix.head
   echo '#PBS -o matrix.out'                                 >> matrix.head
@@ -63,32 +63,26 @@
 if [[ $cmplr == "ukmo_cray" ]] || [[ $cmplr == "ukmo_cray_debug" ]]; then
   # Load targetted versions of Cray Development Tools (bug in Fortran StreamIO
   # for older versions) and netCDF/HDF5 modules:
-    echo "module load  cdt/18.12"                         >> matrix.head
-    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
-    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
-    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS"  >> matrix.head
+    echo "module switch PrgEnv-cray PrgEnv-cray/8.4.0"    >> matrix.head
+    echo "module load cpe/23.05"                          >> matrix.head
+    echo "module switch cce cce/15.0.0"                   >> matrix.head
+    echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
+    echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
+    echo "export METIS_PATH=/data/users/juan.m.castillo/REGTESTS/ParMETIS_CCE"  >> matrix.head
 
 elif [[ $cmplr == ukmo_cray_gnu* ]]; then
     # ParMETIS library not currently working with Cray compiler.
     # Use GNU compiler for programs that use PDLIB.
-    echo "module switch PrgEnv-cray PrgEnv-gnu/5.2.82"    >> matrix.head
-    echo "module load cray-netcdf"                        >> matrix.head
-    echo "export METIS_PATH=/home/d02/frey/WW3/ParMETIS_GNU" >> matrix.head
-
-elif [[ $cmplr == ukmo_cray_intel* ]]; then
-    echo "module switch PrgEnv-cray PrgEnv-intel"         >> matrix.head
-    echo "module swap intel/15.0.0.090 intel/18.0.5.274"  >> matrix.head
-    echo "module load cdt/18.12"                          >> matrix.head
-    echo "module load cray-netcdf/4.6.1.3"                >> matrix.head
-    echo "module load cray-hdf5/1.10.2.0"                 >> matrix.head
+    echo "module switch PrgEnv-cray PrgEnv-gnu/8.4.0"     >> matrix.head
+    echo "module load cpe/23.05"                          >> matrix.head
+    echo "module load cray-hdf5-parallel/1.12.2.1"        >> matrix.head
+    echo "module load cray-netcdf-hdf5parallel/4.9.0.1"   >> matrix.head
+    echo "export METIS_PATH=data/users/juan.m.castillo/REGTESTS/ParMETIS_GNU" >> matrix.head
 
 else
     echo "Unknown compiler for UKMO regression tests: $cmplr"
     exit 1
 fi
-
-# SNP Launcher 7.7.4 allows -np switch:
-  echo "  module load cray-snplauncher/7.7.4"               >> matrix.head
 
   echo "  export NETCDF_CONFIG=\$(which nc-config)"         >> matrix.head
 


### PR DESCRIPTION
# Pull Request Summary
New regtest matrix for the new Met Office EX machine

## Description
The Met Office has a new supercomputer called EX, while the old CrayXC40 is going to be retired in less than two weeks. To allow running regtests on the new machines, the regtest matrix files for the Met Office need updating.


Suggested reviewer: ukmo-kitstokes, mickaelaccensi
Suggested label to be added: _new_feature_
No changed of answers is expected, as this is a technical and not a scientific change.

### Issue(s) addressed
- fixes #1447 

### Commit Message
New regtest matrix for the Met Office EX supercomputer

### Check list  

- [ x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ x] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ x] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
A full regtest was run on the Met Office EX supercomputer. Please notice that the intel compiler is not available on EX.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
No changes expected, as this is a technical change to run on a new machine
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

