### PR TITLE
Address compiler remarks in WW3 and operational workflow when using debug build

### DIFF
--- a/model/src/w3arrymd.F90
+++ b/model/src/w3arrymd.F90
@@ -1697,7 +1697,7 @@ CONTAINS
 #endif
     REAL, SAVE              :: TOPFAC = 1.1
     REAL                    :: FTOP, RLINES, FACFR, FSC, FLINE,    &
-         EMAX, EMIN, EXTR, FLOC
+         EMAX, EMIN, EXTR
     LOGICAL                 :: FLSCLE
     CHARACTER               :: STRA*10, STRA2*2, STRAX*2, PNUM2*2
     DIMENSION               :: PNUM2(NFM2)

--- a/model/src/w3fldsmd.F90
+++ b/model/src/w3fldsmd.F90
@@ -805,8 +805,16 @@ CONTAINS
     INTEGER, SAVE           :: IENT = 0
 #endif
     LOGICAL                 :: WRITE
-    INTEGER                 :: I, IX, TIDE_MF1
+#ifdef W3_TIDE
+    INTEGER                 :: TIDE_MF1
     CHARACTER(LEN=100)      :: LIST(70)
+#endif
+#ifdef W3_TIDET
+    INTEGER                 :: IX
+#endif
+#if defined(W3_TIDE) || defined(W3_TIDET)
+    INTEGER                 :: I
+#endif
     !/
     !/ ------------------------------------------------------------------- /
     !/

--- a/model/src/w3gdatmd.F90
+++ b/model/src/w3gdatmd.F90
@@ -3363,8 +3363,6 @@ CONTAINS
     !/
     !/ ------------------------------------------------------------------- /
     !/
-    INTEGER                 :: IX, IY
-    INTEGER                 :: NEIGH1(0:7)
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
 #endif
@@ -3372,8 +3370,12 @@ CONTAINS
     REAL                    :: COSAVG, SINAVG, THAVG, CLAT
     INTEGER                 :: J, K
 #endif
-
+#if defined(W3_REF1) || defined(W3_REFT)
+    INTEGER                 :: IX, IY
+    INTEGER                 :: NEIGH1(0:7)
     REAL                    :: ANGLES(0:7)
+#endif
+
     !/
     !/ ------------------------------------------------------------------- /
     !/

--- a/model/src/w3idatmd.F90
+++ b/model/src/w3idatmd.F90
@@ -516,7 +516,9 @@ CONTAINS
     !/ Local parameters
     !/
     INTEGER                 :: JGRID
+#ifdef W3_TIDE
     LOGICAL                 :: FLAGSTIDE(4)=.FALSE.
+#endif
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
     CALL STRACE (IENT, 'W3DIMI')

--- a/model/src/w3odatmd.F90
+++ b/model/src/w3odatmd.F90
@@ -1401,7 +1401,7 @@ CONTAINS
     ! 10. Source code :
     !
     !/ ------------------------------------------------------------------- /
-    USE W3GDATMD, ONLY: W3SETG, NGRIDS, IGRID, NX, NY, NSPEC
+    USE W3GDATMD, ONLY: W3SETG, NGRIDS, NSPEC
     USE W3SERVMD, ONLY: EXTCDE
 #ifdef W3_S
     USE W3SERVMD, ONLY: STRACE
@@ -1417,7 +1417,6 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/ Local parameters
     !/
-    INTEGER                 :: JGRID
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
     CALL STRACE (IENT, 'W3DMO5')
@@ -1621,7 +1620,6 @@ CONTAINS
     !/ Local parameters
     !/
     INTEGER                 :: NLOW
-    INTEGER                 :: J
 #ifdef W3_S
     INTEGER, SAVE           :: IENT = 0
     CALL STRACE (IENT, 'W3SETO')

--- a/model/src/w3parall.F90
+++ b/model/src/w3parall.F90
@@ -1086,9 +1086,13 @@ CONTAINS
 #ifdef W3_MPI
     USE W3ADATMD, ONLY: MPI_COMM_WAVE, MPI_COMM_WCMP
 #endif
+#ifdef W3_DIST
     USE CONSTANTS, ONLY : LPDLIB
+#endif
     USE W3GDATMD, ONLY: NSEA
-    USE W3ODATMD, ONLY: NAPROC, IAPROC
+#if defined(W3_DIST) || defined(W3_PDLIB)
+    USE W3ODATMD, ONLY: IAPROC, NAPROC
+#endif
     IMPLICIT NONE
     INTEGER, intent(out) :: NSEALout, NSEALMout
     !/ Local parameters
@@ -1200,12 +1204,14 @@ CONTAINS
     USE W3SERVMD, ONLY: STRACE
 #endif
     !/
-    USE W3ODATMD, ONLY: IAPROC, NAPROC
-    USE W3GDATMD, ONLY: UNGTYPE, MAPSF
-    USE CONSTANTS, ONLY : LPDLIB
+    USE W3ODATMD, ONLY: NAPROC
+    USE W3GDATMD, ONLY: UNGTYPE
 #ifdef W3_PDLIB
     USE yowRankModule, only : IPGL_TO_PROC, IPGL_tot
     use yowNodepool, only: ipgl, iplg
+    USE W3ODATMD, ONLY: IAPROC
+    USE W3GDATMD, ONLY: MAPSF
+    USE CONSTANTS, ONLY : LPDLIB
 #endif
     IMPLICIT NONE
     !/ ------------------------------------------------------------------- /
@@ -1221,7 +1227,10 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     INTEGER, intent(in) :: ISEA
     INTEGER, intent(out) :: JSEA, ISPROC
+#ifdef W3_PDLIB
     INTEGER IP_glob
+#endif
+
 #ifdef W3_S
     CALL STRACE (IENT, 'INIT_GET_JSEA_ISPROC')
 #endif
@@ -1309,11 +1318,12 @@ CONTAINS
 #endif
     !/
     USE W3ODATMD, ONLY: IAPROC, NAPROC
-    USE W3GDATMD, ONLY: GTYPE, UNGTYPE, MAPSF
+    USE W3GDATMD, ONLY: UNGTYPE
     USE CONSTANTS, ONLY : LPDLIB
 #ifdef W3_PDLIB
     USE yowRankModule, only : IPGL_TO_PROC, IPGL_tot, IPGL_npa
     use yowNodepool, only: ipgl, iplg
+    USE W3GDATMD, ONLY: MAPSF, GTYPE
 #endif
     IMPLICIT NONE
     !/ ------------------------------------------------------------------- /
@@ -1330,7 +1340,10 @@ CONTAINS
     !/
     INTEGER, intent(in) :: ISEA
     INTEGER, intent(out) :: JSEA, IBELONG
-    INTEGER ISPROC, IX, JX
+    INTEGER ISPROC
+#ifdef W3_PDLIB
+    INTEGER :: IX, JX
+#endif
 #ifdef W3_S
     CALL STRACE (IENT, 'GET_JSEA_IBELONG')
 #endif
@@ -1435,11 +1448,17 @@ CONTAINS
     USE W3SERVMD, ONLY: STRACE
 #endif
     !/
-    USE W3ODATMD, ONLY: IAPROC, NAPROC
-    USE W3GDATMD, ONLY: GTYPE, UNGTYPE
-    USE CONSTANTS, ONLY : LPDLIB
+    USE W3GDATMD, ONLY: UNGTYPE
 #ifdef W3_PDLIB
     USE YOWNODEPOOL, ONLY: iplg
+    USE W3GDATMD, ONLY: GTYPE
+#endif
+#ifdef W3_DIST
+    USE CONSTANTS, ONLY : LPDLIB
+#endif
+    !/
+#if defined(W3_DIST) || defined(W3_PDLIB)
+    USE W3ODATMD, ONLY: IAPROC, NAPROC
 #endif
     !/ ------------------------------------------------------------------- /
     !/ Parameter list
@@ -1582,14 +1601,14 @@ CONTAINS
     !/
     !/ ------------------------------------------------------------------- /
     !/
-    INTEGER Status(NX), rStatus(NX)
-    INTEGER IPROC, I, ierr, IP, IP_glob
+    INTEGER Status(NX)
 #ifdef W3_PDLIB
     REAL(rkind), intent(inout) :: TheVar(NX)
     REAL(rkind) ::  rVect(NX)
+    INTEGER     ::  IP, IP_glob, IPROC, I, ierr
+    INTEGER     ::  rStatus(NX)
 #else
     DOUBLE PRECISION, intent(inout) :: TheVar(NX)
-    DOUBLE PRECISION                ::  rVect(NX)
 #endif
     Status=0
 #ifdef W3_S

--- a/model/src/w3timemd.F90
+++ b/model/src/w3timemd.F90
@@ -1419,7 +1419,7 @@ CONTAINS
     !/ Local parameters
     !/
     REAL                      :: SECDAY=86400.0d0
-    INTEGER                   :: TIMEZONE(8), TZ
+    INTEGER                   :: TZ
 
     REAL                      :: SECOND
     INTEGER                   :: YEAR, MONTH, DAY, HOUR, MINUTE
@@ -2035,7 +2035,6 @@ CONTAINS
     !/ ------------------------------------------------------------------- /
     !/
     USE W3SERVMD, ONLY: EXTIOF
-    USE W3ODATMD, ONLY: NDSE
     !
     IMPLICIT NONE
     !/


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR silences compiler “remark” in modules w3arrymd, w3fldsmd, w3gdatmd, w3idatmd, w3odatmd, w3parall, and w3timemd  resulting in cleaner WW3/GFS debug builds.
## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->
This PR partially resolves compiler remarks in WW3 and the operational workflow during debug build by addressing remark #7712 (“variable has not been used”): unused variables were removed from source codes: w3arrymd.F90, w3fldsmd.F90, w3gdatmd.F90, w3idatmd.F90, w3odatmd.F90, w3parall.F90, and w3timemd.F90

No answer changes are expected from this PR.
### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
Addressing issue #1501 
### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Fix compiler remarks in modules w3arrymd, w3fldsmd, w3gdatmd, w3idatmd, w3odatmd, w3parall, and w3timemd
### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Ursa Intel and GNU
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

Ursa-Intel:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (23 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (5 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/25021746/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/25021748/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/25021749/matrixDiff.txt)

Ursa-GNU:
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UNO_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (28 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/25021795/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/25021796/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/25021797/matrixDiff.txt)
