### PR TITLE
Make implicit time stepping scheme on unstructured meshes reproducible

### DIFF
--- a/model/src/w3profsmd_pdlib.F90
+++ b/model/src/w3profsmd_pdlib.F90
@@ -5669,6 +5669,10 @@ CONTAINS
         VA(ISP,JSEA) = VA(ISP,JSEA) / CG1(IK) * CLATS(ISEA)
       END DO
     END DO
+    !
+    !    for reproducability state must be communicated at the start of solver
+    !
+    CALL PDLIB_exchange2DREAL_zero(VA)
     VAOLD = VA(1:NSPEC,1:NSEAL)
 
 #ifdef W3_DEBUGSRC


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
## Description
The implicit time stepping scheme for unstructured meshes is changed so that the algorithm is now bit for bit reproducible when using the Jacobi solver. 
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?
Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
The implicit time stepping scheme for unstructured meshes is changed so that the algorithm is now bit for bit reproducible. Communication of the WW3 state (VA) is added to the beginning of PDLIB_JACOBI_GAUSS_SEIDEL_BLOCK.  This makes the Jacobi (not Gauss Siedel) solver bit for bit reproducible across different numbers of MPI processes.  Solutions using the implicit stepping on unstructured meshes may have small changes relative to earlier versions of the code.

Due to the code change, small changes are expected in the output of regtests that use subroutine PDLIB_JACOBI_GAUSS_SEIDEL_BLOCK. This includes:
ww3_ufs1.1: grid_c
ww3_tp2.17: grid_a, grid_b, grid_c, grid_inla, grid_inlb, and grid_inlc
ww3_tp2.19: Case1A, Case1B, and Case1C
ww3_tp2.21: grid_b, grid_glo_unst_b
ww3_tp2.6: grid_pdlib

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addresses issues raised in NOAA-EMC/WW3/issues/322
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Modification to PDLIB_JACOBI_GAUSS_SEIDEL_BLOCK to address reproducibility issues with implicit time stepping on unstructured meshes.
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested?
Full matrix test and paired runs with different numbers of MPI processes to demonstrate reproducibility 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes on Ursa with the intel compiler
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
Due to the code change, small changes are expected in the output of regtests that use subroutine PDLIB_JACOBI_GAUSS_SEIDEL_BLOCK.  This includes:
ww3_ufs1.1: grid_c
ww3_tp2.17: grid_a, grid_b, grid_c, grid_inla, grid_inlb, and grid_inlc
ww3_tp2.19: Case1A, Case1B, and Case1C
ww3_tp2.21: grid_b, grid_glo_unst_b
ww3_tp2.6: grid_pdlib
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[matrixCompSummary.txt](https://github.com/user-attachments/files/23514023/matrixCompSummary.txt)
