### PR TITLE
revert grib2 packing for HAFSv2.2

### DIFF
--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -789,7 +789,7 @@ PROGRAM W3GRIB
   ! ... Set GRIB2 Data Representation Template Number (Code Table 5.0)
   !
 #ifdef W3_NCEP2
-  IDRSNUM = 2 !Complex Packing
+  IDRSNUM = 40 !Complex Packing
 #endif
   !                            clusters with Intel compiler ***
 #ifdef W3_NCEP2


### PR DESCRIPTION
# Pull Request Summary

## Description
Reverting the grib2 packing change for HAFS since it was seen that the grib2 file size was increased. 

### Issue(s) addressed
no issue was made. 

### Commit Message
revert grib2 packing for HAFSv2.2

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

This is a oneline revert.  It will be tested by HAFS team in upcoming tests. 