### PR TITLE
Resolve GNU build issues and clean up EXTERNAL declarations 

### DIFF
--- a/model/src/PDLIB/yowfunction.F90
+++ b/model/src/PDLIB/yowfunction.F90
@@ -45,11 +45,11 @@ CONTAINS
   !*                                                                    *
   !**********************************************************************
   SUBROUTINE PDLIB_ABORT(istat)
+    use yowerr, only: abort
     IMPLICIT NONE
-    external :: ABORT
     integer, intent(in) :: istat
     Print *, 'Error with istat=', istat
-    CALL ABORT
+    call abort()
   END SUBROUTINE PDLIB_ABORT
   !**********************************************************************
   !*                                                                    *

--- a/model/src/PDLIB/yowpdlibmain.F90
+++ b/model/src/PDLIB/yowpdlibmain.F90
@@ -439,7 +439,6 @@ contains
     integer :: IP_glob, itmp
     integer :: ref
     logical :: lexist = .false.
-    external :: SCOTCH_PARMETIS_V3_PARTGEOMKWAY
     ! Node to domain mapping.
     ! np_global long. give the domain number for die global node number
     integer, allocatable :: node2domain(:)

--- a/model/src/w3fld2md.F90
+++ b/model/src/w3fld2md.F90
@@ -144,7 +144,6 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS, ONLY: DWAT, GRAV, TPI, PI, KAPPA
     USE W3GDATMD,  ONLY: NK, NTH, NSPEC, SIG, DTH, XFR, TH
-    !USE W3ODATMD,  ONLY: NDSE
     USE W3FLD1MD,  ONLY: APPENDTAIL,sig2wn,wnd2z0m,infld,tail_choice,&
          tail_level, tail_transition_ratio1,         &
          tail_transition_ratio2

--- a/model/src/w3oacpmd.F90
+++ b/model/src/w3oacpmd.F90
@@ -231,9 +231,6 @@ CONTAINS
 #ifdef W3_SMC
     REAL                 :: DLON, DLAT
 #endif
-!#ifdef W3_MPI
-!    type(MPI_COMM)       :: mpicomm
-!#endif
     !/ ------------------------------------------------------------------- /
     !
     IF (LD_MASTER) THEN

--- a/model/src/w3profsmd.F90
+++ b/model/src/w3profsmd.F90
@@ -1106,7 +1106,6 @@ CONTAINS
     REAL*8  :: INIU(NX)
 
     external bcgstab
-    external ::  ILU0, RUNRC
 
     POS_TRICK(1,1) = 2
     POS_TRICK(1,2) = 3
@@ -2089,7 +2088,6 @@ subroutine bcgstab(n, rhs, sol, ipar, fpar, w)
   real*8 ddot
   logical stopbis, brkdn
   external ddot, stopbis, brkdn
-  external :: bisinit, tidycg
   !
   real*8 one
   parameter(one=1.0D0)
@@ -3788,7 +3786,6 @@ subroutine runrc(n,rhs,sol,ipar,fpar,wk,guess,a,ja,ia,au,jau,ju,solver)
   integer n,ipar(16),ia(n+1),ja(*),ju(*),jau(*)
   real*8 fpar(16),rhs(n),sol(n),guess(n),wk(*),a(*),au(*)
   external solver
-  external :: amux, atmux, lusol, lutsol
   !-----------------------------------------------------------------------
   !     the actual tester. It starts the iterative linear system solvers
   !     with a initial guess suppied by the user.
@@ -3872,7 +3869,6 @@ subroutine ilut(n,a,ja,ia,lfil,droptol,alu,jlu,ju,iwk,w,jw,ierr)
   integer n
   real*8 a(*),alu(*),w(n+1),droptol
   integer ja(*),ia(n+1),jlu(*),ju(n),jw(2*n),lfil,iwk,ierr
-  external :: qsplit
   !----------------------------------------------------------------------*
   !                      *** ILUT preconditioner ***                     *
   !      incomplete LU factorization with dual truncation mechanism      *
@@ -4296,8 +4292,6 @@ subroutine pgmres(n, im, rhs, sol, eps, maxits, aspar, nnz, ia, ja, alu, jlu, ju
 
   real*8  :: hh(im+1,im), c(im), s(im), rs(im+1)
   real*8  :: iw(n)
-
-  external :: amux, lusol, daxpy
 
   logical :: lblas = .false.      ! use sparskit matvec and external blas libs (true), don't use them (false)
   logical :: lilu  = .true.      ! use simple ilu preconditioner

--- a/model/src/w3strkmd.F90
+++ b/model/src/w3strkmd.F90
@@ -5771,13 +5771,13 @@ CONTAINS
       CALL EXTCDE(1)
     ELSE IF ( SIZE(ARRAY).NE.SIZE(IDX) ) THEN
       WRITE(6,201)
-      CALL EXTCDE(1)
+      CALL EXTCDE(2)
     ELSE IF ( LBOUND(ARRAY,1).GT.LO ) THEN
       WRITE(6,203)
-      CALL EXTCDE(1)
+      CALL EXTCDE(3)
     ELSE IF ( UBOUND(ARRAY,1).LT.HI ) THEN
       WRITE(6,205)
-      CALL EXTCDE(1)
+      CALL EXTCDE(4)
     END IF
     !
     TOP = LO
@@ -5895,16 +5895,16 @@ CONTAINS
     !/    --- Check array size and bounds. ---
     IF ( SIZE(ARRAY).EQ. 0 ) THEN
       WRITE(6,199)
-      CALL EXTCDE(1)
+      CALL EXTCDE(5)
     ELSE IF ( SIZE(ARRAY).NE.SIZE(IDX) ) THEN
       WRITE(6,201)
-      CALL EXTCDE(1)
+      CALL EXTCDE(6)
     ELSE IF ( LBOUND(ARRAY,1).GT.LO ) THEN
       WRITE(6,203)
-      CALL EXTCDE(1)
+      CALL EXTCDE(7)
     ELSE IF ( UBOUND(ARRAY,1).LT.HI ) THEN
       WRITE(6,205)
-      CALL EXTCDE(1)
+      CALL EXTCDE(8)
     END IF
     !
     TOP = LO

--- a/model/src/w3strkmd.F90
+++ b/model/src/w3strkmd.F90
@@ -5733,6 +5733,8 @@ CONTAINS
     !     LO      INTEGER      input    First element
     !     HI      INTEGER      input    Last element
     !
+    USE W3SERVMD, ONLY: EXTCDE
+    !/
     IMPLICIT NONE
     !/
     INTEGER, INTENT(IN) :: LO,HI
@@ -5740,7 +5742,6 @@ CONTAINS
     !/
     !     Local variables
     !     ----------------------------------------------------------------
-    EXTERNAL :: ABORT
     LOGICAL :: LOOP
     INTEGER :: TOP, BOT
     REAL    :: VAL, TMP
@@ -5767,16 +5768,16 @@ CONTAINS
     !/    --- Check array size and bounds. ---
     IF ( SIZE(ARRAY).EQ. 0 ) THEN
       WRITE(6,199)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( SIZE(ARRAY).NE.SIZE(IDX) ) THEN
       WRITE(6,201)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( LBOUND(ARRAY,1).GT.LO ) THEN
       WRITE(6,203)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( UBOUND(ARRAY,1).LT.HI ) THEN
       WRITE(6,205)
-      CALL ABORT
+      CALL EXTCDE(1)
     END IF
     !
     TOP = LO
@@ -5859,6 +5860,8 @@ CONTAINS
     !     LO      INTEGER      input    First element
     !     HI      INTEGER      input    Last element
     !
+    USE W3SERVMD, ONLY: EXTCDE
+    !/
     IMPLICIT NONE
     !/
     INTEGER, INTENT(IN) :: LO,HI
@@ -5866,7 +5869,6 @@ CONTAINS
     !/
     !     Local variables
     !     ----------------------------------------------------------------
-    EXTERNAL :: ABORT
     INTEGER :: TOP, BOT, I
     REAL    :: VAL, TMP
     LOGICAL :: LOOP
@@ -5893,16 +5895,16 @@ CONTAINS
     !/    --- Check array size and bounds. ---
     IF ( SIZE(ARRAY).EQ. 0 ) THEN
       WRITE(6,199)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( SIZE(ARRAY).NE.SIZE(IDX) ) THEN
       WRITE(6,201)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( LBOUND(ARRAY,1).GT.LO ) THEN
       WRITE(6,203)
-      CALL ABORT
+      CALL EXTCDE(1)
     ELSE IF ( UBOUND(ARRAY,1).LT.HI ) THEN
       WRITE(6,205)
-      CALL ABORT
+      CALL EXTCDE(1)
     END IF
     !
     TOP = LO

--- a/model/src/ww3_bounc.F90
+++ b/model/src/ww3_bounc.F90
@@ -164,8 +164,6 @@ PROGRAM W3BOUNC
   !/ ------------------------------------------------------------------- /
   !/ Local parameters
   !/
-  EXTERNAL :: CHECK_ERR
-
   TYPE(NML_BOUND_T)       :: NML_BOUND
   !
   INTEGER                 :: IX, IY, ISEA, I,JJ,IP,IP1,J,IT,       &
@@ -842,12 +840,8 @@ PROGRAM W3BOUNC
        '     SPEC FILE DOES NOT EXIST : ',A/)
   !
   !
-  !/
-  !/ End of W3BOUNC ---------------------------------------------------- /
-  !/
-END PROGRAM W3BOUNC
-!/ ------------------------------------------------------------------- /
 
+CONTAINS
 
 !==============================================================================
 !> @brief Check input return status for error value
@@ -876,3 +870,8 @@ SUBROUTINE CHECK_ERR(IRET)
 END SUBROUTINE CHECK_ERR
 
 !==============================================================================
+  !/
+  !/ End of W3BOUNC ---------------------------------------------------- /
+  !/
+END PROGRAM W3BOUNC
+!/ ------------------------------------------------------------------- /

--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -163,9 +163,6 @@ PROGRAM W3GRIB
   !/ ------------------------------------------------------------------- /
   !/ Local variables
   !/
-  EXTERNAL                :: BAOPENW
-  EXTERNAL                :: GRIBCREATE, ADDGRID, ADDFIELD, GRIBEND, WRYTE
-  EXTERNAL                :: BAOPEN, PUTGB
   INTEGER                 :: NDSI, NDSM, NDSOG, NDSDAT, NDSTRC,   &
        NTRACE, IERR, IOTEST, I,J,K, IFI,IFJ,&
        ISEA, IX, IY, TOUT(2), NOUT, TDUM(2),&

--- a/model/src/ww3_prnc.F90
+++ b/model/src/ww3_prnc.F90
@@ -236,8 +236,6 @@ PROGRAM W3PRNC
   !/ ------------------------------------------------------------------- /
   !/ Local parameters
   !/
-  EXTERNAL                :: CHECK_ERROR
-  EXTERNAL                :: INTERP
   TYPE(NML_FORCING_T)     :: NML_FORCING
   TYPE(NML_FILE_T)        :: NML_FILE
   TYPE(T_GSU)             :: GSI
@@ -2491,11 +2489,8 @@ PROGRAM W3PRNC
 #ifdef W3_T3
 9065 FORMAT (' TEST W3PRNC : OUTPUT FIELD(S) :'/)
 #endif
-  !/
-  !/ End of W3PRNC ----------------------------------------------------- /
-  !/
 
-END PROGRAM W3PRNC
+CONTAINS
 
 !==============================================================================
 !>
@@ -2696,3 +2691,8 @@ SUBROUTINE CHECK_ERROR(IRET, ILINE)
 END SUBROUTINE CHECK_ERROR
 
 !==============================================================================
+  !/
+  !/ End of W3PRNC ----------------------------------------------------- /
+  !/
+
+END PROGRAM W3PRNC

--- a/model/src/ww3_systrk.F90
+++ b/model/src/ww3_systrk.F90
@@ -58,6 +58,7 @@ PROGRAM WW3_SYSTRK
   !/
   USE W3STRKMD
   USE W3TIMEMD, ONLY: TDIFF
+  USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_MPI
   use mpi_f08
 #endif
@@ -77,7 +78,6 @@ PROGRAM WW3_SYSTRK
   !
   !  3. Parameters :
   !
-  EXTERNAL     :: ABORT
   LOGICAL      :: testout
   PARAMETER (testout = .FALSE.)
   CHARACTER    :: filename*80, paramFile*32
@@ -210,7 +210,7 @@ PROGRAM WW3_SYSTRK
     IF (.NOT.file_exists) THEN
       WRITE(20,2000)
       WRITE(6,2000)
-      CALL ABORT
+      CALL EXTCDE(1)
     END IF
     OPEN(unit=10,file='ww3_systrk.inp',status='old')
 


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR resolves GNU build errors related to non-referenced ABORT, removes unnecessary EXTERNAL declarations, and cleans up comments.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR addressed issues where `ABORT` was flagged as non-referenced during GNU builds. This occurs because, unlike the Intel compiler, the `ABORT` subroutine is not provided by default in the GNU compiler. Instead of `ABORT`, a WW3 `EXTCDE` subroutine is used in `w3strkmd.F90` and `ww3_systrk.F90`, and subroutine `abort` defined in `yowerr` module is used in PDLIB/yowfunction.F90. All EXTERNAL declaration has been removed from these source codes. In addition, different code numbers for `EXTCDE` has been assigned in `w3strkmd` to improve clarity.

Deleted outdated or redundant comments to streamline the `w3fld2md` and `w3oacpmd` source codes.

To remove the `EXTERNAL` declarations in `ww3_bounc` and `ww3_prnc`, the subroutines were moved inside the program and reorganized using `CONTAINS`. In this way, the compilation warnings were also resolved.

Removed the `EXTERNAL` declarations defined in `PDLIB/yowpdlibmain.F90`, `w3profsmd.F90`, and `ww3_grib.F90` added in [PR#1504](https://github.com/NOAA-EMC/WW3/pull/1504) to avoid potential runtime errors.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Resolve GNU build issues and clean up EXTERNAL declarations 
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? ursa intel
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

No errors or unexpected differences were observed.
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (5 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/23001532/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/23001535/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/23001536/matrixDiff.txt)

In addition, this PR was tested using Ursa-GNU. No error was reported during both building and runtime.

The ufs-wm RT tests were performed and PASSED.
[RegressionTests_ursa.log](https://github.com/user-attachments/files/23001561/RegressionTests_ursa.log)
