### PR TITLE
Fix GitHub CI workflow and Spack environment issues

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -65,7 +65,7 @@ jobs:
           sudo mv /usr/local /usr/local_mv
           # Install NetCDF, ESMF, g2, etc using Spack
           . /opt/intel/oneapi/setvars.sh
-          git clone -c feature.manyFiles=true https://github.com/JCSDA/spack.git
+          git clone -c feature.manyFiles=true --depth=2 --branch=spack-stack-1.9.3 https://github.com/JCSDA/spack.git
           source spack/share/spack/setup-env.sh
           ln -s $(realpath $(which gcc)) spack/lib/spack/env/intel/gcc # spack/make bug in ESMF
           spack env create ww3-intel ww3/model/ci/spack_intel.yaml

--- a/.github/workflows/regtest_gnu.yml
+++ b/.github/workflows/regtest_gnu.yml
@@ -126,5 +126,5 @@ jobs:
         id: cache-data
         uses: actions/cache@v3
         with:
-          path: ww3/ww3_from_ftp.v7.14.1.tar.gz
-          key: ww3_from_ftp.v7.14.1
+          path: ww3/ww3_from_ftp.v7.14.2.tar.gz
+          key: ww3_from_ftp.v7.14.2

--- a/model/ci/spack_gnu.yaml
+++ b/model/ci/spack_gnu.yaml
@@ -3,6 +3,8 @@ spack:
     all:
       compiler:
       - gcc@10.0:10
+      target:
+      - x86_64_v3
   specs:
   - metis@5.1.0~shared
   - parmetis@4.0.3~shared

--- a/model/ci/spack_intel.yaml
+++ b/model/ci/spack_intel.yaml
@@ -5,6 +5,8 @@ spack:
       target: [x86_64_v3]
       providers:
         mpi: [intel-oneapi-mpi]
+    python:
+      require: "@3.11"
   specs:
   - netcdf-c@4.9.2~dap
   - netcdf-fortran@4.6.1

--- a/model/ci/spack_intel.yaml
+++ b/model/ci/spack_intel.yaml
@@ -2,6 +2,7 @@ spack:
   packages:
     all:
       compiler: [intel]
+      target: [x86_64_v3]
       providers:
         mpi: [intel-oneapi-mpi]
   specs:


### PR DESCRIPTION
# Pull Request Summary
<!-- A short overview of the PR --> 
This PR resolves multiple issues causing failures in the WW3 GitHub CI workflows.

## Description
<!--
Provide a detailed description of what this PR does.
What bug does it fix, or what feature does it add?
Is a change of answers expected from this PR?

Please also include the following information: 
* Add any suggestions for a reviewer 
* Mention any labels that should be added:  _bug_, _documentation_, _enhancement_, _new feature_
* Are answer changes expected from this PR? Please describe the changes and the reason why in addition to which of the following labels would apply: _mod_def change_, _out_grd change_, _out_pnt change_, _restart file change_, _Regression test_ 
-->

This PR fixes several issues in the WW3 GitHub CI workflows:

1. Pins the Spack version used by the Intel workflow to provide a consistent and reproducible CI environment.
2. Updates the WW3 FTP regression-test input version to match the current regression tests.
3. Sets the Spack CPU target to x86_64_v3 for the GNU and Intel environments to prevent CPU architecture incompatibilities between GitHub runners and cached Spack dependencies.
4. Pins the Python version used by the Intel Spack environment to avoid the Python 3.13 build failure with the Intel classic compiler.

These changes are limited to the GitHub CI and Spack configurations. No WW3 source code or regression-test cases are modified.

### Issue(s) addressed
<!--
* Please list any issues associated with this PR, including those the PR will fix/close. For example:  
- fixes #<issue_number>
- fixes noaa-emc/ww3/issues/<issue_number>
-->
fixes #1630 

### Commit Message
<!--
Please provide a short summary of this PR, which will be used during _Squash and Merge_ and will be shown as a git log message.  Be sure to add any co-authors here. 
-->
Fix GitHub CI workflow failures and Spack environment issues

### Check list  

<!-- After creating the PR you can check each of the items below that have been completed -->

- [x] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [x] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing

* How were these changes tested? Matrix
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* Have the matrix regression tests been run (if yes, please note HPC and compiler)? Hercules Intel
* Please indicate the expected changes in the regression test output, (Note the [list](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-develop#4-look-at-results) of known non-identical tests.)
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
mww3_test_03/./work_PR1_MPI_d2                     (13 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (17 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (18 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (16 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (15 files differ)
mww3_test_03/./work_PR2_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_e_c                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (14 files differ)
mww3_test_09/./work_MPI_ASCII                     (0 files differ)
ww3_tp2.10/./work_MPI_OMPH                     (7 files differ)
ww3_tp2.16/./work_MPI_OMPH                     (4 files differ)
ww3_tp2.6/./work_ST4_ASCII                     (0 files differ)
ww3_ufs1.3/./work_a                     (2 files differ)
```
[matrixCompFull.txt](https://github.com/user-attachments/files/32108756/matrixCompFull.txt)
[matrixCompSummary.txt](https://github.com/user-attachments/files/32108759/matrixCompSummary.txt)
[matrixDiff.txt](https://github.com/user-attachments/files/32108761/matrixDiff.txt)

