### PR TITLE
[v17] update grib2 packing back to jpeg

### DIFF
--- a/model/src/ww3_grib.F90
+++ b/model/src/ww3_grib.F90
@@ -789,7 +789,7 @@ PROGRAM W3GRIB
   ! ... Set GRIB2 Data Representation Template Number (Code Table 5.0)
   !
 #ifdef W3_NCEP2
-  IDRSNUM = 2 !Complex Packing
+  IDRSNUM = 40 !jpeg2000
 #endif
   !                            clusters with Intel compiler ***
 #ifdef W3_NCEP2


### PR DESCRIPTION
# Pull Request Summary
For v17, update grib2 packing back to jpeg
## Description
For v17, update grib2 packing back to jpeg since this results in smaller files in the end. 

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->

### Commit Message
update grib2 packing back to jpeg

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? on wcoss2 in g-w + ursa intel regression tests. 
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) yes. 
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? ursa intel. 
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)

Grib2 files will show up as different. 
```
ww3_tp2.17/./work_c                     (1 files differ)
ww3_tp2.17/./work_ma1                     (1 files differ)
ww3_tp2.17/./work_ma                     (1 files differ)
ww3_tp2.17/./work_mc1                     (1 files differ)
ww3_tp2.17/./work_mb                     (1 files differ)
ww3_tp2.17/./work_a                     (1 files differ)
ww3_tp2.17/./work_b                     (1 files differ)
ww3_tp2.17/./work_mc                     (1 files differ)
ww3_tp2.21/./work_b_metis                     (1 files differ)
ww3_ufs1.1/./work_c                     (1 files differ)
ww3_ufs1.1/./work_d                     (1 files differ)
ww3_ufs1.1/./work_c_npl                     (1 files differ)
ww3_ufs1.1/./work_c_nth                     (1 files differ)
ww3_ufs1.2/./work_c                     (3 files differ)
ww3_ufs1.2/./work_l                     (1 files differ)
ww3_ufs1.2/./work_a                     (4 files differ)
ww3_ufs1.2/./work_b                     (4 files differ)
ww3_ufs1.3/./work_a                     (7 files differ)
```

* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):
```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (16 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.17/./work_c                     (1 files differ)
ww3_tp2.17/./work_ma1                     (1 files differ)
ww3_tp2.17/./work_ma                     (1 files differ)
ww3_tp2.17/./work_mc1                     (1 files differ)
ww3_tp2.17/./work_mb                     (1 files differ)
ww3_tp2.17/./work_a                     (1 files differ)
ww3_tp2.17/./work_b                     (1 files differ)
ww3_tp2.17/./work_mc                     (1 files differ)
ww3_tp2.21/./work_b_metis                     (1 files differ)
ww3_ufs1.1/./work_c                     (1 files differ)
ww3_ufs1.1/./work_d                     (1 files differ)
ww3_ufs1.1/./work_c_npl                     (1 files differ)
ww3_ufs1.1/./work_c_nth                     (1 files differ)
ww3_ufs1.2/./work_c                     (3 files differ)
ww3_ufs1.2/./work_l                     (1 files differ)
ww3_ufs1.2/./work_a                     (4 files differ)
ww3_ufs1.2/./work_b                     (4 files differ)
ww3_ufs1.3/./work_a                     (7 files differ)
```

[matrixCompFull.txt](https://github.com/user-attachments/files/27730627/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/27730630/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/27730631/matrixDiff.txt)
