### PR TITLE
Fix MPI_WTIME interface warning in debug build using mpi_f08

### DIFF
--- a/model/src/wav_wrapper_mod.F90
+++ b/model/src/wav_wrapper_mod.F90
@@ -11,6 +11,7 @@ module wav_wrapper_mod
 
   use wav_kind_mod  , only : r8 => shr_kind_r8, r4 => shr_kind_r4, i4 => shr_kind_i4
   use wav_kind_mod  , only : CL => shr_kind_cl, CS => shr_kind_cs
+  use mpi_f08       , only : MPI_Wtime
 
   implicit none
 
@@ -49,7 +50,6 @@ contains
     !> @date 01-08-2024
 
     real(r8),    intent(inout) :: timevalue
-    real(r8)                   :: MPI_Wtime
     timevalue = MPI_Wtime()
   end subroutine ufs_settimer
 
@@ -70,7 +70,7 @@ contains
     character(len=*), intent(in)    :: string
     logical,          intent(in)    :: runtimelog
     real(r8),         intent(in)    :: wtime0
-    real(r8)                        :: MPI_Wtime, timevalue
+    real(r8)                        :: timevalue
     if (.not. runtimelog) return
     if (wtime0 > 0.) then
       timevalue = MPI_Wtime()-wtime0


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR resolves the Intel warning `#8889: Explicit interface or EXTERNAL declaration is required` for `MPI_Wtime` in `wav_wrapper_mod.F90`.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
The fix imports `MPI_Wtime` from the `mpi_f08` module to provide a proper explicit interface and removes the incorrect local declarations that previously treated `MPI_Wtime` as a real variable. This aligns the code with modern MPI usage, improves type safety, and avoids compiler ambiguity.

This fix successfully resolves the Intel warnings in debug build: 
```
wav_wrapper_mod.F90(53): warning #8889: Explicit interface or EXTERNAL declaration is required.   [MPI_WTIME]
wav_wrapper_mod.F90(76): warning #8889: Explicit interface or EXTERNAL declaration is required.   [MPI_WTIME]
```

No answers are expected to be changed.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
addressing issue #1501 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. up-to-date with dev/ufs-weather-model
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? UFS-WM RT Tests
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

[RegressionTests_hercules.log](https://github.com/user-attachments/files/23612619/RegressionTests_hercules.log)
