### PR TITLE
Fix Fortran compile flag scope to avoid ifx real-size override warning in WW3 and operational workflow

### DIFF
--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -206,9 +206,17 @@ foreach(program ${programs})
   target_link_libraries(${program} PRIVATE ww3_lib)
 endforeach()
 
-target_compile_options(ww3_lib PUBLIC "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_debug}>")
-target_compile_options(ww3_lib PUBLIC "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_release}>")
+if ("PIO" IN_LIST switches)
+  # Building as part of UFS (submodule)
+  set(WW3_FLAG_SCOPE PRIVATE)
+else()
+  # Standalone WW3 build
+  set(WW3_FLAG_SCOPE PUBLIC)
+endif()
+
+target_compile_options(ww3_lib ${WW3_FLAG_SCOPE} "$<$<COMPILE_LANGUAGE:Fortran>:${compile_flags}>")
+target_compile_options(ww3_lib ${WW3_FLAG_SCOPE} "$<$<AND:$<CONFIG:Debug>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_debug}>")
+target_compile_options(ww3_lib ${WW3_FLAG_SCOPE} "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:Fortran>>:${compile_flags_release}>")
 
 install(
   TARGETS ${programs} ww3_lib

--- a/model/src/CMakeLists.txt
+++ b/model/src/CMakeLists.txt
@@ -206,7 +206,7 @@ foreach(program ${programs})
   target_link_libraries(${program} PRIVATE ww3_lib)
 endforeach()
 
-if ("PIO" IN_LIST switches)
+if (UFS_CAP)
   # Building as part of UFS (submodule)
   set(WW3_FLAG_SCOPE PRIVATE)
 else()


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR fixes an Intel Fortran compiler warning:
`ifx: command line warning #10121: overriding '-real-size 64' with '-real-size 32'`
The issue was caused by conflicting compile flags inherited from public target properties. The fix adjusts the CMake configuration to use `PRIVATE` instead of `PUBLIC` for Intel Fortran compile options in the `ww3_lib` target.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
Previously, in `model/src/CMakeLists.txt`, the `ww3_lib` target used `target_compile_options(... PUBLIC ...)`, which propagated its compile flags to dependent targets. This caused duplicated or conflicting flags when building the WW3/Operational workflow, triggering the Intel compiler warning #10121.

With the help from @DusanJovic-NOAA, this PR updates the compile option scope from `PUBLIC` to `PRIVATE` for Fortran compile flags in `CMakeLists.txt` to ensure they apply only within `ww3_lib` and are not inherited by other targets. The modification removes unnecessary flag propagation and eliminates the compiler warning during builds.

To prevent unexpected differences in WW3 standalone regression tests, the build configuration now separates the standalone WW3 build from the operational workflow by applying conditional logic under `if (UFS_CAP)`.

Special thanks to @DusanJovic-NOAA for identifying the issue and suggesting the fix.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
fixes issue #1514 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Fix Fortran compile flag scope to avoid ifx real-size override warning in WW3 and operational workflow
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Ursa Intel
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

No errors or unexpected differences were observed.
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/23322393/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/23322394/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/23322395/matrixDiff.txt)
