### PR TITLE
HAFSv2.2: remove overwriting of time0/N for inp file

### DIFF
--- a/model/src/wav_comp_nuopc.F90
+++ b/model/src/wav_comp_nuopc.F90
@@ -1694,7 +1694,7 @@ contains
 
     fnmpre = './'
     if (root_task) write(stdout,'(a)') trim(subname)//' call read_shel_config'
-    call read_shel_config(mpicomm, mds, time0_overwrite=time0, timen_overwrite=timen, rstfldlist=fldrst)
+    call read_shel_config(mpicomm, mds) !, time0_overwrite=time0, timen_overwrite=timen, rstfldlist=fldrst)
 
     ! Define any additional restart fields
     if(len_trim(fldrst) > 0) then


### PR DESCRIPTION
# Pull Request Summary
Remove overwriting of inp files for time0/N 

## Description
Make update we did in HAFSv1 (https://github.com/NOAA-EMC/WW3/pull/965) for HAFSv2.2 to use ww3_shel.inp times so that we are not writing restarts every 6 hours and save time. 

<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

### Issue(s) addressed
https://github.com/NOAA-EMC/WW3/issues/963 

### Commit Message
HAFSv2.2: remove overwriting of time0/N for inp file

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

This is being tested by @BinLiu-NOAA, please merge on his request but not before he says okay. 


* How were these changes tested?
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?)
* Have the matrix regression tests been run (if yes, please note HPC and compiler)?
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

