### PR TITLE
Partially address compiler remarks in WW3 and operational workflow when using debug build

### DIFF
--- a/model/src/w3adatmd.F90
+++ b/model/src/w3adatmd.F90
@@ -757,7 +757,6 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     USE W3GDATMD, ONLY: NGRIDS
     USE W3SERVMD, ONLY: EXTCDE
-    USE W3ODATMD, ONLY: IAPROC
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -926,11 +925,9 @@ CONTAINS
     !
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS, ONLY : LPDLIB
-    USE W3GDATMD, ONLY: NGRIDS, IGRID, W3SETG, NK, NX, NY, NSEA,    &
-         NSEAL, NSPEC, NTH, E3DF, P2MSF, US3DF,      &
-         USSPF, GTYPE, UNGTYPE
-    USE W3ODATMD, ONLY: IAPROC, NAPROC, NTPROC, NAPFLD,             &
-         NOSWLL, NOEXTR, UNDEF, FLOGRD, FLOGR2
+    USE W3GDATMD, ONLY: NGRIDS, IGRID, W3SETG, NK, NX, NY, NSEA,        &
+         NSEAL, NSPEC, NTH, E3DF, P2MSF, US3DF, USSPF, GTYPE, UNGTYPE
+    USE W3ODATMD, ONLY: IAPROC, NAPROC, NOSWLL, NOEXTR, UNDEF
     USE W3IDATMD, ONLY: FLCUR, FLWIND, FLTAUA, FLRHOA
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S
@@ -947,7 +944,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER                 :: JGRID, NXXX, NSEAL_tmp
+    INTEGER                 :: JGRID, NXXX
     integer :: memunit
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
@@ -1543,12 +1540,8 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3GDATMD, ONLY: NGRIDS, IGRID, W3SETG, NK, NX, NY, NSEA,    &
-         NSEAL, NSPEC, NTH, E3DF, P2MSF, US3DF,      &
-         USSPF, GTYPE, UNGTYPE
-    USE W3ODATMD, ONLY: IAPROC, NAPROC, NTPROC, NAPFLD,             &
-         NOSWLL, NOEXTR, UNDEF, FLOGRD, FLOGR2,      &
-         NOGRP, NGRPP
+    USE W3GDATMD, ONLY: NGRIDS, IGRID, W3SETG, NK, E3DF, P2MSF, UNGTYPE
+    USE W3ODATMD, ONLY: IAPROC, NAPROC, NOSWLL, NOEXTR, UNDEF, NOGRP, NGRPP
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
@@ -2495,9 +2488,7 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3GDATMD, ONLY: NGRIDS, IGRID, NK, NX, NY, NSEA, NSEAL,     &
-         NSPEC, NTH, GTYPE, UNGTYPE
-    USE W3ODATMD, ONLY: NAPROC
+    USE W3GDATMD, ONLY: NGRIDS, UNGTYPE
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
@@ -2711,7 +2702,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !
     USE W3IDATMD, ONLY: INPUTS
-    USE W3GDATMD, ONLY: E3DF, P2MSF, US3DF, USSPF, GTYPE, UNGTYPE
+    USE W3GDATMD, ONLY: GTYPE, UNGTYPE
     !
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S
@@ -3139,8 +3130,7 @@ CONTAINS
     !
     !/ ------------------------------------------------------------------- /
     !
-    USE W3IDATMD, ONLY: INPUTS
-    USE W3GDATMD, ONLY: E3DF, P2MSF, US3DF, USSPF, GTYPE, UNGTYPE
+    USE W3GDATMD, ONLY: UNGTYPE
     !
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S

--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -2970,7 +2970,10 @@ CONTAINS
     LOGICAL, PARAMETER :: SPHERE = .FALSE.
     INTEGER :: PRANGE(2), QRANGE(2)
     INTEGER :: LBI(2), UBI(2), LBO(2), UBO(2), ISTAT
+#if defined(TEST_W3GDATMD) || defined(TEST_W3GDATMD_W3GNTX)
     REAL   , ALLOCATABLE :: COSA(:,:)
+#endif
+
 #ifdef W3_S
     INTEGER, SAVE      :: IENT = 0
     CALL STRACE (IENT, 'W3GNTX')
@@ -3189,7 +3192,6 @@ CONTAINS
     !/ Parameter list
     !/
     INTEGER, INTENT(IN)     :: IMOD, MTRI, MX, COUNTOTA, NNZ, NDSE, NDST
-    INTEGER                 :: IAPROC = 1
     !/
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
@@ -3361,15 +3363,17 @@ CONTAINS
     !/
     !/ ------------------------------------------------------------------- /
     !/
-    INTEGER                 :: ISEA, IX, IY, IXY, IXN, IXP, IYN, IYP
-    INTEGER                 :: J, K, NEIGH1(0:7)
-    INTEGER                 :: ILEV, NLEV
+    INTEGER                 :: IX, IY
+    INTEGER                 :: NEIGH1(0:7)
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
+#ifdef W3_REF1
+    REAL                    :: COSAVG, SINAVG, THAVG, CLAT
+    INTEGER                 :: J, K
+#endif
 
-    REAL                    :: TRIX(NY*NX), TRIY(NY*NX), DX, DY,    &
-         COSAVG, SINAVG, THAVG, ANGLES(0:7), CLAT
+    REAL                    :: ANGLES(0:7)
     !/
     !/ ------------------------------------------------------------------- /
     !/

--- a/model/src/w3iogomd.F90
+++ b/model/src/w3iogomd.F90
@@ -401,7 +401,6 @@ CONTAINS
     !
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS
-    USE W3GDATMD, ONLY: US3DF, USSPF
     USE W3ODATMD, ONLY: NOGRP, NGRPP, NOGE, IDOUT
     USE W3SERVMD, ONLY: NEXTLN, STRSPLIT, STR_TO_UPPER
 #ifdef W3_S
@@ -657,7 +656,6 @@ CONTAINS
     USE CONSTANTS
     USE W3ODATMD, ONLY: NOGRP, NGRPP, IDOUT
     USE W3SERVMD, ONLY: STRSPLIT, STR_TO_UPPER
-    USE W3GDATMD, ONLY: US3DF, USSPF
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -676,7 +674,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER             :: I, IFI, IFJ, IOUT
+    INTEGER             :: IFI, IFJ, IOUT
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
@@ -1300,24 +1298,23 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS
     USE W3GDATMD
-    USE W3WDATMD, ONLY: UST, FPIS
     USE W3ADATMD, ONLY: CG, WN, DW
     USE W3ADATMD, ONLY: HS, WLM, T02, T0M1, T01, FP0,               &
          THM, THS, THP0
     USE W3ADATMD, ONLY: ABA, ABD, UBA, UBD, FCUT, SXX,              &
          SYY, SXY, PHS, PTP, PLP, PDIR, PSI, PWS,    &
-         PWST, PNR, USERO, TUSX, TUSY, PRMS, TPMS,   &
+         PWST, PNR, TUSX, TUSY, PRMS, TPMS,          &
          USSX, USSY, MSSX, MSSY, MSSD, MSCX, MSCY,   &
-         MSCD, CHARN,                                &
-         BHD, CGE, P2SMS, US3D, EF, TH1M, STH1M,     &
+         MSCD, BHD, CGE, P2SMS, EF, TH1M, STH1M,     &
          TH2M, STH2M, HSIG, STMAXE, STMAXD,          &
-         HCMAXE, HMAXE, HCMAXD, HMAXD, USSP, QP, PQP,&
+         HCMAXE, HMAXE, HCMAXD, HMAXD, QP, PQP,      &
          PTHP0, PPE, PGW, PSW, PTM1, PT1, PT2, PEP,  &
          WBT, QKK
-    USE W3ODATMD, ONLY: NDST, UNDEF, IAPROC, NAPROC, NAPFLD,        &
-         ICPRT, DTPRT, WSCUT, NOSWLL, FLOGRD, FLOGR2,&
-         NOGRP, NGRPP
-    USE W3ADATMD, ONLY: NSEALM
+    USE W3ODATMD, ONLY: UNDEF, ICPRT, DTPRT, WSCUT,  &
+         NOSWLL, FLOGRD, FLOGR2, NOGRP, NGRPP
+#ifdef W3_T
+    USE W3ODATMD, ONLY: NDST
+#endif
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -1335,13 +1332,11 @@ CONTAINS
     !/ Local parameters
     !/
     INTEGER                 :: IK, ITH, JSEA, ISEA, IX, IY,         &
-         IKP0(NSEAL), NKH(NSEAL),             &
-         I, J, LKMS, HKMS, ITL
+         IKP0(NSEAL), NKH(NSEAL), I, J, ITL
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
     REAL                    :: FXPMC, FACTOR, FACTOR2, EBAND, FKD,  &
-         AABS, UABS,                          &
          XL, XH, XL2, XH2, EL, EH, DENOM, KD, &
          M1, M2, MA, MB, MC, STEX, STEY, STED
     REAL                    :: ET(NSEAL), EWN(NSEAL), ETR(NSEAL),   &
@@ -1367,8 +1362,8 @@ CONTAINS
          T02P(NSEAL), NV(NSEAL), NS(NSEAL),   &
          NB(NSEAL), MODE(NSEAL),              &
          MU(NSEAL), NI(NSEAL), STMAXEL(NSEAL),&
-         PHI(21,NSEAL),PHIST(NSEAL),         &
-         EBC(NK,NSEAL), ABP(NSEAL),           &
+         PHI(21,NSEAL),PHIST(NSEAL),          &
+         EBC(NK,NSEAL),                       &
          STMAXDL(NSEAL), TLPHI(NSEAL),        &
          WL02X(NSEAL), WL02Y(NSEAL),          &
          ALPXT(NSEAL), ALPYT(NSEAL),          &
@@ -2518,7 +2513,7 @@ CONTAINS
     USE W3ADATMD, ONLY: W3SETA, W3DIMA, W3XETA
     USE W3ODATMD, ONLY: W3SETO
     !/
-    USE W3WDATMD, ONLY: TIME, DINIT, WLV, ICE, ICEF, ICEH, BERG,    &
+    USE W3WDATMD, ONLY: TIME, DINIT, WLV, ICE, BERG,                &
          UST,  USTDIR, ASF, RHOAIR
     USE W3ADATMD, ONLY: AINIT, DW, UA, UD, AS, CX, CY, WN,          &
          TAUA, TAUADIR
@@ -2537,18 +2532,23 @@ CONTAINS
          STMAXE, STMAXD, HMAXE, HCMAXE, HMAXD, HCMAXD,&
          USSP, TAUOCX, TAUOCY, QKK, SKEW, EMBIA1, EMBIA2
     !/
-    USE W3ODATMD, ONLY: NOGRP, NGRPP, IDOUT, UNDEF, NDST, NDSE,     &
+    USE W3ODATMD, ONLY: NOGRP, NGRPP, UNDEF, NDST, NDSE,     &
          FLOGRD, IPASS => IPASS1, WRITE => WRITE1,   &
          FNMPRE, FNMGRD, NOSWLL, NOEXTR
     !/
     USE W3SERVMD, ONLY: EXTCDE, EXTOPN, EXTIOF
-    USE W3ODATMD, only: IAPROC
     USE W3ODATMD, ONLY: OFILES
+#ifdef W3_T
+    USE W3ODATMD, ONLY: IDOUT
+#endif
 #ifdef W3_SETUP
     USE W3WDATMD, ONLY: ZETA_SETUP
 #endif
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
+#endif
+#ifdef W3_IS2
+    USE W3WDATMD, ONLY: ICEF, ICEH
 #endif
     !
     IMPLICIT NONE
@@ -2569,14 +2569,12 @@ CONTAINS
     !/ Local parameters
     !/
     INTEGER                 :: IGRD, IERR, I, J, IX, IY, MOGRP,     &
-         MGRPP, ISEA, MOSWLL, IK, IFI, IFJ    &
-         ,IFILOUT
+         MGRPP, ISEA, MOSWLL, IK, IFI, IFJ
     INTEGER, ALLOCATABLE    :: MAPTMP(:,:)
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
-    REAL                    :: AUX1(NSEA), AUX2(NSEA),              &
-         AUX3(NSEA), AUX4(NSEA)
+    REAL                    :: AUX1(NSEA), AUX2(NSEA)
 #ifdef W3_SMC
     REAL                    :: UDARC
 #endif
@@ -4191,12 +4189,11 @@ CONTAINS
     !
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS, ONLY: TPIINV, GRAV, TPI
-    USE W3GDATMD,  ONLY: DDEN, DSII, XFR, SIG, NK, NTH, NSEAl,    &
+    USE W3GDATMD,  ONLY: DDEN, DSII, SIG, NK, NTH, NSEAl,    &
          ECOS, ESIN, US3DF, USSPF, USSP_WN
     USE W3ADATMD,  ONLY: CG, WN, DW
-    USE W3ADATMD,  ONLY: USSX, USSY,  US3D, USSP
-    USE W3ODATMD, ONLY: IAPROC, NAPROC
-    USE W3PARALL, ONLY: INIT_GET_ISEA
+    USE W3ADATMD,  ONLY: US3D, USSP
+    USE W3PARALL,  ONLY: INIT_GET_ISEA
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -4645,7 +4642,7 @@ CONTAINS
     !          V E ZAKHAROV(1967)
     !-------------------------------------------------------------------
     USE CONSTANTS, ONLY: GRAV, TPI
-    USE W3GDATMD,  ONLY: NK, NTH, XFR, SIG, TH, DTH, ECOS, ESIN
+    USE W3GDATMD,  ONLY: NTH, XFR, SIG, TH, DTH, ECOS, ESIN
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: NKHF
@@ -4930,7 +4927,7 @@ CONTAINS
    
     REAL(KIND=4) :: CONX, DELTA
     REAL(KIND=4) :: FH, DELF, XK1
-    REAL(KIND=4) :: XPI, XPJ, XPK, XN, XFAC, CO1
+    REAL(KIND=4) :: XPI, XPJ, XPK, XN, CO1
     REAL(KIND=4), DIMENSION(:,:), ALLOCATABLE :: F2
     REAL(KIND=4), DIMENSION(0:3,0:2,0:2) :: XMU, XLAMBDA
     REAL(KIND=4), DIMENSION(:) , ALLOCATABLE::  SIGHF, DFIMHF, FAK

--- a/model/src/w3iopomd.F90
+++ b/model/src/w3iopomd.F90
@@ -344,18 +344,15 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     USE NETCDF
     USE W3GSRUMD, ONLY: W3GRMP
-    USE W3GDATMD, ONLY: NTH, NK, NSPEC, NX, NY, X0, Y0, SX, GSU,&
-         RLGTYPE, CLGTYPE, UNGTYPE, GTYPE, FLAGLL,   &
-         ICLOSE,ICLOSE_NONE,ICLOSE_SMPL,ICLOSE_TRPL, &
-         MAPSTA, MAPFS, FILEXT, ZB, TRNX, TRNY
-    USE W3GDATMD, ONLY: TRIGP,MAXX, MAXY, DXYMAX
+    USE W3GDATMD, ONLY: GSU, RLGTYPE, CLGTYPE, UNGTYPE, GTYPE, FLAGLL,   &
+         ICLOSE_NONE, ICLOSE_SMPL, ICLOSE_TRPL, MAPSTA, FILEXT
 #ifdef W3_RTD
     !!  Use rotated N-Pole lat/lon and conversion sub.  JGLi12Jun2012
-    USE W3GDATMD, ONLY: PoLat, PoLon, FLAGUNR
+    USE W3GDATMD, ONLY: PoLat, PoLon, FLAGUNR, X0
     USE W3SERVMD, ONLY: W3LLTOEQ
 #endif
-    USE W3ODATMD, ONLY: W3DMO2, FNMPRE
-    USE W3ODATMD, ONLY: NDSE, NDST, IAPROC, NAPERR, NAPOUT, SCREEN, &
+    USE W3ODATMD, ONLY: W3DMO2
+    USE W3ODATMD, ONLY: NDSE, NDST, IAPROC, NAPERR,     &
          NOPTS, PTLOC, PTNME, GRDID, IPTINT, PTIFAC
     USE W3SERVMD, ONLY: EXTOPN, EXTIOF
 #ifdef W3_S
@@ -363,6 +360,10 @@ CONTAINS
 #endif
     USE W3TRIAMD, ONLY: IS_IN_UNGRID 
     USE W3GDATMD, ONLY: FILEXT 
+#ifdef W3_O7a
+    USE W3GDATMD, ONLY: NX, NY, ICLOSE, MAPFS, ZB, TRNX, TRNY
+    USE W3ODATMD, ONLY: NAPOUT, SCREEN
+#endif
     !
 #ifdef W3_MPI
     use mpi_f08
@@ -385,8 +386,7 @@ CONTAINS
     !/ Local parameters
     !/
     LOGICAL                 :: INGRID
-    INTEGER                 :: IPT, J, K
-    INTEGER                 :: IX1, IY1, IXS, IYS
+    INTEGER                 :: IPT, K
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
@@ -397,7 +397,7 @@ CONTAINS
     INTEGER                 :: ITOUT          ! Triangle index in unstructured grids
 #ifdef W3_O7a
     INTEGER                 :: IX0, IXN, IY0, IYN, NNX,         &
-         KX, KY, JX, IIX, IX2, IY2, IS1
+         KX, KY, JX, IIX, IX2, IY2, IS1, J, IX1, IY1
     REAL                    :: RD1, RD2, RDTOT, ZBOX(4), DEPTH
     CHARACTER(LEN=1)         :: SEA(5), LND(5), OUT(5)
     CHARACTER(LEN=9)         :: PARTS
@@ -954,8 +954,7 @@ CONTAINS
     !
     !/ ------------------------------------------------------------------- /
     USE CONSTANTS
-    USE W3GDATMD, ONLY: NK, NTH, SIG, NX, NY, NSEA, NSEAL,          &
-         MAPSTA, MAPFS
+    USE W3GDATMD, ONLY: NK, NTH, SIG, NSEAL, MAPSTA, MAPFS
 #ifdef W3_RTD
     !!   Use spectral rotation sub and angle.  JGLi12Jun2012
     USE W3GDATMD, ONLY: NSPEC, AnglD, FLAGUNR
@@ -970,9 +969,8 @@ CONTAINS
 #ifdef W3_FLX5
     USE W3ADATMD, ONLY: TAUA, TAUADIR
 #endif
-    USE W3ODATMD, ONLY: NDST, NOPTS, IPTINT, PTIFAC, IL, IW, II,    &
-         DPO, WAO, WDO, ASO, CAO, CDO, ICEO, ICEHO,  &
-         ICEFO, SPCO, NAPROC
+    USE W3ODATMD, ONLY: NOPTS, IPTINT, PTIFAC, IL, IW, II,          &
+         DPO, WAO, WDO, ASO, CAO, CDO, ICEO, ICEHO, ICEFO, SPCO
 #ifdef W3_FLX5
     USE W3ODATMD, ONLY: TAUAO, TAUDO, DAIRO
 #endif
@@ -988,6 +986,10 @@ CONTAINS
 #endif
 #ifdef W3_T
     USE W3ARRYMD, ONLY: PRT2DS
+    USE W3ODATMD, ONLY: NDST
+#endif
+#ifdef W3_DIST
+    USE W3ODATMD, ONLY: NAPROC
 #endif
     !
 #ifdef W3_MPI
@@ -1003,8 +1005,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER                 :: I, IX1, IY1, IX(4), IY(4), J, IS(4), &
-         IM(4), IK, ITH, ISP
+    INTEGER                 :: I, IX(4), IY(4), J, IS(4), IM(4), IK, ITH, ISP
 #ifdef W3_MPI
     INTEGER                 :: IOFF, IERR_MPI
     type(MPI_STATUS)        :: STAT(4*NOPTS)
@@ -1020,6 +1021,7 @@ CONTAINS
 #endif
     INTEGER                 :: JSEA, ISEA
 #ifdef W3_T
+    INTEGER                 :: IX1, IY1
     REAL                    :: SPTEST(NK,NTH)
 #endif
 #ifdef W3_RTD
@@ -1328,9 +1330,9 @@ CONTAINS
     USE W3ODATMD, ONLY: W3DMO2
     USE W3WDATMD, ONLY: TIME
     USE W3GDATMD, ONLY: NTH, NK, NSPEC, FILEXT
-    USE W3ODATMD, ONLY: NDST, NDSE, IPASS => IPASS2, NOPTS, IPTINT, &
-         IL, IW, II, PTLOC, PTIFAC, DPO, WAO, WDO,   &
-         ASO, CAO, CDO, SPCO, PTNME, O2INIT, FNMPRE, FNMPNT, &
+    USE W3ODATMD, ONLY: NDSE, NDST, IPASS => IPASS2, NOPTS,  &
+         IL, IW, II, PTLOC, DPO, WAO, WDO,                   &
+         ASO, CAO, CDO, SPCO, PTNME, O2INIT, FNMPRE,         &
          GRDID, ICEO, ICEHO, ICEFO, W3DMO2
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_FLX5
@@ -1350,9 +1352,9 @@ CONTAINS
     LOGICAL :: per_time_step
     INTEGER :: IGRD,MK,MTH
     integer :: fh, itime
-    integer :: d_nopts, d_nspec, d_vsize, d_namelen, d_grdidlen, d_time, d_ww3time
-    integer :: d_nopts_len, d_nspec_len, d_vsize_len, d_namelen_len, d_grdidlen_len, d_time_len, d_ww3time_len
-    integer :: v_idtst, v_vertst, v_nk, v_nth, v_ptloc, v_ptnme, v_time, v_ww3time 
+    integer :: d_nopts, d_nspec, d_vsize, d_namelen, d_grdidlen, d_time
+    integer :: d_nopts_len, d_nspec_len, d_vsize_len, d_namelen_len, d_grdidlen_len, d_time_len
+    integer :: v_nk, v_nth, v_ptloc, v_ptnme, v_ww3time 
     integer :: v_dpo, v_wao, v_wdo
 #ifdef W3_FLX5
     integer :: v_tauao,v_taudo, v_dairo
@@ -1617,9 +1619,8 @@ CONTAINS
     USE NETCDF 
     USE W3GDATMD, ONLY: NTH, NK, NSPEC
     USE W3WDATMD, ONLY: TIME
-    USE W3ODATMD, ONLY: NDST, NDSE, IPASS => IPASS2, NOPTS, IPTINT, &
-         PTLOC, PTIFAC, DPO, WAO, WDO,   &
-         ASO, CAO, CDO, SPCO, PTNME, O2INIT, FNMPRE, FNMPNT, &
+    USE W3ODATMD, ONLY: IPASS => IPASS2, NOPTS,               &
+         PTLOC, DPO, WAO, WDO, ASO, CAO, CDO, SPCO, PTNME,    &
          GRDID, ICEO, ICEHO, ICEFO
   USE W3TIMEMD, ONLY: CALTYPE, T2D, U2D, TSUB
 #ifdef W3_FLX5
@@ -1638,9 +1639,9 @@ CONTAINS
     CHARACTER(LEN=124), INTENT(IN), OPTIONAL :: fname
     CHARACTER(LEN=256), INTENT(IN), OPTIONAL :: path
     !
-    integer :: ndim, nvar, fmt, itime, fh
+    integer :: itime, fh
     integer :: d_nopts, d_nspec, d_vsize, d_namelen, d_grdidlen, d_time
-    integer :: v_idtst, v_vertst, v_nk, v_nth, v_ptloc, v_ptnme, v_time, v_ww3time
+    integer :: v_nk, v_nth, v_ptloc, v_ptnme, v_time, v_ww3time
     integer :: v_dpo, v_wao, v_wdo
 #ifdef W3_FLX5
     integer :: v_tauao, v_taudo, v_dairo
@@ -2212,8 +2213,8 @@ CONTAINS
     !/
     USE W3GDATMD, ONLY: NTH, NK, NSPEC, FILEXT
     USE W3WDATMD, ONLY: TIME
-    USE W3ODATMD, ONLY: NDST, NDSE, IPASS => IPASS2, NOPTS, IPTINT, &
-         IL, IW, II, PTLOC, PTIFAC, DPO, WAO, WDO,   &
+    USE W3ODATMD, ONLY: NDST, NDSE, IPASS => IPASS2, NOPTS,    &
+         IL, IW, II, PTLOC, DPO, WAO, WDO,                     &
          ASO, CAO, CDO, SPCO, PTNME, O2INIT, FNMPRE, FNMPNT,   &
          GRDID, ICEO, ICEHO, ICEFO
 #ifdef W3_FLX5

--- a/model/src/w3triamd.F90
+++ b/model/src/w3triamd.F90
@@ -201,11 +201,10 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3ODATMD, ONLY: NDSE, NDST, NDSO
+    USE W3ODATMD, ONLY: NDSE, NDST
     USE W3GDATMD, ONLY: ZB, XGRD, YGRD, NTRI, NX, COUNTOT, TRIGP, NNZ, W3DIMUG
     USE W3SERVMD, ONLY: ITRACE, NEXTLN, EXTCDE
     USE CONSTANTS, only: LPDLIB
-    USE W3ODATMD, ONLY: IAPROC
     !
     IMPLICIT NONE
     !/
@@ -216,20 +215,16 @@ CONTAINS
     !/
     !/ local parameters
     !/
-    INTEGER                            :: i,j,k, NODES, NELTS, ID, KID
-    INTEGER                            :: ID1, ID2, KID1, ITMP(3)
+    INTEGER                            :: i,j,k, NODES, NELTS
+    INTEGER                            :: ITMP(3)
     INTEGER                            :: I1, I2, I3
     INTEGER(KIND=4)                    :: Ind,eltype,ntag, INode
-    CHARACTER                          :: COMSTR*1, SPACE*1 = ' ', CELS*64
+    CHARACTER                          :: COMSTR*1
     REAL, ALLOCATABLE                  :: TAGS(:)
-    CHARACTER(LEN=64), ALLOCATABLE     :: ELS(:)
     CHARACTER(LEN=120)                 :: LINE
-    CHARACTER(LEN=50)                  :: CHTMP
-    CHARACTER(LEN=10)                  :: A, B, C
-    INTEGER,ALLOCATABLE                :: NELS(:), TRIGPTMP1(:,:), TRIGPTMP2(:,:)
+    INTEGER,ALLOCATABLE                :: TRIGPTMP1(:,:), TRIGPTMP2(:,:)
     INTEGER(KIND=4),ALLOCATABLE        :: IFOUND(:), VERTEX(:), BOUNDTMP(:)
     DOUBLE PRECISION, ALLOCATABLE      :: XYBTMP1(:,:),XYBTMP2(:,:)
-    REAL                               :: z
 
     OPEN(NDS,FILE = FNAME,STATUS='old')
     READ (NDS,'(A)') COMSTR
@@ -456,11 +451,9 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3ODATMD, ONLY: NDSE, NDST, NDSO
+    USE W3ODATMD, ONLY: NDSE
     USE W3GDATMD
     USE W3SERVMD, ONLY: ITRACE, NEXTLN, EXTCDE
-    USE CONSTANTS, only: LPDLIB
-    USE W3ODATMD, ONLY: IAPROC
     !
     IMPLICIT NONE
     !/
@@ -473,7 +466,7 @@ CONTAINS
     !/
     INTEGER                            :: i,j,k, NODES
     LOGICAL                            :: lfile_exists
-    CHARACTER                          :: COMSTR*1, SPACE*1 = ' ', CELS*64
+    CHARACTER                          :: COMSTR*1
     DOUBLE PRECISION, ALLOCATABLE      :: XYBTMP1(:,:)
 
     INQUIRE(FILE=FNAME, EXIST=lfile_exists)
@@ -716,8 +709,8 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3GDATMD, ONLY: NX, NY, CCON , COUNTCON
-    USE W3ODATMD, ONLY: NDSE, NDST, NDSO
+    USE W3GDATMD, ONLY: NX, NY
+    USE W3ODATMD, ONLY: NDSE
     USE W3SERVMD, ONLY: ITRACE, NEXTLN, EXTCDE, EXTIOF
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
@@ -734,9 +727,9 @@ CONTAINS
     !/
     !/ local parameters
     !/
-    INTEGER                            :: I, IERR
+    INTEGER                            :: IERR
     INTEGER(KIND=4)                    :: Ind,ntag, INode
-    CHARACTER                          :: COMSTR*1, SPACE*1 = ' ', CELS*64
+    CHARACTER                          :: COMSTR*1
     REAL, ALLOCATABLE                  :: TAGS(:)
     CHARACTER(LEN=120)                 :: LINE
 
@@ -825,7 +818,7 @@ CONTAINS
     !  9. Switches :
     !
     ! 10. Source code :
-    USE W3GDATMD, ONLY: NX, NY, CCON, COUNTCON, IOBP
+    USE W3GDATMD, ONLY: NX, NY
 
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
@@ -933,13 +926,12 @@ CONTAINS
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
-    USE W3ODATMD, ONLY: NDSE
 
     IMPLICIT NONE
     !
     !local parameters
     !
-    REAL              :: TL1, TL2, TL3, TMPTRIGP
+    REAL              :: TMPTRIGP
     INTEGER           :: I1, I2, I3
     INTEGER           :: K
     REAL*8            :: PT(3,2)
@@ -1046,14 +1038,12 @@ CONTAINS
     !
     !local parameter
     !
-    INTEGER :: IP, IE
-    INTEGER :: I1, I2, I3, I11, I22, I33
+    INTEGER :: IE
+    INTEGER :: I1, I2, I3
     !
     REAL*8    :: P1(2), P2(2), P3(2)
     REAL*8    :: R1(2), R2(2), R3(2)
     REAL*8    :: N1(2), N2(2), N3(2)
-    REAL*8    :: TMP(3)
-    REAL*8    :: TMPINV(3)
     REAL*8    :: PT(3,2)
 #ifdef W3_S
     INTEGER                      ::  IENT = 0
@@ -1188,7 +1178,7 @@ CONTAINS
     !/ local parameter
 
     INTEGER               :: CONN(NX)
-    INTEGER               :: COUNTER, IP, IE, I, J, N(3)
+    INTEGER               :: IP, IE, I, J, N(3)
 #ifdef W3_S
     INTEGER                      ::  IENT = 0
 #endif
@@ -1386,10 +1376,9 @@ CONTAINS
 
     !/ local parameters
 
-    INTEGER :: COUNTER,ifound,alreadyfound
-    INTEGER :: I, J, K, II
-    INTEGER :: IP, IE, POS, POS_I, POS_J, POS_K, IP_I, IP_J, IP_K
-    INTEGER :: I1, I2, I3, IP2, CHILF(NX)
+    INTEGER :: I, J, K
+    INTEGER :: IP, IE, POS, POS_J, POS_K, IP_I, IP_J, IP_K
+    INTEGER :: I1, I2, I3, CHILF(NX)
     INTEGER :: TMP(NX), CELLVERTEX(NX,COUNTRI,2)
     INTEGER :: COUNT_MAX
     DOUBLE PRECISION   :: TRIA03
@@ -1696,7 +1685,6 @@ CONTAINS
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
-    USE W3ODATMD, ONLY: NDSE
     IMPLICIT NONE
 
     !/ ------------------------------------------------------------------- /
@@ -1907,7 +1895,6 @@ CONTAINS
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
-    USE W3ODATMD, ONLY: NDSE
     IMPLICIT NONE
 
     !/ ------------------------------------------------------------------- /
@@ -1921,7 +1908,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !local parameters
 
-    DOUBLE PRECISION             :: x1, x2, x3, D1, D2, D3, DISTMIN, DDMIN
+    DOUBLE PRECISION             :: x1, x2, x3, D1, D2, D3
     DOUBLE PRECISION             :: s1, s2, s3, sg1, sg2, sg3, smin, ssum
     DOUBLE PRECISION             :: y1, y2, y3
     INTEGER                      :: ITRI, ITRIS
@@ -2083,8 +2070,7 @@ CONTAINS
     ! 10. Source code :
     USE CONSTANTS
     USE W3GDATMD, ONLY : TRIGP, NTRI, NX, NSEA, MAPFS, CLATIS, &
-         MAPSTA, ANGLE, FLAGLL,  IOBP, IEN, TRIA, NSEAL, NTRI
-    USE W3ADATMD, ONLY : NSEALM
+         FLAGLL,  IEN, TRIA, NSEAL, NTRI
 #ifdef W3_PDLIB
     USE yowElementpool
     use yowNodepool,    only: PDLIB_IEN, PDLIB_TRIA, NPA
@@ -2099,15 +2085,18 @@ CONTAINS
 
     ! local parameters
 
-    INTEGER              :: VERTICES(3), NI(3), NI_GL(3)
-    REAL                 :: TMP1(3), TMP2(3)
-    INTEGER              :: I, IX, IE, IE_GL
+    INTEGER              :: NI(3)
+    INTEGER              :: IE
     REAL                 :: VAR(3), FACT, LATMEAN
-    REAL                 :: DIFFXTMP, DIFFYTMP
     REAL                 :: DEDX(3), DEDY(3)
     REAL                 :: DVDXIE, DVDYIE
-    REAL                 :: WEI(NX), WEI_LOCAL(NSEAL)
-    REAL*8               :: RTMP(NSEAL)
+    REAL                 :: WEI(NX)
+
+#ifdef W3_PDLIB
+    INTEGER              :: NI_GL(3)
+    INTEGER              :: IE_GL
+    REAL                 :: WEI_LOCAL(NSEAL)
+#endif
 
     DIFFX = 0.
     DIFFY = 0.
@@ -2230,8 +2219,12 @@ CONTAINS
     USE W3SERVMD, ONLY: STRACE
 #endif
     !
+#ifdef W3_T
+    USE W3GDATMD, ONLY: MAPSF
+#endif
+    !
     USE W3ODATMD, ONLY: NBI, NDSE, ISBPI, XBPI, YBPI
-    USE W3GDATMD, ONLY: NX, XGRD, YGRD, MAPSTA, MAPFS, MAPSF
+    USE W3GDATMD, ONLY: NX, XGRD, YGRD, MAPSTA, MAPFS
 
 
     REAL, INTENT(IN)         :: DISTMIN
@@ -2371,8 +2364,6 @@ CONTAINS
     !
     !
     USE W3GDATMD, ONLY: NX, NTRI, TRIGP
-    USE W3ODATMD, ONLY: IAPROC
-
 
     IMPLICIT NONE
 
@@ -2387,7 +2378,6 @@ CONTAINS
     INTEGER          :: ISFINISHED !, INEXT, IPREV
     INTEGER :: INEXT(3), IPREV(3)
     INTEGER          :: ZNEXT, IP, I, IE, IPNEXT, IPPREV, COUNT
-    integer nb0, nb1, nbM1
     STATUS = -1
     INEXT=(/ 2, 3, 1 /) !IPREV=1+MOD(I+1,3)
     IPREV=(/ 3, 1, 2 /) !INEXT=1+MOD(I,3)
@@ -2872,19 +2862,13 @@ CONTAINS
     USE CONSTANTS
     !
     !
-    USE W3GDATMD, ONLY: NX, NY, NSEA, MAPFS,                        &
-         NK, NTH, DTH, XFR, MAPSTA, COUNTRI,         &
-         ECOS, ESIN, IEN, NTRI, TRIGP,               &
-         IOBP,IOBPD, IOBPA,                          &
-#ifdef W3_REF1
-         REFPARS, REFLC, REFLD,                      &
-#endif
-         ANGLE0, ANGLE
+    USE W3GDATMD, ONLY: NX, NTH, MAPSTA, ECOS, ESIN, IEN,      &
+         NTRI, TRIGP, IOBP,IOBPD, IOBPA
 
-    USE W3ODATMD, ONLY: TBPI0, TBPIN, FLBPI
-    USE W3ADATMD, ONLY: CG, CX, CY, ATRNX, ATRNY, ITIME, CFLXYMAX
-    USE W3IDATMD, ONLY: FLCUR
-    USE W3ODATMD, only : IAPROC
+#ifdef W3_REF1
+    USE W3GDATMD, ONLY: REFPARS, REFLC, REFLD, MAPFS, DTH
+#endif
+
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
 #endif
@@ -2897,9 +2881,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER                 :: ITH, IX, I, J, IP, IE, NDIRSUM
-    REAL (KIND = 8)         :: COSSUM, SINSUM
-    REAL (KIND = 8)         :: DIRMIN, DIRMAX, SHIFT, TEMPO, DIRCOAST
+    INTEGER                 :: ITH, I, IP, IE
     REAL (KIND = 8)         :: X1, X2, Y1, Y2, DXP1, DXP2, DXP3
     REAL (KIND = 8)         :: DYP1, DYP2, DYP3, eDet1, eDet2, EVX, EVY
     REAL(KIND=8), PARAMETER :: THR    = TINY(1.)
@@ -2908,6 +2890,11 @@ CONTAINS
     CHARACTER(60) :: FNAME
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
+#endif
+
+#ifdef W3_REF1
+    INTEGER                 :: NDIRSUM
+    REAL (KIND = 8)         :: COSSUM, SINSUM, DIRCOAST
 #endif
     !/ ------------------------------------------------------------------- /
     !
@@ -3091,7 +3078,6 @@ CONTAINS
     !
     !     Local variables.
     !     ----------------------------------------------------------------
-    INTEGER :: I
     INTEGER :: R1GT180, R2GT180, R3GT180
     !     ----------------------------------------------------------------
     !


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR silences compiler “remark” in modules w3iopomd, w3iogomd, w3adatmd, w3gdatmd, and w3triamd resulting in cleaner WW3/GFS debug builds.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR partially resolves compiler remarks in WW3 and the operational workflow during debug build by addressing `remark #7712` (“variable has not been used”): unused variables were removed from source codes: w3iopomd.F90, w3iogomd.F90, w3adatmd.F90, w3gdatmd.F90, and w3triamd.F90.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
addressing #1501 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Partially address compiler remarks in modules w3iopomd, w3iogomd, w3adatmd, w3gdatmd, and w3triamd
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Yes
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Yes. Ursa Intel and GNU
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Ursa-Intel regtests passed:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (19 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/24566484/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/24566491/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/24566492/matrixDiff.txt)

Ursa-GNU regtests passed:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (10 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (6 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (27 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/24566529/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/24566543/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/24566544/matrixDiff.txt)
