### PR TITLE
Upgrade WW3 to Spack-Stack 1.9.2

### DIFF
--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -56,11 +56,11 @@ EOF
   modjasper='jasper/2.0.32'
   modzlib='zlib/1.2.13'
   modpng='libpng/1.6.37'
-  modhdf5='hdf5/1.14.0'
+  modhdf5='hdf5/1.14.3'
   modbacio='bacio/2.4.1'
-  modg2='g2/3.4.5'
+  modg2='g2/3.5.1'
   modw3emc='w3emc/2.10.0'
-  modesmf='esmf/8.6.0'
+  modesmf='esmf/8.8.0'
   modscotch='scotch/7.0.4'
 
 # Set batchq queue, choose modules and other custom variables to fit system and
@@ -68,6 +68,7 @@ EOF
   ishera=`hostname | grep hfe`
   isorion=`hostname | grep orion`
   ishercules=`hostname | grep hercules`
+  isursa=`hostname | grep ufe`
   if [ $ishera ]
   then
     batchq='slurm'
@@ -123,6 +124,28 @@ EOF
       modcmake='cmake/3.23.1'
     else
       echo "Compiler $compiler not supported on hercules"
+      exit 1
+    fi
+  elif [ $isursa ]
+  then
+    batchq='slurm'
+    if [ $compiler = "intel" ]
+    then
+      spackstackpath='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core'
+      spackstackpath2='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/intel-oneapi-mpi/2021.13-haww6b3/gcc/12.4.0'
+      modcomp='stack-oneapi/2024.2.1'
+      modmpi='stack-intel-oneapi-mpi/2021.13'
+      metispath='/scratch4/NCEPDEV/marine/Ming.Chen/apps/parmetis/parmetis_intel/ursa/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
+    elif [ $compiler = "gnu" ]
+    then
+      spackstackpath='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-gcc-12.4.0/install/modulefiles/Core'
+      modcomp='stack-gcc/12.4.0'
+      modmpi='stack-openmpi/4.1.6'
+      metispath='/scratch4/NCEPDEV/marine/Ming.Chen/apps/parmetis/parmetis_gnu/ursa/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
+    else
+      echo "Compiler $compiler not supported on ursa"
       exit 1
     fi
   else

--- a/regtests/bin/matrix_cmake_ncep
+++ b/regtests/bin/matrix_cmake_ncep
@@ -56,11 +56,11 @@ EOF
   modjasper='jasper/2.0.32'
   modzlib='zlib/1.2.13'
   modpng='libpng/1.6.37'
-  modhdf5='hdf5/1.14.0'
+  modhdf5='hdf5/1.14.3'
   modbacio='bacio/2.4.1'
-  modg2='g2/3.4.5'
+  modg2='g2/3.5.1'
   modw3emc='w3emc/2.10.0'
-  modesmf='esmf/8.6.0'
+  modesmf='esmf/8.8.0'
   modscotch='scotch/7.0.4'
 
 # Set batchq queue, choose modules and other custom variables to fit system and
@@ -73,18 +73,23 @@ EOF
     batchq='slurm'
     if [ $compiler = "intel" ]
     then
-      spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core'
-      modcomp='stack-intel/2021.5.0'
-      modmpi='stack-intel-oneapi-mpi/2021.5.1'
-      metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hera/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
-      modcmake='cmake/3.23.1'
+      spackstackpath='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/Core'
+      spackstackpath2='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.2.1/install/modulefiles/intel-oneapi-mpi/2021.13-sbi3u54/gcc/13.3.0'
+      modcomp='stack-oneapi/2024.2.1'
+      modmpi='stack-intel-oneapi-mpi/2021.13'
+      metispath='/scratch4/NCEPDEV/marine/Ming.Chen/apps/parmetis/parmetis_intel/hera/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
+      modzlib='zlib/1.2.11'
     elif [ $compiler = "gnu" ]
     then
-      spackstackpath='/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.6.0/envs/unified-env-rocky8/install/modulefiles/Core'
-      modcomp='stack-gcc/9.2.0'
-      modmpi='stack-openmpi/4.1.5'
-      metispath='/scratch1/NCEPDEV/climate/Matthew.Masarik/waves/opt/hera/gnu/spack-stack/1.6.0/parmetis-4.0.3/install'
-      modcmake='cmake/3.23.1'
+      spackstackpath='/contrib/spack-stack/spack-stack-1.9.2/envs/ue-gcc-13.3.0/install/modulefiles/Core'
+      spackstackpath2='/contrib/spack-stack/installs/gnu/modulefiles'
+      spackstackpath3='/contrib/spack-stack/installs/openmpi/modulefiles'
+      modcomp='stack-gcc/13.3.0'
+      modmpi='stack-openmpi/4.1.6'
+      metispath='/scratch4/NCEPDEV/marine/Ming.Chen/apps/parmetis/parmetis_gnu/hera/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
+      modzlib='zlib/1.2.11'
     else
       echo "Compiler $compiler not supported on hera"
       exit 1
@@ -94,11 +99,12 @@ EOF
     if [ $compiler = "intel" ]
     then
       batchq='slurm'
-      spackstackpath='/work/noaa/epic/role-epic/spack-stack/orion/spack-stack-1.6.0/envs/unified-env-rocky9/install/modulefiles/Core'
-      modcomp='stack-intel/2021.9.0'
-      modmpi='stack-intel-oneapi-mpi/2021.9.0'
-      metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/orion/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
-      modcmake='cmake/3.23.1'
+      spackstackpath='/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core/'
+      spackstackpath2='/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/intel-oneapi-mpi/2021.13-li242lf/gcc/12.2.0'
+      modcomp='stack-oneapi/2024.2.1'
+      modmpi='stack-intel-oneapi-mpi/2021.13'
+      metispath='/work/noaa/marine/Ming.Chen/apps/parmetis/parmetis_intel/orion/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
     else
       echo "Compiler $compiler not supported on orion"
       exit 1
@@ -108,19 +114,20 @@ EOF
     batchq='slurm'
     if [ $compiler = "intel" ]
     then
-      spackstackpath='/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core'
-      modcomp='stack-intel/2021.9.0'
-      modmpi='stack-intel-oneapi-mpi/2021.9.0'
-      metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/hercules/intel/spack-stack/1.6.0/parmetis-4.0.3/install'
-      modcmake='cmake/3.23.1'
+      spackstackpath='/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/Core'
+      spackstackpath2='/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-oneapi-2024.1.0/install/modulefiles/intel-oneapi-mpi/2021.13-sqiixt7/gcc/13.3.0'
+      modcomp='stack-oneapi/2024.2.1'
+      modmpi='stack-intel-oneapi-mpi/2021.13'
+      metispath='/work/noaa/marine/Ming.Chen/apps/parmetis/parmetis_intel/hercules/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
     elif [ $compiler = "gnu" ]
     then
-      spackstackpath='/work/noaa/epic/role-epic/spack-stack/hercules/spack-stack-1.6.0/envs/unified-env/install/modulefiles/Core'
-      spackstackpath2='/work/noaa/epic/role-epic/spack-stack/hercules/modulefiles'
-      modcomp='stack-gcc/12.2.0'
-      modmpi='stack-mvapich2/2.3.7'
-      metispath='/work/noaa/marine/Matthew.Masarik/waves/opt/hercules/gnu/spack-stack/1.6.0/parmetis-4.0.3/install'
-      modcmake='cmake/3.23.1'
+      spackstackpath='/apps/contrib/spack-stack/spack-stack-1.9.2/envs/ue-gcc-13.3.0/install/modulefiles/Core'
+      spackstackpath2='/apps/contrib/spack-stack/modulefiles'
+      modcomp='stack-gcc/13.3.0'
+      modmpi='stack-openmpi/4.1.6'
+      metispath='/work/noaa/marine/Ming.Chen/apps/parmetis/parmetis_gnu/hercules/parmetis-4.0.3/install'
+      modcmake='cmake/3.27.9'
     else
       echo "Compiler $compiler not supported on hercules"
       exit 1
@@ -195,6 +202,9 @@ EOF
   echo "  module use $spackstackpath"                       >> matrix.head
   if [ ! -z $spackstackpath2 ]; then
     echo "  module use $spackstackpath2"                    >> matrix.head
+  fi
+  if [ ! -z $spackstackpath3 ]; then
+    echo "  module use $spackstackpath3"                    >> matrix.head
   fi
   echo "  module load $modcomp"                             >> matrix.head
   echo "  module load $modmpi"                              >> matrix.head


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
Upgrade WW3 to Spack‑Stack 1.9.2 on Hera, Orion, Hercules, and add support for Ursa.

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR upgrades WW3 to use Spack‑Stack 1.9.2 on Hera, Orion, and Hercules, and introduces support for the Ursa machine. The _regtests/bin/matrix_cmake_ncep_ script has been updated with the latest module paths, library directories, and versions. In addition, a new configuration for the Ursa machine has been added.

The regression tests were performed on all machines for both Intel and GNU compiler. Results are:

- Hera-Intel: no error, no unexpected differences
- Hera-GNU: out-of-memory error
- Orion-Intel: no error, no unexpected differences
- Hercules-Intel: no error, no unexpected differences
- Hercules-GNU: no error, unexpected differences found
- Ursa-Intel: no error, unexpected differences found
- Ursa-GNU: no error, unexpected differences found

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addresses: #1458 and #1459 

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Upgrade WW3 to Spack‑Stack 1.9.2 and add support for Ursa

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) New baseline created and compared
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? 
   -   Hera with Intel compiler
   -   Hercules with Intel compiler
   -   Hercules with GNU compiler
   -   Orion with Intel compiler
   -   Ursa with Intel compiler
   -   Ursa with GNU compiler
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

New baseline was created and matrix comparison was performed

**Hera-Intel: no unexpected difference:**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/21245414/matrixCompFull.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21245415/matrixDiff.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21245416/matrixCompSummary.txt)

**Hercules-Intel: no unexpected difference:**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (17 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/21264505/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21264506/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21264507/matrixDiff.txt)

**Orion-Intel: no unexpected difference:**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (13 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```

[matrixCompFull.txt](https://github.com/user-attachments/files/21266661/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21266662/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21266663/matrixDiff.txt)

**Hercules-GNU: unexpected differences were found for ww3_tp2.1, ww3_tp2.10, ww3_tp2.16, ww3_tp2.17. Surprisingly, no differences in cases ww3_tic1.4, ww3_tp2.21 and ww3_tp2.7**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_05/./work_ST3_PR3_UQ_MPI                     (0 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.1/./work_PR2_UQ                     (1 files differ)
ww3_tp2.1/./work_PR2_UQ_MPI                     (1 files differ)
ww3_tp2.1/./work_PR3_UNO_MPI                     (1 files differ)
ww3_tp2.1/./work_PR3_UQ                     (1 files differ)
ww3_tp2.1/./work_PR3_UQ_MPI                     (1 files differ)
ww3_tp2.1/./work_PR2_UNO_MPI                     (1 files differ)
ww3_tp2.1/./work_PR1                     (1 files differ)
ww3_tp2.1/./work_PR2_UNO                     (1 files differ)
ww3_tp2.1/./work_PR1_MPI                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.17/./work_ma1                     (3 files differ)
ww3_tp2.17/./work_ma                     (3 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.1/./work_c_nth                     (9 files differ)
ww3_ufs1.1/./work_unstr_b                     (1 files differ)
ww3_ufs1.3/./work_a                     (28 files differ)
```
[matrixCompSummary.txt](https://github.com/user-attachments/files/21322543/matrixCompSummary.txt)
[matrixCompFull.txt](https://github.com/user-attachments/files/21322544/matrixCompFull.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21322545/matrixDiff.txt)

**Ursa-Intel:**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d_c                     (6 files differ)
mww3_test_03/./work_PR1_MPI_b                     (4 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR1_MPI_d                     (6 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (2 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d                     (6 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (22 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_a_c                     (3 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_a                     (3 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (2 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (21 files differ)
mww3_test_03/./work_PR2_UNO_MPI_a                     (3 files differ)
mww3_test_03/./work_PR2_UNO_MPI_b                     (4 files differ)
mww3_test_03/./work_PR3_UQ_MPI_a                     (3 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UQ_MPI_b_c                     (4 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d_c                     (6 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (22 files differ)
mww3_test_03/./work_PR3_UQ_MPI_a_c                     (3 files differ)
mww3_test_03/./work_PR3_UNO_MPI_b_c                     (4 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (2 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (22 files differ)
mww3_test_03/./work_PR1_MPI_a                     (3 files differ)
mww3_test_03/./work_PR1_MPI_e                     (2 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (21 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (2 files differ)
mww3_test_03/./work_PR3_UQ_MPI_b                     (4 files differ)
mww3_test_03/./work_PR2_UQ_MPI_a                     (3 files differ)
mww3_test_03/./work_PR1_MPI_e                     (2 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d                     (6 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (21 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (2 files differ)
mww3_test_03/./work_PR3_UQ_MPI_b                     (4 files differ)
mww3_test_03/./work_PR2_UQ_MPI_a                     (3 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d                     (6 files differ)
mww3_test_04/./work_PR3_UNO_MPI_d_c                     (3 files differ)
mww3_test_04/./work_PR1_MPI_d                     (3 files differ)
mww3_test_04/./work_PR2_UNO_MPI_d                     (3 files differ)
mww3_test_04/./work_PR3_UNO_MPI_d                     (3 files differ)
mww3_test_04/./work_PR3_UQ_MPI_d_c                     (3 files differ)
mww3_test_04/./work_PR3_UQ_MPI_d                     (3 files differ)
mww3_test_04/./work_PR2_UQ_MPI_d                     (3 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.1/./work_c_npl                     (9 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```

**Ursa-GNU:**

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (12 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (13 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.1/./work_c_nth                     (9 files differ)
ww3_ufs1.3/./work_a                     (27 files differ)
```
