### PR TITLE
Add explicit interfaces for BACIO and g2 routines to remove Intel #8889 warnings

### DIFF
--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -160,6 +160,60 @@ PROGRAM W3GRIB
   !
   IMPLICIT NONE
   !/
+#ifdef W3_NCEP2
+  INTERFACE
+    !
+    SUBROUTINE BAOPENW(LU, CFN, IRET)
+      INTEGER, INTENT(IN)          :: LU
+      CHARACTER(LEN=*), INTENT(IN) :: CFN
+      INTEGER, INTENT(OUT)         :: IRET
+    END SUBROUTINE BAOPENW
+    !
+    SUBROUTINE WRYTE(LU, NB, A)
+      INTEGER, INTENT(IN)          :: LU
+      INTEGER, INTENT(IN)          :: NB
+      CHARACTER, INTENT(IN)        :: A(*)
+    END SUBROUTINE WRYTE
+    !
+    SUBROUTINE GRIBCREATE(CGRIB, LCGRIB, LISTSEC0, LISTSEC1, IERR)
+      CHARACTER(LEN=1), INTENT(INOUT) :: CGRIB(*)
+      INTEGER,          INTENT(IN)    :: LCGRIB
+      INTEGER,          INTENT(IN)    :: LISTSEC0(*), LISTSEC1(*)
+      INTEGER,          INTENT(OUT)   :: IERR
+    END SUBROUTINE GRIBCREATE
+    !
+    SUBROUTINE ADDGRID(CGRIB, LCGRIB, IGDS, IGDSTML, IGDSTMLEN,   &
+                   IDEFLIST, IDEFNUM, IERR)
+      CHARACTER(LEN=1), INTENT(INOUT) :: CGRIB(*)
+      INTEGER,          INTENT(IN)    :: LCGRIB, IDEFNUM, IGDSTMLEN
+      INTEGER,          INTENT(IN)    :: IGDS(*), IGDSTML(*), IDEFLIST(*)
+      INTEGER,          INTENT(OUT)   :: IERR
+    END SUBROUTINE ADDGRID
+    !
+    SUBROUTINE ADDFIELD(CGRIB, LCGRIB, IPDSNUM, IPDSTML, IPDSTMLEN, &
+                    COORDLIST, NUMCOORD, IDRSNUM, IDRSTML,      &
+                    IDRSTMLEN, FLD, NGRDPTS, IBMAP, BMAP, IERR)
+      CHARACTER(LEN=1), INTENT(INOUT) :: CGRIB(*)
+      INTEGER,          INTENT(INOUT) :: IDRSTML(*)
+      INTEGER,          INTENT(IN)    :: LCGRIB, IPDSNUM, IPDSTMLEN,    &
+                                         NUMCOORD, IDRSNUM, IDRSTMLEN,  &
+                                         NGRDPTS, IBMAP
+      INTEGER,          INTENT(IN)    :: IPDSTML(*)
+      REAL,             INTENT(IN)    :: COORDLIST(*)
+      REAL,    TARGET,  INTENT(IN)    :: FLD(*)
+      LOGICAL*1,        INTENT(IN)    :: BMAP(*)
+      INTEGER,          INTENT(OUT)   :: IERR
+    END SUBROUTINE ADDFIELD
+    !
+    SUBROUTINE GRIBEND(CGRIB, LCGRIB, LENGRIB, IERR)
+      CHARACTER(LEN=1), INTENT(INOUT) :: CGRIB(*)
+      INTEGER,          INTENT(IN)    :: LCGRIB, LENGRIB
+      INTEGER,          INTENT(OUT)   :: IERR
+    END SUBROUTINE GRIBEND
+    !
+  END INTERFACE
+#endif
+  !/
   !/ ------------------------------------------------------------------- /
   !/ Local variables
   !/
@@ -175,10 +229,11 @@ PROGRAM W3GRIB
   ! GRIB2 specific variables
 #ifdef W3_NCEP2
   INTEGER                 :: KPDS(200), KGDS(200), IDRS(200)
-  INTEGER                 :: LISTSEC0(3), LISTSEC1(13),IGDS(5)
-  INTEGER                 :: IDEFLIST, IDEFNUM, KPDSNUM, NUMCOORD
+  INTEGER                 :: LISTSEC0(3), LISTSEC1(13), IGDS(5), IDEFLIST(1)
+  INTEGER                 :: IDEFNUM, KPDSNUM, NUMCOORD
   INTEGER                 :: IBMP, LCGRIB, LENGRIB, IDRSNUM
-  REAL                    :: COORDLIST, XN
+  REAL                    :: XN
+  REAL                    :: COORDLIST(1)
   CHARACTER(LEN=1), ALLOCATABLE  :: CGRIB(:)
   INTEGER                 :: LATAN1, LONV, SCNMOD, LATIN1, &
        LATIN2, LATSP, LONSP


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR addresses Intel `warning #8889: Explicit declaration of the EXTERNAL attribute is required` by adding explicit interface blocks for all NCEP libraries BACIO and GRIB2 (g2) routines used in `ww3_grib` program. The warnings are successfully removed during debug build in both WW3 and operational workflows.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR adds explicit interface blocks for all NCEP BACIO and GRIB2 (g2) routines used in `ww3_grib.F90`, eliminating Intel `#8889` warnings in debug builds and preventing potential runtime mismatches. Because the installed BACIO library does not export a module file, `USE BACIO_MODULE` cannot be applied; therefore, explicit interfaces are required for safe, type-checked calls to `BAOPENW, WRYTE, GRIBCREATE, ADDGRID, ADDFIELD, and GRIBEND`. The update ensures correct argument ranks and character declarations, removes the need for `EXTERNAL`, and preserves fully consistent behavior with NCEP library APIs.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addressing issue #1501 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Add explicit interfaces for BACIO and g2 routines in ww3_grib.F90 to remove Intel #8889 warnings
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Hercules Intel and GNU
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Hercules Intel:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (17 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/23726984/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/23726985/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/23726986/matrixDiff.txt)

Hercules GNU:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (27 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/23726994/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/23726996/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/23726997/matrixDiff.txt)

