### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # The WAVEWATCH III Framework
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/NOAA-EMC/WW3)
 
 WAVEWATCH III<sup>&reg;</sup>  is a community wave modeling framework that includes the
 latest scientific advancements in the field of wind-wave modeling and dynamics.


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NOAA-EMC/WW3) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.