### PR TITLE
Updates for SCOTCH 7.0.7

### DIFF
--- a/cmake/FindSCOTCH.cmake
+++ b/cmake/FindSCOTCH.cmake
@@ -77,8 +77,46 @@ find_package_handle_standard_args(
     REQUIRED_VARS ptscotchparmetis_lib
     ptscotchparmetis_inc)
 
+
+## Find version of scotch if possible
+if( EXISTS "${scotch_inc}/scotch.h" )
+  
+  file(READ "${scotch_inc}/scotch.h" header_content)
+
+  # Extract the major version number using regex
+  string(REGEX MATCH "SCOTCH_VERSION ([0-9]+)" VERSION_MAJOR_MATCH "${header_content}")
+  if(VERSION_MAJOR_MATCH)
+    set(SCOTCH_VERSION_MAJOR "${CMAKE_MATCH_1}")
+    message(STATUS "SCOTCH_VERSION_MAJOR: ${SCOTCH_VERSION_MAJOR}")
+  else()
+    message(WARNING "Could not find SCOTCH_VERSION in scotch.h")
+  endif()
+
+  # Extract the minor version number using regex
+  string(REGEX MATCH "SCOTCH_RELEASE ([0-9]+)" VERSION_MINOR_MATCH "${header_content}")
+  if(VERSION_MINOR_MATCH)
+    set(SCOTCH_RELEASE "${CMAKE_MATCH_1}")
+    message(STATUS "SCOTCH_RELEASE: ${SCOTCH_RELEASE}")
+  else()
+    message(WARNING "Could not find SCOTCH_RELEASE in scotch.h")
+  endif()
+
+  # Extract the patch version number using regex
+  string(REGEX MATCH "SCOTCH_PATCHLEVEL ([0-9]+)" VERSION_PATCH_MATCH "${header_content}")
+  if(VERSION_PATCH_MATCH)
+    set(SCOTCH_PATCHLEVEL "${CMAKE_MATCH_1}")
+    message(STATUS "SCOTCH_PATCHLEVEL: ${SCOTCH_PATCHLEVEL}")
+  else()
+    message(WARNING "Could not find VERSION_PATCH in scotch.h")
+  endif()
+  set(SCOTCH_VERSION "${SCOTCH_VERSION_MAJOR}.${SCOTCH_RELEASE}.${SCOTCH_PATCHLEVEL}")
+endif()
+
 message(STATUS "Found SCOTCH: ${scotch_lib}")
 message(STATUS "Found PTSCOTCH: ${ptscotch_lib}")
 message(STATUS "Found SCOTCHerr: ${scotcherr_lib}")
 message(STATUS "Found PTSCOTCHerr: ${ptscotcherr_lib}")
 message(STATUS "Found PTSCOTCHparmetis: ${ptscotchparmetis_lib}")
+message(STATUS "SCOTCH version: ${SCOTCH_VERSION}")
+
+

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -91,10 +91,6 @@ elseif(CMAKE_Fortran_COMPILER_ID MATCHES "Cray")
   set(compile_flags_debug -O0 -Rbcps -Ktrap=fp)
 endif()
 
-target_compile_options(ww3_lib PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_debug}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_release}>")
-
 # Executables to always build
 set(programs ww3_strt ww3_grid ww3_bound ww3_outf ww3_outp ww3_trck ww3_grib
   ww3_gint gx_outf gx_outp ww3_uprstr ww3_shel ww3_prep ww3_gspl ww3_multi ww3_systrk)
@@ -155,16 +151,23 @@ endif()
 # Handle PDLIB, SCRIP, SCRIPNC build files directly instead of through configuration file
 if("PDLIB" IN_LIST switches)
   if("SCOTCH" IN_LIST switches)
-  find_package(SCOTCH REQUIRED)
-  target_sources(ww3_lib PRIVATE ${pdlib_src})
-  target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)
-elseif("METIS"  IN_LIST switches)
-  find_package(ParMETIS REQUIRED)
-  target_sources(ww3_lib PRIVATE ${pdlib_src})
-  target_link_libraries(ww3_lib PUBLIC ParMETIS::ParMETIS)
+    find_package(SCOTCH REQUIRED)
+    target_sources(ww3_lib PRIVATE ${pdlib_src})
+    target_link_libraries(ww3_lib PUBLIC PTSCOTCHparmetis::PTSCOTCHparmetis)
+    if(SCOTCH_VERSION VERSION_GREATER "7.0.6")
+      list(APPEND compile_flags -DSCOTCH_707)
+      list(APPEND compile_flags_release -DSCOTCH_707)
+      list(APPEND compile_flags_debug -DSCOTCH_707)
+    else()
+      message(STATUS "SOCTCH version 7.06 or lower")
+    endif()
+  elseif("METIS"  IN_LIST switches)
+    find_package(ParMETIS REQUIRED)
+    target_sources(ww3_lib PRIVATE ${pdlib_src})
+    target_link_libraries(ww3_lib PUBLIC ParMETIS::ParMETIS)
   else()
     message(FATAL_ERROR "PDLIB requires METIS or SCOTCH library for domain decomposition")
- endif()
+  endif()
 endif()
 
 if("MPI" IN_LIST switches)
@@ -202,6 +205,10 @@ foreach(program ${programs})
   add_executable(${program} ${program}.F90)
   target_link_libraries(${program} PRIVATE ww3_lib)
 endforeach()
+
+target_compile_options(ww3_lib PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
+target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_debug}>")
+target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_release}>")
 
 install(
   TARGETS ${programs} ww3_lib

--- a/model/src/PDLIB/yowpdlibmain.F90
+++ b/model/src/PDLIB/yowpdlibmain.F90
@@ -629,12 +629,22 @@ contains
 
     !if(debugParmetis) write(710+myrank,*) "Run ParMETIS now..."
 #ifdef W3_SCOTCH
+#ifdef SCOTCH_707 
+! Starting with SCOTCH 7.0.7 need ot explicitly call the SCOTCHF
+    call SCOTCHFParMETIS_V3_PartGeomKway(vtxdist, xadj, adjncy, &
+         vwgt, & !vwgt - ignore weights
+         adjwgt, & ! adjwgt - ignore weights
+         wgtflag, &
+         numflag,ndims,xyz,ncon,nparts,tpwgts,ubvec,options, &
+         edgecut,part, comm,ref)
+#else 
     call SCOTCH_ParMETIS_V3_PartGeomKway(vtxdist, xadj, adjncy, &
          vwgt, & !vwgt - ignore weights
          adjwgt, & ! adjwgt - ignore weights
          wgtflag, &
          numflag,ndims,xyz,ncon,nparts,tpwgts,ubvec,options, &
          edgecut,part, comm,ref)
+#endif
 #endif
 
 #ifdef W3_METIS


### PR DESCRIPTION
# Pull Request Summary
Updates to CMake build and code for SCOTCH 7.0.7 

## Description
There are slight API changes for SCOTCH 7.0.7.  This code allows flexibility in the SCOTCH calls. 

### Issue(s) addressed
No issue, bringing in code from dev/ufs-weather-model 

### Commit Message
Updates for SCOTCH 7.0.7

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?  matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)  Yes/No.  We do not use SCOTCH 7.0.7 in the regression tests, but this code was tested before with SCOTCH 7.0.7 and allows flexibility if we want to move to 7.0.7 in the future. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? hera intel spack stack 1.9.2 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) No changes. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (2 files differ)
```

[matrixCompFull.txt](https://github.com/user-attachments/files/21411127/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21411128/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21411129/matrixDiff.txt)
