### PR TITLE
Remove compiler remarks in WW3 and operational workflow when using debug build

### DIFF
--- a/model/src/w3wdasmd.F90
+++ b/model/src/w3wdasmd.F90
@@ -194,10 +194,12 @@ CONTAINS
     USE W3GDATMD
     USE W3WDATMD
     USE W3ADATMD
-    USE W3ODATMD, ONLY: NDSO, NDSE, NDST, SCREEN, NAPROC, IAPROC,   &
-         NAPLOG, NAPOUT, NAPERR
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
+#endif
+    !
+#ifdef W3_T
+    USE W3ODATMD, ONLY: NDSO, NDSE, NDST, SCREEN, NAPROC, IAPROC, NAPOUT, NAPERR
 #endif
     !
 #ifdef W3_MPI
@@ -218,9 +220,8 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters :
     !/
-    INTEGER                 :: J
 #ifdef W3_T
-    INTEGER                 :: MREC, MDAT, IREC, IDAT
+    INTEGER                 :: MREC, MDAT, IREC, IDAT, J
 #endif
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0

--- a/model/src/ww3_gint.F90
+++ b/model/src/ww3_gint.F90
@@ -115,13 +115,11 @@ PROGRAM W3GRID_INTERP
   USE W3IOGOMD, ONLY : W3IOGO
   USE W3ADATMD, ONLY : W3DIMA, W3NAUX, W3SETA
   USE W3GDATMD
-  USE W3ODATMD, ONLY : FNMPRE, NOGRP, NGRPP, OUTPTS, UNDEF, FLOGRD,      &
-       NAPROC, NOSWLL, IDOUT
+  USE W3ODATMD, ONLY : FNMPRE, NOGRP, NGRPP, OUTPTS, UNDEF, FLOGRD, IDOUT
   USE W3ODATMD, ONLY : W3NOUT, W3SETO
   USE W3IDATMD
   USE W3WDATMD, ONLY : W3NDAT, W3DIMW, W3SETW
-  USE W3WDATMD, ONLY : WDATAS, TIME, WLV, ICE, ICEH, ICEF,               &
-       UST, USTDIR, ASF, RHOAIR
+  USE W3WDATMD, ONLY : WDATAS
   USE W3SERVMD, ONLY : ITRACE, NEXTLN, EXTCDE, EXTOPN, EXTIOF
 #ifdef W3_S
   USE W3SERVMD, ONLY : STRACE
@@ -129,7 +127,6 @@ PROGRAM W3GRID_INTERP
   USE W3ARRYMD, ONLY : PRTBLK
   USE W3GSRUMD
   USE W3TRIAMD
-  USE W3WDATMD, ONLY: VA
   USE W3IORSMD, ONLY: W3IORS
   !/
   IMPLICIT NONE
@@ -161,7 +158,7 @@ PROGRAM W3GRID_INTERP
   INTEGER, ALLOCATABLE    :: FIDOUT(:), MAP(:,:), TMP_INDX(:)
   REAL                    :: SXT, SYT, XT, YT, XTT
   DOUBLE PRECISION        :: DAREA, SAREA
-  REAL                    :: XCRNR(5),YCRNR(5),DT(4),DX,DY,XSUB,YSUB
+  REAL                    :: XCRNR(5),YCRNR(5),DT(4)
   INTEGER                 :: TOUT(2), NOUT, IOUT
   REAL                    :: DTREQ, DTEST
   INTEGER                 :: IS(4), JS(4)
@@ -175,7 +172,6 @@ PROGRAM W3GRID_INTERP
   CHARACTER               :: COMSTR*1, IDTIME*23, FNAMEWHT*32
   REAL                    :: XXX !< Dummy Value for w3iors call
   LOGICAL                 :: OUTorREST !< True interpolate out_grd or False restart
-  INTEGER                 :: INTYPE !check if this can be removed
   INTEGER, ALLOCATABLE    :: MAPSTA_NG(:,:),MAPST2_NG(:,:) 
   INTEGER, ALLOCATABLE    :: NOINT(:),NOINT2(:),MAPSTATMP(:,:) 
   INTEGER                 :: iNOINT,iNOINT2,JSEA,iloops 
@@ -1133,7 +1129,6 @@ CONTAINS
     !variables for restart 
     LOGICAL                 :: OUTorRESTflag
     REAL                    :: VAAUX(NSPEC), SUMRES(NSPEC)
-    INTEGER                 :: INTYPE 
     REAL                    :: XXX
     INTEGER                 :: MAPSTA_NG(NY,NX),MAPST2_NG(NY,NX)
     !/

--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -218,7 +218,7 @@ PROGRAM W3GRIB
   !/ Local variables
   !/
   INTEGER                 :: NDSI, NDSM, NDSOG, NDSDAT, NDSTRC,   &
-       NTRACE, IERR, IOTEST, I,J , IFI, IFJ,&
+       NTRACE, IERR, IOTEST, I, J, IFI, IFJ,&
        ISEA, IX, IY, TOUT(2), NOUT, TDUM(2),&
        FTIME(2), CID, PID, GID, GDS, IOUT,  &
        GDTN

--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -156,7 +156,7 @@ PROGRAM W3GRIB
   USE W3WDATMD, ONLY: TIME, WLV, ICE, UST, USTDIR, RHOAIR
   USE W3ADATMD
   USE W3ODATMD, ONLY: NDSE, NDST, NDSO, NOGRP, NGRPP, IDOUT, UNDEF,&
-       FLOGRD, FNMPRE, NOSWLL, NOGE, FLOGD
+       FLOGRD, NOSWLL, NOGE, FLOGD
   !
   IMPLICIT NONE
   !/
@@ -218,7 +218,7 @@ PROGRAM W3GRIB
   !/ Local variables
   !/
   INTEGER                 :: NDSI, NDSM, NDSOG, NDSDAT, NDSTRC,   &
-       NTRACE, IERR, IOTEST, I,J,K, IFI,IFJ,&
+       NTRACE, IERR, IOTEST, I,J , IFI, IFJ,&
        ISEA, IX, IY, TOUT(2), NOUT, TDUM(2),&
        FTIME(2), CID, PID, GID, GDS, IOUT,  &
        GDTN
@@ -244,7 +244,7 @@ PROGRAM W3GRIB
   INTEGER, SAVE           :: IENT = 0
 #endif
   REAL                    :: DTREQ, DTEST, RFTIME
-  LOGICAL                 :: FLREQ(NOGRP,NGRPP), FLGRIB(NOGRP,NGRPP)
+  LOGICAL                 :: FLREQ(NOGRP,NGRPP)
   CHARACTER               :: COMSTR*1, IDTIME*23, IDDDAY*11
   CHARACTER(LEN=80)       :: LINEIN
   CHARACTER(LEN=8)        :: WORDS(5)
@@ -1034,7 +1034,7 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER                 :: J, IXY, NDATA
+    INTEGER                 :: IXY, NDATA
     INTEGER                 :: IO
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0

--- a/model/src/ww3_outf.F90
+++ b/model/src/ww3_outf.F90
@@ -155,8 +155,7 @@ PROGRAM W3OUTF
   USE W3IOGOMD, ONLY: W3IOGO, W3READFLGRD
   !/
   USE W3GDATMD
-  USE W3WDATMD, ONLY: TIME, WLV, ICE, ICEH, ICEF, BERG, UST,      &
-       USTDIR, RHOAIR
+  USE W3WDATMD, ONLY: TIME, WLV, ICE, BERG, UST, USTDIR, RHOAIR
   USE W3ADATMD, ONLY: DW, UA, UD, AS, CX, CY, HS, WLM, T0M1, THM, &
        THS, FP0, THP0, DTDYN, FCUT,                &
        ABA, ABD, UBA, UBD, SXX, SYY, SXY, USERO,   &
@@ -173,7 +172,10 @@ PROGRAM W3OUTF
        HCMAXE, HMAXD, HCMAXD, MSSD, MSCD, WBT,     &
        WNMEAN, TAUA, TAUADIR
   USE W3ODATMD, ONLY: NDSO, NDSE, NDST, NOGRP, NGRPP, IDOUT,      &
-       UNDEF, FLOGRD, FNMPRE, FNMGRD, FNMPNT, FNMRST, NOSWLL, NOGE
+       UNDEF, FLOGRD, FNMPRE, NOSWLL
+#ifdef W3_IS2
+  USE W3WDATMD, ONLY: ICEH, ICEF
+#endif
   !
   IMPLICIT NONE
   !/
@@ -192,7 +194,7 @@ PROGRAM W3OUTF
   CHARACTER               :: COMSTR*1, IDTIME*23, IDDDAY*11,      &
        TABNME*9
   LOGICAL                 :: FLREQ(NOGRP,NGRPP), FLOG(NOGRP),     &
-       SCALE, VECTOR, LTEMP(NGRPP)
+       SCALE, VECTOR
   !/
   !/ ------------------------------------------------------------------- /
   !/
@@ -632,7 +634,7 @@ CONTAINS
     !/ Local parameters
     !/
     INTEGER                 :: NXMAX, NXTOT, NBLOK, IH, IM, IS,     &
-         MFILL, J, ISEA, IX, IY, IXB, IB,     &
+         MFILL, ISEA, IX, IY, IXB, IB,     &
          IXA, NINGRD, JJ, IFI, IFJ
     INTEGER                 :: MAP(NX+1,NY), MP2(NX+1,NY),          &
          MX1(NX,NY), MXX(NX,NY), MYY(NX,NY),  &

--- a/model/src/ww3_outp.F90
+++ b/model/src/ww3_outp.F90
@@ -224,13 +224,15 @@ PROGRAM W3OUTP
   USE W3GDATMD
   USE W3WDATMD, ONLY: TIME
   USE W3ODATMD, ONLY: NDSE, NDST, NDSO, NOPTS, PTLOC, PTNME,     &
-       DPO, WAO, WDO, ASO, CAO, CDO, SPCO, FNMPRE,&
-       ICEO, ICEHO, ICEFO, DIMP
+       DPO, WAO, WDO, ASO, CAO, CDO, SPCO, FNMPRE, DIMP
+#ifdef W3_IS2
+  USE W3ODATMD, ONLY: ICEO, ICEHO, ICEFO
+#endif
 #ifdef W3_FLX5
   USE W3ODATMD, ONLY: TAUAO, TAUDO, DAIRO
 #endif
-  USE W3BULLMD, ONLY: NPTAB, NFLD, NPMAX, BHSMIN, BHSDROP, IYY,  &
-       HST, TPT, DMT, ASCBLINE, CSVBLINE
+  USE W3BULLMD, ONLY: NPTAB, NFLD, NPMAX, BHSMIN, BHSDROP,       &
+       ASCBLINE, CSVBLINE
 #ifdef W3_NCO
   USE W3BULLMD, ONLY: CASCBLINE
 #endif
@@ -1417,7 +1419,7 @@ CONTAINS
     !/
     INTEGER                 :: J, I1, I2, ISP, IKM, ITH,            &
          IK, IH, IM, IS, IYR, IMTH, IDY, ITT, &
-         I, NPART, IP, IX, IY, ISEA
+         I, NPART, IX, IY
     INTEGER, SAVE           :: IPASS  = 0
 #ifdef W3_S
     INTEGER, SAVE           :: IENT   = 0
@@ -1430,15 +1432,20 @@ CONTAINS
          SPP, CD, USTAR, FACTOR, UNORM, ESTAR,&
          FPSTAR, FACF, FACE, FACS, HMAT, WNA, &
          XYZ, AGE1, AFR, AGE2, FACT, XSTAR,   &
-         YSTAR, FHIGH, ZWND, Z0, USTD, EMEAN, &
+         YSTAR, ZWND, Z0, USTD, EMEAN,        &
          FMEAN, WNMEAN, UDIRCA, X, Y, CHARN,  &
-         M2KM, ICEF, ICEDMAX, ICETHICK,       &
-         ICECON
+         M2KM
+#if defined(W3_ST0) || defined(W3_ST1) || defined(W3_ST2) || defined(W3_ST6) || defined(W3_LN1)
+    REAL                    :: FHIGH
+#endif
+
 #ifdef W3_FLX5
-    REAL                     ::TAUA, TAUADIR, RHOAIR
+    REAL                    :: TAUA, TAUADIR, RHOAIR
 #endif
 #ifdef W3_IS2
-    REAL                    :: WN_R(NK),CG_ICE(NK), ALPHA_LIU(NK)
+    REAL                    :: WN_R(NK), CG_ICE(NK), ALPHA_LIU(NK), R(NK)
+    REAL                    :: DIA2(NTH,NK)
+    REAL                    :: ICEF, ICEDMAX, ICETHICK, ICECON
 #endif
 #ifdef W3_ST1
     REAL                    :: AMAX, FH1, FH2
@@ -1448,10 +1455,10 @@ CONTAINS
 #endif
 #ifdef W3_ST3
     REAL                    :: AMAX, FMEANS, FMEANWS, TAUWX, TAUWY, &
-         TAUWNX, TAUWNY
+         TAUWNX, TAUWNY, ICE
 #endif
 #ifdef W3_ST4
-    REAL                    :: AMAX, FMEANS, FMEANWS, TAUWX, TAUWY, &
+    REAL                    :: AMAX, FMEANWS, TAUWX, TAUWY, &
          TAUWNX, TAUWNY, FMEAN1, WHITECAP(1:4), DLWMEAN
 #endif
 #ifdef W3_ST6
@@ -1461,21 +1468,21 @@ CONTAINS
     REAL                    :: TAUSCX, TAUSCY
 #endif
 #ifdef W3_BT4
+    INTEGER                 :: ISEA
     REAL                    :: D50, PSIC, BEDFORM(3), TAUBBL(2)
 #endif
-    REAL                    :: ICE
 #ifdef W3_STAB2
     REAL                    :: STAB0, STAB,  COR1, COR2, ASFAC,     &
          THARG1, THARG2
 #endif
     REAL, SAVE              :: HSMIN  = 0.05
-    REAL                    :: WN(NK), CG(NK), R(NK)
+    REAL                    :: WN(NK), CG(NK)
     REAL                    :: E(NK,NTH), E1(NK), APM(NK),           &
          THBND(NK), SPBND(NK), A(NTH,NK),      &
          WN2(NTH,NK)
     REAL                    :: DIA(NTH,NK), SWN(NK,NTH), SNL(NK,NTH),&
          SDS(NK,NTH), SBT(NK,NTH), SIS(NK,NTH),&
-         STT(NK,NTH), DIA2(NTH,NK)
+         STT(NK,NTH)
     REAL                    :: XLN(NTH,NK), XIN(NTH,NK), XNL(NTH,NK),&
          XTR(NTH,NK), XDS(NTH,NK), XDB(NTH,NK),&
          XBT(NTH,NK), XBS(NTH,NK), XXX(NTH,NK),&


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR silences compiler “remark” in modules and programs w3wdasmd ww3_outf ww3_outp ww3_grib ww3_gint resulting in cleaner WW3/GFS debug builds.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR partially resolves compiler remarks in WW3 and the operational workflow during debug build by addressing remark #7712 (“variable has not been used”): unused variables were removed from source codes: w3wdasmd.F90 ww3_outf.F90 ww3_outp.F90 ww3_grib.F90 ww3_gint.F90.

No answer changes are expected from this PR.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addressing issue #1501 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Silence compiler remarks in modules and programs w3wdasmd ww3_outf ww3_outp ww3_grib ww3_gint
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Ursa Intel and GNU
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Ursa-Intel:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (20 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (18 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/24967906/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/24967908/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/24967909/matrixDiff.txt)


Ursa-GNU:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (6 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (10 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (5 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (28 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/24967959/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/24967962/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/24967963/matrixDiff.txt)

