### PR TITLE
Changes to the scaling of lateral boundary conditions - removes unnecessary computation and allows B4B restarts for cases with BCS and time varying water level

### DIFF
--- a/model/src/w3pro1md.F90
+++ b/model/src/w3pro1md.F90
@@ -817,7 +817,8 @@ CONTAINS
         DO IBI=1, NBI
           IX    = MAPSF(ISBPI(IBI),1)
           IY    = MAPSF(ISBPI(IBI),2)
-          FLD2D(IY,IX) = RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI)
+          ISEA   = ISBPI(IBI)
+          FLD2D(IY,IX) = CG(IK,ISEA) * ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )
         END DO
       END IF
       !

--- a/model/src/w3pro1md.F90
+++ b/model/src/w3pro1md.F90
@@ -817,8 +817,12 @@ CONTAINS
         DO IBI=1, NBI
           IX    = MAPSF(ISBPI(IBI),1)
           IY    = MAPSF(ISBPI(IBI),2)
+#ifdef W3_PDLIB
           ISEA   = ISBPI(IBI)
           FLD2D(IY,IX) = CG(IK,ISEA) * ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )
+#else
+          FLD2D(IY,IX) = RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) 
+#endif
         END DO
       END IF
       !

--- a/model/src/w3pro2md.F90
+++ b/model/src/w3pro2md.F90
@@ -1084,7 +1084,12 @@ CONTAINS
         DO IBI=1, NBI
           ISEA    = ISBPI(IBI)
           IXY     = MAPSF(ISBPI(IBI),3)
+#ifdef W3_PDLIB
           VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISEA)
+#else
+          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
+               / CG(IK,ISEA) * CLATS(ISEA)
+#endif
         END DO
       END IF
       !

--- a/model/src/w3pro2md.F90
+++ b/model/src/w3pro2md.F90
@@ -1084,8 +1084,7 @@ CONTAINS
         DO IBI=1, NBI
           ISEA    = ISBPI(IBI)
           IXY     = MAPSF(ISBPI(IBI),3)
-          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-               / CG(IK,ISEA) * CLATS(ISEA)
+          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISEA)
         END DO
       END IF
       !

--- a/model/src/w3pro3md.F90
+++ b/model/src/w3pro3md.F90
@@ -1405,7 +1405,12 @@ CONTAINS
         END IF
         DO IBI=1, NBI
           IXY     = MAPSF(ISBPI(IBI),3)
+#ifdef W3_PDLIB
           VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
+#else
+          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
+               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+#endif
         END DO
       END IF
       !

--- a/model/src/w3pro3md.F90
+++ b/model/src/w3pro3md.F90
@@ -1405,8 +1405,7 @@ CONTAINS
         END IF
         DO IBI=1, NBI
           IXY     = MAPSF(ISBPI(IBI),3)
-          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+          VQ(IXY) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
         END DO
       END IF
       !

--- a/model/src/w3profsmd.F90
+++ b/model/src/w3profsmd.F90
@@ -706,7 +706,12 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
+#ifdef W3_PDLIB 
           AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
+#else
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
+               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+#endif
         END DO
 
       ENDIF
@@ -956,7 +961,12 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
+#ifdef W3_PDLIB
           AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
+#else
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
+               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+#endif
         END DO
 
       ENDIF
@@ -1562,7 +1572,12 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
+#ifdef W3_PDLIB
           AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
+#else
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
+               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+#endif
         END DO
 
       ENDIF

--- a/model/src/w3profsmd.F90
+++ b/model/src/w3profsmd.F90
@@ -706,8 +706,7 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
-          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
         END DO
 
       ENDIF
@@ -957,8 +956,7 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
-          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
         END DO
 
       ENDIF
@@ -1261,7 +1259,7 @@ CONTAINS
       DO IBI=1, NBI
         IP    = MAPSF(ISBPI(IBI),1)
         AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-             *IOBPA(IP)*IOBPD(ITH,IP) / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+             * IOBPA(IP) * IOBPD(ITH,IP) * CLATS(ISBPI(IBI))
       END DO
     END IF
 
@@ -1564,8 +1562,7 @@ CONTAINS
         !
         DO IBI=1, NBI
           IP = MAPSF(ISBPI(IBI),1)
-          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-               / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+          AC(IP) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
         END DO
 
       ENDIF

--- a/model/src/w3profsmd_pdlib.F90
+++ b/model/src/w3profsmd_pdlib.F90
@@ -1162,12 +1162,11 @@ CONTAINS
           IP_glob = MAPSF(ISBPI(IBI),1)
           JX=IPGL_npa(IP_glob)
           IF (JX .gt. 0) THEN
-            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-                 / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
 #ifdef W3_DEBUGSOLVER
             sumAC=sumAC + AC(JX)
-            sumBPI0=sumBPI0 + BBPI0(ISP,IBI)
-            sumBPIN=sumBPIN + BBPIN(ISP,IBI)
+            sumBPI0=sumBPI0 + BBPI0(ISP,IBI) * CG(IK,ISBPI(IBI))
+            sumBPIN=sumBPIN + BBPIN(ISP,IBI) * CG(IK,ISBPI(IBI))
             sumCG=sumCG + CG(IK,ISBPI(IBI))
             sumCLATS=sumCLATS + CLATS(ISBPI(IBI))
 #endif
@@ -1462,12 +1461,11 @@ CONTAINS
           IP_glob    = MAPSF(ISBPI(IBI),1)
           JX=IPGL_npa(IP_glob)
           IF (JX .gt. 0) THEN
-            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-                 / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
 #ifdef W3_DEBUGSOLVER
             sumAC=sumAC + AC(JX)
-            sumBPI0=sumBPI0 + BBPI0(ISP,IBI)
-            sumBPIN=sumBPIN + BBPIN(ISP,IBI)
+            sumBPI0=sumBPI0 + BBPI0(ISP,IBI) * CG(IK,ISBPI(IBI))
+            sumBPIN=sumBPIN + BBPIN(ISP,IBI) * CG(IK,ISBPI(IBI))
             sumCG=sumCG + CG(IK,ISBPI(IBI))
             sumCLATS=sumCLATS + CLATS(ISBPI(IBI))
 #endif
@@ -1837,12 +1835,11 @@ CONTAINS
           IP_glob = MAPSF(ISBPI(IBI),1)
           JX=IPGL_npa(IP_glob)
           IF (JX .gt. 0) THEN
-            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-                 / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
+            AC(JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
 #ifdef W3_DEBUGSOLVER
             sumAC=sumAC + AC(JX)
-            sumBPI0=sumBPI0 + BBPI0(ISP,IBI)
-            sumBPIN=sumBPIN + BBPIN(ISP,IBI)
+            sumBPI0=sumBPI0 + BBPI0(ISP,IBI) * CG(IK,ISBPI(IBI))
+            sumBPIN=sumBPIN + BBPIN(ISP,IBI) * CG(IK,ISBPI(IBI))
             sumCG=sumCG + CG(IK,ISBPI(IBI))
             sumCLATS=sumCLATS + CLATS(ISBPI(IBI))
 #endif
@@ -5136,9 +5133,8 @@ CONTAINS
             DO ITH=1,NTH
               DO IK=1,NK
                 ISP=ITH + (IK-1)*NTH
-                eAC = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )   &
-                     / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))
-                eVA = MAX(0., CG(IK,ISEA)/CLATS(ISEA)*eAC)
+                eAC = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )
+                eVA = MAX(0., CG(IK,ISEA) * eAC)
                 VA(ISP,JSEA) = eVA
               END DO
             END DO
@@ -5283,7 +5279,7 @@ CONTAINS
             DO IK=1,NK
               ISP=ITH + (IK-1)*NTH
               VA(ISP,JX) = (( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) )  &
-                   / CG(IK,ISBPI(IBI)) * CLATS(ISBPI(IBI))) * IOBDP_LOC(JX)
+                   * CLATS(ISBPI(IBI))) * IOBDP_LOC(JX)
             END DO
           END DO
 #ifdef W3_DEBUGIOBC
@@ -5303,8 +5299,8 @@ CONTAINS
 
 #ifdef W3_DEBUGSOLVER
           sumAC=sumAC + VA(:,JX)
-          sumBPI0=sumBPI0 + BBPI0(:,IBI)
-          sumBPIN=sumBPIN + BBPIN(:,IBI)
+          sumBPI0=sumBPI0 + BBPI0(:,IBI) * CG(IK,ISBPI(IBI))
+          sumBPIN=sumBPIN + BBPIN(:,IBI) * CG(IK,ISBPI(IBI))
           sumCG=sumCG + CG(IK,ISBPI(IBI))
           sumCLATS=sumCLATS + CLATS(ISBPI(IBI))
 #endif
@@ -6659,7 +6655,7 @@ CONTAINS
               IP_glob = MAPSF(ISBPI(IBI),1)
               JX      = IPGL_npa(IP_glob)
               IF (JX .gt. 0) THEN
-                U(ITH,JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) / CGSIG(ISBPI(IBI)) * CLATS(ISBPI(IBI))
+                U(ITH,JX) = ( RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI) ) * CLATS(ISBPI(IBI))
               END IF
             END DO
           ENDDO

--- a/model/src/w3psmcmd.F90
+++ b/model/src/w3psmcmd.F90
@@ -881,7 +881,12 @@ CONTAINS
         END IF
         DO IBI=1, NBI
           ISEA     = ISBPI(IBI)
+#ifdef W3_PDLIB
           CQ(ISEA) = (RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI))
+#else
+          CQ(ISEA) = (RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI))   &
+               /CG(IK,ISEA)
+#endif
         END DO
       ENDIF
       !

--- a/model/src/w3psmcmd.F90
+++ b/model/src/w3psmcmd.F90
@@ -881,8 +881,7 @@ CONTAINS
         END IF
         DO IBI=1, NBI
           ISEA     = ISBPI(IBI)
-          CQ(ISEA) = (RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI))   &
-               /CG(IK,ISEA)
+          CQ(ISEA) = (RD1*BBPI0(ISP,IBI) + RD2*BBPIN(ISP,IBI))
         END DO
       ENDIF
       !

--- a/model/src/w3updtmd.F90
+++ b/model/src/w3updtmd.F90
@@ -1447,11 +1447,10 @@ CONTAINS
       DO IBI=1, NBI
         ISEA   = ISBPI(IBI)
         DO ISP=1, NSPEC
-          BBPI0(ISP,IBI) = CG(MAPWN(ISP),ISEA) / SIG2(ISP) *      &
-               ( RDBPI(IBI,1) * ABPI0(ISP,IPBPI(IBI,1))   &
+          BBPI0(ISP,IBI) = ( RDBPI(IBI,1) * ABPI0(ISP,IPBPI(IBI,1))   &
                + RDBPI(IBI,2) * ABPI0(ISP,IPBPI(IBI,2))   &
                + RDBPI(IBI,3) * ABPI0(ISP,IPBPI(IBI,3))   &
-               + RDBPI(IBI,4) * ABPI0(ISP,IPBPI(IBI,4)) )
+               + RDBPI(IBI,4) * ABPI0(ISP,IPBPI(IBI,4)) ) / SIG2(ISP)
         END DO
       END DO
       !
@@ -1466,11 +1465,10 @@ CONTAINS
     DO IBI=1, NBI
       ISEA   = ISBPI(IBI)
       DO ISP=1, NSPEC
-        BBPIN(ISP,IBI) = CG(MAPWN(ISP),ISEA) / SIG2(ISP) *          &
-             ( RDBPI(IBI,1) * ABPIN(ISP,IPBPI(IBI,1))       &
+        BBPIN(ISP,IBI) = ( RDBPI(IBI,1) * ABPIN(ISP,IPBPI(IBI,1))       &
              + RDBPI(IBI,2) * ABPIN(ISP,IPBPI(IBI,2))       &
              + RDBPI(IBI,3) * ABPIN(ISP,IPBPI(IBI,3))       &
-             + RDBPI(IBI,4) * ABPIN(ISP,IPBPI(IBI,4)) )
+             + RDBPI(IBI,4) * ABPIN(ISP,IPBPI(IBI,4)) ) / SIG2(ISP)
       END DO
       !
 #ifdef W3_RTD
@@ -1495,10 +1493,8 @@ CONTAINS
       HS1    = 0.
       HS2    = 0.
       DO ISP=1, NSPEC
-        HS1    = HS1 + BBPI0(ISP,IBI) * DDEN(MAPWN(ISP)) /       &
-             CG(MAPWN(ISP),ISBPI(IBI))
-        HS2    = HS2 + BBPIN(ISP,IBI) * DDEN(MAPWN(ISP)) /       &
-             CG(MAPWN(ISP),ISBPI(IBI))
+        HS1    = HS1 + BBPI0(ISP,IBI) * DDEN(MAPWN(ISP))
+        HS2    = HS2 + BBPIN(ISP,IBI) * DDEN(MAPWN(ISP))
       END DO
       HS1    = 4. * SQRT ( HS1 )
       HS2    = 4. * SQRT ( HS2 )

--- a/model/src/w3updtmd.F90
+++ b/model/src/w3updtmd.F90
@@ -1447,10 +1447,18 @@ CONTAINS
       DO IBI=1, NBI
         ISEA   = ISBPI(IBI)
         DO ISP=1, NSPEC
+#ifdef W3_PDLIB
           BBPI0(ISP,IBI) = ( RDBPI(IBI,1) * ABPI0(ISP,IPBPI(IBI,1))   &
                + RDBPI(IBI,2) * ABPI0(ISP,IPBPI(IBI,2))   &
                + RDBPI(IBI,3) * ABPI0(ISP,IPBPI(IBI,3))   &
                + RDBPI(IBI,4) * ABPI0(ISP,IPBPI(IBI,4)) ) / SIG2(ISP)
+#else
+          BBPI0(ISP,IBI) = CG(MAPWN(ISP),ISEA) / SIG2(ISP) *      &
+               ( RDBPI(IBI,1) * ABPI0(ISP,IPBPI(IBI,1))   &
+               + RDBPI(IBI,2) * ABPI0(ISP,IPBPI(IBI,2))   &
+               + RDBPI(IBI,3) * ABPI0(ISP,IPBPI(IBI,3))   &
+               + RDBPI(IBI,4) * ABPI0(ISP,IPBPI(IBI,4)) )
+#endif
         END DO
       END DO
       !
@@ -1465,10 +1473,18 @@ CONTAINS
     DO IBI=1, NBI
       ISEA   = ISBPI(IBI)
       DO ISP=1, NSPEC
+#ifdef W3_PDLIB
         BBPIN(ISP,IBI) = ( RDBPI(IBI,1) * ABPIN(ISP,IPBPI(IBI,1))       &
              + RDBPI(IBI,2) * ABPIN(ISP,IPBPI(IBI,2))       &
              + RDBPI(IBI,3) * ABPIN(ISP,IPBPI(IBI,3))       &
              + RDBPI(IBI,4) * ABPIN(ISP,IPBPI(IBI,4)) ) / SIG2(ISP)
+#else
+       BBPIN(ISP,IBI) = CG(MAPWN(ISP),ISEA) / SIG2(ISP) *          &
+             ( RDBPI(IBI,1) * ABPIN(ISP,IPBPI(IBI,1))       &
+             + RDBPI(IBI,2) * ABPIN(ISP,IPBPI(IBI,2))       &
+             + RDBPI(IBI,3) * ABPIN(ISP,IPBPI(IBI,3))       &
+             + RDBPI(IBI,4) * ABPIN(ISP,IPBPI(IBI,4)) )
+#endif
       END DO
       !
 #ifdef W3_RTD
@@ -1493,8 +1509,15 @@ CONTAINS
       HS1    = 0.
       HS2    = 0.
       DO ISP=1, NSPEC
+#ifdef W3_PDLIB
         HS1    = HS1 + BBPI0(ISP,IBI) * DDEN(MAPWN(ISP))
         HS2    = HS2 + BBPIN(ISP,IBI) * DDEN(MAPWN(ISP))
+#else
+        HS1    = HS1 + BBPI0(ISP,IBI) * DDEN(MAPWN(ISP)) /       &
+             CG(MAPWN(ISP),ISBPI(IBI))
+        HS2    = HS2 + BBPIN(ISP,IBI) * DDEN(MAPWN(ISP)) /       &
+             CG(MAPWN(ISP),ISBPI(IBI))
+#endif
       END DO
       HS1    = 4. * SQRT ( HS1 )
       HS2    = 4. * SQRT ( HS2 )

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -567,6 +567,9 @@ CONTAINS
 #if defined(W3_T) || defined(W3_SBS)
     USE W3GDATMD,  ONLY : FILEXT
 #endif
+#ifdef W3_PDLIB
+    USE yowExchangeModule, only : PDLIB_exchange2Dreal_zero
+#endif
     !
 #ifdef W3_MPI 
     use mpi_f08
@@ -1315,6 +1318,7 @@ CONTAINS
 
 #ifdef W3_PDLIB
         CALL APPLY_BOUNDARY_CONDITION_VA
+        CALL PDLIB_exchange2DREAL_zero(VA)
 #ifdef W3_DEBUGCOH
         CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After FLBPI and LOCAL", 1)
 #endif

--- a/model/src/w3wavemd.F90
+++ b/model/src/w3wavemd.F90
@@ -1317,8 +1317,10 @@ CONTAINS
         call print_memcheck(memunit, 'memcheck_____:'//' WW3_WAVE TIME LOOP 7')
 
 #ifdef W3_PDLIB
-        CALL APPLY_BOUNDARY_CONDITION_VA
-        CALL PDLIB_exchange2DREAL_zero(VA)
+        IF ( FLBPI ) THEN
+          CALL APPLY_BOUNDARY_CONDITION_VA
+          CALL PDLIB_exchange2DREAL_zero(VA)
+        END IF
 #ifdef W3_DEBUGCOH
         CALL ALL_VA_INTEGRAL_PRINT(IMOD, "After FLBPI and LOCAL", 1)
 #endif


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 

Changes to the scaling of lateral boundary conditions are introduced so that simulations with both time varying water level and boundary conditions are bit for bit reproducible. These changes are apply only to cases with switch PDLIB is present.

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

The scaling of BCS by group velocity, CG, in SUBROUTINE W3UBPT is removed.  Most of this scaling was undone later in the code when boundary conditions were applied.  The scaling causes problems with restarts when water level is varying (and thus CG and WN are varying).  The changes simplify the code somewhat as fewer scaling operations are used with the update.  These changes are apply only to cases with switch PDLIB is present.

Additionally state communication was added in w3wave after the call to SUBROUTINE APPLY_BOUNDARY_CONDITION_VA in w3wave.  This change is needed so that restart runs with different numbers of MPI processes (than the cold start run) are bit for bit identical to the cold start run from which they are initiated.

This PR addresses a bug- failure of restart reproducability.

* Are answer changes expected from this PR? 

Yes, changes are expected in all simulations using lateral boundary conditions with PDLIB.  These changes should be small relative to the scale of the wave state.  The following regetests results are expected to change: ww3_tp2.19 and ww3_tp2.17.  In particular the following changes in matrix comparison are expected:

ww3_tp2.17/./work_b                     (10 files differ)
ww3_tp2.17/./work_ice_restart                     (33 files differ)
ww3_tp2.17/./work_c                     (10 files differ)
ww3_tp2.17/./work_iceB                     (44 files differ)
ww3_tp2.17/./work_mc                     (6 files differ)
ww3_tp2.17/./work_ice                     (44 files differ)
ww3_tp2.17/./work_mc1                     (6 files differ)
ww3_tp2.17/./work_mb                     (6 files differ)
ww3_tp2.19/./work_1A_a                     (9 files differ)
ww3_tp2.19/./work_1C_a                     (9 files differ)
ww3_tp2.19/./work_1B_a                     (9 files differ)

This fixes issue #1543 

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

-fixes noaa-emc/ww3/issues/1543

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Scaling of lateral boundary conditions by group velocity are simplified for cases with switch PDLIB.

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [X] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [X] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? 
These changes are tested with regtest ww3_tp2.17.  Specifically the restart run with ice forcing, ww3_tp2.17/work_ice_restart should now be bit for bit identical to  ww3_tp2.17/work_ice (and  ww3_tp2.17/work_iceB)

* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
Yes, they are  tested with regtest ww3_tp2.17

* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
Yes, on Ursa with intel compiler

* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
[matrixCompFull.txt](https://github.com/user-attachments/files/26471172/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/26471173/matrixCompSummary.txt)

MATRIX COMPARISON WHEN "Changes in application of BCS restricted to cases when PDLIB flag is present."
[matrixCompSummary.txt](https://github.com/user-attachments/files/26605406/matrixCompSummary.txt)
[matrixCompFull.txt](https://github.com/user-attachments/files/26605410/matrixCompFull.txt)
