### PR TITLE
[v17]: Add a unique NDSTABSPC for each point for ww3_outp ITYPE=1, OTYPE=3

### DIFF
--- a/model/src/ww3_outp.F90
+++ b/model/src/ww3_outp.F90
@@ -253,7 +253,7 @@ PROGRAM W3OUTP
        IERR, I, TOUT(2), NOUT, TDUM(2),     &
        NREQ, IPOINT, ITYPE, OTYPE, NDSTAB,  &
        IOTEST, IK, ITH, IOUT, J, DIMXP,     &
-       NDSBUL, NDSCSV, ICSV, IJ
+       NDSBUL, NDSCSV, ICSV, IJ, NDSTABSPC
 #ifdef W3_NCO
   INTEGER                 :: NDSCBUL
 #endif
@@ -577,27 +577,29 @@ PROGRAM W3OUTP
         WRITE (NDSO,943) 'Transfer file for each point'
         DO IJ = 1, NOPTS
           IF (FLREQ(IJ)) THEN
+            !JDM MAD UPDATES HERE
             TFNAME = TRIM(prefix)//TRIM(PTNME(IJ))//'.spec'
             WRITE (NDSO,1943) TRIM(TFNAME), 'Transfer File'
             J = LEN_TRIM(FNMPRE)
+            NDSTABSPC = NDSTAB + (IJ - 1) + NOPTS*2
             IF (FLFORM) THEN
-              OPEN (NDSTAB, FILE=TRIM(TFNAME),  &
+              OPEN (NDSTABSPC, FILE=TRIM(TFNAME),  &
                    IOSTAT=IERR, FORM='UNFORMATTED')
               IF (IERR.NE.0) CALL EXTOPN(NDSE,IERR,'W3OUTP','IDL',44)
-              WRITE (NDSTAB) 'WAVEWATCH III SPECTRA',     &
+              WRITE (NDSTABSPC) 'WAVEWATCH III SPECTRA',     &
                    NK, NTH, 1, GNAME
-              WRITE (NDSTAB) (SIG(IK)*TPIINV, IK = 1, NK)
-              WRITE (NDSTAB) (MOD(2.5*PI-TH(ITH), TPI), ITH = 1, NTH)
+              WRITE (NDSTABSPC) (SIG(IK)*TPIINV, IK = 1, NK)
+              WRITE (NDSTABSPC) (MOD(2.5*PI-TH(ITH), TPI), ITH = 1, NTH)
             ELSE
-              OPEN (NDSTAB, FILE=TRIM(TFNAME),  &
+              OPEN (NDSTABSPC, FILE=TRIM(TFNAME),  &
                    IOSTAT=IERR, FORM='FORMATTED')
               IF (IERR.NE.0) CALL EXTOPN(NDSE,IERR,'W3OUTP','IDL',44)
-              WRITE (NDSTAB,1944) 'WAVEWATCH III SPECTRA', &
+              WRITE (NDSTABSPC,1944) 'WAVEWATCH III SPECTRA', &
                    NK, NTH, 1, GNAME
-              WRITE (NDSTAB,1945) (SIG(IK)*TPIINV, IK = 1, NK)
-              WRITE (NDSTAB,1946) (MOD(2.5*PI-TH(ITH), TPI), ITH= 1, NTH)
+              WRITE (NDSTABSPC,1945) (SIG(IK)*TPIINV, IK = 1, NK)
+              WRITE (NDSTABSPC,1946) (MOD(2.5*PI-TH(ITH), TPI), ITH= 1, NTH)
             END IF
-            CLOSE(NDSTAB)
+            !CLOSE(NDSTAB)
           END IF
         END DO
       ELSE
@@ -606,6 +608,7 @@ PROGRAM W3OUTP
         WRITE (TFNAME(5:12),'(I6.6,I2.2)')                      &
              MOD(TOUT(1),1000000), TOUT(2)/10000
         WRITE (NDSO,943) 'Transfer file'
+        NDSTABSPC = NDSTAB
         IF ( FLFORM ) THEN
           WRITE (NDSO,1943) TRIM(TFNAME), 'UNFORMATTED'
           J      = LEN_TRIM(FNMPRE)
@@ -965,21 +968,21 @@ PROGRAM W3OUTP
     IF (ITYPE .EQ. 1 .AND. OTYPE .EQ. 3 .AND. dynpnt .EQ. 1) THEN
       DO IJ = 1, NOPTS
         IF (FLREQ(IJ)) THEN
-          TFNAME = TRIM(prefix)//TRIM(PTNME(IJ))//'.spec'
-          J = LEN_TRIM(FNMPRE)
-          IF (FLFORM) THEN
-            OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
-                IOSTAT=IERR, FORM='UNFORMATTED', ACCESS='APPEND')
-          ELSE
-            OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
-                IOSTAT=IERR, FORM='FORMATTED', ACCESS='APPEND')
-          END IF
-
+          !TFNAME = TRIM(prefix)//TRIM(PTNME(IJ))//'.spec'
+          !J = LEN_TRIM(FNMPRE)
+          NDSTABSPC = NDSTAB + (IJ - 1) + NOPTS*2
+          !IF (FLFORM) THEN
+          !  OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
+          !      IOSTAT=IERR, FORM='UNFORMATTED', ACCESS='APPEND')
+          !ELSE
+          !  OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
+          !      IOSTAT=IERR, FORM='FORMATTED', ACCESS='APPEND')
+          !END IF
           PROCESS_POINT_ONLY = .TRUE.
           ACTIVE_POINT = IJ
           CALL W3EXPO
           PROCESS_POINT_ONLY = .FALSE.
-          CLOSE(NDSTAB)
+          !CLOSE(NDSTABSPC)
         END IF
       END DO
     ELSE
@@ -989,6 +992,15 @@ PROGRAM W3OUTP
     CALL TICK21 ( TOUT , DTREQ )
     IF ( IOUT .GE. NOUT ) EXIT
   END DO
+
+  ! Close files: 
+  IF (ITYPE .EQ. 1 .AND. OTYPE .EQ. 3 .AND. dynpnt .EQ. 1) THEN
+    DO IJ = 1, NOPTS
+      NDSTABSPC = NDSTAB + (IJ - 1) + NOPTS*2
+      CLOSE(NDSTABSPC)
+    END DO
+  END IF
+
 
   !
   ! ... ITYPE=4 & OTYPES=[2,4] requires adding lines at bottom of
@@ -2353,15 +2365,15 @@ CONTAINS
           ELSE IF ( OTYPE .EQ. 3 ) THEN
             !
             IF ( FLFORM ) THEN
-              WRITE (NDSTAB) PTNME(J), PTLOC(2,J),          &
+              WRITE (NDSTABSPC) PTNME(J), PTLOC(2,J),          &
                    PTLOC(1,J), DPO(J), WAO(J),    &
                    UDIR, CAO(J), CDIR
-              WRITE (NDSTAB) ((E(IK,ITH),IK=1,NK),ITH=1,NTH)
+              WRITE (NDSTABSPC) ((E(IK,ITH),IK=1,NK),ITH=1,NTH)
             ELSE
-              WRITE (NDSTAB,901) PTNME(J), M2KM*PTLOC(2,J), &
+              WRITE (NDSTABSPC,901) PTNME(J), M2KM*PTLOC(2,J), &
                    M2KM*PTLOC(1,J), DPO(J),   &
                    WAO(J), UDIR, CAO(J), CDIR
-              WRITE (NDSTAB,902)                            &
+              WRITE (NDSTABSPC,902)                            &
                    ((E(IK,ITH),IK=1,NK),ITH=1,NTH)
             END IF
             !

--- a/model/src/ww3_outp.F90
+++ b/model/src/ww3_outp.F90
@@ -577,7 +577,6 @@ PROGRAM W3OUTP
         WRITE (NDSO,943) 'Transfer file for each point'
         DO IJ = 1, NOPTS
           IF (FLREQ(IJ)) THEN
-            !JDM MAD UPDATES HERE
             TFNAME = TRIM(prefix)//TRIM(PTNME(IJ))//'.spec'
             WRITE (NDSO,1943) TRIM(TFNAME), 'Transfer File'
             J = LEN_TRIM(FNMPRE)
@@ -599,7 +598,6 @@ PROGRAM W3OUTP
               WRITE (NDSTABSPC,1945) (SIG(IK)*TPIINV, IK = 1, NK)
               WRITE (NDSTABSPC,1946) (MOD(2.5*PI-TH(ITH), TPI), ITH= 1, NTH)
             END IF
-            !CLOSE(NDSTAB)
           END IF
         END DO
       ELSE
@@ -968,21 +966,11 @@ PROGRAM W3OUTP
     IF (ITYPE .EQ. 1 .AND. OTYPE .EQ. 3 .AND. dynpnt .EQ. 1) THEN
       DO IJ = 1, NOPTS
         IF (FLREQ(IJ)) THEN
-          !TFNAME = TRIM(prefix)//TRIM(PTNME(IJ))//'.spec'
-          !J = LEN_TRIM(FNMPRE)
           NDSTABSPC = NDSTAB + (IJ - 1) + NOPTS*2
-          !IF (FLFORM) THEN
-          !  OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
-          !      IOSTAT=IERR, FORM='UNFORMATTED', ACCESS='APPEND')
-          !ELSE
-          !  OPEN(NDSTAB, FILE=TRIM(TFNAME), STATUS='OLD', &
-          !      IOSTAT=IERR, FORM='FORMATTED', ACCESS='APPEND')
-          !END IF
           PROCESS_POINT_ONLY = .TRUE.
           ACTIVE_POINT = IJ
           CALL W3EXPO
           PROCESS_POINT_ONLY = .FALSE.
-          !CLOSE(NDSTABSPC)
         END IF
       END DO
     ELSE
@@ -1569,7 +1557,7 @@ CONTAINS
         WRITE (NDSTAB) TIME
       ELSE
         WRITE (NDSTAB,900) TIME
-      END IF      
+      END IF
     END IF
     !
     IF (ITYPE.EQ.2) THEN

--- a/model/src/ww3_outp.F90
+++ b/model/src/ww3_outp.F90
@@ -1558,13 +1558,18 @@ CONTAINS
     !
     !     Output of time
     !
-    IF (  ( ITYPE.EQ.1 .AND. OTYPE.EQ.3 ) .OR.                      &
-         ( ITYPE.EQ.3 .AND. OTYPE.EQ.4 ) ) THEN
+    IF ( ITYPE.EQ.1 .AND. OTYPE.EQ.3 ) THEN
+      IF ( FLFORM ) THEN
+        WRITE (NDSTABSPC) TIME
+      ELSE
+        WRITE (NDSTABSPC,900) TIME
+      END IF
+    ELSE IF ( ITYPE.EQ.3 .AND. OTYPE.EQ.4 ) THEN 
       IF ( FLFORM ) THEN
         WRITE (NDSTAB) TIME
       ELSE
         WRITE (NDSTAB,900) TIME
-      END IF
+      END IF      
     END IF
     !
     IF (ITYPE.EQ.2) THEN


### PR DESCRIPTION
# Pull Request Summary
For v17 branch: add a unique NDSTABSPC for each point for ww3_outp ITYPE=1, OTYPE=3

## Description
When using ww3_outp ITYPE=1, OTYPE=3 and dynpnt=1, the spectral output point writes are particularly slow on machines like gaea. After further inspection, one cause is because we are opening and closing NDSTAB for each point (in operational cases this can be 3k+ points) for each forecast hour. This is a lot of I/O and if the file system is being slow this job is even slower. By giving each point a unique NDSTABSPC based on the point number (NDSTABSPC = NDSTAB + (IJ - 1) + NOPTS*2), this can cut the runtime in about half.

### Issue(s) addressed
n/a

### Commit Message
[v17]: Add a unique NDSTABSPC for each point for ww3_outp ITYPE=1, OTYPE=3

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? matrix + global-workflow 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? hercules intel 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.) none. 
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (14 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (15 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (6 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (3 files differ)
```



A test with the global-workflow was run.  Output for stations is identical and runtimes are now significantly decreased for gfs_wavepostbndpnt and gfs_wavepostpnt on both wcoss2 and gaea c6. 
