### PR TITLE
Update CMAKE so that OASIS requires MPI

### DIFF
--- a/model/src/cmake/switches.json
+++ b/model/src/cmake/switches.json
@@ -697,6 +697,7 @@
         "valid-options": [
             {
                 "name": "OASACM",
+                "requires": ["OASIS"],
                 "build_files": ["w3agcmmd.F90"]
             }
         ]
@@ -708,6 +709,7 @@
         "valid-options": [
             {
                 "name": "OASOCM",
+                "requires": ["OASIS"],
                 "build_files": ["w3ogcmmd.F90"]
             }
         ]
@@ -719,6 +721,7 @@
         "valid-options": [
             {
                 "name": "OASICM",
+                "requires": ["OASIS"],
                 "build_files": ["w3igcmmd.F90"]
             }
         ]
@@ -740,6 +743,7 @@
         "valid-options": [
             {
                 "name": "OASIS",
+		"requires": ["MPI"],
                 "build_files": ["w3oacpmd.F90"],
                 "conflicts": ["FLX1", "FLX2", "FLX3", "FLX4"]
 

--- a/model/src/cmake/switches.json
+++ b/model/src/cmake/switches.json
@@ -732,7 +732,8 @@
         "description": "use of the coupler",
         "valid-options": [
             {
-                "name": "COU"
+                "name": "COU",
+                "requires": ["MPI"]
             }
         ]
     },

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -428,6 +428,7 @@ then
                   sed 's/B4B //'     | sed 's/METIS //' | \
                   sed 's/OASIS //'   | sed 's/OASACM //' | \
                   sed 's/OASOCM //'  | sed 's/OASICM //' | \
+                  sed 's/COU //'  | \
                   sed 's/SCOTCH //'  > $path_build/switch
   else
     cat $file_c | sed 's/SCRIPMPI //'| \
@@ -437,6 +438,7 @@ then
                   sed 's/B4B //'     | sed 's/METIS //' | \
                   sed 's/OASIS //'   | sed 's/OASACM //' | \
                   sed 's/OASOCM //'  | sed 's/OASICM //' | \
+                  sed 's/COU //'  | \
                   sed 's/SCOTCH //'  > $path_build/switch
   fi
 

--- a/regtests/bin/run_cmake_test
+++ b/regtests/bin/run_cmake_test
@@ -426,6 +426,8 @@ then
                   sed 's/OMPG //'    | sed 's/NOGRB/NCEP2/' | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
                   sed 's/B4B //'     | sed 's/METIS //' | \
+                  sed 's/OASIS //'   | sed 's/OASACM //' | \
+                  sed 's/OASOCM //'  | sed 's/OASICM //' | \
                   sed 's/SCOTCH //'  > $path_build/switch
   else
     cat $file_c | sed 's/SCRIPMPI //'| \
@@ -433,6 +435,8 @@ then
                   sed 's/OMPG //'    | \
                   sed 's/OMPH //'    | sed 's/PDLIB //' | \
                   sed 's/B4B //'     | sed 's/METIS //' | \
+                  sed 's/OASIS //'   | sed 's/OASACM //' | \
+                  sed 's/OASOCM //'  | sed 's/OASICM //' | \
                   sed 's/SCOTCH //'  > $path_build/switch
   fi
 


### PR DESCRIPTION
# Pull Request Summary
Updates cmake related items so that MPI is required for OASIS. 

## Description
This is a minor update for cmake and regtests reuiqring MPI for OASIS and other similar updates. 

### Issue(s) addressed
Closes https://github.com/NOAA-EMC/WW3/issues/1486

### Commit Message
Update CMAKE so that OASIS requires MPI


### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? matrix 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? intel ursa 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)

The ww3_tp2.14 tests change because the netcdf file will have different switches.  The contents otherwise is the same. 

```
ww3_tp2.14/./work_OASICM                     (1 files differ)
ww3_tp2.14/./work_OASACM5                     (1 files differ)
ww3_tp2.14/./work_OASOCM                     (1 files differ)
ww3_tp2.14/./work_OASACM4                     (1 files differ)
ww3_tp2.14/./work_OASACM2                     (1 files differ)
ww3_tp2.14/./work_OASACM6                     (1 files differ)
ww3_tp2.14/./work_OASACM                     (1 files differ)
```

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompFull.txt](https://github.com/user-attachments/files/21975963/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/21975964/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/21975965/matrixDiff.txt)


```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (5 files differ)
ww3_tp2.14/./work_OASICM                     (1 files differ)
ww3_tp2.14/./work_OASACM5                     (1 files differ)
ww3_tp2.14/./work_OASOCM                     (1 files differ)
ww3_tp2.14/./work_OASACM4                     (1 files differ)
ww3_tp2.14/./work_OASACM2                     (1 files differ)
ww3_tp2.14/./work_OASACM6                     (1 files differ)
ww3_tp2.14/./work_OASACM                     (1 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)

```


