### PR TITLE
Fix 3/2 integer division in W3FLD1

### DIFF
--- a/model/src/w3fld1md.F90
+++ b/model/src/w3fld1md.F90
@@ -586,12 +586,12 @@ CONTAINS
         Z2=NKT
         UP1(ZI) = ( ( ( WN(Z2)**2 / DELTA ) * FTILDE(z2) ) + &
              ( DAIR / ( ZOFK(Z2) * KAPPA ) ) * ( SQRT( &
-             TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(3/2) ) &
+             TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(1.5) ) &
              * ( TLTE(ZI) ) / ( TLTE(ZI) * TAUX &
              + TLTN(ZI) * TAUY )
         VP1(ZI) = ( ( ( WN(Z2)**2 / DELTA ) * FTILDE(z2) ) + &
              ( DAIR / ( ZOFK(Z2) * KAPPA ) ) * ( SQRT ( &
-             TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(3/2) ) &
+             TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(1.5) ) &
              * ( TLTN(ZI) ) / ( TLTE(ZI) * TAUX &
              + TLTN(ZI) * TAUY )
         UP(ZI) = UP1(ZI)


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
Address compiler warning and bug that (x)**(3/2) is truncated to (x)**1 from integer division

This is pulling the code update form https://github.com/NOAA-EMC/WW3/pull/1431 which was targeting dev/ufs-weather-model and bringing it into develop.  

The author of the code changes is @NickSzapiro-NOAA , I just pulled them into a PR to develop & ran the tests. 

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
Fix compiler warning (and integer division _bug_)
```
.../ufs-weather-model/WW3/model/src/w3fld1md.F90:590:53:

  590 |              TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(3/2) ) &
      |                                                     1
Warning: Integer division truncated to constant '1' at (1) [-Winteger-division]
.../ufs-weather-model/WW3/model/src/w3fld1md.F90:595:53:

  595 |              TLTN(ZI)**2 + TLTE(ZI)**2 ) / DAIR )**(3/2) ) &
      |                                                     1
Warning: Integer division truncated to constant '1' at (1) [-Winteger-division]
```

As wind stress BC is not used in coupling, this is a bit-for-bit change in UFS GEFS regression test and presumably others as well. 

For full testing and commit queue, can combine with https://github.com/NOAA-EMC/WW3/pull/1423 and others

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Part of https://github.com/ufs-community/ufs-weather-model/issues/2703

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Fix 3/2 integer division in W3FLD1


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?  matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? intel hera 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)

Any test using FLD1 flag. The FLD1 flag is used in the following switch files: 

```
ww3_ts3/input/switch_ST4_PR1_FLD1:1:NOGRB SHRD PR1 FLX0 LN1 ST4 NL1 BT0 DB0 TR0 BS0 IC0 IS0 REF0 WNT1 WNX1 RWND CRT1 CRX1 MGW MGP MGG FLD1 O0 O1 O2 O3 O4 O5 O6 O7 O10 O11
ww3_ts3/input/switch_ST4_PR1_FLD1_MPI:1:NOGRB DIST MPI PR1 FLX0 LN1 ST4 NL1 BT0 DB0 TR0 BS0 IC0 IS0 REF0 WNT1 WNX1 RWND CRT1 CRX1 MGW MGP MGG FLD1 O0 O1 O2 O3 O4 O5 O6 O7 O10 O11
ww3_ufs1.1/input_unstr/switch_PDLIB:1:NCO PDLIB SCOTCH NOGRB DIST MPI PR3 UQ FLX0 SEED ST4 STAB0 NL1 BT1 DB1 MLIM FLD1 TR0 BS0 WNX1 WNT1 CRX1 CRT1 O0 O1 O2 O3 O4 O5 O6 O7 O14 O15 IC0 IS0 REF0 BIN2NC

```
I only got diffs in the following regtests because of FLD1: 

```
ww3_ufs1.1/./work_unstr_a                     (3 files differ)
ww3_ufs1.1/./work_unstr_c                     (3 files differ)
ww3_ufs1.1/./work_unstr_b                     (3 files differ)
```





* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):


```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (12 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.1/./work_unstr_a                     (3 files differ)
ww3_ufs1.1/./work_unstr_c                     (3 files differ)
ww3_ufs1.1/./work_unstr_b                     (3 files differ)
ww3_ufs1.2/./work_a                     (3 files differ)
ww3_ufs1.3/./work_a                     (1 files differ)
```

Note the expected diffs in ufs1.1 and ufs.12 (unexpected).  On closer examinations these diffs are: 
     ww3_grid_aoc_9km.out differ.
     ww3_grid_gnh_10m.out differ.
     ww3_grid_gsh_15m.out differ.
and not actual answer diffs.  

