### PR TITLE
Fix Uninitialized FLOGRR in W3IORS to Ensure Consistent Restart File Output

### DIFF
--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -695,6 +695,7 @@ CONTAINS
       OUTPTS(I)%TBPIN = (-1,0)
       !
       OUTPTS(I)%OUT1%IPASS1 = 0
+      OUTPTS(I)%OUT1%FLOGRR = .FALSE.
 #ifdef W3_MPI
       OUTPTS(I)%OUT1%NRQGO  = 0
       OUTPTS(I)%OUT1%NRQGO2 = 0


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR fixes an uninitialized FLOGRR variable in the W3IORS subroutine of w3iorsmd.F90, which caused inconsistent values in restart binary files on Ursa (GNU).

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR fixes an uninitialized FLOGRR variable in the W3IORS subroutine of w3iorsmd.F90, which was causing inconsistent values in restart binary files on Ursa (GNU).
The issue was found during regression tests. Unexpected differences were observed in binary restart files. Using a debug text output, the difference was traced to the variable FLOGRR had uninitialized values. An initialization of the variable FLOGRR = .FALSE. has been added in subroutine W3NOUT in w3odatmd.F90 to fix the issue.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
addressing issue #1471 and #1467
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Fix uninitialized FLOGRR for consistent restart files

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Ursa (GNU)
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Regression tests and matrix comparisons on Ursa GNU:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (7 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (5 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (27 files differ)
```

[matrixCompFull.txt](https://github.com/user-attachments/files/21498574/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21498575/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21498576/matrixDiff.txt)

```
Regression tests and matrix comparisons on Hercules GNU:

**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ts1/./work_ST4_WRT                     (1 files differ)
ww3_ufs1.3/./work_a                     (27 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/21498627/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21498628/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21498629/matrixDiff.txt)
