### PR TITLE
Change grib2 packing from JPEG to Complex

### DIFF
--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -734,10 +734,11 @@ PROGRAM W3GRIB
   ! ... Set GRIB2 Data Representation Template Number (Code Table 5.0)
   !
 #ifdef W3_NCEP2
-  IDRSNUM = 40 !jpeg2000 *** SEGFAULTS in some linux
+  IDRSNUM = 2 !Complex Packing
 #endif
   !                            clusters with Intel compiler ***
 #ifdef W3_NCEP2
+  !IDRSNUM = 40 !jpeg2000 *** SEGFAULTS in some linux
   !IDRSNUM = 0 !simple packing
   !IDRSNUM = 41 !png packing
   !IDRSNUM = 2 !Complex Packing (Grid Point Data)


### PR DESCRIPTION
Change packing from jpeg to complex

# Pull Request Summary
This PR will change the grib2 packing in order to reduce file sizes and resolves warning issue [#923](https://github.com/NOAA-EMC/WW3/issues/923)

## Description
The issue was originally brought up in 2023 with the GLWU implementation. When grib2 commands were executed a warning would show up that "jpeg encode/deocde may differ from WMO standard". The solution that was suggested was changing the grib2 packing in the WW3 code directly.

### Issue(s) addressed

- fixes [issue 923](https://github.com/NOAA-EMC/WW3/issues/923)


### Commit Message
Update grib2 outputs to have complex packing 

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? regtest + glwu workflow+ global-workflow
* Are the changes covered by regression tests? yes, some regtests create grib outputs
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes on Ursa with intel. grib files in ufs regtests will differ due to packing change.


